### PR TITLE
cli: Changed home directory finding function to fix paths on MSYS/Cygwin.

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -187,10 +187,11 @@ func readConfig() error {
 }
 
 func homedir() string {
-	if runtime.GOOS == "windows" {
+	home := os.Getenv("HOME")
+	if home == "" && runtime.GOOS == "windows" {
 		return os.Getenv("%APPDATA%")
 	}
-	return os.Getenv("HOME")
+	return home
 }
 
 var ErrNoClusters = errors.New("no clusters configured")


### PR DESCRIPTION
Without this change, .flynnrc would end up in the current working directory. Not testable due to being platform-dependent.
