### PR TITLE
host: Ensure etcd is started with a unique name

### DIFF
--- a/host/manifest.go
+++ b/host/manifest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flynn/flynn/host/ports"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/random"
 )
 
 func parseEnviron() map[string]string {
@@ -23,6 +24,11 @@ func parseEnviron() map[string]string {
 		kv := strings.SplitN(v, "=", 2)
 		res[kv[0]] = kv[1]
 	}
+
+	if _, ok := res["ETCD_NAME"]; !ok {
+		res["ETCD_NAME"] = random.String(8)
+	}
+
 	return res
 }
 

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -10,7 +10,7 @@
       "-bind-addr=0.0.0.0:{{ .TCPPort 0 }}",
       "-peer-addr={{ .ExternalIP }}:{{ .TCPPort 1 }}",
       "-peer-bind-addr=0.0.0.0:{{ .TCPPort 1 }}",
-      "-name={{ .Env.HOSTNAME }}",
+      "-name={{ .Env.ETCD_NAME }}",
       "{{ if .Env.ETCD_PEERS }}-peers={{ .Env.ETCD_PEERS }}{{ end }}",
       "{{ if .Env.ETCD_DISCOVERY }}-discovery={{ .Env.ETCD_DISCOVERY }}{{ end }}"
     ],


### PR DESCRIPTION
When using the libvirt-lxc backend, it is likely that `HOSTNAME` will not be set, resulting in etcd always being started with a name of `<no value>` which is problematic for multi node clusters.
