### PR TITLE
controller,router: Add timestamps to HTTP logs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -121,6 +121,7 @@ func responseHelperHandler(c martini.Context, w http.ResponseWriter, r render.Re
 func appHandler(c handlerConfig) (http.Handler, *martini.Martini) {
 	r := martini.NewRouter()
 	m := martini.New()
+	m.Map(log.New(os.Stdout, "[controller] ", log.LstdFlags|log.Lmicroseconds))
 	m.Use(martini.Logger())
 	m.Use(martini.Recovery())
 	m.Use(render.Renderer())

--- a/router/api.go
+++ b/router/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 func apiHandler(rtr *Router) http.Handler {
 	r := martini.NewRouter()
 	m := martini.New()
+	m.Map(log.New(os.Stdout, "[router] ", log.LstdFlags|log.Lmicroseconds))
 	m.Use(martini.Logger())
 	m.Use(martini.Recovery())
 	m.Use(render.Renderer())


### PR DESCRIPTION
Useful when debugging.

Example:

```
[router] 2014/09/23 17:03:53.560195 Started GET /routes
[router] 2014/09/23 17:03:53.560778 Completed 200 OK in 582.006us

[controller] 2014/09/23 17:02:08.161646 Started POST /apps
[controller] 2014/09/23 17:02:08.163668 Completed 200 OK in 2.019025ms
```
