### PR TITLE
Improve wording and links to Flynn Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ anyone has already reported the issue.
 
 ## Getting Started
 
-We built a [tool](https://dashboard.flynn.io) for launching Flynn clusters on your
-Amazon Web Services account [here](https://dashboard.flynn.io).
+We built the [Flynn Dashboard](https://dashboard.flynn.io) for launching Flynn clusters on your
+Amazon Web Services account.
 
 You can also download a [demo environment](/demo) for your local machine or
 learn about the components below.


### PR DESCRIPTION
- The Dashboard was linked twice in one sentence 
- The link title wasn't semantic, just call things as they are
