### PR TITLE
Updates flynnlocal to localflynn

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ every node IP address and a second, wildcard domain CNAME to the cluster domain.
 respective domains.
 
 ```text
-  CONTROLLER_DOMAIN=demo.flynnlocal.com \
-  DEFAULT_ROUTE_DOMAIN=demo.flynnlocal.com \
+  CONTROLLER_DOMAIN=demo.localflynn.com \
+  DEFAULT_ROUTE_DOMAIN=demo.localflynn.com \
   flynn-bootstrap /etc/flynn/bootstrap-manifest.json
 ```
 


### PR DESCRIPTION
Flynn demo environment uses `localflynn.com` rather than `flynnlocal.com` (and they don't seem to be the same thing).

Signed-off-by: Reinaldo Junior juniorz@gmail.com
