### PR TITLE
controller: Track jobs possibly started before the controller

### DIFF
--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -153,6 +153,13 @@ func (c *context) syncCluster(events chan<- *host.Event) {
 			}
 
 			gg.Log(grohl.Data{"at": "addJob"})
+			go c.PutJob(&ct.Job{
+				ID:        h.ID + "-" + job.ID,
+				AppID:     appID,
+				ReleaseID: releaseID,
+				Type:      jobType,
+				State:     "up",
+			})
 			j := f.jobs.Add(jobType, h.ID, job.ID)
 			j.Formation = f
 			c.jobs.Add(j)


### PR DESCRIPTION
Both controller and postgres jobs can be seen with `flynn ps`:

```
vagrant@flynn:~/go/src/github.com/flynn/flynn$ flynn apps
ID                                NAME
db49ae4840d2448f9d33746c535e371d  gitreceive
cd3a804c55ac4c69baf63d05c933d9ae  router
6c00263e0974445b912d74e5236477e2  blobstore
0bc8a5c4232b4779bcf18e47a8376294  postgres
26513bdcdd534bdf8d13b46c7b57b64f  controller
vagrant@flynn:~/go/src/github.com/flynn/flynn$ flynn -a controller ps                                                                                            
ID                                      TYPE
flynn-9f22dc5501fa46388a4ee879530c8ee7  web
flynn-61c6dda8c1a643a6b98dd986995fafc2  scheduler
vagrant@flynn:~/go/src/github.com/flynn/flynn$ flynn -a postgres ps                                                                                              
ID                                      TYPE
flynn-8263af3e2d544a3a80c6bbe537b0cf1d  web
flynn-5578e8d642ec4354ac593f9044054023  postgres
```

Closes #37
