### PR TITLE
cli: Fix help json output

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -72,7 +72,7 @@ See 'flynn help <command>' for more information on a specific command.
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Println(out)
+			fmt.Println(string(out))
 			return
 		} else { // `flynn help <command>`
 			cmd = cmdArgs[0]


### PR DESCRIPTION
Before this change we got pretty-printed bytes, not JSON.
