### PR TITLE
travis: Don't send success email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ notifications:
     on_failure: always
     template:
       - "%{repository}/%{branch} - %{commit}: %{message} %{build_url}"
+  email:
+    on_success: never
+    on_failure: always
 
 matrix:
   allow_failures:


### PR DESCRIPTION
I got annoyed at receiving a success email after pushing each new branch.
