### PR TITLE
website: Improve style of <code> tags

### DIFF
--- a/website/lib/cli.md.erb
+++ b/website/lib/cli.md.erb
@@ -14,7 +14,7 @@ To list available commands, run `flynn help`.
 <% description.each do |par| %>
 <%= par + "\n" %>
 <% end %>
-<pre><code><%= h usage.sub("usage: ", "       ").strip_heredoc %></code></pre>
+<pre><%= h usage.sub("usage: ", "       ").strip_heredoc %></pre>
 <% sections.each do |section| %>
 ### <%= h section[:title] %>
 <%= preprocess(section) + "\n\n" %>

--- a/website/source/stylesheets/application.css.scss
+++ b/website/source/stylesheets/application.css.scss
@@ -25,6 +25,15 @@ pre {
   white-space: pre;
 }
 
+code {
+  background-color: darken($lightColor, 6%);
+  border: 1px solid darken($lightColor, 12%);
+  border-radius: 2px;
+  color: $paraTextColor;
+  font-size: 0.75em;
+  padding: 0.2em 0.5em;
+}
+
 #coming-soon-banner {
   background-color: $almostBlackColor;
   color: $dirtyWhiteColor;


### PR DESCRIPTION
CSS similar to [<pre> tags](https://github.com/cupcake/fly/blob/flynn/assets/stylesheets/fly.css.scss#L107-L117):

Preview:

![Preview](https://s3.amazonaws.com/lmars.net/flynn-website-code-blocks.png)
