### PR TITLE
host: Set job exit status to 0 if it was signaled

### DIFF
--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -417,6 +417,9 @@ func babySit(process *os.Process) int {
 		}
 	}
 
+	if wstatus.Signaled() {
+		return 0
+	}
 	return wstatus.ExitStatus()
 }
 


### PR DESCRIPTION
This is so that a job which is explicitly stopped via `SIGTERM` (or any other signal) has a status of `done` rather than `crashed` in the controller
