### PR TITLE
Update vagrant sudo syntax

### DIFF
--- a/misc/packer/ubuntu-14.04/scripts/vagrant.sh
+++ b/misc/packer/ubuntu-14.04/scripts/vagrant.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set up sudo
-echo %vagrant ALL=NOPASSWD:ALL > /etc/sudoers.d/vagrant
+echo "%vagrant ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vagrant
 chmod 0440 /etc/sudoers.d/vagrant
 
 # Setup sudo to allow no-password sudo for "sudo"


### PR DESCRIPTION
Before:

```
$ sudo -l
Matching Defaults entries for vagrant on flynn:
    env_reset, mail_badpass, secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin

User vagrant may run the following commands on flynn:
    (ALL : ALL) ALL
    (root) NOPASSWD: ALL

$ bash -c "sudo -u nobody date"
[sudo] password for vagrant: 
```

After:

```
$ sudo -l
Matching Defaults entries for vagrant on flynn:
    env_reset, mail_badpass, secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin

User vagrant may run the following commands on flynn:
    (ALL : ALL) ALL
    (ALL) NOPASSWD: ALL

$ bash -c "sudo -u nobody date"
Sun Aug 10 18:07:12 UTC 2014
```
