### PR TITLE
Added a version filter to the Vagrantfile to require at least vagrant 1.6.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,12 @@
 # vi: set ft=ruby :
 
 # Fail if Vagrant version is too old
-Vagrant.require_version ">= 1.6.0"
+begin
+  Vagrant.require_version ">= 1.6.0"
+rescue NoMethodError
+  $stderr.puts "This Vagrantfile requires Vagrant version >= 1.6.0"
+  exit 1
+end
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"

--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -1,6 +1,14 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Fail if Vagrant version is too old
+begin
+  Vagrant.require_version ">= 1.6.0"
+rescue NoMethodError
+  $stderr.puts "This Vagrantfile requires Vagrant version >= 1.6.0"
+  exit 1
+end
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 


### PR DESCRIPTION
Manually tested the change due to the need to test with multiple vagrant
versions, which are external to this project.

Fixes #335

Signed-off-by: John Zila john@jzila.com
