### PR TITLE
router: Support custom etcd prefix.

### DIFF
--- a/router/data_store.go
+++ b/router/data_store.go
@@ -119,7 +119,7 @@ func (s *etcdDataStore) List() ([]*router.Route, error) {
 }
 
 func (s *etcdDataStore) path(id string) string {
-	return s.prefix + path.Base(id)
+	return path.Join(s.prefix, path.Base(id))
 }
 
 func (s *etcdDataStore) Sync(h SyncHandler, started chan<- error) {

--- a/router/server.go
+++ b/router/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
@@ -85,9 +86,13 @@ func main() {
 	}
 	etcdc := etcd.NewClient(etcdAddrs)
 
+	prefix := os.Getenv("ETCD_PREFIX")
+	if prefix == "" {
+		prefix = "/router"
+	}
 	var r Router
-	r.TCP = NewTCPListener(*tcpIP, 0, 0, NewEtcdDataStore(etcdc, "/router/tcp/"), d)
-	r.HTTP = NewHTTPListener(*httpAddr, *httpsAddr, cookieKey, NewEtcdDataStore(etcdc, "/router/http/"), d)
+	r.TCP = NewTCPListener(*tcpIP, 0, 0, NewEtcdDataStore(etcdc, path.Join(prefix, "tcp/")), d)
+	r.HTTP = NewHTTPListener(*httpAddr, *httpsAddr, cookieKey, NewEtcdDataStore(etcdc, path.Join(prefix, "http/")), d)
 
 	go func() { log.Fatal(r.ListenAndServe(nil)) }()
 	log.Fatal(http.ListenAndServe(*apiAddr, apiHandler(&r)))


### PR DESCRIPTION
I don't know how much the Flynn components are still supposed to be separable, but this would be useful for custom usage.
