### PR TITLE
router: Set RemoteAddr in backend request object. Closes #105.

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -334,6 +334,7 @@ func (s *HTTPListener) handle(conn net.Conn, isTLS bool) {
 		}
 	}
 
+	req.RemoteAddr = conn.RemoteAddr().String()
 	r.service.handle(req, sc, isTLS, r.Sticky)
 }
 


### PR DESCRIPTION
I've added a line to the `http.go` file that sets the RemoteAddr from the `conn` object before passing it on to the handle() function.

I also added tests to verify (from the backend app's point of view) that it is receiving the X-Forwarded-\* headers as well as the `X-Request-Start` header.
