### PR TITLE
host: Use a custom libvirt network

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -143,18 +143,18 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libcontainer/label",
-			"Comment": "v1.2.0-4-g1ecaf30",
-			"Rev": "1ecaf30408c3caece87a49b275dbe4b23d7160ff"
+			"Comment": "v1.2.0-37-g185328a",
+			"Rev": "185328a42654f6dc9a41814e57882f69d65f6ab7"
 		},
 		{
 			"ImportPath": "github.com/docker/libcontainer/netlink",
-			"Comment": "v1.2.0-4-g1ecaf30",
-			"Rev": "1ecaf30408c3caece87a49b275dbe4b23d7160ff"
+			"Comment": "v1.2.0-37-g185328a",
+			"Rev": "185328a42654f6dc9a41814e57882f69d65f6ab7"
 		},
 		{
 			"ImportPath": "github.com/docker/libcontainer/user",
-			"Comment": "v1.2.0-4-g1ecaf30",
-			"Rev": "1ecaf30408c3caece87a49b275dbe4b23d7160ff"
+			"Comment": "v1.2.0-37-g185328a",
+			"Rev": "185328a42654f6dc9a41814e57882f69d65f6ab7"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-docopt",

--- a/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_arm.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_arm.go
@@ -1,9 +1,5 @@
 package netlink
 
-import (
-	"math/rand"
-)
-
-func randIfrDataByte() uint8 {
-	return uint8(rand.Intn(255))
+func ifrDataByte(b byte) uint8 {
+	return uint8(b)
 }

--- a/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_notarm.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_notarm.go
@@ -2,10 +2,6 @@
 
 package netlink
 
-import (
-	"math/rand"
-)
-
-func randIfrDataByte() int8 {
-	return int8(rand.Intn(255))
+func ifrDataByte(b byte) int8 {
+	return int8(b)
 }

--- a/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_test.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux_test.go
@@ -115,6 +115,7 @@ func TestCreateVethPair(t *testing.T) {
 	if err := NetworkCreateVethPair(name1, name2); err != nil {
 		t.Fatal(err)
 	}
+	defer NetworkLinkDel(name1)
 
 	if _, err := net.InterfaceByName(name1); err != nil {
 		t.Fatal(err)
@@ -122,5 +123,32 @@ func TestCreateVethPair(t *testing.T) {
 
 	if _, err := net.InterfaceByName(name2); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSetMACAddress(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	name := "testmac"
+	mac := randMacAddr()
+
+	if err := NetworkLinkAdd(name, "bridge"); err != nil {
+		t.Fatal(err)
+	}
+	defer NetworkLinkDel(name)
+
+	if err := NetworkSetMacAddress(name, mac); err != nil {
+		t.Fatal(err)
+	}
+
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if iface.HardwareAddr.String() != mac {
+		t.Fatalf("mac address %q does not match %q", iface.HardwareAddr, mac)
 	}
 }

--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -105,3 +105,31 @@ type InterfaceSrc struct {
 type Console struct {
 	Type string `xml:"type,attr"`
 }
+
+type Network struct {
+	XMLName xml.Name `xml:"network"`
+	Name    string   `xml:"name"`
+	Bridge  Bridge   `xml:"bridge"`
+	Forward string   `xml:"forward"`
+	IP      IP       `xml:"ip"`
+	MAC     MAC      `xml:"mac"`
+}
+
+func (n *Network) XML() []byte {
+	data, _ := xml.Marshal(n)
+	return data
+}
+
+type Bridge struct {
+	Name string `xml:"name,attr"`
+	STP  string `xml:"stp,attr"`
+}
+
+type IP struct {
+	Address string `xml:"address,attr"`
+	Netmask string `xml:"netmask,attr"`
+}
+
+type MAC struct {
+	Address string `xml:"address,attr"`
+}

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/alexzorin/libvirt-go"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/networkdriver/ipallocator"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/libcontainer/netlink"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/lumberjack"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/technoweenie/grohl"
 	"github.com/flynn/flynn/host/containerinit"
@@ -31,7 +32,17 @@ import (
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/iptables"
+	"github.com/flynn/flynn/pkg/random"
 )
+
+const (
+	libvirtNetName = "flynn"
+	bridgeName     = "flynnbr0"
+	bridgeMask     = "255.255.255.0"
+)
+
+// TODO: read these from a configurable libvirt network
+var bridgeAddr, bridgeNet, _ = net.ParseCIDR("192.168.200.1/24")
 
 func NewLibvirtLXCBackend(state *State, portAlloc map[string]*ports.Allocator, volPath, logPath, initPath string) (Backend, error) {
 	libvirtc, err := libvirt.NewVirConnection("lxc:///")
@@ -39,18 +50,45 @@ func NewLibvirtLXCBackend(state *State, portAlloc map[string]*ports.Allocator, v
 		return nil, err
 	}
 
-	iptables.RemoveExistingChain("FLYNN", "virbr0")
-	chain, err := iptables.NewChain("FLYNN", "virbr0")
+	b := random.Bytes(5)
+	bridgeMAC := fmt.Sprintf("fe:%02x:%02x:%02x:%02x:%02x", b[0], b[1], b[2], b[3], b[4])
+
+	network, err := libvirtc.LookupNetworkByName(libvirtNetName)
+	if err != nil {
+		n := &lt.Network{
+			Name:   libvirtNetName,
+			Bridge: lt.Bridge{Name: bridgeName, STP: "off"},
+			IP:     lt.IP{Address: bridgeAddr.String(), Netmask: bridgeMask},
+			MAC:    lt.MAC{Address: bridgeMAC},
+		}
+		network, err = libvirtc.NetworkDefineXML(string(n.XML()))
+		if err != nil {
+			return nil, err
+		}
+	}
+	active, err := network.IsActive()
 	if err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/virbr0/route_localnet", []byte("1"), 0666); err != nil {
-		return nil, err
+	if !active {
+		if err := network.Create(); err != nil {
+			return nil, err
+		}
 	}
-	if err := ioutil.WriteFile("/sys/class/net/virbr0/bridge/stp_state", []byte("0"), 0666); err != nil {
+	// We need to explicitly assign the MAC address to avoid it changing to a lower value
+	// See: https://github.com/flynn/flynn/issues/223
+	if err := netlink.NetworkSetMacAddress(bridgeName, bridgeMAC); err != nil {
 		return nil, err
 	}
 
+	iptables.RemoveExistingChain("FLYNN", bridgeName)
+	chain, err := iptables.NewChain("FLYNN", bridgeName)
+	if err != nil {
+		return nil, err
+	}
+	if err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+bridgeName+"/route_localnet", []byte("1"), 0666); err != nil {
+		return nil, err
+	}
 	return &LibvirtLXCBackend{
 		LogPath:    logPath,
 		VolPath:    volPath,
@@ -88,9 +126,6 @@ type libvirtContainer struct {
 	done     chan struct{}
 	*containerinit.Client
 }
-
-// TODO: read these from a configurable libvirt network
-var defaultGW, defaultNet, _ = net.ParseCIDR("192.168.122.1/24")
 
 const dockerBase = "/var/lib/docker"
 
@@ -161,7 +196,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job) (err error) {
 	g := grohl.NewContext(grohl.Data{"backend": "libvirt-lxc", "fn": "run", "job.id": job.ID})
 	g.Log(grohl.Data{"at": "start", "job.artifact.uri": job.Artifact.URI, "job.cmd": job.Config.Cmd})
 
-	ip, err := ipallocator.RequestIP(defaultNet, nil)
+	ip, err := ipallocator.RequestIP(bridgeNet, nil)
 	if err != nil {
 		g.Log(grohl.Data{"at": "request_ip", "status": "error", "err": err})
 		return err
@@ -307,7 +342,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job) (err error) {
 
 	args := []string{
 		"-i", ip.String() + "/24",
-		"-g", defaultGW.String(),
+		"-g", bridgeAddr.String(),
 	}
 	if job.Config.TTY {
 		args = append(args, "-tty")
@@ -357,7 +392,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job) (err error) {
 			}},
 			Interfaces: []lt.Interface{{
 				Type:   "network",
-				Source: lt.InterfaceSrc{Network: "default"},
+				Source: lt.InterfaceSrc{Network: libvirtNetName},
 			}},
 			Consoles: []lt.Console{{Type: "pty"}},
 		},
@@ -563,7 +598,7 @@ func (c *libvirtContainer) cleanup() error {
 			c.l.ports[p.Proto].Put(uint16(i))
 		}
 	}
-	ipallocator.ReleaseIP(defaultNet, &c.IP)
+	ipallocator.ReleaseIP(bridgeNet, &c.IP)
 	g.Log(grohl.Data{"at": "finish"})
 	return nil
 }

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -261,10 +261,6 @@ type hostScriptData struct {
 
 var flynnHostScripts = map[string]*template.Template{
 	"libvirt-lxc": template.Must(template.New("flynn-host-libvirt").Parse(`
-set -e
-
-sudo virsh net-start default
-
 sudo start-stop-daemon \
   --start \
   --background \


### PR DESCRIPTION
This was previously implemented in #229 but caused issues when re-bootstrapping a cluster. In the previous change, bootstrapping for the second time would get stuck at `wait router-wait` as the router would crash with the following error:

```
2014/09/22 21:53:05 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
```

After modifying the change to explicitly set the MAC address of the `flynnbr0` interface everytime (rather than previously only setting it when we creating the bridge, not on subsequent invocations of `flynn-host`), this no longer happens and I can bootstrap the cluster many times.

I can't pin down the underlying issue, but this change has fixed it :expressionless:
