### PR TITLE
Do not override environment variables if set

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -21,7 +21,7 @@ cd $HOME
 shopt -s nullglob
 mkdir -p .profile.d
 if [[ -s .release ]]; then
-	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}='#{v}'\"}" > .profile.d/config_vars
+	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=${#{k}:-'#{v}'}\"}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do
 	source $file


### PR DESCRIPTION
Hi and thanks for all of the great work on this project! I have a small improvement to propose.

It looks like environment variables are overwritten by `./profile.d/config_vars` even if they are explicitly set via the `-e` flag to `docker run`. My interpretation rom reading the ruby buildpack source (https://github.com/heroku/heroku-buildpack-ruby/blob/588746851e1468dce5e72a8e0339100a5a52d6c6/lib/language_pack/base.rb#L99) is that  the values in `config_vars` are intended to be defaults. If that is the case, the values should only be used if they are not defined. If I'm wrong about that, and they are intended to force a value for a variable, then this change is not appropriate.
