### PR TITLE
router: Fix sync with pruned etcd instances.

### DIFF
--- a/discoverd/agent/backend_etcd.go
+++ b/discoverd/agent/backend_etcd.go
@@ -46,7 +46,7 @@ func (b *EtcdBackend) Subscribe(name string) (UpdateStream, error) {
 	sync:
 		for {
 			nextIndex := uint64(1)
-			response, _ := b.getCurrentState(name)
+			response, err := b.getCurrentState(name)
 			if response != nil {
 				for _, n := range response.Node.Nodes {
 					if modified, ok := keys[n.Key]; ok && modified >= n.ModifiedIndex {
@@ -57,6 +57,8 @@ func (b *EtcdBackend) Subscribe(name string) (UpdateStream, error) {
 					}
 				}
 				nextIndex = response.EtcdIndex + 1
+			} else if e, ok := err.(*etcd.EtcdError); ok {
+				nextIndex = e.Index + 1
 			}
 			if !sentinel {
 				if !send(&ServiceUpdate{}) {

--- a/router/data_store.go
+++ b/router/data_store.go
@@ -130,6 +130,7 @@ func (s *etcdDataStore) Sync(h SyncHandler, started chan<- error) {
 fullSync:
 	data, err := s.etcd.Get(s.prefix, false, true)
 	if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == 100 {
+		nextIndex = e.Index + 1
 		// key not found, delete existing keys and then watch
 		for id := range keys {
 			delete(keys, id)


### PR DESCRIPTION
If I start using the router with an existing etcd instance, where the router keys do not yet exists, I end up in a 

```
2014/09/02 13:02:46 Got etcd error 401, doing full sync
```

loop. The reason is that `nextIndex` starts at 1, and as soon as that index has been pruned, watching with that index will always fail.
