### PR TITLE
Support releasing Vagrant VirtualBox images

### DIFF
--- a/script/lib/aws.sh
+++ b/script/lib/aws.sh
@@ -1,0 +1,23 @@
+# Helpers for interacting with AWS services
+
+sync_cloudfront() {
+  local src=$1
+  local dst=$2
+
+  # the sync command will output another command to check CloudFront invalidation, so we need to capture that
+  cf_cmd=$(s3cmd sync --acl-public --cf-invalidate --no-preserve "${src}" "${dst}" | tee /dev/stderr | grep -oP 's3cmd cfinvalinfo cf://\w+/\w+')
+  if [[ "${cf_cmd:0:5}" != "s3cmd" ]]; then
+    fail "could not determine CloudFront invalidation command"
+  fi
+
+  info "waiting for CloudFront invalidation (can take ~10mins)"
+  while true; do
+    local status="$($cf_cmd | grep '^Status' | awk '{print $2}')"
+    if [[ "${status}" = "Completed" ]]; then
+      break
+    fi
+    info "invalidation status is currently ${status}, waiting 10s"
+    sleep 10
+  done
+  info "CloudFront invalidation complete"
+}

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -36,6 +36,7 @@ set -eo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "${ROOT}/script/lib/ui.sh"
+source "${ROOT}/script/lib/aws.sh"
 
 # S3_URI must have a trailing slash
 S3_URI="s3://flynn/ubuntu/"
