### PR TITLE
slugrunner: fix writing of config_vars

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -21,7 +21,7 @@ cd $HOME
 shopt -s nullglob
 mkdir -p .profile.d
 if [[ -s .release ]]; then
-	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=${#{k}:-'#{v}'}\"}" > .profile.d/config_vars
+	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=\${#{k}:-'#{v}'}\"}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do
 	source $file


### PR DESCRIPTION
Got the following error:

```
/runner/init: line 24: require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts "#{k}=${#{k}:-'#{v}'}"}: bad substitution
```

I believe the `$` needs escaping...
