### PR TITLE
router: Added X-Request-Id header to close #66

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -444,6 +444,7 @@ func (s *httpService) getBackendSticky(req *http.Request) (*httputil.ClientConn,
 func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, tls, sticky bool) {
 	for {
 		req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+		req.Header.Set("X-Request-Id", random.UUID())
 
 		var backend *httputil.ClientConn
 		var stickyCookie *http.Cookie


### PR DESCRIPTION
I realize this is a feature and not a bug, but I hoped it would be worth doing. And it was some low hanging fruit that I could tackle.

router: Added X-Request-Id header to requests sent to backends. Will reuse existing X-Request-Id, if the client supplies it.
router: Added tests to verify X-Forwarded-For will append existing X-Forwarded-For header from the client.
Closes #66.