@@ -131,22 +132,7 @@ main() {
   reprepro -b "${apt_dir}" includedeb flynn "${deb}"
 
   info "uploading apt repo"
-  # the sync command will output another command to check CloudFront invalidation, so we need to capture that
-  cf_cmd=$(s3cmd sync --acl-public --cf-invalidate --no-preserve "${apt_dir}" $S3_URI | tee /dev/stderr | grep -oP 's3cmd cfinvalinfo cf://\w+/\w+')
-  if [[ "${cf_cmd:0:5}" != "s3cmd" ]]; then
-    fail "could not determine CloudFront invalidation command"
-  fi
-
-  info "waiting for CloudFront invalidation (can take ~10mins)"
-  while true; do
-    local status="$($cf_cmd | grep '^Status' | awk '{print $2}')"
-    if [[ "${status}" = "Completed" ]]; then
-      break
-    fi
-    info "invalidation status is currently ${status}, waiting 10s"
-    sleep 10
-  done
-  info "CloudFront invalidation complete"
+  sync_cloudfront "${apt_dir}" $S3_URI
 
   info "cleaning up"
   rm -rf "${dir}"

--- a/script/release-vm-images
+++ b/script/release-vm-images
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# A script to build and release Flynn VM images.
+#
+# PREREQUISITES:
+#
+# - Install packer
+#   sudo apt-get install -y unzip
+#   wget -O /tmp/packer.zip https://dl.bintray.com/mitchellh/packer/packer_0.7.1_linux_amd64.zip
+#   sudo unzip -d /usr/local/bin /tmp/packer.zip
+#   rm /tmp/packer.zip
+#
+# - Install up-to-date s3cmd so "s3cmd info" works
+#   sudo apt-get install -y python-dateutil
+#   wget -O /tmp/s3cmd.deb http://archive.ubuntu.com/ubuntu/pool/universe/s/s3cmd/s3cmd_1.5.0~rc1-2_all.deb
+#   sudo dpkg -i /tmp/s3cmd.deb
+#   rm /tmp/s3cmd.deb
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/ui.sh"
+source "${ROOT}/script/lib/aws.sh"
+
+UBUNTU_BOX_NAME="ubuntu-trusty-20141016" # used in filenames for caching, bump at the same time as UBUNTU_BOX_URL
+UBUNTU_BOX_URL="http://cloud-images.ubuntu.com/vagrant/trusty/20141016/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+UBUNTU_BOX_SHA="c6623a4850c4d61bc6b96c3b2d2150eb60ca1e4a38f2cb2a8087370139b08d30"
+
+usage() {
+  cat <<USAGE >&2
+usage: $0 [options] VERSION DEB_URL
+
+OPTIONS:
+  -h            Show this message
+  -b BUCKET     The S3 bucket to upload vagrant images to [default: flynn]
+  -d DOMAIN     The CloudFront domain [default: dl.flynn.io]
+  -r DIR        Resume the release using DIR
+USAGE
+}
+
+main() {
+  local bucket dir domain
+
+  while getopts "hb:d:r:" opt; do
+    case $opt in
+      h)
+	usage
+	exit 1
+	;;
+      b)
+	bucket=$OPTARG
+	;;
+      d)
+        domain=$OPTARG
+        ;;
+      r)
+        dir=$OPTARG
+        if [[ ! -d "${dir}" ]]; then
+          fail "No such directory: ${dir}"
+        fi
+        ;;
+      ?)
+	usage
+	exit 1
+	;;
+    esac
+  done
+  shift $(($OPTIND - 1))
+
+  if [[ $# -ne 2 ]]; then
+    usage
+    exit 1
+  fi
+
+  local version=$1
+  local deb_url=$2
+  bucket=${bucket:-"flynn"}
+  dir="${dir:-$(mktemp -d)}"
+  domain="${domain:-"dl.flynn.io"}"
+
+  info "using base dir: ${dir}"
+
+  local box=$(ls "${dir}"/*_virtualbox.box 2>/dev/null)
+  if [[ -z "${box}" ]]; then
+    local ubuntu_box="/tmp/${UBUNTU_BOX_NAME}.box"
+    if [[ ! -f "${ubuntu_box}" ]]; then
+      info "fetching base Ubuntu box"
+      curl "${UBUNTU_BOX_URL}" > "${ubuntu_box}"
+    fi
+
+    info "validating base Ubuntu box"
+    if [[ "$(sha256 "${ubuntu_box}")" != "${UBUNTU_BOX_SHA}" ]]; then
+      rm -f "${ubuntu_box}"
+      fail "base Ubuntu box has incorrect checksum"
+    fi
+
+    local ova_path="/tmp/${UBUNTU_BOX_NAME}.ova"
+    if [[ ! -f "${ova_path}" ]]; then
+      info "converting base Ubuntu box to OVA archive"
+      tar --delete Vagrantfile < "${ubuntu_box}" > "${ova_path}"
+    fi
+
+    info "building virtualbox image"
+    pushd "${ROOT}/util/packer/ubuntu-14.04" >/dev/null
+    packer build \
+      -only="virtualbox-ovf" \
+      -var "flynn_deb_url=${deb_url}" \
+      -var "headless=true" \
+      -var "output_dir=${dir}" \
+      -var "ova_path=${ova_path}" \
+      -var "version=${version}" \
+      vagrant.json
+    popd >/dev/null
+
+    box=$(ls "${dir}"/*_virtualbox.box 2>/dev/null)
+  fi
+
+  local box_name="$(basename "${box}")"
+  if ! s3cmd info "s3://${bucket}/vagrant/boxes/${box_name}" &>/dev/null; then
+    info "uploading ${box_name} to s3://${bucket}/vagrant/boxes"
+    s3cmd put --acl-public "${box}" "s3://${bucket}/vagrant/boxes/"
+  fi
+
+  info "calculating SHA256 checksum of ${box_name}"
+  checksum=$(sha256 "${box}")
+  if [[ ${#checksum} -ne 64 ]]; then
+    fail "invalid checksum generated: '${checksum}'"
+  fi
+  info "checksum is ${checksum}"
+
+  info "fetching current vagrant manifest"
+  local manifest="$(s3cmd --no-progress get "s3://${bucket}/vagrant/flynn-base.json" - 2>/dev/null)"
+  if [[ -z "${manifest}" ]]; then
+    manifest='{"name":"flynn-base"}'
+  fi
+
+  info "updating vagrant manifest"
+  mkdir -p "${dir}/manifest"
+  "${ROOT}/util/release/flynn-release" vagrant \
+    "https://${domain}/vagrant/boxes/${box_name}" \
+    "${checksum}" \
+    "${version}" \
+    "virtualbox" \
+    <<< "${manifest}" \
+    > "${dir}/manifest/flynn-base.json"
+
+  info "releasing vagrant manifest"
+  sync_cloudfront "${dir}/manifest/" "s3://${bucket}/vagrant/"
+
+  info "cleaning up"
+  rm -rf "${dir}"
+
+  info "done!"
+}
+
+sha256() {
+  local file=$1
+  sha256sum "${file}" | cut -d ' ' -f 1
+}
+
+main $@

--- a/util/packer/ubuntu-14.04/vagrant.json
+++ b/util/packer/ubuntu-14.04/vagrant.json
@@ -2,7 +2,9 @@
   "variables": {
     "flynn_deb_url": "",
     "headless": "false",
-    "ova_path": "ubuntu.ova"
+    "output_dir": ".",
+    "ova_path": "ubuntu.ova",
+    "version": ""
   },
   "builders": [
     {
@@ -92,5 +94,10 @@
       "type": "shell"
     }
   ],
-  "post-processors": [{ "type": "vagrant" }]
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "{{ user `output_dir` }}/flynn-base_{{ user `version` }}_{{ .Provider }}.box"
+    }
+  ]
 }

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -12,6 +12,7 @@ Usage:
   flynn-release manifest [--output=<dest>] [--id-file=<file>] <template>
   flynn-release download [--driver=<name>] [--root=<path>] <manifest>
   flynn-release upload <manifest> [<tag>]
+  flynn-release vagrant <url> <checksum> <version> <provider>
 
 Options:
   -o --output=<dest>   output destination file ("-" for stdout) [default: -]
@@ -30,5 +31,7 @@ Options:
 		download(args)
 	case args.Bool["upload"]:
 		upload(args)
+	case args.Bool["vagrant"]:
+		vagrant(args)
 	}
 }

--- a/util/release/vagrant.go
+++ b/util/release/vagrant.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+)
+
+func vagrant(args *docopt.Args) {
+	manifest := &Manifest{}
+
+	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
+		log.Fatal(err)
+	}
+
+	manifest.Add(args.String["<version>"], &Provider{
+		Name:         args.String["<provider>"],
+		URL:          args.String["<url>"],
+		Checksum:     args.String["<checksum>"],
+		ChecksumType: "sha256",
+	})
+
+	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type Manifest struct {
+	Name     string     `json:"name"`
+	Versions []*Version `json:"versions"`
+}
+
+// Add adds a provider to the manifest.
+//
+// If the version is already in the manifest, the given provider either
+// replaces any existing provider with the same name, or is appended to
+// the existing list of providers for that version.
+//
+// If the version is not already in the manifest a new version is added
+// containing the provider.
+func (m *Manifest) Add(version string, provider *Provider) {
+	for _, v := range m.Versions {
+		if v.Version == version {
+			providers := make([]*Provider, len(v.Providers))
+			added := false
+			for i, p := range v.Providers {
+				if p.Name == provider.Name {
+					// replace existing provider
+					providers[i] = provider
+					added = true
+					continue
+				}
+				providers[i] = p
+			}
+			if !added {
+				providers = append(providers, provider)
+			}
+			v.Providers = providers
+			return
+		}
+	}
+
+	m.Versions = append(m.Versions, &Version{
+		Version:   version,
+		Providers: []*Provider{provider},
+	})
+}
+
+type Version struct {
+	Version   string      `json:"version"`
+	Providers []*Provider `json:"providers"`
+}
+
+type Provider struct {
+	Name         string `json:"name"`
+	URL          string `json:"url"`
+	ChecksumType string `json:"checksum_type"`
+	Checksum     string `json:"checksum"`
+}


### PR DESCRIPTION
I originally wrote [a Packer plugin](https://github.com/lmars/packer-post-processor-vagrant-s3) to do this but I kept getting timeout errors when uploading to S3 via the `goamz` package (see [this issue](https://github.com/lmars/packer-post-processor-vagrant-s3/issues/2)).

Since the `goamz` package is seemingly unreliable, I've chosen to use `s3cmd` to upload the box to S3, and then added `flynn-release vagrant -b BUCKET` which will scan the bucket for any boxes not in the manifest (`vagrant/flynn-base.json`) and add them in, referring to their metadata to determine the provider, version and SHA256 checksum.

This will get called like:

```
script/release-vm-images \
  20141011.0 \
  https://s3.amazonaws.com/flynn/ubuntu/pool/main/f/flynn-host/flynn-host_20140817.0~19e570e1_amd64.deb
```

with the two arguments likely coming from the output of running `script/release-flynn`.
