### PR TITLE
Specifying [] as default CMD

### DIFF
--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -9,4 +9,5 @@ RUN chown -R slugbuilder:slugbuilder /app
 ADD ./builder/ /tmp/builder
 RUN xargs -L 1 /tmp/builder/install-buildpack /tmp/buildpacks < /tmp/builder/buildpacks.txt
 ENTRYPOINT ["/tmp/builder/build.sh"]
+CMD []
 USER slugbuilder


### PR DESCRIPTION
Piping a source tar to `docker run` causes the slugbuilder to exit with a status code of `3` even though the slug was successfully compiled. The $put_url is being set to `/bin/bash` if the slugbuilder is not invoked with an explicit empty command:

```
# Exits with a status of 3
id=$(git archive master | docker run -i -a stdin flynn/slugbuilder)
# Exits with a status of 0
id=$(git archive master | docker run -i -a stdin flynn/slugbuilder "")
```

Setting the default CMD to an empty array by default allows the first form of the command, taken from the README, to again return an exit status of 0.

Thanks to `lmars` on IRC (#flynn) for all of the help.
