### PR TITLE
Add heroku-buildpack-apt to slugbuilder

### DIFF
--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,4 +1,5 @@
 https://github.com/ddollar/heroku-buildpack-multi.git#93505719
+https://github.com/ddollar/heroku-buildpack-apt.git#7993a88465
 https://github.com/heroku/heroku-buildpack-ruby.git#v126
 https://github.com/heroku/heroku-buildpack-nodejs.git#v60
 https://github.com/heroku/heroku-buildpack-clojure.git#8ae65497


### PR DESCRIPTION
Rationale: when managing multiple applications with constantly changing dependencies it's much easier to install packages directly via `Aptfile` than creating buildpack for each of them. It also have advantage of much easier updating dependencies to new version (just invalidate cache).
