### PR TITLE
website: Don’t double escape CLI examples

### DIFF
--- a/website/lib/cli_doc_compiler.rb
+++ b/website/lib/cli_doc_compiler.rb
@@ -37,7 +37,7 @@ module Processor
       section[:content].split("\n\n").map do |example|
         example.strip!
         if example.start_with? '$'
-          "```\n#{h example}\n```\n"
+          "```\n#{example}\n```\n"
         else
           h example
         end


### PR DESCRIPTION
Code blocks are escaped by the highlighter.
