### PR TITLE
script: Update release-vm-images to release EC2 AMIs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -68,6 +68,11 @@
 			"Rev": "78d7708fc6ca767a04a26c777cdc618f39a34ac4"
 		},
 		{
+			"ImportPath": "github.com/cupcake/goamz/ec2",
+			"Comment": "r2013.02.13-151-g78d7708",
+			"Rev": "78d7708fc6ca767a04a26c777cdc618f39a34ac4"
+		},
+		{
 			"ImportPath": "github.com/cupcake/goamz/s3",
 			"Comment": "r2013.02.13-151-g78d7708",
 			"Rev": "78d7708fc6ca767a04a26c777cdc618f39a34ac4"

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2.go
@@ -1,0 +1,1167 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2011 Canonical Ltd.
+//
+
+package ec2
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+)
+
+const (
+	debug = false
+
+	// legacyAPIVersion is the AWS API version used for all but
+	// VPC-related requests.
+	legacyAPIVersion = "2011-12-15"
+
+	// AWS API version used for VPC-related calls.
+	vpcAPIVersion = "2013-10-15"
+)
+
+// The EC2 type encapsulates operations with a specific EC2 region.
+type EC2 struct {
+	aws.Auth
+	aws.Region
+	private byte // Reserve the right of using private data.
+}
+
+// New creates a new EC2.
+func New(auth aws.Auth, region aws.Region) *EC2 {
+	return &EC2{auth, region, 0}
+}
+
+// ----------------------------------------------------------------------------
+// Filtering helper.
+
+// Filter builds filtering parameters to be used in an EC2 query which supports
+// filtering.  For example:
+//
+//     filter := NewFilter()
+//     filter.Add("architecture", "i386")
+//     filter.Add("launch-index", "0")
+//     resp, err := ec2.Instances(nil, filter)
+//
+type Filter struct {
+	m map[string][]string
+}
+
+// NewFilter creates a new Filter.
+func NewFilter() *Filter {
+	return &Filter{make(map[string][]string)}
+}
+
+// Add appends a filtering parameter with the given name and value(s).
+func (f *Filter) Add(name string, value ...string) {
+	f.m[name] = append(f.m[name], value...)
+}
+
+func (f *Filter) addParams(params map[string]string) {
+	if f != nil {
+		a := make([]string, len(f.m))
+		i := 0
+		for k := range f.m {
+			a[i] = k
+			i++
+		}
+		sort.StringSlice(a).Sort()
+		for i, k := range a {
+			prefix := "Filter." + strconv.Itoa(i+1)
+			params[prefix+".Name"] = k
+			for j, v := range f.m[k] {
+				params[prefix+".Value."+strconv.Itoa(j+1)] = v
+			}
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Request dispatching logic.
+
+// Error encapsulates an error returned by EC2.
+//
+// See http://goo.gl/VZGuC for more details.
+type Error struct {
+	// HTTP status code (200, 403, ...)
+	StatusCode int
+	// EC2 error code ("UnsupportedOperation", ...)
+	Code string
+	// The human-oriented error message
+	Message   string
+	RequestId string `xml:"RequestID"`
+}
+
+func (err *Error) Error() string {
+	if err.Code == "" {
+		return err.Message
+	}
+
+	return fmt.Sprintf("%s (%s)", err.Message, err.Code)
+}
+
+// For now a single error inst is being exposed. In the future it may be useful
+// to provide access to all of them, but rather than doing it as an array/slice,
+// use a *next pointer, so that it's backward compatible and it continues to be
+// easy to handle the first error, which is what most people will want.
+type xmlErrors struct {
+	RequestId string  `xml:"RequestID"`
+	Errors    []Error `xml:"Errors>Error"`
+}
+
+var timeNow = time.Now
+
+func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
+	params["Timestamp"] = timeNow().In(time.UTC).Format(time.RFC3339)
+	endpoint, err := url.Parse(ec2.Region.EC2Endpoint)
+	if err != nil {
+		return err
+	}
+	if endpoint.Path == "" {
+		endpoint.Path = "/"
+	}
+	sign(ec2.Auth, "GET", endpoint.Path, params, endpoint.Host)
+	endpoint.RawQuery = multimap(params).Encode()
+	if debug {
+		log.Printf("get { %v } -> {\n", endpoint.String())
+	}
+	r, err := http.Get(endpoint.String())
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	if debug {
+		dump, _ := httputil.DumpResponse(r, true)
+		log.Printf("response:\n")
+		log.Printf("%v\n}\n", string(dump))
+	}
+	if r.StatusCode != 200 {
+		return buildError(r)
+	}
+	err = xml.NewDecoder(r.Body).Decode(resp)
+	return err
+}
+
+func multimap(p map[string]string) url.Values {
+	q := make(url.Values, len(p))
+	for k, v := range p {
+		q[k] = []string{v}
+	}
+	return q
+}
+
+func buildError(r *http.Response) error {
+	errors := xmlErrors{}
+	xml.NewDecoder(r.Body).Decode(&errors)
+	var err Error
+	if len(errors.Errors) > 0 {
+		err = errors.Errors[0]
+	}
+	err.RequestId = errors.RequestId
+	err.StatusCode = r.StatusCode
+	if err.Message == "" {
+		err.Message = r.Status
+	}
+	return &err
+}
+
+func makeParams(action string) map[string]string {
+	return makeParamsWithVersion(action, legacyAPIVersion)
+}
+
+func makeParamsVPC(action string) map[string]string {
+	return makeParamsWithVersion(action, vpcAPIVersion)
+}
+
+func makeParamsWithVersion(action, version string) map[string]string {
+	params := make(map[string]string)
+	params["Action"] = action
+	params["Version"] = version
+	return params
+}
+
+func addParamsList(params map[string]string, label string, ids []string) {
+	for i, id := range ids {
+		params[label+"."+strconv.Itoa(i+1)] = id
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Instance management functions and types.
+
+// RunNetworkInterface encapsulates options for a single network
+// interface, specified when calling RunInstances.
+//
+// If Id is set, it must match an existing VPC network interface, and
+// in this case only a single instance can be launched. If Id is not
+// set, a new network interface will be created for each instance.
+//
+// The following fields are required when creating a new network
+// interface (i.e. Id is empty): DeviceIndex, SubnetId, Description
+// (only used if set), SecurityGroupIds.
+//
+// PrivateIPs can be used to add one or more private IP addresses to a
+// network interface. Only one of the IP addresses can be set as
+// primary. If none are given, EC2 selects a primary IP for each
+// created interface from the subnet pool.
+//
+// When SecondaryPrivateIPCount is non-zero, EC2 allocates that number
+// of IP addresses from within the subnet range and sets them as
+// secondary IPs. The number of IP addresses that can be assigned to a
+// network interface varies by instance type.
+type RunNetworkInterface struct {
+	Id                       string
+	DeviceIndex              int
+	SubnetId                 string
+	Description              string
+	PrivateIPs               []PrivateIP
+	SecurityGroupIds         []string
+	DeleteOnTermination      bool
+	SecondaryPrivateIPCount  int
+	AssociatePublicIPAddress bool
+}
+
+// The RunInstances type encapsulates options for the respective request in EC2.
+//
+// See http://goo.gl/Mcm3b for more details.
+type RunInstances struct {
+	ImageId               string
+	MinCount              int
+	MaxCount              int
+	KeyName               string
+	InstanceType          string
+	SecurityGroups        []SecurityGroup
+	KernelId              string
+	RamdiskId             string
+	UserData              []byte
+	AvailZone             string
+	PlacementGroupName    string
+	Monitoring            bool
+	SubnetId              string
+	DisableAPITermination bool
+	ShutdownBehavior      string
+	PrivateIPAddress      string
+	BlockDeviceMappings   []BlockDeviceMapping
+	NetworkInterfaces     []RunNetworkInterface
+}
+
+// Response to a RunInstances request.
+//
+// See http://goo.gl/Mcm3b for more details.
+type RunInstancesResp struct {
+	RequestId      string          `xml:"requestId"`
+	ReservationId  string          `xml:"reservationId"`
+	OwnerId        string          `xml:"ownerId"`
+	SecurityGroups []SecurityGroup `xml:"groupSet>item"`
+	Instances      []Instance      `xml:"instancesSet>item"`
+}
+
+// Instance encapsulates a running instance in EC2.
+//
+// See http://goo.gl/OCH8a for more details.
+type Instance struct {
+	InstanceId         string             `xml:"instanceId"`
+	InstanceType       string             `xml:"instanceType"`
+	ImageId            string             `xml:"imageId"`
+	PrivateDNSName     string             `xml:"privateDnsName"`
+	DNSName            string             `xml:"dnsName"`
+	IPAddress          string             `xml:"ipAddress"`
+	PrivateIPAddress   string             `xml:"privateIpAddress"`
+	SubnetId           string             `xml:"subnetId"`
+	VPCId              string             `xml:"vpcId"`
+	SourceDestCheck    bool               `xml:"sourceDestCheck"`
+	KeyName            string             `xml:"keyName"`
+	AMILaunchIndex     int                `xml:"amiLaunchIndex"`
+	Hypervisor         string             `xml:"hypervisor"`
+	VirtType           string             `xml:"virtualizationType"`
+	Monitoring         string             `xml:"monitoring>state"`
+	AvailZone          string             `xml:"placement>availabilityZone"`
+	PlacementGroupName string             `xml:"placement>groupName"`
+	State              InstanceState      `xml:"instanceState"`
+	Tags               []Tag              `xml:"tagSet>item"`
+	SecurityGroups     []SecurityGroup    `xml:"groupSet>item"`
+	NetworkInterfaces  []NetworkInterface `xml:"networkInterfaceSet>item"`
+}
+
+// RunInstances starts new instances in EC2.
+// If options.MinCount and options.MaxCount are both zero, a single instance
+// will be started; otherwise if options.MaxCount is zero, options.MinCount
+// will be used instead.
+//
+// See http://goo.gl/Mcm3b for more details.
+func (ec2 *EC2) RunInstances(options *RunInstances) (resp *RunInstancesResp, err error) {
+	params := prepareRunParams(*options)
+	params["ImageId"] = options.ImageId
+	params["InstanceType"] = options.InstanceType
+	var min, max int
+	if options.MinCount == 0 && options.MaxCount == 0 {
+		min = 1
+		max = 1
+	} else if options.MaxCount == 0 {
+		min = options.MinCount
+		max = min
+	} else {
+		min = options.MinCount
+		max = options.MaxCount
+	}
+	params["MinCount"] = strconv.Itoa(min)
+	params["MaxCount"] = strconv.Itoa(max)
+	i, j := 1, 1
+	for _, g := range options.SecurityGroups {
+		if g.Id != "" {
+			params["SecurityGroupId."+strconv.Itoa(i)] = g.Id
+			i++
+		} else {
+			params["SecurityGroup."+strconv.Itoa(j)] = g.Name
+			j++
+		}
+	}
+	prepareBlockDevices(params, options.BlockDeviceMappings)
+	prepareNetworkInterfaces(params, options.NetworkInterfaces)
+	token, err := clientToken()
+	if err != nil {
+		return nil, err
+	}
+	params["ClientToken"] = token
+
+	if options.KeyName != "" {
+		params["KeyName"] = options.KeyName
+	}
+	if options.KernelId != "" {
+		params["KernelId"] = options.KernelId
+	}
+	if options.RamdiskId != "" {
+		params["RamdiskId"] = options.RamdiskId
+	}
+	if options.UserData != nil {
+		userData := make([]byte, b64.EncodedLen(len(options.UserData)))
+		b64.Encode(userData, options.UserData)
+		params["UserData"] = string(userData)
+	}
+	if options.AvailZone != "" {
+		params["Placement.AvailabilityZone"] = options.AvailZone
+	}
+	if options.PlacementGroupName != "" {
+		params["Placement.GroupName"] = options.PlacementGroupName
+	}
+	if options.Monitoring {
+		params["Monitoring.Enabled"] = "true"
+	}
+	if options.SubnetId != "" {
+		params["SubnetId"] = options.SubnetId
+	}
+	if options.DisableAPITermination {
+		params["DisableApiTermination"] = "true"
+	}
+	if options.ShutdownBehavior != "" {
+		params["InstanceInitiatedShutdownBehavior"] = options.ShutdownBehavior
+	}
+	if options.PrivateIPAddress != "" {
+		params["PrivateIpAddress"] = options.PrivateIPAddress
+	}
+
+	resp = &RunInstancesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func prepareRunParams(options RunInstances) map[string]string {
+	if options.SubnetId != "" || len(options.NetworkInterfaces) > 0 {
+		// When either SubnetId or NetworkInterfaces are specified, we
+		// need to use the API version with complete VPC support.
+		return makeParamsVPC("RunInstances")
+	} else {
+		return makeParams("RunInstances")
+	}
+}
+
+func prepareBlockDevices(params map[string]string, blockDevs []BlockDeviceMapping) {
+	for i, b := range blockDevs {
+		n := strconv.Itoa(i + 1)
+		prefix := "BlockDeviceMapping." + n
+		if b.DeviceName != "" {
+			params[prefix+".DeviceName"] = b.DeviceName
+		}
+		if b.VirtualName != "" {
+			params[prefix+".VirtualName"] = b.VirtualName
+		}
+		if b.SnapshotId != "" {
+			params[prefix+".Ebs.SnapshotId"] = b.SnapshotId
+		}
+		if b.VolumeType != "" {
+			params[prefix+".Ebs.VolumeType"] = b.VolumeType
+		}
+		if b.VolumeSize > 0 {
+			params[prefix+".Ebs.VolumeSize"] = strconv.FormatInt(b.VolumeSize, 10)
+		}
+		if b.IOPS > 0 {
+			params[prefix+".Ebs.Iops"] = strconv.FormatInt(b.IOPS, 10)
+		}
+		if b.DeleteOnTermination {
+			params[prefix+".Ebs.DeleteOnTermination"] = "true"
+		}
+	}
+}
+
+func prepareNetworkInterfaces(params map[string]string, nics []RunNetworkInterface) {
+	for i, ni := range nics {
+		// Unlike other lists, NetworkInterface and PrivateIpAddresses
+		// should start from 0, not 1, according to the examples
+		// requests in the API documentation here http://goo.gl/Mcm3b.
+		n := strconv.Itoa(i)
+		prefix := "NetworkInterface." + n
+		if ni.Id != "" {
+			params[prefix+".NetworkInterfaceId"] = ni.Id
+		}
+		params[prefix+".DeviceIndex"] = strconv.Itoa(ni.DeviceIndex)
+		if ni.SubnetId != "" {
+			params[prefix+".SubnetId"] = ni.SubnetId
+		}
+		if ni.Description != "" {
+			params[prefix+".Description"] = ni.Description
+		}
+		for j, gid := range ni.SecurityGroupIds {
+			k := strconv.Itoa(j + 1)
+			params[prefix+".SecurityGroupId."+k] = gid
+		}
+		if ni.DeleteOnTermination {
+			params[prefix+".DeleteOnTermination"] = "true"
+		}
+		if ni.SecondaryPrivateIPCount > 0 {
+			val := strconv.Itoa(ni.SecondaryPrivateIPCount)
+			params[prefix+".SecondaryPrivateIpAddressCount"] = val
+		}
+		params[prefix+".AssociatePublicIpAddress"] = fmt.Sprintf("%t", ni.AssociatePublicIPAddress)
+		for j, ip := range ni.PrivateIPs {
+			k := strconv.Itoa(j)
+			subprefix := prefix + ".PrivateIpAddresses." + k
+			params[subprefix+".PrivateIpAddress"] = ip.Address
+			params[subprefix+".Primary"] = strconv.FormatBool(ip.IsPrimary)
+		}
+	}
+}
+
+func clientToken() (string, error) {
+	// Maximum EC2 client token size is 64 bytes.
+	// Each byte expands to two when hex encoded.
+	buf := make([]byte, 32)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// Response to a TerminateInstances request.
+//
+// See http://goo.gl/3BKHj for more details.
+type TerminateInstancesResp struct {
+	RequestId    string                `xml:"requestId"`
+	StateChanges []InstanceStateChange `xml:"instancesSet>item"`
+}
+
+// InstanceState encapsulates the state of an instance in EC2.
+//
+// See http://goo.gl/y3ZBq for more details.
+type InstanceState struct {
+	Code int    `xml:"code"` // Watch out, bits 15-8 have unpublished meaning.
+	Name string `xml:"name"`
+}
+
+// InstanceStateChange informs of the previous and current states
+// for an instance when a state change is requested.
+type InstanceStateChange struct {
+	InstanceId    string        `xml:"instanceId"`
+	CurrentState  InstanceState `xml:"currentState"`
+	PreviousState InstanceState `xml:"previousState"`
+}
+
+// TerminateInstances requests the termination of instances when the given ids.
+//
+// See http://goo.gl/3BKHj for more details.
+func (ec2 *EC2) TerminateInstances(instIds []string) (resp *TerminateInstancesResp, err error) {
+	params := makeParams("TerminateInstances")
+	addParamsList(params, "InstanceId", instIds)
+	resp = &TerminateInstancesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// Response to a DescribeInstances request.
+//
+// See http://goo.gl/mLbmw for more details.
+type InstancesResp struct {
+	RequestId    string        `xml:"requestId"`
+	Reservations []Reservation `xml:"reservationSet>item"`
+}
+
+// Reservation represents details about a reservation in EC2.
+//
+// See http://goo.gl/0ItPT for more details.
+type Reservation struct {
+	ReservationId  string          `xml:"reservationId"`
+	OwnerId        string          `xml:"ownerId"`
+	RequesterId    string          `xml:"requesterId"`
+	SecurityGroups []SecurityGroup `xml:"groupSet>item"`
+	Instances      []Instance      `xml:"instancesSet>item"`
+}
+
+// Instances returns details about instances in EC2.  Both parameters
+// are optional, and if provided will limit the instances returned to those
+// matching the given instance ids or filtering rules.
+//
+// See http://goo.gl/4No7c for more details.
+func (ec2 *EC2) Instances(instIds []string, filter *Filter) (resp *InstancesResp, err error) {
+	params := makeParams("DescribeInstances")
+	addParamsList(params, "InstanceId", instIds)
+	filter.addParams(params)
+	resp = &InstancesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Image and snapshot management functions and types.
+
+// Response to a DescribeImages request.
+//
+// See http://goo.gl/hLnyg for more details.
+type ImagesResp struct {
+	RequestId string  `xml:"requestId"`
+	Images    []Image `xml:"imagesSet>item"`
+}
+
+// BlockDeviceMapping represents the association of a block device with an image.
+//
+// See http://goo.gl/wnDBf for more details.
+type BlockDeviceMapping struct {
+	DeviceName          string `xml:"deviceName"`
+	VirtualName         string `xml:"virtualName"`
+	SnapshotId          string `xml:"ebs>snapshotId"`
+	VolumeType          string `xml:"ebs>volumeType"`
+	VolumeSize          int64  `xml:"ebs>volumeSize"` // Size is given in GB
+	DeleteOnTermination bool   `xml:"ebs>deleteOnTermination"`
+
+	// The number of I/O operations per second (IOPS) that the volume supports.
+	IOPS int64 `xml:"ebs>iops"`
+}
+
+// Image represents details about an image.
+//
+// See http://goo.gl/iSqJG for more details.
+type Image struct {
+	Id                 string               `xml:"imageId"`
+	Name               string               `xml:"name"`
+	Description        string               `xml:"description"`
+	Type               string               `xml:"imageType"`
+	State              string               `xml:"imageState"`
+	Location           string               `xml:"imageLocation"`
+	Public             bool                 `xml:"isPublic"`
+	Architecture       string               `xml:"architecture"`
+	Platform           string               `xml:"platform"`
+	ProductCodes       []string             `xml:"productCode>item>productCode"`
+	KernelId           string               `xml:"kernelId"`
+	RamdiskId          string               `xml:"ramdiskId"`
+	StateReason        string               `xml:"stateReason"`
+	OwnerId            string               `xml:"imageOwnerId"`
+	OwnerAlias         string               `xml:"imageOwnerAlias"`
+	RootDeviceType     string               `xml:"rootDeviceType"`
+	RootDeviceName     string               `xml:"rootDeviceName"`
+	VirtualizationType string               `xml:"virtualizationType"`
+	Hypervisor         string               `xml:"hypervisor"`
+	BlockDevices       []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
+}
+
+// Images returns details about available images.
+// The ids and filter parameters, if provided, will limit the images returned.
+// For example, to get all the private images associated with this account set
+// the boolean filter "is-private" to true.
+//
+// Note: calling this function with nil ids and filter parameters will result in
+// a very large number of images being returned.
+//
+// See http://goo.gl/SRBhW for more details.
+func (ec2 *EC2) Images(ids []string, filter *Filter) (resp *ImagesResp, err error) {
+	params := makeParams("DescribeImages")
+	for i, id := range ids {
+		params["ImageId."+strconv.Itoa(i+1)] = id
+	}
+	filter.addParams(params)
+
+	resp = &ImagesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// Response to a CreateSnapshot request.
+//
+// See http://goo.gl/ttcda for more details.
+type CreateSnapshotResp struct {
+	RequestId string `xml:"requestId"`
+	Snapshot
+}
+
+// CreateSnapshot creates a volume snapshot and stores it in S3.
+//
+// See http://goo.gl/ttcda for more details.
+func (ec2 *EC2) CreateSnapshot(volumeId, description string) (resp *CreateSnapshotResp, err error) {
+	params := makeParams("CreateSnapshot")
+	params["VolumeId"] = volumeId
+	params["Description"] = description
+
+	resp = &CreateSnapshotResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// DeleteSnapshots deletes the volume snapshots with the given ids.
+//
+// Note: If you make periodic snapshots of a volume, the snapshots are
+// incremental so that only the blocks on the device that have changed
+// since your last snapshot are incrementally saved in the new snapshot.
+// Even though snapshots are saved incrementally, the snapshot deletion
+// process is designed so that you need to retain only the most recent
+// snapshot in order to restore the volume.
+//
+// See http://goo.gl/vwU1y for more details.
+func (ec2 *EC2) DeleteSnapshots(ids []string) (resp *SimpleResp, err error) {
+	params := makeParams("DeleteSnapshot")
+	for i, id := range ids {
+		params["SnapshotId."+strconv.Itoa(i+1)] = id
+	}
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// Response to a DescribeSnapshots request.
+//
+// See http://goo.gl/nClDT for more details.
+type SnapshotsResp struct {
+	RequestId string     `xml:"requestId"`
+	Snapshots []Snapshot `xml:"snapshotSet>item"`
+}
+
+// Snapshot represents details about a volume snapshot.
+//
+// See http://goo.gl/nkovs for more details.
+type Snapshot struct {
+	Id          string `xml:"snapshotId"`
+	VolumeId    string `xml:"volumeId"`
+	VolumeSize  string `xml:"volumeSize"`
+	Status      string `xml:"status"`
+	StartTime   string `xml:"startTime"`
+	Description string `xml:"description"`
+	Progress    string `xml:"progress"`
+	OwnerId     string `xml:"ownerId"`
+	OwnerAlias  string `xml:"ownerAlias"`
+	Tags        []Tag  `xml:"tagSet>item"`
+}
+
+// Snapshots returns details about volume snapshots available to the user.
+// The ids and filter parameters, if provided, limit the snapshots returned.
+//
+// See http://goo.gl/ogJL4 for more details.
+func (ec2 *EC2) Snapshots(ids []string, filter *Filter) (resp *SnapshotsResp, err error) {
+	params := makeParams("DescribeSnapshots")
+	for i, id := range ids {
+		params["SnapshotId."+strconv.Itoa(i+1)] = id
+	}
+	filter.addParams(params)
+
+	resp = &SnapshotsResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// ----------------------------------------------------------------------------
+// Security group management functions and types.
+
+// SimpleResp represents a response to an EC2 request which on success will
+// return no other information besides a request id.
+type SimpleResp struct {
+	XMLName   xml.Name
+	RequestId string `xml:"requestId"`
+}
+
+// CreateSecurityGroupResp represents a response to a CreateSecurityGroup request.
+type CreateSecurityGroupResp struct {
+	SecurityGroup
+	RequestId string `xml:"requestId"`
+}
+
+// CreateSecurityGroup creates a security group with the provided name
+// and description.
+//
+// See http://goo.gl/Eo7Yl for more details.
+func (ec2 *EC2) CreateSecurityGroup(name, description string) (resp *CreateSecurityGroupResp, err error) {
+	return ec2.CreateSecurityGroupVPC("", name, description)
+}
+
+// CreateSecurityGroupVPC creates a security group in EC2, associated
+// with the given VPC ID. If vpcId is empty, this call is equivalent
+// to CreateSecurityGroup.
+//
+// See http://goo.gl/Eo7Yl for more details.
+func (ec2 *EC2) CreateSecurityGroupVPC(vpcId, name, description string) (resp *CreateSecurityGroupResp, err error) {
+	params := makeParamsVPC("CreateSecurityGroup")
+	params["GroupName"] = name
+	params["GroupDescription"] = description
+	if vpcId != "" {
+		params["VpcId"] = vpcId
+	}
+
+	resp = &CreateSecurityGroupResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	resp.Name = name
+	return resp, nil
+}
+
+// SecurityGroupsResp represents a response to a DescribeSecurityGroups
+// request in EC2.
+//
+// See http://goo.gl/k12Uy for more details.
+type SecurityGroupsResp struct {
+	RequestId string              `xml:"requestId"`
+	Groups    []SecurityGroupInfo `xml:"securityGroupInfo>item"`
+}
+
+// SecurityGroup encapsulates details for a security group in EC2.
+//
+// See http://goo.gl/CIdyP for more details.
+type SecurityGroupInfo struct {
+	SecurityGroup
+	VPCId       string   `xml:"vpcId"`
+	OwnerId     string   `xml:"ownerId"`
+	Description string   `xml:"groupDescription"`
+	IPPerms     []IPPerm `xml:"ipPermissions>item"`
+}
+
+// IPPerm represents an allowance within an EC2 security group.
+//
+// See http://goo.gl/4oTxv for more details.
+type IPPerm struct {
+	Protocol     string              `xml:"ipProtocol"`
+	FromPort     int                 `xml:"fromPort"`
+	ToPort       int                 `xml:"toPort"`
+	SourceIPs    []string            `xml:"ipRanges>item>cidrIp"`
+	SourceGroups []UserSecurityGroup `xml:"groups>item"`
+}
+
+// UserSecurityGroup holds a security group and the owner
+// of that group.
+type UserSecurityGroup struct {
+	Id      string `xml:"groupId"`
+	Name    string `xml:"groupName"`
+	OwnerId string `xml:"userId"`
+}
+
+// SecurityGroup represents an EC2 security group.
+// If SecurityGroup is used as a parameter, then one of Id or Name
+// may be empty. If both are set, then Id is used.
+type SecurityGroup struct {
+	Id   string `xml:"groupId"`
+	Name string `xml:"groupName"`
+}
+
+// SecurityGroupNames is a convenience function that
+// returns a slice of security groups with the given names.
+func SecurityGroupNames(names ...string) []SecurityGroup {
+	g := make([]SecurityGroup, len(names))
+	for i, name := range names {
+		g[i] = SecurityGroup{Name: name}
+	}
+	return g
+}
+
+// SecurityGroupNames is a convenience function that
+// returns a slice of security groups with the given ids.
+func SecurityGroupIds(ids ...string) []SecurityGroup {
+	g := make([]SecurityGroup, len(ids))
+	for i, id := range ids {
+		g[i] = SecurityGroup{Id: id}
+	}
+	return g
+}
+
+// SecurityGroups returns details about security groups in EC2.  Both parameters
+// are optional, and if provided will limit the security groups returned to those
+// matching the given groups or filtering rules.
+//
+// See http://goo.gl/k12Uy for more details.
+func (ec2 *EC2) SecurityGroups(groups []SecurityGroup, filter *Filter) (resp *SecurityGroupsResp, err error) {
+	params := makeParams("DescribeSecurityGroups")
+	i, j := 1, 1
+	for _, g := range groups {
+		if g.Id != "" {
+			params["GroupId."+strconv.Itoa(i)] = g.Id
+			i++
+		} else {
+			params["GroupName."+strconv.Itoa(j)] = g.Name
+			j++
+		}
+	}
+	filter.addParams(params)
+
+	resp = &SecurityGroupsResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteSecurityGroup removes the given security group in EC2.
+//
+// See http://goo.gl/QJJDO for more details.
+func (ec2 *EC2) DeleteSecurityGroup(group SecurityGroup) (resp *SimpleResp, err error) {
+	params := makeParams("DeleteSecurityGroup")
+	if group.Id != "" {
+		params["GroupId"] = group.Id
+	} else {
+		params["GroupName"] = group.Name
+	}
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// AuthorizeSecurityGroup creates an allowance for clients matching the provided
+// rules to access instances within the given security group.
+//
+// See http://goo.gl/u2sDJ for more details.
+func (ec2 *EC2) AuthorizeSecurityGroup(group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
+	return ec2.authOrRevoke("AuthorizeSecurityGroupIngress", group, perms)
+}
+
+// RevokeSecurityGroup revokes permissions from a group.
+//
+// See http://goo.gl/ZgdxA for more details.
+func (ec2 *EC2) RevokeSecurityGroup(group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
+	return ec2.authOrRevoke("RevokeSecurityGroupIngress", group, perms)
+}
+
+func (ec2 *EC2) authOrRevoke(op string, group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
+	params := makeParams(op)
+	if group.Id != "" {
+		params["GroupId"] = group.Id
+	} else {
+		params["GroupName"] = group.Name
+	}
+
+	for i, perm := range perms {
+		prefix := "IpPermissions." + strconv.Itoa(i+1)
+		params[prefix+".IpProtocol"] = perm.Protocol
+		params[prefix+".FromPort"] = strconv.Itoa(perm.FromPort)
+		params[prefix+".ToPort"] = strconv.Itoa(perm.ToPort)
+		for j, ip := range perm.SourceIPs {
+			params[prefix+".IpRanges."+strconv.Itoa(j+1)+".CidrIp"] = ip
+		}
+		for j, g := range perm.SourceGroups {
+			subprefix := prefix + ".Groups." + strconv.Itoa(j+1)
+			if g.OwnerId != "" {
+				params[subprefix+".UserId"] = g.OwnerId
+			}
+			if g.Id != "" {
+				params[subprefix+".GroupId"] = g.Id
+			} else {
+				params[subprefix+".GroupName"] = g.Name
+			}
+		}
+	}
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+
+}
+
+// Tag represents key-value metadata used to classify and organize
+// EC2 instances.
+//
+// See http://goo.gl/bncl3 for more details
+type Tag struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+// CreateTags adds or overwrites one or more tags for the specified instance ids.
+//
+// See http://goo.gl/Vmkqc for more details
+func (ec2 *EC2) CreateTags(instIds []string, tags []Tag) (resp *SimpleResp, err error) {
+	params := makeParams("CreateTags")
+	addParamsList(params, "ResourceId", instIds)
+
+	for j, tag := range tags {
+		params["Tag."+strconv.Itoa(j+1)+".Key"] = tag.Key
+		params["Tag."+strconv.Itoa(j+1)+".Value"] = tag.Value
+	}
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Response to a StartInstances request.
+//
+// See http://goo.gl/awKeF for more details.
+type StartInstanceResp struct {
+	RequestId    string                `xml:"requestId"`
+	StateChanges []InstanceStateChange `xml:"instancesSet>item"`
+}
+
+// Response to a StopInstances request.
+//
+// See http://goo.gl/436dJ for more details.
+type StopInstanceResp struct {
+	RequestId    string                `xml:"requestId"`
+	StateChanges []InstanceStateChange `xml:"instancesSet>item"`
+}
+
+// StartInstances starts an Amazon EBS-backed AMI that you've previously stopped.
+//
+// See http://goo.gl/awKeF for more details.
+func (ec2 *EC2) StartInstances(ids ...string) (resp *StartInstanceResp, err error) {
+	params := makeParams("StartInstances")
+	addParamsList(params, "InstanceId", ids)
+	resp = &StartInstanceResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// StopInstances requests stopping one or more Amazon EBS-backed instances.
+//
+// See http://goo.gl/436dJ for more details.
+func (ec2 *EC2) StopInstances(ids ...string) (resp *StopInstanceResp, err error) {
+	params := makeParams("StopInstances")
+	addParamsList(params, "InstanceId", ids)
+	resp = &StopInstanceResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// RebootInstance requests a reboot of one or more instances. This operation is asynchronous;
+// it only queues a request to reboot the specified instance(s). The operation will succeed
+// if the instances are valid and belong to you.
+//
+// Requests to reboot terminated instances are ignored.
+//
+// See http://goo.gl/baoUf for more details.
+func (ec2 *EC2) RebootInstances(ids ...string) (resp *SimpleResp, err error) {
+	params := makeParams("RebootInstances")
+	addParamsList(params, "InstanceId", ids)
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+type CreateInternetGatewayResp struct {
+	InternetGateway InternetGateway `xml:"internetGateway"`
+	RequestId       string          `xml:"requestId"`
+}
+
+type InternetGateway struct {
+	InternetGatewayId string `xml:"internetGatewayId"`
+}
+
+func (ec2 *EC2) CreateInternetGateway() (*CreateInternetGatewayResp, error) {
+	resp := &CreateInternetGatewayResp{}
+	err := ec2.query(makeParams("CreateInternetGateway"), resp)
+	return resp, err
+}
+
+func (ec2 *EC2) AttachInternetGateway(gatewayId, vpcId string) (*SimpleResp, error) {
+	params := makeParams("AttachInternetGateway")
+	params["InternetGatewayId"] = gatewayId
+	params["VpcId"] = vpcId
+
+	resp := &SimpleResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+type Route struct {
+	RouteTableId         string
+	DestinationCIDRBlock string
+	GatewayId            string
+	InstanceId           string
+	NetworkInterfaceId   string
+}
+
+func (ec2 *EC2) CreateRoute(r *Route) (*SimpleResp, error) {
+	params := makeParams("CreateRoute")
+	params["RouteTableId"] = r.RouteTableId
+	params["DestinationCidrBlock"] = r.DestinationCIDRBlock
+	if r.GatewayId != "" {
+		params["GatewayId"] = r.GatewayId
+	}
+	if r.InstanceId != "" {
+		params["InstanceId"] = r.InstanceId
+	}
+	if r.NetworkInterfaceId != "" {
+		params["NetworkInterfaceId"] = r.NetworkInterfaceId
+	}
+
+	resp := &SimpleResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+type RouteTable struct {
+	RouteTableId string         `xml:"routeTableId"`
+	VpcId        string         `xml:"vpcId"`
+	RouteSet     []RouteSetItem `xml:"routeSet>item"`
+}
+
+type RouteSetItem struct {
+	DestinationCIDRBlock string `xml:"destinationCidrBlock"`
+	GatewayId            string `xml:"gatewayId"`
+	State                string `xml:"state"`
+}
+
+type CreateRouteTableResp struct {
+	RouteTable RouteTable `xml:"routeTable"`
+	RequestId  string     `xml:"requestId"`
+}
+
+func (ec2 *EC2) CreateRouteTable(vpcId string) (*CreateRouteTableResp, error) {
+	params := makeParams("CreateRouteTable")
+	params["VpcId"] = vpcId
+
+	resp := &CreateRouteTableResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+type RouteTablesResp struct {
+	RequestId   string       `xml:"requestId"`
+	RouteTables []RouteTable `xml:"routeTableSet>item"`
+}
+
+func (ec2 *EC2) RouteTables(routeTableIds []string, filter *Filter) (*RouteTablesResp, error) {
+	params := makeParams("DescribeRouteTables")
+	addParamsList(params, "RouteTableId", routeTableIds)
+	filter.addParams(params)
+	resp := &RouteTablesResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+func (ec2 *EC2) DeleteInternetGateway(gatewayId string) (*SimpleResp, error) {
+	params := makeParams("DeleteInternetGateway")
+	params["InternetGatewayId"] = gatewayId
+	resp := &SimpleResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+func (ec2 *EC2) DetachInternetGateway(gatewayId, vpcId string) (*SimpleResp, error) {
+	params := makeParams("DetachInternetGateway")
+	params["InternetGatewayId"] = gatewayId
+	params["VpcId"] = vpcId
+	resp := &SimpleResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+type ImportKeyPairResp struct {
+	RequestId   string `xml:"requestId"`
+	Name        string `xml:"keyName"`
+	Fingerprint string `xml:"keyFingerprint"`
+}
+
+func (ec2 *EC2) ImportKeyPair(name, key string) (*ImportKeyPairResp, error) {
+	params := makeParams("ImportKeyPair")
+	params["KeyName"] = name
+	params["PublicKeyMaterial"] = key
+	resp := &ImportKeyPairResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+func (ec2 *EC2) DeleteKeyPair(name string) (*SimpleResp, error) {
+	params := makeParams("DeleteKeyPair")
+	params["KeyName"] = name
+	resp := &SimpleResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}
+
+type AccountAttributesResp struct {
+	RequestID  string             `xml:"requestId"`
+	Attributes []AccountAttribute `xml:"accountAttributeSet>item"`
+}
+
+type AccountAttribute struct {
+	Name   string   `xml:"attributeName"`
+	Values []string `xml:"attributeValueSet>item>attributeValue"`
+}
+
+func (ec2 *EC2) AccountAttributes() (*AccountAttributesResp, error) {
+	params := makeParamsVPC("DescribeAccountAttributes")
+	params["AttributeName.1"] = "supported-platforms"
+	params["AttributeName.2"] = "default-vpc"
+	resp := &AccountAttributesResp{}
+	err := ec2.query(params, resp)
+	return resp, err
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2_test.go
@@ -1,0 +1,808 @@
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/testutil"
+	. "launchpad.net/gocheck"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&S{})
+
+type S struct {
+	ec2 *ec2.EC2
+}
+
+var testServer = testutil.NewHTTPServer()
+
+func (s *S) SetUpSuite(c *C) {
+	testServer.Start()
+	auth := aws.Auth{"abc", "123"}
+	s.ec2 = ec2.New(auth, aws.Region{EC2Endpoint: testServer.URL})
+}
+
+func (s *S) TearDownSuite(c *C) {
+	testServer.Stop()
+}
+
+func (s *S) TearDownTest(c *C) {
+	testServer.Flush()
+}
+
+func (s *S) TestRunInstancesErrorDump(c *C) {
+	testServer.Response(400, nil, ErrorDump)
+
+	options := ec2.RunInstances{
+		ImageId:      "ami-a6f504cf", // Ubuntu Maverick, i386, instance store
+		InstanceType: "t1.micro",     // Doesn't work with micro, results in 400.
+	}
+
+	msg := `AMIs with an instance-store root device are not supported for the instance type 't1\.micro'\.`
+
+	resp, err := s.ec2.RunInstances(&options)
+
+	testServer.WaitRequest()
+
+	c.Assert(resp, IsNil)
+	c.Assert(err, ErrorMatches, msg+` \(UnsupportedOperation\)`)
+
+	ec2err, ok := err.(*ec2.Error)
+	c.Assert(ok, Equals, true)
+	c.Assert(ec2err.StatusCode, Equals, 400)
+	c.Assert(ec2err.Code, Equals, "UnsupportedOperation")
+	c.Assert(ec2err.Message, Matches, msg)
+	c.Assert(ec2err.RequestId, Equals, "0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4")
+}
+
+func (s *S) TestRunInstancesErrorWithoutXML(c *C) {
+	testServer.Response(500, nil, "")
+	options := ec2.RunInstances{ImageId: "image-id"}
+
+	resp, err := s.ec2.RunInstances(&options)
+
+	testServer.WaitRequest()
+
+	c.Assert(resp, IsNil)
+	c.Assert(err, ErrorMatches, "500 Internal Server Error")
+
+	ec2err, ok := err.(*ec2.Error)
+	c.Assert(ok, Equals, true)
+	c.Assert(ec2err.StatusCode, Equals, 500)
+	c.Assert(ec2err.Code, Equals, "")
+	c.Assert(ec2err.Message, Equals, "500 Internal Server Error")
+	c.Assert(ec2err.RequestId, Equals, "")
+}
+
+func (s *S) TestRunInstancesExample(c *C) {
+	testServer.Response(200, nil, RunInstancesExample)
+
+	options := ec2.RunInstances{
+		KeyName:               "my-keys",
+		ImageId:               "image-id",
+		InstanceType:          "inst-type",
+		SecurityGroups:        []ec2.SecurityGroup{{Name: "g1"}, {Id: "g2"}, {Name: "g3"}, {Id: "g4"}},
+		UserData:              []byte("1234"),
+		KernelId:              "kernel-id",
+		RamdiskId:             "ramdisk-id",
+		AvailZone:             "zone",
+		PlacementGroupName:    "group",
+		Monitoring:            true,
+		SubnetId:              "subnet-id",
+		DisableAPITermination: true,
+		ShutdownBehavior:      "terminate",
+		PrivateIPAddress:      "10.0.0.25",
+		BlockDeviceMappings: []ec2.BlockDeviceMapping{{
+			DeviceName:          "device-name",
+			VirtualName:         "virtual-name",
+			SnapshotId:          "snapshot-id",
+			VolumeType:          "volume-type",
+			VolumeSize:          10,
+			DeleteOnTermination: true,
+			IOPS:                1000,
+		}},
+		NetworkInterfaces: []ec2.RunNetworkInterface{{
+			DeviceIndex: 0,
+			SubnetId:    "subnet-id",
+			Description: "eth0",
+			PrivateIPs: []ec2.PrivateIP{
+				{Address: "10.0.0.25", IsPrimary: true},
+			},
+			DeleteOnTermination:     true,
+			SecurityGroupIds:        []string{"sg-1", "sg-2"},
+			SecondaryPrivateIPCount: 2,
+		}, {
+			Id:          "eni-id",
+			DeviceIndex: 1,
+			PrivateIPs: []ec2.PrivateIP{{
+				Address:   "10.0.1.10",
+				IsPrimary: true,
+			}, {
+				Address:   "10.0.1.20",
+				IsPrimary: false,
+			}},
+		}},
+	}
+	params := ec2.PrepareRunParams(options)
+	c.Assert(params, DeepEquals, map[string]string{
+		"Version": "2013-10-15",
+		"Action":  "RunInstances",
+	})
+	resp, err := s.ec2.RunInstances(&options)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RunInstances"})
+	c.Assert(req.Form["ImageId"], DeepEquals, []string{"image-id"})
+	c.Assert(req.Form["MinCount"], DeepEquals, []string{"1"})
+	c.Assert(req.Form["MaxCount"], DeepEquals, []string{"1"})
+	c.Assert(req.Form["KeyName"], DeepEquals, []string{"my-keys"})
+	c.Assert(req.Form["InstanceType"], DeepEquals, []string{"inst-type"})
+	c.Assert(req.Form["SecurityGroup.1"], DeepEquals, []string{"g1"})
+	c.Assert(req.Form["SecurityGroup.2"], DeepEquals, []string{"g3"})
+	c.Assert(req.Form["SecurityGroupId.1"], DeepEquals, []string{"g2"})
+	c.Assert(req.Form["SecurityGroupId.2"], DeepEquals, []string{"g4"})
+	c.Assert(req.Form["UserData"], DeepEquals, []string{"MTIzNA=="})
+	c.Assert(req.Form["KernelId"], DeepEquals, []string{"kernel-id"})
+	c.Assert(req.Form["RamdiskId"], DeepEquals, []string{"ramdisk-id"})
+	c.Assert(req.Form["Placement.AvailabilityZone"], DeepEquals, []string{"zone"})
+	c.Assert(req.Form["Placement.GroupName"], DeepEquals, []string{"group"})
+	c.Assert(req.Form["Monitoring.Enabled"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["SubnetId"], DeepEquals, []string{"subnet-id"})
+	c.Assert(req.Form["DisableApiTermination"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["InstanceInitiatedShutdownBehavior"], DeepEquals, []string{"terminate"})
+	c.Assert(req.Form["PrivateIpAddress"], DeepEquals, []string{"10.0.0.25"})
+	c.Assert(req.Form["BlockDeviceMapping.1.DeviceName"], DeepEquals, []string{"device-name"})
+	c.Assert(req.Form["BlockDeviceMapping.1.VirtualName"], DeepEquals, []string{"virtual-name"})
+	c.Assert(req.Form["BlockDeviceMapping.1.Ebs.SnapshotId"], DeepEquals, []string{"snapshot-id"})
+	c.Assert(req.Form["BlockDeviceMapping.1.Ebs.VolumeType"], DeepEquals, []string{"volume-type"})
+	c.Assert(req.Form["BlockDeviceMapping.1.Ebs.VolumeSize"], DeepEquals, []string{"10"})
+	c.Assert(req.Form["BlockDeviceMapping.1.Ebs.Iops"], DeepEquals, []string{"1000"})
+	c.Assert(req.Form["BlockDeviceMapping.1.Ebs.DeleteOnTermination"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["NetworkInterface.0.DeviceIndex"], DeepEquals, []string{"0"})
+	c.Assert(req.Form["NetworkInterface.0.SubnetId"], DeepEquals, []string{"subnet-id"})
+	c.Assert(req.Form["NetworkInterface.0.Description"], DeepEquals, []string{"eth0"})
+	c.Assert(req.Form["NetworkInterface.0.SecurityGroupId.1"], DeepEquals, []string{"sg-1"})
+	c.Assert(req.Form["NetworkInterface.0.SecurityGroupId.2"], DeepEquals, []string{"sg-2"})
+	c.Assert(req.Form["NetworkInterface.0.DeleteOnTermination"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["NetworkInterface.0.SecondaryPrivateIpAddressCount"], DeepEquals, []string{"2"})
+	c.Assert(req.Form["NetworkInterface.1.NetworkInterfaceId"], DeepEquals, []string{"eni-id"})
+	c.Assert(req.Form["NetworkInterface.1.DeviceIndex"], DeepEquals, []string{"1"})
+	c.Assert(req.Form["NetworkInterface.1.PrivateIpAddresses.0.PrivateIpAddress"], DeepEquals, []string{"10.0.1.10"})
+	c.Assert(req.Form["NetworkInterface.1.PrivateIpAddresses.0.Primary"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress"], DeepEquals, []string{"10.0.1.20"})
+	c.Assert(req.Form["NetworkInterface.1.PrivateIpAddresses.1.Primary"], DeepEquals, []string{"false"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.ReservationId, Equals, "r-47a5402e")
+	c.Assert(resp.OwnerId, Equals, "999988887777")
+	c.Assert(resp.SecurityGroups, DeepEquals, []ec2.SecurityGroup{{Name: "default", Id: "sg-67ad940e"}})
+	c.Assert(resp.Instances, HasLen, 3)
+
+	i0 := resp.Instances[0]
+	c.Assert(i0.InstanceId, Equals, "i-2ba64342")
+	c.Assert(i0.InstanceType, Equals, "m1.small")
+	c.Assert(i0.ImageId, Equals, "ami-60a54009")
+	c.Assert(i0.Monitoring, Equals, "enabled")
+	c.Assert(i0.KeyName, Equals, "example-key-name")
+	c.Assert(i0.AMILaunchIndex, Equals, 0)
+	c.Assert(i0.VirtType, Equals, "paravirtual")
+	c.Assert(i0.Hypervisor, Equals, "xen")
+	c.Assert(i0.SubnetId, Equals, "subnet-id")
+	c.Assert(i0.VPCId, Equals, "vpc-id")
+	c.Assert(i0.NetworkInterfaces, HasLen, 2)
+	c.Assert(i0.NetworkInterfaces, DeepEquals, []ec2.NetworkInterface{{
+		Id:              "eni-c6bb50ae",
+		SubnetId:        "subnet-id",
+		VPCId:           "vpc-id",
+		Description:     "eth0",
+		SourceDestCheck: true,
+		OwnerId:         "111122223333",
+		Status:          "in-use",
+		Groups: []ec2.SecurityGroup{
+			{Name: "vpc sg-1", Id: "sg-1"},
+			{Name: "vpc sg-2", Id: "sg-2"},
+		},
+		MACAddress:       "11:22:33:44:55:66",
+		PrivateIPAddress: "10.0.0.25",
+		PrivateIPs:       []ec2.PrivateIP{{Address: "10.0.0.25", IsPrimary: true}},
+		Attachment: ec2.NetworkInterfaceAttachment{
+			Id:                  "eni-attach-0326646a",
+			DeviceIndex:         0,
+			Status:              "attaching",
+			AttachTime:          "2011-12-20T08:29:31.000Z",
+			DeleteOnTermination: true,
+		},
+	}, {
+		Id:               "eni-id",
+		SubnetId:         "subnet-id",
+		VPCId:            "vpc-id",
+		SourceDestCheck:  true,
+		OwnerId:          "111122223333",
+		Status:           "in-use",
+		Groups:           []ec2.SecurityGroup{{Name: "vpc default", Id: "sg-id"}},
+		MACAddress:       "11:22:33:44:55:66",
+		PrivateIPAddress: "10.0.1.10",
+		PrivateIPs: []ec2.PrivateIP{
+			{Address: "10.0.1.10", IsPrimary: true},
+			{Address: "10.0.1.20", IsPrimary: false},
+		},
+		Attachment: ec2.NetworkInterfaceAttachment{
+			Id:                  "eni-attach-id",
+			DeviceIndex:         1,
+			Status:              "attaching",
+			AttachTime:          "2011-12-20T08:29:31.000Z",
+			DeleteOnTermination: false,
+		},
+	}})
+
+	i1 := resp.Instances[1]
+	c.Assert(i1.InstanceId, Equals, "i-2bc64242")
+	c.Assert(i1.InstanceType, Equals, "m1.small")
+	c.Assert(i1.ImageId, Equals, "ami-60a54009")
+	c.Assert(i1.Monitoring, Equals, "enabled")
+	c.Assert(i1.KeyName, Equals, "example-key-name")
+	c.Assert(i1.AMILaunchIndex, Equals, 1)
+	c.Assert(i1.VirtType, Equals, "paravirtual")
+	c.Assert(i1.Hypervisor, Equals, "xen")
+
+	i2 := resp.Instances[2]
+	c.Assert(i2.InstanceId, Equals, "i-2be64332")
+	c.Assert(i2.InstanceType, Equals, "m1.small")
+	c.Assert(i2.ImageId, Equals, "ami-60a54009")
+	c.Assert(i2.Monitoring, Equals, "enabled")
+	c.Assert(i2.KeyName, Equals, "example-key-name")
+	c.Assert(i2.AMILaunchIndex, Equals, 2)
+	c.Assert(i2.VirtType, Equals, "paravirtual")
+	c.Assert(i2.Hypervisor, Equals, "xen")
+}
+
+func (s *S) TestTerminateInstancesExample(c *C) {
+	testServer.Response(200, nil, TerminateInstancesExample)
+
+	resp, err := s.ec2.TerminateInstances([]string{"i-1", "i-2"})
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"TerminateInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-1"})
+	c.Assert(req.Form["InstanceId.2"], DeepEquals, []string{"i-2"})
+	c.Assert(req.Form["UserData"], IsNil)
+	c.Assert(req.Form["KernelId"], IsNil)
+	c.Assert(req.Form["RamdiskId"], IsNil)
+	c.Assert(req.Form["Placement.AvailabilityZone"], IsNil)
+	c.Assert(req.Form["Placement.GroupName"], IsNil)
+	c.Assert(req.Form["Monitoring.Enabled"], IsNil)
+	c.Assert(req.Form["SubnetId"], IsNil)
+	c.Assert(req.Form["DisableApiTermination"], IsNil)
+	c.Assert(req.Form["InstanceInitiatedShutdownBehavior"], IsNil)
+	c.Assert(req.Form["PrivateIpAddress"], IsNil)
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.StateChanges, HasLen, 1)
+	c.Assert(resp.StateChanges[0].InstanceId, Equals, "i-3ea74257")
+	c.Assert(resp.StateChanges[0].CurrentState.Code, Equals, 32)
+	c.Assert(resp.StateChanges[0].CurrentState.Name, Equals, "shutting-down")
+	c.Assert(resp.StateChanges[0].PreviousState.Code, Equals, 16)
+	c.Assert(resp.StateChanges[0].PreviousState.Name, Equals, "running")
+}
+
+func (s *S) TestDescribeInstancesExample1(c *C) {
+	testServer.Response(200, nil, DescribeInstancesExample1)
+
+	filter := ec2.NewFilter()
+	filter.Add("key1", "value1")
+	filter.Add("key2", "value2", "value3")
+
+	resp, err := s.ec2.Instances([]string{"i-1", "i-2"}, nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-1"})
+	c.Assert(req.Form["InstanceId.2"], DeepEquals, []string{"i-2"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "98e3c9a4-848c-4d6d-8e8a-b1bdEXAMPLE")
+	c.Assert(resp.Reservations, HasLen, 2)
+
+	expectedGroups := []ec2.SecurityGroup{{Name: "default", Id: "sg-67ad940e"}}
+	r0 := resp.Reservations[0]
+	c.Assert(r0.ReservationId, Equals, "r-b27e30d9")
+	c.Assert(r0.OwnerId, Equals, "999988887777")
+	c.Assert(r0.RequesterId, Equals, "854251627541")
+	c.Assert(r0.SecurityGroups, DeepEquals, expectedGroups)
+	c.Assert(r0.Instances, HasLen, 1)
+
+	r0i := r0.Instances[0]
+	c.Assert(r0i.InstanceId, Equals, "i-c5cd56af")
+	c.Assert(r0i.PrivateDNSName, Equals, "domU-12-31-39-10-56-34.compute-1.internal")
+	c.Assert(r0i.DNSName, Equals, "ec2-174-129-165-232.compute-1.amazonaws.com")
+	c.Assert(r0i.PrivateIPAddress, Equals, "10.198.85.190")
+	c.Assert(r0i.IPAddress, Equals, "174.129.165.232")
+	c.Assert(r0i.AvailZone, Equals, "us-east-1b")
+	c.Assert(r0i.SecurityGroups, DeepEquals, expectedGroups)
+}
+
+func (s *S) TestDescribeInstancesExample2(c *C) {
+	testServer.Response(200, nil, DescribeInstancesExample2)
+
+	filter := ec2.NewFilter()
+	filter.Add("key1", "value1")
+	filter.Add("key2", "value2", "value3")
+
+	resp, err := s.ec2.Instances([]string{"i-1", "i-2"}, filter)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-1"})
+	c.Assert(req.Form["InstanceId.2"], DeepEquals, []string{"i-2"})
+	c.Assert(req.Form["Filter.1.Name"], DeepEquals, []string{"key1"})
+	c.Assert(req.Form["Filter.1.Value.1"], DeepEquals, []string{"value1"})
+	c.Assert(req.Form["Filter.1.Value.2"], IsNil)
+	c.Assert(req.Form["Filter.2.Name"], DeepEquals, []string{"key2"})
+	c.Assert(req.Form["Filter.2.Value.1"], DeepEquals, []string{"value2"})
+	c.Assert(req.Form["Filter.2.Value.2"], DeepEquals, []string{"value3"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Reservations, HasLen, 1)
+
+	r0 := resp.Reservations[0]
+	r0i := r0.Instances[0]
+	c.Assert(r0i.State.Code, Equals, 16)
+	c.Assert(r0i.State.Name, Equals, "running")
+
+	r0t0 := r0i.Tags[0]
+	r0t1 := r0i.Tags[1]
+	c.Assert(r0t0.Key, Equals, "webserver")
+	c.Assert(r0t0.Value, Equals, "")
+	c.Assert(r0t1.Key, Equals, "stack")
+	c.Assert(r0t1.Value, Equals, "Production")
+}
+
+func (s *S) TestDescribeImagesExample(c *C) {
+	testServer.Response(200, nil, DescribeImagesExample)
+
+	filter := ec2.NewFilter()
+	filter.Add("key1", "value1")
+	filter.Add("key2", "value2", "value3")
+
+	resp, err := s.ec2.Images([]string{"ami-1", "ami-2"}, filter)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeImages"})
+	c.Assert(req.Form["ImageId.1"], DeepEquals, []string{"ami-1"})
+	c.Assert(req.Form["ImageId.2"], DeepEquals, []string{"ami-2"})
+	c.Assert(req.Form["Filter.1.Name"], DeepEquals, []string{"key1"})
+	c.Assert(req.Form["Filter.1.Value.1"], DeepEquals, []string{"value1"})
+	c.Assert(req.Form["Filter.1.Value.2"], IsNil)
+	c.Assert(req.Form["Filter.2.Name"], DeepEquals, []string{"key2"})
+	c.Assert(req.Form["Filter.2.Value.1"], DeepEquals, []string{"value2"})
+	c.Assert(req.Form["Filter.2.Value.2"], DeepEquals, []string{"value3"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "4a4a27a2-2e7c-475d-b35b-ca822EXAMPLE")
+	c.Assert(resp.Images, HasLen, 1)
+
+	i0 := resp.Images[0]
+	c.Assert(i0.Id, Equals, "ami-a2469acf")
+	c.Assert(i0.Type, Equals, "machine")
+	c.Assert(i0.Name, Equals, "example-marketplace-amzn-ami.1")
+	c.Assert(i0.Description, Equals, "Amazon Linux AMI i386 EBS")
+	c.Assert(i0.Location, Equals, "aws-marketplace/example-marketplace-amzn-ami.1")
+	c.Assert(i0.State, Equals, "available")
+	c.Assert(i0.Public, Equals, true)
+	c.Assert(i0.OwnerId, Equals, "123456789999")
+	c.Assert(i0.OwnerAlias, Equals, "aws-marketplace")
+	c.Assert(i0.Architecture, Equals, "i386")
+	c.Assert(i0.KernelId, Equals, "aki-805ea7e9")
+	c.Assert(i0.RootDeviceType, Equals, "ebs")
+	c.Assert(i0.RootDeviceName, Equals, "/dev/sda1")
+	c.Assert(i0.VirtualizationType, Equals, "paravirtual")
+	c.Assert(i0.Hypervisor, Equals, "xen")
+
+	c.Assert(i0.BlockDevices, HasLen, 1)
+	c.Assert(i0.BlockDevices[0].DeviceName, Equals, "/dev/sda1")
+	c.Assert(i0.BlockDevices[0].SnapshotId, Equals, "snap-787e9403")
+	c.Assert(i0.BlockDevices[0].VolumeSize, Equals, int64(8))
+	c.Assert(i0.BlockDevices[0].DeleteOnTermination, Equals, true)
+}
+
+func (s *S) TestCreateSnapshotExample(c *C) {
+	testServer.Response(200, nil, CreateSnapshotExample)
+
+	resp, err := s.ec2.CreateSnapshot("vol-4d826724", "Daily Backup")
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateSnapshot"})
+	c.Assert(req.Form["VolumeId"], DeepEquals, []string{"vol-4d826724"})
+	c.Assert(req.Form["Description"], DeepEquals, []string{"Daily Backup"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Snapshot.Id, Equals, "snap-78a54011")
+	c.Assert(resp.Snapshot.VolumeId, Equals, "vol-4d826724")
+	c.Assert(resp.Snapshot.Status, Equals, "pending")
+	c.Assert(resp.Snapshot.StartTime, Equals, "2008-05-07T12:51:50.000Z")
+	c.Assert(resp.Snapshot.Progress, Equals, "60%")
+	c.Assert(resp.Snapshot.OwnerId, Equals, "111122223333")
+	c.Assert(resp.Snapshot.VolumeSize, Equals, "10")
+	c.Assert(resp.Snapshot.Description, Equals, "Daily Backup")
+}
+
+func (s *S) TestDeleteSnapshotsExample(c *C) {
+	testServer.Response(200, nil, DeleteSnapshotExample)
+
+	resp, err := s.ec2.DeleteSnapshots([]string{"snap-78a54011"})
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteSnapshot"})
+	c.Assert(req.Form["SnapshotId.1"], DeepEquals, []string{"snap-78a54011"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestDescribeSnapshotsExample(c *C) {
+	testServer.Response(200, nil, DescribeSnapshotsExample)
+
+	filter := ec2.NewFilter()
+	filter.Add("key1", "value1")
+	filter.Add("key2", "value2", "value3")
+
+	resp, err := s.ec2.Snapshots([]string{"snap-1", "snap-2"}, filter)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSnapshots"})
+	c.Assert(req.Form["SnapshotId.1"], DeepEquals, []string{"snap-1"})
+	c.Assert(req.Form["SnapshotId.2"], DeepEquals, []string{"snap-2"})
+	c.Assert(req.Form["Filter.1.Name"], DeepEquals, []string{"key1"})
+	c.Assert(req.Form["Filter.1.Value.1"], DeepEquals, []string{"value1"})
+	c.Assert(req.Form["Filter.1.Value.2"], IsNil)
+	c.Assert(req.Form["Filter.2.Name"], DeepEquals, []string{"key2"})
+	c.Assert(req.Form["Filter.2.Value.1"], DeepEquals, []string{"value2"})
+	c.Assert(req.Form["Filter.2.Value.2"], DeepEquals, []string{"value3"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Snapshots, HasLen, 1)
+
+	s0 := resp.Snapshots[0]
+	c.Assert(s0.Id, Equals, "snap-1a2b3c4d")
+	c.Assert(s0.VolumeId, Equals, "vol-8875daef")
+	c.Assert(s0.VolumeSize, Equals, "15")
+	c.Assert(s0.Status, Equals, "pending")
+	c.Assert(s0.StartTime, Equals, "2010-07-29T04:12:01.000Z")
+	c.Assert(s0.Progress, Equals, "30%")
+	c.Assert(s0.OwnerId, Equals, "111122223333")
+	c.Assert(s0.Description, Equals, "Daily Backup")
+
+	c.Assert(s0.Tags, HasLen, 1)
+	c.Assert(s0.Tags[0].Key, Equals, "Purpose")
+	c.Assert(s0.Tags[0].Value, Equals, "demo_db_14_backup")
+}
+
+func (s *S) checkCreateSGResponse(c *C, resp *ec2.CreateSecurityGroupResp, id, name, description, vpcId string) {
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateSecurityGroup"})
+	c.Assert(req.Form["GroupName"], DeepEquals, []string{name})
+	c.Assert(req.Form["GroupDescription"], DeepEquals, []string{description})
+	if vpcId != "" {
+		c.Assert(req.Form["VpcId"], DeepEquals, []string{vpcId})
+	}
+
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Name, Equals, name)
+	c.Assert(resp.Id, Equals, id)
+}
+
+func (s *S) TestCreateSecurityGroupExample(c *C) {
+	testServer.Response(200, nil, CreateSecurityGroupExample)
+	resp, err := s.ec2.CreateSecurityGroup("websrv", "Web Servers")
+	c.Assert(err, IsNil)
+	s.checkCreateSGResponse(c, resp, "sg-67ad940e", "websrv", "Web Servers", "")
+
+	testServer.Response(200, nil, CreateSecurityGroupExample)
+	resp, err = s.ec2.CreateSecurityGroupVPC("vpc-id", "websrv", "Web Servers")
+	c.Assert(err, IsNil)
+	s.checkCreateSGResponse(c, resp, "sg-67ad940e", "websrv", "Web Servers", "vpc-id")
+}
+
+func (s *S) TestDescribeSecurityGroupsExample(c *C) {
+	testServer.Response(200, nil, DescribeSecurityGroupsExample)
+
+	resp, err := s.ec2.SecurityGroups([]ec2.SecurityGroup{{Name: "WebServers"}, {Name: "RangedPortsBySource"}}, nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSecurityGroups"})
+	c.Assert(req.Form["GroupName.1"], DeepEquals, []string{"WebServers"})
+	c.Assert(req.Form["GroupName.2"], DeepEquals, []string{"RangedPortsBySource"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.Groups, HasLen, 2)
+
+	g0 := resp.Groups[0]
+	c.Assert(g0.OwnerId, Equals, "999988887777")
+	c.Assert(g0.Name, Equals, "WebServers")
+	c.Assert(g0.Id, Equals, "sg-67ad940e")
+	c.Assert(g0.Description, Equals, "Web Servers")
+	c.Assert(g0.IPPerms, HasLen, 1)
+
+	g0ipp := g0.IPPerms[0]
+	c.Assert(g0ipp.Protocol, Equals, "tcp")
+	c.Assert(g0ipp.FromPort, Equals, 80)
+	c.Assert(g0ipp.ToPort, Equals, 80)
+	c.Assert(g0ipp.SourceIPs, DeepEquals, []string{"0.0.0.0/0"})
+
+	g1 := resp.Groups[1]
+	c.Assert(g1.OwnerId, Equals, "999988887777")
+	c.Assert(g1.Name, Equals, "RangedPortsBySource")
+	c.Assert(g1.Id, Equals, "sg-76abc467")
+	c.Assert(g1.Description, Equals, "Group A")
+	c.Assert(g1.IPPerms, HasLen, 1)
+
+	g1ipp := g1.IPPerms[0]
+	c.Assert(g1ipp.Protocol, Equals, "tcp")
+	c.Assert(g1ipp.FromPort, Equals, 6000)
+	c.Assert(g1ipp.ToPort, Equals, 7000)
+	c.Assert(g1ipp.SourceIPs, IsNil)
+}
+
+func (s *S) TestDescribeSecurityGroupsExampleWithFilter(c *C) {
+	testServer.Response(200, nil, DescribeSecurityGroupsExample)
+
+	filter := ec2.NewFilter()
+	filter.Add("ip-permission.protocol", "tcp")
+	filter.Add("ip-permission.from-port", "22")
+	filter.Add("ip-permission.to-port", "22")
+	filter.Add("ip-permission.group-name", "app_server_group", "database_group")
+
+	_, err := s.ec2.SecurityGroups(nil, filter)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSecurityGroups"})
+	c.Assert(req.Form["Filter.1.Name"], DeepEquals, []string{"ip-permission.from-port"})
+	c.Assert(req.Form["Filter.1.Value.1"], DeepEquals, []string{"22"})
+	c.Assert(req.Form["Filter.2.Name"], DeepEquals, []string{"ip-permission.group-name"})
+	c.Assert(req.Form["Filter.2.Value.1"], DeepEquals, []string{"app_server_group"})
+	c.Assert(req.Form["Filter.2.Value.2"], DeepEquals, []string{"database_group"})
+	c.Assert(req.Form["Filter.3.Name"], DeepEquals, []string{"ip-permission.protocol"})
+	c.Assert(req.Form["Filter.3.Value.1"], DeepEquals, []string{"tcp"})
+	c.Assert(req.Form["Filter.4.Name"], DeepEquals, []string{"ip-permission.to-port"})
+	c.Assert(req.Form["Filter.4.Value.1"], DeepEquals, []string{"22"})
+
+	c.Assert(err, IsNil)
+}
+
+func (s *S) TestDescribeSecurityGroupsDumpWithGroup(c *C) {
+	testServer.Response(200, nil, DescribeSecurityGroupsDump)
+
+	resp, err := s.ec2.SecurityGroups(nil, nil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSecurityGroups"})
+	c.Assert(err, IsNil)
+	c.Check(resp.Groups, HasLen, 1)
+	c.Check(resp.Groups[0].IPPerms, HasLen, 2)
+
+	ipp0 := resp.Groups[0].IPPerms[0]
+	c.Assert(ipp0.SourceIPs, IsNil)
+	c.Check(ipp0.Protocol, Equals, "icmp")
+	c.Assert(ipp0.SourceGroups, HasLen, 1)
+	c.Check(ipp0.SourceGroups[0].OwnerId, Equals, "12345")
+	c.Check(ipp0.SourceGroups[0].Name, Equals, "default")
+	c.Check(ipp0.SourceGroups[0].Id, Equals, "sg-67ad940e")
+
+	ipp1 := resp.Groups[0].IPPerms[1]
+	c.Check(ipp1.Protocol, Equals, "tcp")
+	c.Assert(ipp0.SourceIPs, IsNil)
+	c.Assert(ipp0.SourceGroups, HasLen, 1)
+	c.Check(ipp1.SourceGroups[0].Id, Equals, "sg-76abc467")
+	c.Check(ipp1.SourceGroups[0].OwnerId, Equals, "12345")
+	c.Check(ipp1.SourceGroups[0].Name, Equals, "other")
+}
+
+func (s *S) TestDeleteSecurityGroupExample(c *C) {
+	testServer.Response(200, nil, DeleteSecurityGroupExample)
+
+	resp, err := s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: "websrv"})
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteSecurityGroup"})
+	c.Assert(req.Form["GroupName"], DeepEquals, []string{"websrv"})
+	c.Assert(req.Form["GroupId"], IsNil)
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestDeleteSecurityGroupExampleWithId(c *C) {
+	testServer.Response(200, nil, DeleteSecurityGroupExample)
+
+	// ignore return and error - we're only want to check the parameter handling.
+	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Id: "sg-67ad940e", Name: "ignored"})
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["GroupName"], IsNil)
+	c.Assert(req.Form["GroupId"], DeepEquals, []string{"sg-67ad940e"})
+}
+
+func (s *S) TestAuthorizeSecurityGroupExample1(c *C) {
+	testServer.Response(200, nil, AuthorizeSecurityGroupIngressExample)
+
+	perms := []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  80,
+		ToPort:    80,
+		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
+	}}
+	resp, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: "websrv"}, perms)
+
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AuthorizeSecurityGroupIngress"})
+	c.Assert(req.Form["GroupName"], DeepEquals, []string{"websrv"})
+	c.Assert(req.Form["IpPermissions.1.IpProtocol"], DeepEquals, []string{"tcp"})
+	c.Assert(req.Form["IpPermissions.1.FromPort"], DeepEquals, []string{"80"})
+	c.Assert(req.Form["IpPermissions.1.ToPort"], DeepEquals, []string{"80"})
+	c.Assert(req.Form["IpPermissions.1.IpRanges.1.CidrIp"], DeepEquals, []string{"205.192.0.0/16"})
+	c.Assert(req.Form["IpPermissions.1.IpRanges.2.CidrIp"], DeepEquals, []string{"205.159.0.0/16"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestAuthorizeSecurityGroupExample1WithId(c *C) {
+	testServer.Response(200, nil, AuthorizeSecurityGroupIngressExample)
+
+	perms := []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  80,
+		ToPort:    80,
+		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
+	}}
+	// ignore return and error - we're only want to check the parameter handling.
+	s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Id: "sg-67ad940e", Name: "ignored"}, perms)
+
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["GroupName"], IsNil)
+	c.Assert(req.Form["GroupId"], DeepEquals, []string{"sg-67ad940e"})
+}
+
+func (s *S) TestAuthorizeSecurityGroupExample2(c *C) {
+	testServer.Response(200, nil, AuthorizeSecurityGroupIngressExample)
+
+	perms := []ec2.IPPerm{{
+		Protocol: "tcp",
+		FromPort: 80,
+		ToPort:   81,
+		SourceGroups: []ec2.UserSecurityGroup{
+			{OwnerId: "999988887777", Name: "OtherAccountGroup"},
+			{Id: "sg-67ad940e"},
+		},
+	}}
+	resp, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: "websrv"}, perms)
+
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AuthorizeSecurityGroupIngress"})
+	c.Assert(req.Form["GroupName"], DeepEquals, []string{"websrv"})
+	c.Assert(req.Form["IpPermissions.1.IpProtocol"], DeepEquals, []string{"tcp"})
+	c.Assert(req.Form["IpPermissions.1.FromPort"], DeepEquals, []string{"80"})
+	c.Assert(req.Form["IpPermissions.1.ToPort"], DeepEquals, []string{"81"})
+	c.Assert(req.Form["IpPermissions.1.Groups.1.UserId"], DeepEquals, []string{"999988887777"})
+	c.Assert(req.Form["IpPermissions.1.Groups.1.GroupName"], DeepEquals, []string{"OtherAccountGroup"})
+	c.Assert(req.Form["IpPermissions.1.Groups.2.UserId"], IsNil)
+	c.Assert(req.Form["IpPermissions.1.Groups.2.GroupName"], IsNil)
+	c.Assert(req.Form["IpPermissions.1.Groups.2.GroupId"], DeepEquals, []string{"sg-67ad940e"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestRevokeSecurityGroupExample(c *C) {
+	// RevokeSecurityGroup is implemented by the same code as AuthorizeSecurityGroup
+	// so there's no need to duplicate all the tests.
+	testServer.Response(200, nil, RevokeSecurityGroupIngressExample)
+
+	resp, err := s.ec2.RevokeSecurityGroup(ec2.SecurityGroup{Name: "websrv"}, nil)
+
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RevokeSecurityGroupIngress"})
+	c.Assert(req.Form["GroupName"], DeepEquals, []string{"websrv"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestCreateTags(c *C) {
+	testServer.Response(200, nil, CreateTagsExample)
+
+	resp, err := s.ec2.CreateTags([]string{"ami-1a2b3c4d", "i-7f4d3a2b"}, []ec2.Tag{{"webserver", ""}, {"stack", "Production"}})
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["ResourceId.1"], DeepEquals, []string{"ami-1a2b3c4d"})
+	c.Assert(req.Form["ResourceId.2"], DeepEquals, []string{"i-7f4d3a2b"})
+	c.Assert(req.Form["Tag.1.Key"], DeepEquals, []string{"webserver"})
+	c.Assert(req.Form["Tag.1.Value"], DeepEquals, []string{""})
+	c.Assert(req.Form["Tag.2.Key"], DeepEquals, []string{"stack"})
+	c.Assert(req.Form["Tag.2.Value"], DeepEquals, []string{"Production"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestStartInstances(c *C) {
+	testServer.Response(200, nil, StartInstancesExample)
+
+	resp, err := s.ec2.StartInstances("i-10a64379")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"StartInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-10a64379"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+
+	s0 := resp.StateChanges[0]
+	c.Assert(s0.InstanceId, Equals, "i-10a64379")
+	c.Assert(s0.CurrentState.Code, Equals, 0)
+	c.Assert(s0.CurrentState.Name, Equals, "pending")
+	c.Assert(s0.PreviousState.Code, Equals, 80)
+	c.Assert(s0.PreviousState.Name, Equals, "stopped")
+}
+
+func (s *S) TestStopInstances(c *C) {
+	testServer.Response(200, nil, StopInstancesExample)
+
+	resp, err := s.ec2.StopInstances("i-10a64379")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"StopInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-10a64379"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+
+	s0 := resp.StateChanges[0]
+	c.Assert(s0.InstanceId, Equals, "i-10a64379")
+	c.Assert(s0.CurrentState.Code, Equals, 64)
+	c.Assert(s0.CurrentState.Name, Equals, "stopping")
+	c.Assert(s0.PreviousState.Code, Equals, 16)
+	c.Assert(s0.PreviousState.Name, Equals, "running")
+}
+
+func (s *S) TestRebootInstances(c *C) {
+	testServer.Response(200, nil, RebootInstancesExample)
+
+	resp, err := s.ec2.RebootInstances("i-10a64379")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RebootInstances"})
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-10a64379"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestSignatureWithEndpointPath(c *C) {
+	ec2.FakeTime(true)
+	defer ec2.FakeTime(false)
+
+	testServer.Response(200, nil, RebootInstancesExample)
+
+	// https://bugs.launchpad.net/goamz/+bug/1022749
+	ec2 := ec2.New(s.ec2.Auth, aws.Region{EC2Endpoint: testServer.URL + "/services/Cloud"})
+
+	_, err := ec2.RebootInstances("i-10a64379")
+	c.Assert(err, IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Signature"], DeepEquals, []string{"gdG/vEm+c6ehhhfkrJy3+wuVzw/rzKR42TYelMwti7M="})
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2i_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2i_test.go
@@ -1,0 +1,203 @@
+package ec2_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/testutil"
+	. "launchpad.net/gocheck"
+)
+
+// AmazonServer represents an Amazon EC2 server.
+type AmazonServer struct {
+	auth aws.Auth
+}
+
+func (s *AmazonServer) SetUp(c *C) {
+	auth, err := aws.EnvAuth()
+	if err != nil {
+		c.Fatal(err.Error())
+	}
+	s.auth = auth
+}
+
+// Suite cost per run: 0.02 USD
+var _ = Suite(&AmazonClientSuite{})
+
+// AmazonClientSuite tests the client against a live EC2 server.
+type AmazonClientSuite struct {
+	srv AmazonServer
+	ClientTests
+}
+
+func (s *AmazonClientSuite) SetUpSuite(c *C) {
+	if !testutil.Amazon {
+		c.Skip("AmazonClientSuite tests not enabled")
+	}
+	s.srv.SetUp(c)
+	s.ec2 = ec2.New(s.srv.auth, aws.USEast)
+}
+
+// ClientTests defines integration tests designed to test the client.
+// It is not used as a test suite in itself, but embedded within
+// another type.
+type ClientTests struct {
+	ec2 *ec2.EC2
+}
+
+var imageId = "ami-ccf405a5" // Ubuntu Maverick, i386, EBS store
+
+// Cost: 0.00 USD
+func (s *ClientTests) TestRunInstancesError(c *C) {
+	options := ec2.RunInstances{
+		ImageId:      "ami-a6f504cf", // Ubuntu Maverick, i386, instance store
+		InstanceType: "t1.micro",     // Doesn't work with micro, results in 400.
+	}
+
+	resp, err := s.ec2.RunInstances(&options)
+
+	c.Assert(resp, IsNil)
+	c.Assert(err, ErrorMatches, "AMI.*root device.*not supported.*")
+
+	ec2err, ok := err.(*ec2.Error)
+	c.Assert(ok, Equals, true)
+	c.Assert(ec2err.StatusCode, Equals, 400)
+	c.Assert(ec2err.Code, Equals, "UnsupportedOperation")
+	c.Assert(ec2err.Message, Matches, "AMI.*root device.*not supported.*")
+	c.Assert(ec2err.RequestId, Matches, ".+")
+}
+
+// Cost: 0.02 USD
+func (s *ClientTests) TestRunAndTerminate(c *C) {
+	options := ec2.RunInstances{
+		ImageId:      imageId,
+		InstanceType: "t1.micro",
+	}
+	resp1, err := s.ec2.RunInstances(&options)
+	c.Assert(err, IsNil)
+	c.Check(resp1.ReservationId, Matches, "r-[0-9a-f]*")
+	c.Check(resp1.OwnerId, Matches, "[0-9]+")
+	c.Check(resp1.Instances, HasLen, 1)
+	c.Check(resp1.Instances[0].InstanceType, Equals, "t1.micro")
+
+	instId := resp1.Instances[0].InstanceId
+
+	resp2, err := s.ec2.Instances([]string{instId}, nil)
+	c.Assert(err, IsNil)
+	if c.Check(resp2.Reservations, HasLen, 1) && c.Check(len(resp2.Reservations[0].Instances), Equals, 1) {
+		inst := resp2.Reservations[0].Instances[0]
+		c.Check(inst.InstanceId, Equals, instId)
+	}
+
+	resp3, err := s.ec2.TerminateInstances([]string{instId})
+	c.Assert(err, IsNil)
+	c.Check(resp3.StateChanges, HasLen, 1)
+	c.Check(resp3.StateChanges[0].InstanceId, Equals, instId)
+	c.Check(resp3.StateChanges[0].CurrentState.Name, Equals, "shutting-down")
+	c.Check(resp3.StateChanges[0].CurrentState.Code, Equals, 32)
+}
+
+// Cost: 0.00 USD
+func (s *ClientTests) TestSecurityGroups(c *C) {
+	name := "goamz-test"
+	descr := "goamz security group for tests"
+
+	// Clean it up, if a previous test left it around and avoid leaving it around.
+	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+	defer s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+
+	resp1, err := s.ec2.CreateSecurityGroup(name, descr)
+	c.Assert(err, IsNil)
+	c.Assert(resp1.RequestId, Matches, ".+")
+	c.Assert(resp1.Name, Equals, name)
+	c.Assert(resp1.Id, Matches, ".+")
+
+	resp1, err = s.ec2.CreateSecurityGroup(name, descr)
+	ec2err, _ := err.(*ec2.Error)
+	c.Assert(resp1, IsNil)
+	c.Assert(ec2err, NotNil)
+	c.Assert(ec2err.Code, Equals, "InvalidGroup.Duplicate")
+
+	perms := []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  0,
+		ToPort:    1024,
+		SourceIPs: []string{"127.0.0.1/24"},
+	}}
+
+	resp2, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms)
+	c.Assert(err, IsNil)
+	c.Assert(resp2.RequestId, Matches, ".+")
+
+	resp3, err := s.ec2.SecurityGroups(ec2.SecurityGroupNames(name), nil)
+	c.Assert(err, IsNil)
+	c.Assert(resp3.RequestId, Matches, ".+")
+	c.Assert(resp3.Groups, HasLen, 1)
+
+	g0 := resp3.Groups[0]
+	c.Assert(g0.Name, Equals, name)
+	c.Assert(g0.Description, Equals, descr)
+	c.Assert(g0.IPPerms, HasLen, 1)
+	c.Assert(g0.IPPerms[0].Protocol, Equals, "tcp")
+	c.Assert(g0.IPPerms[0].FromPort, Equals, 0)
+	c.Assert(g0.IPPerms[0].ToPort, Equals, 1024)
+	c.Assert(g0.IPPerms[0].SourceIPs, DeepEquals, []string{"127.0.0.1/24"})
+
+	resp2, err = s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+	c.Assert(err, IsNil)
+	c.Assert(resp2.RequestId, Matches, ".+")
+}
+
+var sessionId = func() string {
+	buf := make([]byte, 8)
+	// if we have no randomness, we'll just make do, so ignore the error.
+	rand.Read(buf)
+	return fmt.Sprintf("%x", buf)
+}()
+
+// sessionName reutrns a name that is probably
+// unique to this test session.
+func sessionName(prefix string) string {
+	return prefix + "-" + sessionId
+}
+
+var allRegions = []aws.Region{
+	aws.USEast,
+	aws.USWest,
+	aws.EUWest,
+	aws.APSoutheast,
+	aws.APNortheast,
+}
+
+// Communicate with all EC2 endpoints to see if they are alive.
+func (s *ClientTests) TestRegions(c *C) {
+	name := sessionName("goamz-region-test")
+	perms := []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  80,
+		ToPort:    80,
+		SourceIPs: []string{"127.0.0.1/32"},
+	}}
+	errs := make(chan error, len(allRegions))
+	for _, region := range allRegions {
+		go func(r aws.Region) {
+			e := ec2.New(s.ec2.Auth, r)
+			_, err := e.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms)
+			errs <- err
+		}(region)
+	}
+	for _ = range allRegions {
+		err := <-errs
+		if err != nil {
+			ec2_err, ok := err.(*ec2.Error)
+			if ok {
+				c.Check(ec2_err.Code, Matches, "InvalidGroup.NotFound")
+			} else {
+				c.Errorf("Non-EC2 error: %s", err)
+			}
+		} else {
+			c.Errorf("Test should have errored but it seems to have succeeded")
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2t_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2t_test.go
@@ -1,0 +1,828 @@
+package ec2_test
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2test"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/testutil"
+	. "launchpad.net/gocheck"
+)
+
+// LocalServer represents a local ec2test fake server.
+type LocalServer struct {
+	auth   aws.Auth
+	region aws.Region
+	srv    *ec2test.Server
+}
+
+func (s *LocalServer) SetUp(c *C) {
+	srv, err := ec2test.NewServer()
+	c.Assert(err, IsNil)
+	c.Assert(srv, NotNil)
+
+	s.srv = srv
+	s.region = aws.Region{EC2Endpoint: srv.URL()}
+}
+
+// LocalServerSuite defines tests that will run
+// against the local ec2test server. It includes
+// selected tests from ClientTests;
+// when the ec2test functionality is sufficient, it should
+// include all of them, and ClientTests can be simply embedded.
+type LocalServerSuite struct {
+	srv LocalServer
+	ServerTests
+	clientTests ClientTests
+}
+
+var _ = Suite(&LocalServerSuite{})
+
+func (s *LocalServerSuite) SetUpSuite(c *C) {
+	s.srv.SetUp(c)
+	s.ServerTests.ec2 = ec2.New(s.srv.auth, s.srv.region)
+	s.clientTests.ec2 = ec2.New(s.srv.auth, s.srv.region)
+}
+
+func (s *LocalServerSuite) TestRunAndTerminate(c *C) {
+	s.clientTests.TestRunAndTerminate(c)
+}
+
+func (s *LocalServerSuite) TestSecurityGroups(c *C) {
+	s.clientTests.TestSecurityGroups(c)
+}
+
+// TestUserData is not defined on ServerTests because it
+// requires the ec2test server to function.
+func (s *LocalServerSuite) TestUserData(c *C) {
+	data := make([]byte, 256)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	inst, err := s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:      imageId,
+		InstanceType: "t1.micro",
+		UserData:     data,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(inst, NotNil)
+
+	id := inst.Instances[0].InstanceId
+
+	defer s.ec2.TerminateInstances([]string{id})
+
+	tinst := s.srv.srv.Instance(id)
+	c.Assert(tinst, NotNil)
+	c.Assert(tinst.UserData, DeepEquals, data)
+}
+
+func (s *LocalServerSuite) TestInstanceInfo(c *C) {
+	list, err := s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:      imageId,
+		InstanceType: "t1.micro",
+	})
+	c.Assert(err, IsNil)
+
+	inst := list.Instances[0]
+	c.Assert(inst, NotNil)
+
+	id := inst.InstanceId
+	defer s.ec2.TerminateInstances([]string{id})
+
+	masked := func(addr string) string {
+		return net.ParseIP(addr).Mask(net.CIDRMask(24, 32)).String()
+	}
+	c.Check(masked(inst.IPAddress), Equals, "8.0.0.0")
+	c.Check(masked(inst.PrivateIPAddress), Equals, "127.0.0.0")
+	// DNSName is empty initially, to check it we need to refresh.
+	c.Check(inst.DNSName, Equals, "")
+	c.Check(inst.PrivateDNSName, Equals, id+".internal.invalid")
+
+	// Get the instance again to verify DNSName.
+	resp, err := s.ec2.Instances([]string{id}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Reservations, HasLen, 1)
+	c.Assert(resp.Reservations[0].Instances, HasLen, 1)
+	c.Check(resp.Reservations[0].Instances[0].DNSName, Equals, id+".testing.invalid")
+}
+
+// AmazonServerSuite runs the ec2test server tests against a live EC2 server.
+// It will only be activated if the -amazon flag is specified.
+type AmazonServerSuite struct {
+	srv AmazonServer
+	ServerTests
+}
+
+var _ = Suite(&AmazonServerSuite{})
+
+func (s *AmazonServerSuite) SetUpSuite(c *C) {
+	if !testutil.Amazon {
+		c.Skip("AmazonServerSuite tests not enabled")
+	}
+	s.srv.SetUp(c)
+	s.ServerTests.ec2 = ec2.New(s.srv.auth, aws.USEast)
+}
+
+// ServerTests defines a set of tests designed to test
+// the ec2test local fake ec2 server.
+// It is not used as a test suite in itself, but embedded within
+// another type.
+type ServerTests struct {
+	ec2 *ec2.EC2
+}
+
+func terminateInstances(c *C, e *ec2.EC2, ids []string) {
+	_, err := e.TerminateInstances(ids)
+	c.Assert(err, IsNil, Commentf("%v INSTANCES LEFT RUNNING!!!", ids))
+	// We need to wait until the instances are really off, because
+	// entities that depend on them won't be deleted (i.e. groups,
+	// NICs, subnets, etc.)
+	testAttempt := aws.AttemptStrategy{
+		Total: 10 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	f := ec2.NewFilter()
+	f.Add("instance-state-name", "terminated")
+	idsLeft := make(map[string]bool)
+	for _, id := range ids {
+		idsLeft[id] = true
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for %v to get terminated", ids)
+		resp, err := e.Instances(ids, f)
+		if err != nil {
+			c.Fatalf("not waiting for %v to terminate: %v", ids, err)
+		}
+		for _, r := range resp.Reservations {
+			for _, inst := range r.Instances {
+				delete(idsLeft, inst.InstanceId)
+			}
+		}
+		ids = []string{}
+		for id, _ := range idsLeft {
+			ids = append(ids, id)
+		}
+		if len(ids) == 0 {
+			c.Logf("all instances terminated.")
+			return
+		}
+	}
+	c.Fatalf("%v INSTANCES LEFT RUNNING!!!", ids)
+}
+
+func (s *ServerTests) makeTestGroup(c *C, name, descr string) ec2.SecurityGroup {
+	return s.makeTestGroupVPC(c, "", name, descr)
+}
+
+func (s *ServerTests) makeTestGroupVPC(c *C, vpcId, name, descr string) ec2.SecurityGroup {
+	// Clean it up if a previous test left it around.
+	_, err := s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+	if err != nil && errorCode(err) != "InvalidGroup.NotFound" {
+		c.Fatalf("delete security group: %v", err)
+	}
+
+	resp, err := s.ec2.CreateSecurityGroupVPC(vpcId, name, descr)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Name, Equals, name)
+	return resp.SecurityGroup
+}
+
+func (s *ServerTests) TestIPPerms(c *C) {
+	g0 := s.makeTestGroup(c, "goamz-test0", "ec2test group 0")
+	g1 := s.makeTestGroup(c, "goamz-test1", "ec2test group 1")
+	defer s.deleteGroups(c, []ec2.SecurityGroup{g0, g1})
+
+	resp, err := s.ec2.SecurityGroups([]ec2.SecurityGroup{g0, g1}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Groups, HasLen, 2)
+	c.Assert(resp.Groups[0].IPPerms, HasLen, 0)
+	c.Assert(resp.Groups[1].IPPerms, HasLen, 0)
+
+	ownerId := resp.Groups[0].OwnerId
+
+	// test some invalid parameters
+	// TODO more
+	_, err = s.ec2.AuthorizeSecurityGroup(g0, []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  0,
+		ToPort:    1024,
+		SourceIPs: []string{"z127.0.0.1/24"},
+	}})
+	c.Assert(err, NotNil)
+	c.Check(errorCode(err), Equals, "InvalidPermission.Malformed")
+
+	// Check that AuthorizeSecurityGroup adds the correct authorizations.
+	_, err = s.ec2.AuthorizeSecurityGroup(g0, []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  2000,
+		ToPort:    2001,
+		SourceIPs: []string{"127.0.0.0/24"},
+		SourceGroups: []ec2.UserSecurityGroup{{
+			Name: g1.Name,
+		}, {
+			Id: g0.Id,
+		}},
+	}, {
+		Protocol:  "tcp",
+		FromPort:  2000,
+		ToPort:    2001,
+		SourceIPs: []string{"200.1.1.34/32"},
+	}})
+	c.Assert(err, IsNil)
+
+	resp, err = s.ec2.SecurityGroups([]ec2.SecurityGroup{g0}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Groups, HasLen, 1)
+	c.Assert(resp.Groups[0].IPPerms, HasLen, 1)
+
+	perm := resp.Groups[0].IPPerms[0]
+	srcg := perm.SourceGroups
+	c.Assert(srcg, HasLen, 2)
+
+	// Normalize so we don't care about returned order.
+	if srcg[0].Name == g1.Name {
+		srcg[0], srcg[1] = srcg[1], srcg[0]
+	}
+	c.Check(srcg[0].Name, Equals, g0.Name)
+	c.Check(srcg[0].Id, Equals, g0.Id)
+	c.Check(srcg[0].OwnerId, Equals, ownerId)
+	c.Check(srcg[1].Name, Equals, g1.Name)
+	c.Check(srcg[1].Id, Equals, g1.Id)
+	c.Check(srcg[1].OwnerId, Equals, ownerId)
+
+	sort.Strings(perm.SourceIPs)
+	c.Check(perm.SourceIPs, DeepEquals, []string{"127.0.0.0/24", "200.1.1.34/32"})
+
+	// Check that we can't delete g1 (because g0 is using it)
+	_, err = s.ec2.DeleteSecurityGroup(g1)
+	c.Assert(err, NotNil)
+	c.Check(errorCode(err), Equals, "InvalidGroup.InUse")
+
+	_, err = s.ec2.RevokeSecurityGroup(g0, []ec2.IPPerm{{
+		Protocol:     "tcp",
+		FromPort:     2000,
+		ToPort:       2001,
+		SourceGroups: []ec2.UserSecurityGroup{{Id: g1.Id}},
+	}, {
+		Protocol:  "tcp",
+		FromPort:  2000,
+		ToPort:    2001,
+		SourceIPs: []string{"200.1.1.34/32"},
+	}})
+	c.Assert(err, IsNil)
+
+	resp, err = s.ec2.SecurityGroups([]ec2.SecurityGroup{g0}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Groups, HasLen, 1)
+	c.Assert(resp.Groups[0].IPPerms, HasLen, 1)
+
+	perm = resp.Groups[0].IPPerms[0]
+	srcg = perm.SourceGroups
+	c.Assert(srcg, HasLen, 1)
+	c.Check(srcg[0].Name, Equals, g0.Name)
+	c.Check(srcg[0].Id, Equals, g0.Id)
+	c.Check(srcg[0].OwnerId, Equals, ownerId)
+
+	c.Check(perm.SourceIPs, DeepEquals, []string{"127.0.0.0/24"})
+
+	// We should be able to delete g1 now because we've removed its only use.
+	_, err = s.ec2.DeleteSecurityGroup(g1)
+	c.Assert(err, IsNil)
+
+	_, err = s.ec2.DeleteSecurityGroup(g0)
+	c.Assert(err, IsNil)
+
+	f := ec2.NewFilter()
+	f.Add("group-id", g0.Id, g1.Id)
+	resp, err = s.ec2.SecurityGroups(nil, f)
+	c.Assert(err, IsNil)
+	c.Assert(resp.Groups, HasLen, 0)
+}
+
+func (s *ServerTests) TestDuplicateIPPerm(c *C) {
+	name := "goamz-test"
+	descr := "goamz security group for tests"
+
+	// Clean it up, if a previous test left it around and avoid leaving it around.
+	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+	defer s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
+
+	resp1, err := s.ec2.CreateSecurityGroup(name, descr)
+	c.Assert(err, IsNil)
+	c.Assert(resp1.Name, Equals, name)
+
+	perms := []ec2.IPPerm{{
+		Protocol:  "tcp",
+		FromPort:  200,
+		ToPort:    1024,
+		SourceIPs: []string{"127.0.0.1/24"},
+	}, {
+		Protocol:  "tcp",
+		FromPort:  0,
+		ToPort:    100,
+		SourceIPs: []string{"127.0.0.1/24"},
+	}}
+
+	_, err = s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms[0:1])
+	c.Assert(err, IsNil)
+
+	_, err = s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms[0:2])
+	c.Assert(errorCode(err), Equals, "InvalidPermission.Duplicate")
+}
+
+type filterSpec struct {
+	name   string
+	values []string
+}
+
+func (s *ServerTests) TestInstanceFiltering(c *C) {
+	vpcResp, err := s.ec2.CreateVPC("10.4.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := vpcResp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	subResp := s.createSubnet(c, vpcId, "10.4.1.0/24", "")
+	subId := subResp.Subnet.Id
+	defer s.deleteSubnets(c, []string{subId})
+
+	groupResp, err := s.ec2.CreateSecurityGroup(
+		sessionName("testgroup1"),
+		"testgroup one description",
+	)
+	c.Assert(err, IsNil)
+	group1 := groupResp.SecurityGroup
+
+	groupResp, err = s.ec2.CreateSecurityGroupVPC(
+		vpcId,
+		sessionName("testgroup2"),
+		"testgroup two description vpc",
+	)
+	c.Assert(err, IsNil)
+	group2 := groupResp.SecurityGroup
+
+	defer s.deleteGroups(c, []ec2.SecurityGroup{group1, group2})
+
+	insts := make([]*ec2.Instance, 3)
+	inst, err := s.ec2.RunInstances(&ec2.RunInstances{
+		MinCount:       2,
+		ImageId:        imageId,
+		InstanceType:   "t1.micro",
+		SecurityGroups: []ec2.SecurityGroup{group1},
+	})
+	c.Assert(err, IsNil)
+	insts[0] = &inst.Instances[0]
+	insts[1] = &inst.Instances[1]
+
+	imageId2 := "ami-e358958a" // Natty server, i386, EBS store
+	inst, err = s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:        imageId2,
+		InstanceType:   "t1.micro",
+		SubnetId:       subId,
+		SecurityGroups: []ec2.SecurityGroup{group2},
+	})
+	c.Assert(err, IsNil)
+	insts[2] = &inst.Instances[0]
+
+	ids := func(indices ...int) (instIds []string) {
+		for _, index := range indices {
+			instIds = append(instIds, insts[index].InstanceId)
+		}
+		return
+	}
+
+	defer terminateInstances(c, s.ec2, ids(0, 1, 2))
+
+	tests := []struct {
+		about       string
+		instanceIds []string     // instanceIds argument to Instances method.
+		filters     []filterSpec // filters argument to Instances method.
+		resultIds   []string     // set of instance ids of expected results.
+		allowExtra  bool         // resultIds may be incomplete.
+		err         string       // expected error.
+	}{
+		{
+			about:      "check that Instances returns all instances",
+			resultIds:  ids(0, 1, 2),
+			allowExtra: true,
+		}, {
+			about:       "check that specifying two instance ids returns them",
+			instanceIds: ids(0, 2),
+			resultIds:   ids(0, 2),
+		}, {
+			about:       "check that specifying a non-existent instance id gives an error",
+			instanceIds: append(ids(0), "i-deadbeef"),
+			err:         `.*\(InvalidInstanceID\.NotFound\)`,
+		}, {
+			about: "check that a filter allowed both instances returns both of them",
+			filters: []filterSpec{
+				{"instance-id", ids(0, 2)},
+			},
+			resultIds: ids(0, 2),
+		}, {
+			about: "check that a filter allowing only one instance returns it",
+			filters: []filterSpec{
+				{"instance-id", ids(1)},
+			},
+			resultIds: ids(1),
+		}, {
+			about: "check that a filter allowing no instances returns none",
+			filters: []filterSpec{
+				{"instance-id", []string{"i-deadbeef12345"}},
+			},
+		}, {
+			about: "check that filtering on group id works",
+			filters: []filterSpec{
+				{"group-id", []string{group1.Id}},
+			},
+			resultIds: ids(0, 1),
+		}, {
+			about: "check that filtering on group id with instance prefix works",
+			filters: []filterSpec{
+				{"instance.group-id", []string{group1.Id}},
+			},
+			resultIds: ids(0, 1),
+		}, {
+			about: "check that filtering on group name works",
+			filters: []filterSpec{
+				{"group-name", []string{group1.Name}},
+			},
+			resultIds: ids(0, 1),
+		}, {
+			about: "check that filtering on group name with instance prefix works",
+			filters: []filterSpec{
+				{"instance.group-name", []string{group1.Name}},
+			},
+			resultIds: ids(0, 1),
+		}, {
+			about: "check that filtering on image id works",
+			filters: []filterSpec{
+				{"image-id", []string{imageId}},
+			},
+			resultIds:  ids(0, 1),
+			allowExtra: true,
+		}, {
+			about: "combination filters 1",
+			filters: []filterSpec{
+				{"image-id", []string{imageId, imageId2}},
+				{"group-name", []string{group1.Name}},
+			},
+			resultIds: ids(0, 1),
+		}, {
+			about: "combination filters 2",
+			filters: []filterSpec{
+				{"image-id", []string{imageId2}},
+				{"group-name", []string{group1.Name}},
+			},
+		}, {
+			about: "VPC filters in combination",
+			filters: []filterSpec{
+				{"vpc-id", []string{vpcId}},
+				{"subnet-id", []string{subId}},
+			},
+			resultIds: ids(2),
+		},
+	}
+	for i, t := range tests {
+		c.Logf("%d. %s", i, t.about)
+		var f *ec2.Filter
+		if t.filters != nil {
+			f = ec2.NewFilter()
+			for _, spec := range t.filters {
+				f.Add(spec.name, spec.values...)
+			}
+		}
+		resp, err := s.ec2.Instances(t.instanceIds, f)
+		if t.err != "" {
+			c.Check(err, ErrorMatches, t.err)
+			continue
+		}
+		c.Assert(err, IsNil)
+		insts := make(map[string]*ec2.Instance)
+		for _, r := range resp.Reservations {
+			for j := range r.Instances {
+				inst := &r.Instances[j]
+				c.Check(insts[inst.InstanceId], IsNil, Commentf("duplicate instance id: %q", inst.InstanceId))
+				insts[inst.InstanceId] = inst
+			}
+		}
+		if !t.allowExtra {
+			c.Check(insts, HasLen, len(t.resultIds), Commentf("expected %d instances got %#v", len(t.resultIds), insts))
+		}
+		for j, id := range t.resultIds {
+			c.Check(insts[id], NotNil, Commentf("instance id %d (%q) not found; got %#v", j, id, insts))
+		}
+	}
+}
+
+func (s *AmazonServerSuite) TestRunInstancesVPC(c *C) {
+	vpcResp, err := s.ec2.CreateVPC("10.6.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := vpcResp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	subResp := s.createSubnet(c, vpcId, "10.6.1.0/24", "")
+	subId := subResp.Subnet.Id
+	defer s.deleteSubnets(c, []string{subId})
+
+	groupResp, err := s.ec2.CreateSecurityGroupVPC(
+		vpcId,
+		sessionName("testgroup1 vpc"),
+		"testgroup description vpc",
+	)
+	c.Assert(err, IsNil)
+	group := groupResp.SecurityGroup
+
+	defer s.deleteGroups(c, []ec2.SecurityGroup{group})
+
+	// Run a single instance with a new network interface.
+	ips := []ec2.PrivateIP{
+		{Address: "10.6.1.10", IsPrimary: true},
+		{Address: "10.6.1.20", IsPrimary: false},
+	}
+	instResp, err := s.ec2.RunInstances(&ec2.RunInstances{
+		MinCount:     1,
+		ImageId:      imageId,
+		InstanceType: "t1.micro",
+		NetworkInterfaces: []ec2.RunNetworkInterface{{
+			DeviceIndex:         0,
+			SubnetId:            subId,
+			PrivateIPs:          ips,
+			SecurityGroupIds:    []string{group.Id},
+			DeleteOnTermination: true,
+		}},
+	})
+	c.Assert(err, IsNil)
+	inst := &instResp.Instances[0]
+
+	defer terminateInstances(c, s.ec2, []string{inst.InstanceId})
+
+	// Now list the network interfaces and find ours.
+	testAttempt := aws.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	f := ec2.NewFilter()
+	f.Add("subnet-id", subId)
+	var newNIC *ec2.NetworkInterface
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for NIC to become available")
+		listNICs, err := s.ec2.NetworkInterfaces(nil, f)
+		if err != nil {
+			c.Logf("retrying; NetworkInterfaces returned: %v", err)
+			continue
+		}
+		for _, iface := range listNICs.Interfaces {
+			c.Logf("found NIC %v", iface)
+			if iface.Attachment.InstanceId == inst.InstanceId {
+				c.Logf("instance %v new NIC appeared", inst.InstanceId)
+				newNIC = &iface
+				break
+			}
+		}
+		if newNIC != nil {
+			break
+		}
+	}
+	if newNIC == nil {
+		c.Fatalf("timeout while waiting for NIC to appear.")
+	}
+	c.Check(newNIC.Id, Matches, `^eni-[0-9a-f]+$`)
+	c.Check(newNIC.SubnetId, Equals, subId)
+	c.Check(newNIC.VPCId, Equals, vpcId)
+	c.Check(newNIC.Status, Matches, `^(attaching|in-use)$`)
+	c.Check(newNIC.PrivateIPAddress, Equals, ips[0].Address)
+	c.Check(newNIC.PrivateIPs, DeepEquals, ips)
+	c.Check(newNIC.Groups, HasLen, 1)
+	c.Check(newNIC.Groups[0].Id, Equals, group.Id)
+	c.Check(newNIC.Attachment.Status, Matches, `^(attaching|attached)$`)
+	c.Check(newNIC.Attachment.DeviceIndex, Equals, 0)
+	c.Check(newNIC.Attachment.DeleteOnTermination, Equals, true)
+}
+
+func idsOnly(gs []ec2.SecurityGroup) []ec2.SecurityGroup {
+	for i := range gs {
+		gs[i].Name = ""
+	}
+	return gs
+}
+
+func namesOnly(gs []ec2.SecurityGroup) []ec2.SecurityGroup {
+	for i := range gs {
+		gs[i].Id = ""
+	}
+	return gs
+}
+
+func (s *ServerTests) TestGroupFiltering(c *C) {
+	vpcResp, err := s.ec2.CreateVPC("10.5.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := vpcResp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	subResp := s.createSubnet(c, vpcId, "10.5.1.0/24", "")
+	subId := subResp.Subnet.Id
+	defer s.deleteSubnets(c, []string{subId})
+
+	g := make([]ec2.SecurityGroup, 5)
+	for i := range g {
+		var resp *ec2.CreateSecurityGroupResp
+		gid := sessionName(fmt.Sprintf("testgroup%d", i))
+		desc := fmt.Sprintf("testdescription%d", i)
+		if i == 0 {
+			// Create the first one as a VPC group.
+			gid += " vpc"
+			desc += " vpc"
+			resp, err = s.ec2.CreateSecurityGroupVPC(vpcId, gid, desc)
+		} else {
+			resp, err = s.ec2.CreateSecurityGroup(gid, desc)
+		}
+		c.Assert(err, IsNil)
+		g[i] = resp.SecurityGroup
+		c.Logf("group %d: %v", i, g[i])
+	}
+	// Reorder the groups below, so that g[3] is first (some of the
+	// reset depend on it, so they can't be deleted before g[3]). A
+	// slight optimization for local live tests, so that we don't need
+	// to wait 5s each time deleteGroups runs.
+	defer s.deleteGroups(c, []ec2.SecurityGroup{g[3], g[0], g[1], g[2], g[4]})
+
+	perms := [][]ec2.IPPerm{
+		{{
+			Protocol:  "tcp",
+			FromPort:  100,
+			ToPort:    200,
+			SourceIPs: []string{"1.2.3.4/32"},
+		}},
+		{{
+			Protocol:     "tcp",
+			FromPort:     200,
+			ToPort:       300,
+			SourceGroups: []ec2.UserSecurityGroup{{Id: g[2].Id}},
+		}},
+		{{
+			Protocol:     "udp",
+			FromPort:     200,
+			ToPort:       400,
+			SourceGroups: []ec2.UserSecurityGroup{{Id: g[2].Id}},
+		}},
+	}
+	for i, ps := range perms {
+		_, err := s.ec2.AuthorizeSecurityGroup(g[i+1], ps)
+		c.Assert(err, IsNil)
+	}
+
+	groups := func(indices ...int) (gs []ec2.SecurityGroup) {
+		for _, index := range indices {
+			gs = append(gs, g[index])
+		}
+		return
+	}
+
+	type groupTest struct {
+		about      string
+		groups     []ec2.SecurityGroup // groupIds argument to SecurityGroups method.
+		filters    []filterSpec        // filters argument to SecurityGroups method.
+		results    []ec2.SecurityGroup // set of expected result groups.
+		allowExtra bool                // specified results may be incomplete.
+		err        string              // expected error.
+	}
+	filterCheck := func(name, val string, gs []ec2.SecurityGroup) groupTest {
+		return groupTest{
+			about:      "filter check " + name,
+			filters:    []filterSpec{{name, []string{val}}},
+			results:    gs,
+			allowExtra: true,
+		}
+	}
+	tests := []groupTest{
+		{
+			about:      "check that SecurityGroups returns all groups",
+			results:    groups(0, 1, 2, 3, 4),
+			allowExtra: true,
+		}, {
+			about:   "check that specifying two group ids returns them",
+			groups:  idsOnly(groups(0, 2)),
+			results: groups(0, 2),
+		}, {
+			about:   "check that specifying names only works",
+			groups:  namesOnly(groups(1, 2)),
+			results: groups(1, 2),
+		}, {
+			about:  "check that specifying a non-existent group id gives an error",
+			groups: append(groups(0), ec2.SecurityGroup{Id: "sg-eeeeeeeee"}),
+			err:    `.*\(InvalidGroup\.NotFound\)`,
+		}, {
+			about: "check that a filter allowed two groups returns both of them",
+			filters: []filterSpec{
+				{"group-id", []string{g[0].Id, g[2].Id}},
+			},
+			results: groups(0, 2),
+		},
+		{
+			about:  "check that the previous filter works when specifying a list of ids",
+			groups: groups(1, 2),
+			filters: []filterSpec{
+				{"group-id", []string{g[0].Id, g[2].Id}},
+			},
+			results: groups(2),
+		}, {
+			about: "check that a filter allowing no groups returns none",
+			filters: []filterSpec{
+				{"group-id", []string{"sg-eeeeeeeee"}},
+			},
+		},
+		filterCheck("description", "testdescription1", groups(1)),
+		filterCheck("group-name", g[2].Name, groups(2)),
+		filterCheck("ip-permission.cidr", "1.2.3.4/32", groups(1)),
+		filterCheck("ip-permission.group-name", g[2].Name, groups(2, 3)),
+		filterCheck("ip-permission.protocol", "udp", groups(3)),
+		filterCheck("ip-permission.from-port", "200", groups(2, 3)),
+		filterCheck("ip-permission.to-port", "200", groups(1)),
+		filterCheck("vpc-id", vpcId, groups(0)),
+		// TODO owner-id
+	}
+	for i, t := range tests {
+		c.Logf("%d. %s", i, t.about)
+		var f *ec2.Filter
+		if t.filters != nil {
+			f = ec2.NewFilter()
+			for _, spec := range t.filters {
+				f.Add(spec.name, spec.values...)
+			}
+		}
+		resp, err := s.ec2.SecurityGroups(t.groups, f)
+		if t.err != "" {
+			c.Check(err, ErrorMatches, t.err)
+			continue
+		}
+		c.Assert(err, IsNil)
+		groups := make(map[string]*ec2.SecurityGroup)
+		for j := range resp.Groups {
+			group := &resp.Groups[j].SecurityGroup
+			c.Check(groups[group.Id], IsNil, Commentf("duplicate group id: %q", group.Id))
+
+			groups[group.Id] = group
+		}
+		// If extra groups may be returned, eliminate all groups that
+		// we did not create in this session apart from the default group.
+		if t.allowExtra {
+			namePat := regexp.MustCompile(sessionName("testgroup[0-9]"))
+			for id, g := range groups {
+				if !namePat.MatchString(g.Name) {
+					delete(groups, id)
+				}
+			}
+		}
+		c.Check(groups, HasLen, len(t.results))
+		for j, g := range t.results {
+			rg := groups[g.Id]
+			c.Assert(rg, NotNil, Commentf("group %d (%v) not found; got %#v", j, g, groups))
+			c.Check(rg.Name, Equals, g.Name, Commentf("group %d (%v)", j, g))
+		}
+	}
+}
+
+// deleteGroups ensures the given groups are deleted, by retrying
+// until a timeout or all groups cannot be found anymore.
+// This should be used to make sure tests leave no groups around.
+func (s *ServerTests) deleteGroups(c *C, groups []ec2.SecurityGroup) {
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		deleted := 0
+		c.Logf("deleting groups %v", groups)
+		for _, group := range groups {
+			_, err := s.ec2.DeleteSecurityGroup(group)
+			if err == nil || errorCode(err) == "InvalidGroup.NotFound" {
+				c.Logf("group %v deleted", group)
+				deleted++
+				continue
+			}
+			if err != nil {
+				c.Logf("retrying; DeleteSecurityGroup returned: %v", err)
+			}
+		}
+		if deleted == len(groups) {
+			c.Logf("all groups deleted")
+			return
+		}
+	}
+	c.Fatalf("timeout while waiting %v groups to get deleted!", groups)
+}
+
+// errorCode returns the code of the given error, assuming it's not
+// nil and it's an instance of *ec2.Error. It returns an empty string
+// otherwise.
+func errorCode(err error) string {
+	if err, _ := err.(*ec2.Error); err != nil {
+		return err.Code
+	}
+	return ""
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2test/filter.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2test/filter.go
@@ -1,0 +1,84 @@
+package ec2test
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// filter holds an ec2 filter.  A filter maps an attribute to a set of
+// possible values for that attribute. For an item to pass through the
+// filter, every attribute of the item mentioned in the filter must match
+// at least one of its given values.
+type filter map[string][]string
+
+// newFilter creates a new filter from the Filter fields in the url form.
+//
+// The filtering is specified through a map of name=>values, where the
+// name is a well-defined key identifying the data to be matched,
+// and the list of values holds the possible values the filtered
+// item can take for the key to be included in the
+// result set. For example:
+//
+//   Filter.1.Name=instance-type
+//   Filter.1.Value.1=m1.small
+//   Filter.1.Value.2=m1.large
+//
+func newFilter(form url.Values) filter {
+	// TODO return an error if the fields are not well formed?
+	names := make(map[int]string)
+	values := make(map[int][]string)
+	maxId := 0
+	for name, fvalues := range form {
+		var rest string
+		var id int
+		if x, _ := fmt.Sscanf(name, "Filter.%d.%s", &id, &rest); x != 2 {
+			continue
+		}
+		if id > maxId {
+			maxId = id
+		}
+		if rest == "Name" {
+			names[id] = fvalues[0]
+			continue
+		}
+		if !strings.HasPrefix(rest, "Value.") {
+			continue
+		}
+		values[id] = append(values[id], fvalues[0])
+	}
+
+	f := make(filter)
+	for id, name := range names {
+		f[name] = values[id]
+	}
+	return f
+}
+
+func notDigit(r rune) bool {
+	return r < '0' || r > '9'
+}
+
+// filterable represents an object that can be passed through a filter.
+type filterable interface {
+	// matchAttr returns true if given attribute of the
+	// object matches value. It returns an error if the
+	// attribute is not recognised or the value is malformed.
+	matchAttr(attr, value string) (bool, error)
+}
+
+// ok returns true if x passes through the filter.
+func (f filter) ok(x filterable) (bool, error) {
+next:
+	for a, vs := range f {
+		for _, v := range vs {
+			if ok, err := x.matchAttr(a, v); ok {
+				continue next
+			} else if err != nil {
+				return false, fmt.Errorf("bad attribute or value %q=%q for type %T: %v", a, v, x, err)
+			}
+		}
+		return false, nil
+	}
+	return true, nil
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2test/server.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/ec2test/server.go
@@ -1,0 +1,1527 @@
+// The ec2test package implements a fake EC2 provider with
+// the capability of inducing errors on any given operation,
+// and retrospectively determining what operations have been
+// carried out.
+package ec2test
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var b64 = base64.StdEncoding
+
+// Action represents a request that changes the ec2 state.
+type Action struct {
+	RequestId string
+
+	// Request holds the requested action as a url.Values instance
+	Request url.Values
+
+	// If the action succeeded, Response holds the value that
+	// was marshalled to build the XML response for the request.
+	Response interface{}
+
+	// If the action failed, Err holds an error giving details of the failure.
+	Err *ec2.Error
+}
+
+// TODO possible other things:
+// - some virtual time stamp interface, so a client
+// can ask for all actions after a certain virtual time.
+
+// Server implements an EC2 simulator for use in testing.
+type Server struct {
+	url      string
+	listener net.Listener
+	mu       sync.Mutex
+	reqs     []*Action
+
+	instances            map[string]*Instance      // id -> instance
+	reservations         map[string]*reservation   // id -> reservation
+	groups               map[string]*securityGroup // id -> group
+	vpcs                 map[string]*vpc           // id -> vpc
+	subnets              map[string]*subnet        // id -> subnet
+	ifaces               map[string]*iface         // id -> iface
+	attachments          map[string]*attachment    // id -> attachment
+	maxId                counter
+	reqId                counter
+	reservationId        counter
+	groupId              counter
+	vpcId                counter
+	dhcpOptsId           counter
+	subnetId             counter
+	ifaceId              counter
+	attachId             counter
+	initialInstanceState ec2.InstanceState
+}
+
+// reservation holds a simulated ec2 reservation.
+type reservation struct {
+	id        string
+	instances map[string]*Instance
+	groups    []*securityGroup
+}
+
+// instance holds a simulated ec2 instance
+type Instance struct {
+	seq        int
+	dnsNameSet bool
+	// UserData holds the data that was passed to the RunInstances request
+	// when the instance was started.
+	UserData    []byte
+	imageId     string
+	reservation *reservation
+	instType    string
+	state       ec2.InstanceState
+	subnetId    string
+	vpcId       string
+}
+
+// permKey represents permission for a given security
+// group or IP address (but not both) to access a given range of
+// ports. Equality of permKeys is used in the implementation of
+// permission sets, relying on the uniqueness of securityGroup
+// instances.
+type permKey struct {
+	protocol string
+	fromPort int
+	toPort   int
+	group    *securityGroup
+	ipAddr   string
+}
+
+// securityGroup holds a simulated ec2 security group.
+// Instances of securityGroup should only be created through
+// Server.createSecurityGroup to ensure that groups can be
+// compared by pointer value.
+type securityGroup struct {
+	id          string
+	name        string
+	description string
+	vpcId       string
+
+	perms map[permKey]bool
+}
+
+func (g *securityGroup) ec2SecurityGroup() ec2.SecurityGroup {
+	return ec2.SecurityGroup{
+		Name: g.name,
+		Id:   g.id,
+	}
+}
+
+func (g *securityGroup) matchAttr(attr, value string) (ok bool, err error) {
+	switch attr {
+	case "description":
+		return g.description == value, nil
+	case "group-id":
+		return g.id == value, nil
+	case "group-name":
+		return g.name == value, nil
+	case "ip-permission.cidr":
+		return g.hasPerm(func(k permKey) bool { return k.ipAddr == value }), nil
+	case "ip-permission.group-name":
+		return g.hasPerm(func(k permKey) bool {
+			return k.group != nil && k.group.name == value
+		}), nil
+	case "ip-permission.from-port":
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			return false, err
+		}
+		return g.hasPerm(func(k permKey) bool { return k.fromPort == port }), nil
+	case "ip-permission.to-port":
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			return false, err
+		}
+		return g.hasPerm(func(k permKey) bool { return k.toPort == port }), nil
+	case "ip-permission.protocol":
+		return g.hasPerm(func(k permKey) bool { return k.protocol == value }), nil
+	case "owner-id":
+		return value == ownerId, nil
+	case "vpc-id":
+		return g.vpcId == value, nil
+	}
+	return false, fmt.Errorf("unknown attribute %q", attr)
+}
+
+func (g *securityGroup) hasPerm(test func(k permKey) bool) bool {
+	for k := range g.perms {
+		if test(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// ec2Perms returns the list of EC2 permissions granted
+// to g. It groups permissions by port range and protocol.
+func (g *securityGroup) ec2Perms() (perms []ec2.IPPerm) {
+	// The grouping is held in result. We use permKey for convenience,
+	// (ensuring that the group and ipAddr of each key is zero). For
+	// each protocol/port range combination, we build up the permission
+	// set in the associated value.
+	result := make(map[permKey]*ec2.IPPerm)
+	for k := range g.perms {
+		groupKey := k
+		groupKey.group = nil
+		groupKey.ipAddr = ""
+
+		ec2p := result[groupKey]
+		if ec2p == nil {
+			ec2p = &ec2.IPPerm{
+				Protocol: k.protocol,
+				FromPort: k.fromPort,
+				ToPort:   k.toPort,
+			}
+			result[groupKey] = ec2p
+		}
+		if k.group != nil {
+			ec2p.SourceGroups = append(ec2p.SourceGroups,
+				ec2.UserSecurityGroup{
+					Id:      k.group.id,
+					Name:    k.group.name,
+					OwnerId: ownerId,
+				})
+		} else {
+			ec2p.SourceIPs = append(ec2p.SourceIPs, k.ipAddr)
+		}
+	}
+	for _, ec2p := range result {
+		perms = append(perms, *ec2p)
+	}
+	return
+}
+
+type vpc struct {
+	ec2.VPC
+}
+
+func (v *vpc) matchAttr(attr, value string) (ok bool, err error) {
+	switch attr {
+	case "cidr":
+		return v.CIDRBlock == value, nil
+	case "state":
+		return v.State == value, nil
+	case "vpc-id":
+		return v.Id == value, nil
+	case "tag", "tag-key", "tag-value", "dhcp-options-id", "isDefault":
+		return false, fmt.Errorf("%q filter is not implemented", attr)
+	}
+	return false, fmt.Errorf("unknown attribute %q", attr)
+}
+
+type subnet struct {
+	ec2.Subnet
+}
+
+func (s *subnet) matchAttr(attr, value string) (ok bool, err error) {
+	switch attr {
+	case "cidr":
+		return s.CIDRBlock == value, nil
+	case "availability-zone":
+		return s.AvailZone == value, nil
+	case "state":
+		return s.State == value, nil
+	case "subnet-id":
+		return s.Id == value, nil
+	case "vpc-id":
+		return s.VPCId == value, nil
+	case "tag", "tag-key", "tag-value", "available-ip-address-count", "defaultForAz":
+		return false, fmt.Errorf("%q filter not implemented", attr)
+	}
+	return false, fmt.Errorf("unknown attribute %q", attr)
+}
+
+type iface struct {
+	ec2.NetworkInterface
+}
+
+func (i *iface) matchAttr(attr, value string) (ok bool, err error) {
+	notImplemented := []string{
+		"addresses.", "association.", "tag", "requester-",
+		"attachment.", "source-dest-check", "mac-address",
+		"group-", "description", "private-", "owner-id",
+	}
+	switch attr {
+	case "availability-zone":
+		return i.AvailZone == value, nil
+	case "network-interface-id":
+		return i.Id == value, nil
+	case "status":
+		return i.Status == value, nil
+	case "subnet-id":
+		return i.SubnetId == value, nil
+	case "vpc-id":
+		return i.VPCId == value, nil
+	default:
+		for _, item := range notImplemented {
+			if strings.HasPrefix(attr, item) {
+				return false, fmt.Errorf("%q filter not implemented", attr)
+			}
+		}
+	}
+	return false, fmt.Errorf("unknown attribute %q", attr)
+}
+
+type attachment struct {
+	ec2.NetworkInterfaceAttachment
+}
+
+var actions = map[string]func(*Server, http.ResponseWriter, *http.Request, string) interface{}{
+	"RunInstances":                  (*Server).runInstances,
+	"TerminateInstances":            (*Server).terminateInstances,
+	"DescribeInstances":             (*Server).describeInstances,
+	"CreateSecurityGroup":           (*Server).createSecurityGroup,
+	"DescribeSecurityGroups":        (*Server).describeSecurityGroups,
+	"DeleteSecurityGroup":           (*Server).deleteSecurityGroup,
+	"AuthorizeSecurityGroupIngress": (*Server).authorizeSecurityGroupIngress,
+	"RevokeSecurityGroupIngress":    (*Server).revokeSecurityGroupIngress,
+	"CreateVpc":                     (*Server).createVpc,
+	"DeleteVpc":                     (*Server).deleteVpc,
+	"DescribeVpcs":                  (*Server).describeVpcs,
+	"CreateSubnet":                  (*Server).createSubnet,
+	"DeleteSubnet":                  (*Server).deleteSubnet,
+	"DescribeSubnets":               (*Server).describeSubnets,
+	"CreateNetworkInterface":        (*Server).createIFace,
+	"DeleteNetworkInterface":        (*Server).deleteIFace,
+	"DescribeNetworkInterfaces":     (*Server).describeIFaces,
+	"AttachNetworkInterface":        (*Server).attachIFace,
+	"DetachNetworkInterface":        (*Server).detachIFace,
+}
+
+const ownerId = "9876"
+
+// newAction allocates a new action and adds it to the
+// recorded list of server actions.
+func (srv *Server) newAction() *Action {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	a := new(Action)
+	srv.reqs = append(srv.reqs, a)
+	return a
+}
+
+// NewServer returns a new server.
+func NewServer() (*Server, error) {
+	srv := &Server{
+		instances:            make(map[string]*Instance),
+		groups:               make(map[string]*securityGroup),
+		vpcs:                 make(map[string]*vpc),
+		subnets:              make(map[string]*subnet),
+		ifaces:               make(map[string]*iface),
+		attachments:          make(map[string]*attachment),
+		reservations:         make(map[string]*reservation),
+		initialInstanceState: Pending,
+	}
+
+	// Add default security group.
+	g := &securityGroup{
+		name:        "default",
+		description: "default group",
+		id:          fmt.Sprintf("sg-%d", srv.groupId.next()),
+	}
+	g.perms = map[permKey]bool{
+		permKey{
+			protocol: "icmp",
+			fromPort: -1,
+			toPort:   -1,
+			group:    g,
+		}: true,
+		permKey{
+			protocol: "tcp",
+			fromPort: 0,
+			toPort:   65535,
+			group:    g,
+		}: true,
+		permKey{
+			protocol: "udp",
+			fromPort: 0,
+			toPort:   65535,
+			group:    g,
+		}: true,
+	}
+	srv.groups[g.id] = g
+
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, fmt.Errorf("cannot listen on localhost: %v", err)
+	}
+	srv.listener = l
+
+	srv.url = "http://" + l.Addr().String()
+
+	// we use HandlerFunc rather than *Server directly so that we
+	// can avoid exporting HandlerFunc from *Server.
+	go http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		srv.serveHTTP(w, req)
+	}))
+	return srv, nil
+}
+
+// Quit closes down the server.
+func (srv *Server) Quit() {
+	srv.listener.Close()
+}
+
+// SetInitialInstanceState sets the state that any new instances will be started in.
+func (srv *Server) SetInitialInstanceState(state ec2.InstanceState) {
+	srv.mu.Lock()
+	srv.initialInstanceState = state
+	srv.mu.Unlock()
+}
+
+// URL returns the URL of the server.
+func (srv *Server) URL() string {
+	return srv.url
+}
+
+// serveHTTP serves the EC2 protocol.
+func (srv *Server) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
+
+	a := srv.newAction()
+	a.RequestId = fmt.Sprintf("req%d", srv.reqId.next())
+	a.Request = req.Form
+
+	// Methods on Server that deal with parsing user data
+	// may fail. To save on error handling code, we allow these
+	// methods to call fatalf, which will panic with an *ec2.Error
+	// which will be caught here and returned
+	// to the client as a properly formed EC2 error.
+	defer func() {
+		switch err := recover().(type) {
+		case *ec2.Error:
+			a.Err = err
+			err.RequestId = a.RequestId
+			writeError(w, err)
+		case nil:
+		default:
+			panic(err)
+		}
+	}()
+
+	f := actions[req.Form.Get("Action")]
+	if f == nil {
+		fatalf(400, "InvalidParameterValue", "Unrecognized Action")
+	}
+
+	response := f(srv, w, req, a.RequestId)
+	a.Response = response
+
+	w.Header().Set("Content-Type", `xml version="1.0" encoding="UTF-8"`)
+	xmlMarshal(w, response)
+}
+
+// Instance returns the instance for the given instance id.
+// It returns nil if there is no such instance.
+func (srv *Server) Instance(id string) *Instance {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return srv.instances[id]
+}
+
+// writeError writes an appropriate error response.
+// TODO how should we deal with errors when the
+// error itself is potentially generated by backend-agnostic
+// code?
+func writeError(w http.ResponseWriter, err *ec2.Error) {
+	// Error encapsulates an error returned by EC2.
+	// TODO merge with ec2.Error when xml supports ignoring a field.
+	type ec2error struct {
+		Code      string // EC2 error code ("UnsupportedOperation", ...)
+		Message   string // The human-oriented error message
+		RequestId string
+	}
+
+	type Response struct {
+		RequestId string
+		Errors    []ec2error `xml:"Errors>Error"`
+	}
+
+	w.Header().Set("Content-Type", `xml version="1.0" encoding="UTF-8"`)
+	w.WriteHeader(err.StatusCode)
+	xmlMarshal(w, Response{
+		RequestId: err.RequestId,
+		Errors: []ec2error{{
+			Code:    err.Code,
+			Message: err.Message,
+		}},
+	})
+}
+
+// xmlMarshal is the same as xml.Marshal except that
+// it panics on error. The marshalling should not fail,
+// but we want to know if it does.
+func xmlMarshal(w io.Writer, x interface{}) {
+	if err := xml.NewEncoder(w).Encode(x); err != nil {
+		panic(fmt.Errorf("error marshalling %#v: %v", x, err))
+	}
+}
+
+// formToGroups parses a set of SecurityGroup form values
+// as found in a RunInstances request, and returns the resulting
+// slice of security groups.
+// It calls fatalf if a group is not found.
+func (srv *Server) formToGroups(form url.Values) []*securityGroup {
+	var groups []*securityGroup
+	for name, values := range form {
+		switch {
+		case strings.HasPrefix(name, "SecurityGroupId."):
+			if g := srv.groups[values[0]]; g != nil {
+				groups = append(groups, g)
+			} else {
+				fatalf(400, "InvalidGroup.NotFound", "unknown group id %q", values[0])
+			}
+		case strings.HasPrefix(name, "SecurityGroup."):
+			var found *securityGroup
+			for _, g := range srv.groups {
+				if g.name == values[0] {
+					found = g
+				}
+			}
+			if found == nil {
+				fatalf(400, "InvalidGroup.NotFound", "unknown group name %q", values[0])
+			}
+			groups = append(groups, found)
+		}
+	}
+	return groups
+}
+
+// runInstances implements the EC2 RunInstances entry point.
+func (srv *Server) runInstances(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	min := atoi(req.Form.Get("MinCount"))
+	max := atoi(req.Form.Get("MaxCount"))
+	if min < 0 || max < 1 {
+		fatalf(400, "InvalidParameterValue", "bad values for MinCount or MaxCount")
+	}
+	if min > max {
+		fatalf(400, "InvalidParameterCombination", "MinCount is greater than MaxCount")
+	}
+	var userData []byte
+	if data := req.Form.Get("UserData"); data != "" {
+		var err error
+		userData, err = b64.DecodeString(data)
+		if err != nil {
+			fatalf(400, "InvalidParameterValue", "bad UserData value: %v", err)
+		}
+	}
+
+	// TODO attributes still to consider:
+	//    ImageId:                  accept anything, we can verify later
+	//    KeyName                   ?
+	//    InstanceType              ?
+	//    KernelId                  ?
+	//    RamdiskId                 ?
+	//    AvailZone                 ?
+	//    GroupName                 tag
+	//    Monitoring                ignore?
+	//    DisableAPITermination     bool
+	//    ShutdownBehavior          string
+	//    PrivateIPAddress          string
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	var vpcId string
+	subnetId := req.Form.Get("SubnetId")
+	if subnetId != "" {
+		sub, found := srv.subnets[subnetId]
+		if !found {
+			fatalf(400, "InvalidSubnetID.NotFound", "subnet %s not found", subnetId)
+		}
+		vpcId = sub.VPCId
+	}
+
+	// make sure that form fields are correct before creating the reservation.
+	instType := req.Form.Get("InstanceType")
+	imageId := req.Form.Get("ImageId")
+
+	r := srv.newReservation(srv.formToGroups(req.Form))
+
+	var resp ec2.RunInstancesResp
+	resp.RequestId = reqId
+	resp.ReservationId = r.id
+	resp.OwnerId = ownerId
+
+	for i := 0; i < max; i++ {
+		inst := srv.newInstance(r, instType, imageId, srv.initialInstanceState, subnetId, vpcId)
+		inst.UserData = userData
+		resp.Instances = append(resp.Instances, inst.ec2instance())
+	}
+	return &resp
+}
+
+func (srv *Server) group(group ec2.SecurityGroup) *securityGroup {
+	if group.Id != "" {
+		return srv.groups[group.Id]
+	}
+	for _, g := range srv.groups {
+		if g.name == group.Name {
+			return g
+		}
+	}
+	return nil
+}
+
+// NewInstancesVPC creates n new VPC instances in srv with the given
+// instance type, image ID, initial state, and security groups,
+// belonging to the given vpcId and subnetId. If any group does not
+// already exist, it will be created. NewInstancesVPC returns the ids
+// of the new instances.
+//
+// If vpcId and subnetId are both empty, this call is equivalent to
+// calling NewInstances.
+func (srv *Server) NewInstancesVPC(vpcId, subnetId string, n int, instType string, imageId string, state ec2.InstanceState, groups []ec2.SecurityGroup) []string {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	rgroups := make([]*securityGroup, len(groups))
+	for i, group := range groups {
+		g := srv.group(group)
+		if g == nil {
+			fatalf(400, "InvalidGroup.NotFound", "no such group %v", g)
+		}
+		rgroups[i] = g
+	}
+	r := srv.newReservation(rgroups)
+
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		inst := srv.newInstance(r, instType, imageId, state, subnetId, vpcId)
+		ids[i] = inst.id()
+	}
+	return ids
+}
+
+// NewInstances creates n new instances in srv with the given instance
+// type, image ID, initial state, and security groups. If any group
+// does not already exist, it will be created. NewInstances returns
+// the ids of the new instances.
+func (srv *Server) NewInstances(n int, instType string, imageId string, state ec2.InstanceState, groups []ec2.SecurityGroup) []string {
+	return srv.NewInstancesVPC("", "", n, instType, imageId, state, groups)
+}
+
+func (srv *Server) newInstance(r *reservation, instType string, imageId string, state ec2.InstanceState, subnetId, vpcId string) *Instance {
+	inst := &Instance{
+		seq:         srv.maxId.next(),
+		instType:    instType,
+		imageId:     imageId,
+		state:       state,
+		reservation: r,
+	}
+	if vpcId != "" && subnetId != "" {
+		inst.vpcId = vpcId
+		inst.subnetId = subnetId
+	}
+	id := inst.id()
+	srv.instances[id] = inst
+	r.instances[id] = inst
+	return inst
+}
+
+func (srv *Server) newReservation(groups []*securityGroup) *reservation {
+	r := &reservation{
+		id:        fmt.Sprintf("r-%d", srv.reservationId.next()),
+		instances: make(map[string]*Instance),
+		groups:    groups,
+	}
+
+	srv.reservations[r.id] = r
+	return r
+}
+
+func (srv *Server) terminateInstances(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	var resp ec2.TerminateInstancesResp
+	resp.RequestId = reqId
+	var insts []*Instance
+	for attr, vals := range req.Form {
+		if strings.HasPrefix(attr, "InstanceId.") {
+			id := vals[0]
+			inst := srv.instances[id]
+			if inst == nil {
+				fatalf(400, "InvalidInstanceID.NotFound", "no such instance id %q", id)
+			}
+			insts = append(insts, inst)
+		}
+	}
+	for _, inst := range insts {
+		resp.StateChanges = append(resp.StateChanges, inst.terminate())
+	}
+	return &resp
+}
+
+func (inst *Instance) id() string {
+	return fmt.Sprintf("i-%d", inst.seq)
+}
+
+func (inst *Instance) terminate() (d ec2.InstanceStateChange) {
+	d.PreviousState = inst.state
+	inst.state = ShuttingDown
+	d.CurrentState = inst.state
+	d.InstanceId = inst.id()
+	return d
+}
+
+func (inst *Instance) ec2instance() ec2.Instance {
+	id := inst.id()
+	// The first time the instance is returned, its DNSName
+	// will be empty. The client should then refresh the instance.
+	var dnsName string
+	if inst.dnsNameSet {
+		dnsName = fmt.Sprintf("%s.testing.invalid", id)
+	} else {
+		inst.dnsNameSet = true
+	}
+	return ec2.Instance{
+		InstanceId:       id,
+		InstanceType:     inst.instType,
+		ImageId:          inst.imageId,
+		DNSName:          dnsName,
+		PrivateDNSName:   fmt.Sprintf("%s.internal.invalid", id),
+		IPAddress:        fmt.Sprintf("8.0.0.%d", inst.seq%256),
+		PrivateIPAddress: fmt.Sprintf("127.0.0.%d", inst.seq%256),
+		State:            inst.state,
+		VPCId:            inst.vpcId,
+		SubnetId:         inst.subnetId,
+		// TODO the rest
+	}
+}
+
+func (inst *Instance) matchAttr(attr, value string) (ok bool, err error) {
+	switch attr {
+	case "architecture":
+		return value == "i386", nil
+	case "instance-id":
+		return inst.id() == value, nil
+	case "subnet-id":
+		return inst.subnetId == value, nil
+	case "vpc-id":
+		return inst.vpcId == value, nil
+	case "instance.group-id", "group-id":
+		for _, g := range inst.reservation.groups {
+			if g.id == value {
+				return true, nil
+			}
+		}
+		return false, nil
+	case "instance.group-name", "group-name":
+		for _, g := range inst.reservation.groups {
+			if g.name == value {
+				return true, nil
+			}
+		}
+		return false, nil
+	case "image-id":
+		return value == inst.imageId, nil
+	case "instance-state-code":
+		code, err := strconv.Atoi(value)
+		if err != nil {
+			return false, err
+		}
+		return code&0xff == inst.state.Code, nil
+	case "instance-state-name":
+		return value == inst.state.Name, nil
+	}
+	return false, fmt.Errorf("unknown attribute %q", attr)
+}
+
+var (
+	Pending      = ec2.InstanceState{0, "pending"}
+	Running      = ec2.InstanceState{16, "running"}
+	ShuttingDown = ec2.InstanceState{32, "shutting-down"}
+	Terminated   = ec2.InstanceState{16, "terminated"}
+	Stopped      = ec2.InstanceState{16, "stopped"}
+)
+
+func (srv *Server) createSecurityGroup(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	name := req.Form.Get("GroupName")
+	if name == "" {
+		fatalf(400, "InvalidParameterValue", "empty security group name")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.group(ec2.SecurityGroup{Name: name}) != nil {
+		fatalf(400, "InvalidGroup.Duplicate", "group %q already exists", name)
+	}
+	g := &securityGroup{
+		name:        name,
+		description: req.Form.Get("GroupDescription"),
+		id:          fmt.Sprintf("sg-%d", srv.groupId.next()),
+		perms:       make(map[permKey]bool),
+	}
+	vpcId := req.Form.Get("VpcId")
+	if vpcId != "" {
+		g.vpcId = vpcId
+	}
+	srv.groups[g.id] = g
+	// we define a local type for this because ec2.CreateSecurityGroupResp
+	// contains SecurityGroup, but the response to this request
+	// should not contain the security group name.
+	type CreateSecurityGroupResponse struct {
+		RequestId string `xml:"requestId"`
+		Return    bool   `xml:"return"`
+		GroupId   string `xml:"groupId"`
+	}
+	r := &CreateSecurityGroupResponse{
+		RequestId: reqId,
+		Return:    true,
+		GroupId:   g.id,
+	}
+	return r
+}
+
+func (srv *Server) notImplemented(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	fatalf(500, "InternalError", "not implemented")
+	panic("not reached")
+}
+
+func (srv *Server) describeInstances(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	insts := make(map[*Instance]bool)
+	for name, vals := range req.Form {
+		if !strings.HasPrefix(name, "InstanceId.") {
+			continue
+		}
+		inst := srv.instances[vals[0]]
+		if inst == nil {
+			fatalf(400, "InvalidInstanceID.NotFound", "instance %q not found", vals[0])
+		}
+		insts[inst] = true
+	}
+
+	f := newFilter(req.Form)
+
+	var resp ec2.InstancesResp
+	resp.RequestId = reqId
+	for _, r := range srv.reservations {
+		var instances []ec2.Instance
+		var groups []ec2.SecurityGroup
+		for _, g := range r.groups {
+			groups = append(groups, g.ec2SecurityGroup())
+		}
+		for _, inst := range r.instances {
+			if len(insts) > 0 && !insts[inst] {
+				continue
+			}
+			// make instances in state "shutting-down" to transition
+			// to "terminated" first, so we can simulate: shutdown,
+			// subsequent refresh of the state with Instances(),
+			// terminated.
+			if inst.state == ShuttingDown {
+				inst.state = Terminated
+			}
+
+			ok, err := f.ok(inst)
+			if ok {
+				instance := inst.ec2instance()
+				instance.SecurityGroups = groups
+				instances = append(instances, instance)
+			} else if err != nil {
+				fatalf(400, "InvalidParameterValue", "describe instances: %v", err)
+			}
+		}
+		if len(instances) > 0 {
+			resp.Reservations = append(resp.Reservations, ec2.Reservation{
+				ReservationId:  r.id,
+				OwnerId:        ownerId,
+				Instances:      instances,
+				SecurityGroups: groups,
+			})
+		}
+	}
+	return &resp
+}
+
+func (srv *Server) describeSecurityGroups(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	// BUG similar bug to describeInstances, but for GroupName and GroupId
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	var groups []*securityGroup
+	for name, vals := range req.Form {
+		var g ec2.SecurityGroup
+		switch {
+		case strings.HasPrefix(name, "GroupName."):
+			g.Name = vals[0]
+		case strings.HasPrefix(name, "GroupId."):
+			g.Id = vals[0]
+		default:
+			continue
+		}
+		sg := srv.group(g)
+		if sg == nil {
+			fatalf(400, "InvalidGroup.NotFound", "no such group %v", g)
+		}
+		groups = append(groups, sg)
+	}
+	if len(groups) == 0 {
+		for _, g := range srv.groups {
+			groups = append(groups, g)
+		}
+	}
+
+	f := newFilter(req.Form)
+	var resp ec2.SecurityGroupsResp
+	resp.RequestId = reqId
+	for _, group := range groups {
+		ok, err := f.ok(group)
+		if ok {
+			resp.Groups = append(resp.Groups, ec2.SecurityGroupInfo{
+				OwnerId:       ownerId,
+				SecurityGroup: group.ec2SecurityGroup(),
+				Description:   group.description,
+				IPPerms:       group.ec2Perms(),
+			})
+		} else if err != nil {
+			fatalf(400, "InvalidParameterValue", "describe security groups: %v", err)
+		}
+	}
+	return &resp
+}
+
+func (srv *Server) authorizeSecurityGroupIngress(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	g := srv.group(ec2.SecurityGroup{
+		Name: req.Form.Get("GroupName"),
+		Id:   req.Form.Get("GroupId"),
+	})
+	if g == nil {
+		fatalf(400, "InvalidGroup.NotFound", "group not found")
+	}
+	perms := srv.parsePerms(req)
+
+	for _, p := range perms {
+		if g.perms[p] {
+			fatalf(400, "InvalidPermission.Duplicate", "Permission has already been authorized on the specified group")
+		}
+	}
+	for _, p := range perms {
+		g.perms[p] = true
+	}
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "AuthorizeSecurityGroupIngressResponse"},
+		RequestId: reqId,
+	}
+}
+
+func (srv *Server) revokeSecurityGroupIngress(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	g := srv.group(ec2.SecurityGroup{
+		Name: req.Form.Get("GroupName"),
+		Id:   req.Form.Get("GroupId"),
+	})
+	if g == nil {
+		fatalf(400, "InvalidGroup.NotFound", "group not found")
+	}
+	perms := srv.parsePerms(req)
+
+	// Note EC2 does not give an error if asked to revoke an authorization
+	// that does not exist.
+	for _, p := range perms {
+		delete(g.perms, p)
+	}
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "RevokeSecurityGroupIngressResponse"},
+		RequestId: reqId,
+	}
+}
+
+var (
+	secGroupPat = regexp.MustCompile(`^sg-[a-z0-9]+$`)
+	cidrIpPat   = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/([0-9]+)$`)
+	ownerIdPat  = regexp.MustCompile(`^[0-9]+$`)
+)
+
+// parsePerms returns a slice of permKey values extracted
+// from the permission fields in req.
+func (srv *Server) parsePerms(req *http.Request) []permKey {
+	// perms maps an index found in the form to its associated
+	// IPPerm. For instance, the form value with key
+	// "IpPermissions.3.FromPort" will be stored in perms[3].FromPort
+	perms := make(map[int]ec2.IPPerm)
+
+	type subgroupKey struct {
+		id1, id2 int
+	}
+	// Each IPPerm can have many source security groups.  The form key
+	// for a source security group contains two indices: the index
+	// of the IPPerm and the sub-index of the security group. The
+	// sourceGroups map maps from a subgroupKey containing these
+	// two indices to the associated security group. For instance,
+	// the form value with key "IPPermissions.3.Groups.2.GroupName"
+	// will be stored in sourceGroups[subgroupKey{3, 2}].Name.
+	sourceGroups := make(map[subgroupKey]ec2.UserSecurityGroup)
+
+	// For each value in the form we store its associated information in the
+	// above maps. The maps are necessary because the form keys may
+	// arrive in any order, and the indices are not
+	// necessarily sequential or even small.
+	for name, vals := range req.Form {
+		val := vals[0]
+		var id1 int
+		var rest string
+		if x, _ := fmt.Sscanf(name, "IpPermissions.%d.%s", &id1, &rest); x != 2 {
+			continue
+		}
+		ec2p := perms[id1]
+		switch {
+		case rest == "FromPort":
+			ec2p.FromPort = atoi(val)
+		case rest == "ToPort":
+			ec2p.ToPort = atoi(val)
+		case rest == "IpProtocol":
+			switch val {
+			case "tcp", "udp", "icmp":
+				ec2p.Protocol = val
+			default:
+				// check it's a well formed number
+				atoi(val)
+				ec2p.Protocol = val
+			}
+		case strings.HasPrefix(rest, "Groups."):
+			k := subgroupKey{id1: id1}
+			if x, _ := fmt.Sscanf(rest[len("Groups."):], "%d.%s", &k.id2, &rest); x != 2 {
+				continue
+			}
+			g := sourceGroups[k]
+			switch rest {
+			case "UserId":
+				// BUG if the user id is blank, this does not conform to the
+				// way that EC2 handles it - a specified but blank owner id
+				// can cause RevokeSecurityGroupIngress to fail with
+				// "group not found" even if the security group id has been
+				// correctly specified.
+				// By failing here, we ensure that we fail early in this case.
+				if !ownerIdPat.MatchString(val) {
+					fatalf(400, "InvalidUserID.Malformed", "Invalid user ID: %q", val)
+				}
+				g.OwnerId = val
+			case "GroupName":
+				g.Name = val
+			case "GroupId":
+				if !secGroupPat.MatchString(val) {
+					fatalf(400, "InvalidGroupId.Malformed", "Invalid group ID: %q", val)
+				}
+				g.Id = val
+			default:
+				fatalf(400, "UnknownParameter", "unknown parameter %q", name)
+			}
+			sourceGroups[k] = g
+		case strings.HasPrefix(rest, "IpRanges."):
+			var id2 int
+			if x, _ := fmt.Sscanf(rest[len("IpRanges."):], "%d.%s", &id2, &rest); x != 2 {
+				continue
+			}
+			switch rest {
+			case "CidrIp":
+				if !cidrIpPat.MatchString(val) {
+					fatalf(400, "InvalidPermission.Malformed", "Invalid IP range: %q", val)
+				}
+				ec2p.SourceIPs = append(ec2p.SourceIPs, val)
+			default:
+				fatalf(400, "UnknownParameter", "unknown parameter %q", name)
+			}
+		default:
+			fatalf(400, "UnknownParameter", "unknown parameter %q", name)
+		}
+		perms[id1] = ec2p
+	}
+	// Associate each set of source groups with its IPPerm.
+	for k, g := range sourceGroups {
+		p := perms[k.id1]
+		p.SourceGroups = append(p.SourceGroups, g)
+		perms[k.id1] = p
+	}
+
+	// Now that we have built up the IPPerms we need, we check for
+	// parameter errors and build up a permKey for each permission,
+	// looking up security groups from srv as we do so.
+	var result []permKey
+	for _, p := range perms {
+		if p.FromPort > p.ToPort {
+			fatalf(400, "InvalidParameterValue", "invalid port range")
+		}
+		k := permKey{
+			protocol: p.Protocol,
+			fromPort: p.FromPort,
+			toPort:   p.ToPort,
+		}
+		for _, g := range p.SourceGroups {
+			if g.OwnerId != "" && g.OwnerId != ownerId {
+				fatalf(400, "InvalidGroup.NotFound", "group %q not found", g.Name)
+			}
+			var ec2g ec2.SecurityGroup
+			switch {
+			case g.Id != "":
+				ec2g.Id = g.Id
+			case g.Name != "":
+				ec2g.Name = g.Name
+			}
+			k.group = srv.group(ec2g)
+			if k.group == nil {
+				fatalf(400, "InvalidGroup.NotFound", "group %v not found", g)
+			}
+			result = append(result, k)
+		}
+		k.group = nil
+		for _, ip := range p.SourceIPs {
+			k.ipAddr = ip
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+func (srv *Server) deleteSecurityGroup(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	g := srv.group(ec2.SecurityGroup{
+		Name: req.Form.Get("GroupName"),
+		Id:   req.Form.Get("GroupId"),
+	})
+	if g == nil {
+		fatalf(400, "InvalidGroup.NotFound", "group not found")
+	}
+	for _, r := range srv.reservations {
+		for _, h := range r.groups {
+			if h == g && r.hasRunningMachine() {
+				fatalf(500, "InvalidGroup.InUse", "group is currently in use by a running instance")
+			}
+		}
+	}
+	for _, sg := range srv.groups {
+		// If a group refers to itself, it's ok to delete it.
+		if sg == g {
+			continue
+		}
+		for k := range sg.perms {
+			if k.group == g {
+				fatalf(500, "InvalidGroup.InUse", "group is currently in use by group %q", sg.id)
+			}
+		}
+	}
+
+	delete(srv.groups, g.id)
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "DeleteSecurityGroupResponse"},
+		RequestId: reqId,
+	}
+}
+
+func (srv *Server) createVpc(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	cidrBlock := parseCidr(req.Form.Get("CidrBlock"))
+	tenancy := req.Form.Get("InstanceTenancy")
+	if tenancy == "" {
+		tenancy = "default"
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	v := &vpc{ec2.VPC{
+		Id:              fmt.Sprintf("vpc-%d", srv.vpcId.next()),
+		State:           "available",
+		CIDRBlock:       cidrBlock,
+		DHCPOptionsId:   fmt.Sprintf("dopt-%d", srv.dhcpOptsId.next()),
+		InstanceTenancy: tenancy,
+	}}
+	srv.vpcs[v.Id] = v
+	r := &ec2.CreateVPCResp{
+		RequestId: reqId,
+		VPC:       v.VPC,
+	}
+	return r
+}
+
+func (srv *Server) deleteVpc(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	v := srv.vpc(req.Form.Get("VpcId"))
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	delete(srv.vpcs, v.Id)
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "DeleteVpcResponse"},
+		RequestId: reqId,
+	}
+}
+
+func (srv *Server) describeVpcs(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	idMap := collectIds(req.Form, "VpcId.")
+	f := newFilter(req.Form)
+	var resp ec2.VPCsResp
+	resp.RequestId = reqId
+	for _, v := range srv.vpcs {
+		ok, err := f.ok(v)
+		if ok && (len(idMap) == 0 || idMap[v.Id]) {
+			resp.VPCs = append(resp.VPCs, v.VPC)
+		} else if err != nil {
+			fatalf(400, "InvalidParameterValue", "describe VPCs: %v", err)
+		}
+	}
+	return &resp
+}
+
+func (srv *Server) createSubnet(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	v := srv.vpc(req.Form.Get("VpcId"))
+	cidrBlock := parseCidr(req.Form.Get("CidrBlock"))
+	availZone := req.Form.Get("AvailabilityZone")
+	if availZone == "" {
+		// Assign one automatically as AWS does.
+		availZone = "us-east-1b"
+	}
+	// calculate the available IP addresses, removing the first 4 and
+	// the last, which are reserved by AWS. Since we already checked
+	// the CIDR is valid, we don't check the error here.
+	_, ipnet, _ := net.ParseCIDR(cidrBlock)
+	maskOnes, maskBits := ipnet.Mask.Size()
+	availIPs := 1<<uint(maskBits-maskOnes) - 5
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	s := &subnet{ec2.Subnet{
+		Id:               fmt.Sprintf("subnet-%d", srv.subnetId.next()),
+		VPCId:            v.Id,
+		State:            "available",
+		CIDRBlock:        cidrBlock,
+		AvailZone:        availZone,
+		AvailableIPCount: availIPs,
+	}}
+	srv.subnets[s.Id] = s
+	r := &ec2.CreateSubnetResp{
+		RequestId: reqId,
+		Subnet:    s.Subnet,
+	}
+	return r
+}
+
+func (srv *Server) deleteSubnet(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	s := srv.subnet(req.Form.Get("SubnetId"))
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	delete(srv.subnets, s.Id)
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "DeleteSubnetResponse"},
+		RequestId: reqId,
+	}
+}
+
+func (srv *Server) describeSubnets(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	idMap := collectIds(req.Form, "SubnetId.")
+	f := newFilter(req.Form)
+	var resp ec2.SubnetsResp
+	resp.RequestId = reqId
+	for _, s := range srv.subnets {
+		ok, err := f.ok(s)
+		if ok && (len(idMap) == 0 || idMap[s.Id]) {
+			resp.Subnets = append(resp.Subnets, s.Subnet)
+		} else if err != nil {
+			fatalf(400, "InvalidParameterValue", "describe subnets: %v", err)
+		}
+	}
+	return &resp
+}
+
+func (srv *Server) createIFace(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	s := srv.subnet(req.Form.Get("SubnetId"))
+	ipMap := make(map[int]ec2.PrivateIP)
+	primaryIP := req.Form.Get("PrivateIpAddress")
+	if primaryIP != "" {
+		ipMap[0] = ec2.PrivateIP{Address: primaryIP, IsPrimary: true}
+	}
+	desc := req.Form.Get("Description")
+
+	var groups []ec2.SecurityGroup
+	for name, vals := range req.Form {
+		if strings.HasPrefix(name, "SecurityGroupId.") {
+			g := ec2.SecurityGroup{Id: vals[0]}
+			sg := srv.group(g)
+			if sg == nil {
+				fatalf(400, "InvalidGroup.NotFound", "no such group %v", g)
+			}
+			groups = append(groups, sg.ec2SecurityGroup())
+		}
+		if strings.HasPrefix(name, "PrivateIpAddresses.") {
+			var ip ec2.PrivateIP
+			parts := strings.Split(name, ".")
+			index := atoi(parts[1]) - 1
+			if index < 0 {
+				fatalf(400, "InvalidParameterValue", "invalid index %s", name)
+			}
+			if _, ok := ipMap[index]; ok {
+				ip = ipMap[index]
+			}
+			switch parts[2] {
+			case "PrivateIpAddress":
+				ip.Address = vals[0]
+			case "Primary":
+				val, err := strconv.ParseBool(vals[0])
+				if err != nil {
+					fatalf(400, "InvalidParameterValue", "bad flag %s: %s", name, vals[0])
+				}
+				ip.IsPrimary = val
+			}
+			ipMap[index] = ip
+		}
+	}
+	privateIPs := make([]ec2.PrivateIP, len(ipMap))
+	for index, ip := range ipMap {
+		if ip.IsPrimary {
+			primaryIP = ip.Address
+		}
+		privateIPs[index] = ip
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	i := &iface{ec2.NetworkInterface{
+		Id:               fmt.Sprintf("eni-%d", srv.ifaceId.next()),
+		SubnetId:         s.Id,
+		VPCId:            s.VPCId,
+		AvailZone:        s.AvailZone,
+		Description:      desc,
+		OwnerId:          ownerId,
+		Status:           "available",
+		MACAddress:       fmt.Sprintf("%02d:81:60:cb:27:37", srv.ifaceId),
+		PrivateIPAddress: primaryIP,
+		SourceDestCheck:  true,
+		Groups:           groups,
+		PrivateIPs:       privateIPs,
+	}}
+	srv.ifaces[i.Id] = i
+	r := &ec2.CreateNetworkInterfaceResp{
+		RequestId:        reqId,
+		NetworkInterface: i.NetworkInterface,
+	}
+	return r
+}
+
+func (srv *Server) deleteIFace(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	i := srv.iface(req.Form.Get("NetworkInterfaceId"))
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	delete(srv.ifaces, i.Id)
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "DeleteNetworkInterface"},
+		RequestId: reqId,
+	}
+}
+
+func (srv *Server) describeIFaces(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	idMap := collectIds(req.Form, "NetworkInterfaceId.")
+	f := newFilter(req.Form)
+	var resp ec2.NetworkInterfacesResp
+	resp.RequestId = reqId
+	for _, i := range srv.ifaces {
+		ok, err := f.ok(i)
+		if ok && (len(idMap) == 0 || idMap[i.Id]) {
+			resp.Interfaces = append(resp.Interfaces, i.NetworkInterface)
+		} else if err != nil {
+			fatalf(400, "InvalidParameterValue", "describe ifaces: %v", err)
+		}
+	}
+	return &resp
+}
+
+func (srv *Server) attachIFace(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	i := srv.iface(req.Form.Get("NetworkInterfaceId"))
+	inst := srv.instance(req.Form.Get("InstanceId"))
+	devIndex := atoi(req.Form.Get("DeviceIndex"))
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	a := &attachment{ec2.NetworkInterfaceAttachment{
+		Id:                  fmt.Sprintf("eni-attach-%d", srv.attachId.next()),
+		InstanceId:          inst.id(),
+		InstanceOwnerId:     ownerId,
+		DeviceIndex:         devIndex,
+		Status:              "in-use",
+		AttachTime:          time.Now().Format(time.RFC3339),
+		DeleteOnTermination: true,
+	}}
+	srv.attachments[a.Id] = a
+	i.Attachment = a.NetworkInterfaceAttachment
+	srv.ifaces[i.Id] = i
+	r := &ec2.AttachNetworkInterfaceResp{
+		RequestId:    reqId,
+		AttachmentId: a.Id,
+	}
+	return r
+}
+
+func (srv *Server) detachIFace(w http.ResponseWriter, req *http.Request, reqId string) interface{} {
+	att := srv.attachment(req.Form.Get("AttachmentId"))
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	for _, i := range srv.ifaces {
+		if i.Attachment.Id == att.Id {
+			i.Attachment = ec2.NetworkInterfaceAttachment{}
+			srv.ifaces[i.Id] = i
+			break
+		}
+	}
+	delete(srv.attachments, att.Id)
+	return &ec2.SimpleResp{
+		XMLName:   xml.Name{"", "DetachNetworkInterface"},
+		RequestId: reqId,
+	}
+}
+
+func (r *reservation) hasRunningMachine() bool {
+	for _, inst := range r.instances {
+		if inst.state.Code != ShuttingDown.Code && inst.state.Code != Terminated.Code {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCidr(val string) string {
+	if val == "" {
+		fatalf(400, "MissingParameter", "missing cidrBlock")
+	}
+	if _, _, err := net.ParseCIDR(val); err != nil {
+		fatalf(400, "InvalidParameterValue", "bad CIDR %q: %v", val, err)
+	}
+	return val
+}
+
+func (srv *Server) vpc(id string) *vpc {
+	if id == "" {
+		fatalf(400, "MissingParameter", "missing vpcId")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	v, found := srv.vpcs[id]
+	if !found {
+		fatalf(400, "InvalidVpcID.NotFound", "VPC %s not found", id)
+	}
+	return v
+}
+
+func (srv *Server) subnet(id string) *subnet {
+	if id == "" {
+		fatalf(400, "MissingParameter", "missing subnetId")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	s, found := srv.subnets[id]
+	if !found {
+		fatalf(400, "InvalidSubnetID.NotFound", "subnet %s not found", id)
+	}
+	return s
+}
+
+func (srv *Server) iface(id string) *iface {
+	if id == "" {
+		fatalf(400, "MissingParameter", "missing networkInterfaceId")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	i, found := srv.ifaces[id]
+	if !found {
+		fatalf(400, "InvalidNetworkInterfaceID.NotFound", "interface %s not found", id)
+	}
+	return i
+}
+
+func (srv *Server) instance(id string) *Instance {
+	if id == "" {
+		fatalf(400, "MissingParameter", "missing instanceId")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	inst, found := srv.instances[id]
+	if !found {
+		fatalf(400, "InvalidInstanceID.NotFound", "instance %s not found", id)
+	}
+	return inst
+}
+
+func (srv *Server) attachment(id string) *attachment {
+	if id == "" {
+		fatalf(400, "MissingParameter", "missing attachmentId")
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	att, found := srv.attachments[id]
+	if !found {
+		fatalf(
+			400,
+			"InvalidNetworkInterfaceAttachmentId.NotFound",
+			"attachment %s not found", id,
+		)
+	}
+	return att
+}
+
+// collectIds takes all values with the given prefix from form and
+// returns a map with the ids as keys.
+func collectIds(form url.Values, prefix string) map[string]bool {
+	idMap := make(map[string]bool)
+	for name, vals := range form {
+		if strings.HasPrefix(name, prefix) {
+			idMap[vals[0]] = true
+		}
+	}
+	return idMap
+}
+
+type counter int
+
+func (c *counter) next() (i int) {
+	i = int(*c)
+	(*c)++
+	return
+}
+
+// atoi is like strconv.Atoi but is fatal if the
+// string is not well formed.
+func atoi(s string) int {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		fatalf(400, "InvalidParameterValue", "bad number: %v", err)
+	}
+	return i
+}
+
+func fatalf(statusCode int, code string, f string, a ...interface{}) {
+	panic(&ec2.Error{
+		StatusCode: statusCode,
+		Code:       code,
+		Message:    fmt.Sprintf(f, a...),
+	})
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/export_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/export_test.go
@@ -1,0 +1,24 @@
+package ec2
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"time"
+)
+
+func Sign(auth aws.Auth, method, path string, params map[string]string, host string) {
+	sign(auth, method, path, params, host)
+}
+
+func fixedTime() time.Time {
+	return time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func FakeTime(fakeIt bool) {
+	if fakeIt {
+		timeNow = fixedTime
+	} else {
+		timeNow = time.Now
+	}
+}
+
+var PrepareRunParams = prepareRunParams

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/networkinterfaces.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/networkinterfaces.go
@@ -1,0 +1,212 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// NetworkInterfaceAttachment describes a network interface
+// attachment.
+//
+// See http://goo.gl/KtiKuV for more details.
+type NetworkInterfaceAttachment struct {
+	Id                  string `xml:"attachmentId"`
+	InstanceId          string `xml:"instanceId"`
+	InstanceOwnerId     string `xml:"instanceOwnerId"`
+	DeviceIndex         int    `xml:"deviceIndex"`
+	Status              string `xml:"status"`
+	AttachTime          string `xml:"attachTime"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
+}
+
+// PrivateIP describes a private IP address of a network interface.
+//
+// See http://goo.gl/jtuQEJ for more details.
+type PrivateIP struct {
+	Address   string `xml:"privateIpAddress"`
+	DNSName   string `xml:"privateDnsName"`
+	IsPrimary bool   `xml:"primary"`
+}
+
+// NetworkInterface describes a network interface for VPC.
+//
+// See http://goo.gl/G63OQL for more details.
+type NetworkInterface struct {
+	Id               string                     `xml:"networkInterfaceId"`
+	SubnetId         string                     `xml:"subnetId"`
+	VPCId            string                     `xml:"vpcId"`
+	AvailZone        string                     `xml:"availabilityZone"`
+	Description      string                     `xml:"description"`
+	OwnerId          string                     `xml:"ownerId"`
+	RequesterId      string                     `xml:"requesterId"`
+	RequesterManaged bool                       `xml:"requesterManaged"`
+	Status           string                     `xml:"status"`
+	MACAddress       string                     `xml:"macAddress"`
+	PrivateIPAddress string                     `xml:"privateIpAddress"`
+	PrivateDNSName   string                     `xml:"privateDnsName"`
+	SourceDestCheck  bool                       `xml:"sourceDestCheck"`
+	Groups           []SecurityGroup            `xml:"groupSet>item"`
+	Attachment       NetworkInterfaceAttachment `xml:"attachment"`
+	Tags             []Tag                      `xml:"tagSet>item"`
+	PrivateIPs       []PrivateIP                `xml:"privateIpAddressesSet>item"`
+}
+
+// CreateNetworkInterface encapsulates options for the
+// CreateNetworkInterface call.
+//
+// SubnetId is the only required field.
+//
+// One or more private IP addresses can be specified by using the
+// PrivateIPs slice. Only one provided PrivateIP may be set as
+// primary.
+//
+// If PrivateIPs is empty, EC2 selects a primary private IP from the
+// subnet range.
+//
+// When SecondaryPrivateIPCount is non-zero, EC2 allocates that
+// number of IP addresses from within the subnet range.  The number of
+// IP addresses you can assign to a network interface varies by
+// instance type.
+type CreateNetworkInterface struct {
+	SubnetId                string
+	PrivateIPs              []PrivateIP
+	SecondaryPrivateIPCount int
+	Description             string
+	SecurityGroupIds        []string
+}
+
+// CreateNetworkInterfaceResp is the response to a
+// CreateNetworkInterface request.
+//
+// See http://goo.gl/ze3VhA for more details.
+type CreateNetworkInterfaceResp struct {
+	RequestId        string           `xml:"requestId"`
+	NetworkInterface NetworkInterface `xml:"networkInterface"`
+}
+
+// CreateNetworkInterface creates a network interface in the specified
+// subnet.
+//
+// See http://goo.gl/ze3VhA for more details.
+func (ec2 *EC2) CreateNetworkInterface(opts CreateNetworkInterface) (resp *CreateNetworkInterfaceResp, err error) {
+	params := makeParamsVPC("CreateNetworkInterface")
+	params["SubnetId"] = opts.SubnetId
+	for i, ip := range opts.PrivateIPs {
+		prefix := fmt.Sprintf("PrivateIpAddresses.%d.", i+1)
+		params[prefix+"PrivateIpAddress"] = ip.Address
+		params[prefix+"Primary"] = strconv.FormatBool(ip.IsPrimary)
+	}
+	if opts.Description != "" {
+		params["Description"] = opts.Description
+	}
+	if opts.SecondaryPrivateIPCount > 0 {
+		count := strconv.Itoa(opts.SecondaryPrivateIPCount)
+		params["SecondaryPrivateIpAddressCount"] = count
+	}
+	for i, groupId := range opts.SecurityGroupIds {
+		params["SecurityGroupId."+strconv.Itoa(i+1)] = groupId
+	}
+	resp = &CreateNetworkInterfaceResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteNetworkInterface deletes the specified network interface,
+// which must have been previously detached.
+//
+// See http://goo.gl/MC1yOj for more details.
+func (ec2 *EC2) DeleteNetworkInterface(id string) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("DeleteNetworkInterface")
+	params["NetworkInterfaceId"] = id
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// NetworkInterfacesResp is the response to a NetworkInterfaces
+// request.
+//
+// See http://goo.gl/2LcXtM for more details.
+type NetworkInterfacesResp struct {
+	RequestId  string             `xml:"requestId"`
+	Interfaces []NetworkInterface `xml:"networkInterfaceSet>item"`
+}
+
+// NetworkInterfaces returns a list of network interfaces.
+//
+// If the ids or filter parameters are provided, only matching
+// interfaces are returned.
+//
+// See http://goo.gl/2LcXtM for more details.
+func (ec2 *EC2) NetworkInterfaces(ids []string, filter *Filter) (resp *NetworkInterfacesResp, err error) {
+	params := makeParamsVPC("DescribeNetworkInterfaces")
+	for i, id := range ids {
+		params["NetworkInterfaceId."+strconv.Itoa(i+1)] = id
+	}
+	filter.addParams(params)
+
+	resp = &NetworkInterfacesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// AttachNetworkInterfaceResp is the response to an
+// AttachNetworkInterface request.
+//
+// See http://goo.gl/rEbSii for more details.
+type AttachNetworkInterfaceResp struct {
+	RequestId    string `xml:"requestId"`
+	AttachmentId string `xml:"attachmentId"`
+}
+
+// AttachNetworkInterface attaches a network interface to an instance.
+//
+// See http://goo.gl/rEbSii for more details.
+func (ec2 *EC2) AttachNetworkInterface(interfaceId, instanceId string, deviceIndex int) (resp *AttachNetworkInterfaceResp, err error) {
+	params := makeParamsVPC("AttachNetworkInterface")
+	params["NetworkInterfaceId"] = interfaceId
+	params["InstanceId"] = instanceId
+	params["DeviceIndex"] = strconv.Itoa(deviceIndex)
+	resp = &AttachNetworkInterfaceResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DetachNetworkInterface detaches a network interface from an
+// instance.
+//
+// See http://goo.gl/0Xc1px for more details.
+func (ec2 *EC2) DetachNetworkInterface(attachmentId string, force bool) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("DetachNetworkInterface")
+	params["AttachmentId"] = attachmentId
+	if force {
+		// Force is optional.
+		params["Force"] = "true"
+	}
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/networkinterfaces_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/networkinterfaces_test.go
@@ -1,0 +1,360 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2_test
+
+import (
+	"launchpad.net/goamz/aws"
+	"launchpad.net/goamz/ec2"
+	. "launchpad.net/gocheck"
+	"time"
+)
+
+// Network interface tests with example responses
+
+func (s *S) TestCreateNetworkInterfaceExample(c *C) {
+	testServer.Response(200, nil, CreateNetworkInterfaceExample)
+
+	resp, err := s.ec2.CreateNetworkInterface(ec2.CreateNetworkInterface{
+		SubnetId: "subnet-b2a249da",
+		PrivateIPs: []ec2.PrivateIP{
+			{Address: "10.0.2.157", IsPrimary: true},
+		},
+		SecurityGroupIds: []string{"sg-1a2b3c4d"},
+	})
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateNetworkInterface"})
+	c.Assert(req.Form["SubnetId"], DeepEquals, []string{"subnet-b2a249da"})
+	c.Assert(req.Form["PrivateIpAddress"], HasLen, 0)
+	c.Assert(
+		req.Form["PrivateIpAddresses.1.PrivateIpAddress"],
+		DeepEquals,
+		[]string{"10.0.2.157"},
+	)
+	c.Assert(
+		req.Form["PrivateIpAddresses.1.Primary"],
+		DeepEquals,
+		[]string{"true"},
+	)
+	c.Assert(req.Form["Description"], HasLen, 0)
+	c.Assert(req.Form["SecurityGroupId.1"], DeepEquals, []string{"sg-1a2b3c4d"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "8dbe591e-5a22-48cb-b948-dd0aadd55adf")
+	iface := resp.NetworkInterface
+	c.Check(iface.Id, Equals, "eni-cfca76a6")
+	c.Check(iface.SubnetId, Equals, "subnet-b2a249da")
+	c.Check(iface.VPCId, Equals, "vpc-c31dafaa")
+	c.Check(iface.AvailZone, Equals, "ap-southeast-1b")
+	c.Check(iface.Description, Equals, "")
+	c.Check(iface.OwnerId, Equals, "251839141158")
+	c.Check(iface.RequesterManaged, Equals, false)
+	c.Check(iface.Status, Equals, "available")
+	c.Check(iface.MACAddress, Equals, "02:74:b0:72:79:61")
+	c.Check(iface.PrivateIPAddress, Equals, "10.0.2.157")
+	c.Check(iface.SourceDestCheck, Equals, true)
+	c.Check(iface.Groups, DeepEquals, []ec2.SecurityGroup{
+		{Id: "sg-1a2b3c4d", Name: "default"},
+	})
+	c.Check(iface.Tags, HasLen, 0)
+	c.Check(iface.PrivateIPs, DeepEquals, []ec2.PrivateIP{
+		{Address: "10.0.2.157", IsPrimary: true},
+	})
+}
+
+func (s *S) TestDeleteNetworkInterfaceExample(c *C) {
+	testServer.Response(200, nil, DeleteNetworkInterfaceExample)
+
+	resp, err := s.ec2.DeleteNetworkInterface("eni-id")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteNetworkInterface"})
+	c.Assert(req.Form["NetworkInterfaceId"], DeepEquals, []string{"eni-id"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "e1c6d73b-edaa-4e62-9909-6611404e1739")
+}
+
+func (s *S) TestNetworkInterfacesExample(c *C) {
+	testServer.Response(200, nil, DescribeNetworkInterfacesExample)
+
+	ids := []string{"eni-0f62d866", "eni-a66ed5cf"}
+	resp, err := s.ec2.NetworkInterfaces(ids, nil)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeNetworkInterfaces"})
+	c.Assert(req.Form["NetworkInterfaceId.1"], DeepEquals, []string{ids[0]})
+	c.Assert(req.Form["NetworkInterfaceId.2"], DeepEquals, []string{ids[1]})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "fc45294c-006b-457b-bab9-012f5b3b0e40")
+	c.Check(resp.Interfaces, HasLen, 2)
+	iface := resp.Interfaces[0]
+	c.Check(iface.Id, Equals, ids[0])
+	c.Check(iface.SubnetId, Equals, "subnet-c53c87ac")
+	c.Check(iface.VPCId, Equals, "vpc-cc3c87a5")
+	c.Check(iface.AvailZone, Equals, "ap-southeast-1b")
+	c.Check(iface.Description, Equals, "")
+	c.Check(iface.OwnerId, Equals, "053230519467")
+	c.Check(iface.RequesterManaged, Equals, false)
+	c.Check(iface.Status, Equals, "in-use")
+	c.Check(iface.MACAddress, Equals, "02:81:60:cb:27:37")
+	c.Check(iface.PrivateIPAddress, Equals, "10.0.0.146")
+	c.Check(iface.SourceDestCheck, Equals, true)
+	c.Check(iface.Groups, DeepEquals, []ec2.SecurityGroup{
+		{Id: "sg-3f4b5653", Name: "default"},
+	})
+	c.Check(iface.Attachment, DeepEquals, ec2.NetworkInterfaceAttachment{
+		Id:                  "eni-attach-6537fc0c",
+		InstanceId:          "i-22197876",
+		InstanceOwnerId:     "053230519467",
+		DeviceIndex:         0,
+		Status:              "attached",
+		AttachTime:          "2012-07-01T21:45:27.000Z",
+		DeleteOnTermination: true,
+	})
+	c.Check(iface.PrivateIPs, DeepEquals, []ec2.PrivateIP{
+		{Address: "10.0.0.146", IsPrimary: true},
+		{Address: "10.0.0.148", IsPrimary: false},
+		{Address: "10.0.0.150", IsPrimary: false},
+	})
+	c.Check(iface.Tags, HasLen, 0)
+
+	iface = resp.Interfaces[1]
+	c.Check(iface.Id, Equals, ids[1])
+	c.Check(iface.SubnetId, Equals, "subnet-cd8a35a4")
+	c.Check(iface.VPCId, Equals, "vpc-f28a359b")
+	c.Check(iface.AvailZone, Equals, "ap-southeast-1b")
+	c.Check(iface.Description, Equals, "Primary network interface")
+	c.Check(iface.OwnerId, Equals, "053230519467")
+	c.Check(iface.RequesterManaged, Equals, false)
+	c.Check(iface.Status, Equals, "in-use")
+	c.Check(iface.MACAddress, Equals, "02:78:d7:00:8a:1e")
+	c.Check(iface.PrivateIPAddress, Equals, "10.0.1.233")
+	c.Check(iface.SourceDestCheck, Equals, true)
+	c.Check(iface.Groups, DeepEquals, []ec2.SecurityGroup{
+		{Id: "sg-a2a0b2ce", Name: "quick-start-1"},
+	})
+	c.Check(iface.Attachment, DeepEquals, ec2.NetworkInterfaceAttachment{
+		Id:                  "eni-attach-a99c57c0",
+		InstanceId:          "i-886401dc",
+		InstanceOwnerId:     "053230519467",
+		DeviceIndex:         0,
+		Status:              "attached",
+		AttachTime:          "2012-06-27T20:08:44.000Z",
+		DeleteOnTermination: true,
+	})
+	c.Check(iface.PrivateIPs, DeepEquals, []ec2.PrivateIP{
+		{Address: "10.0.1.233", IsPrimary: true},
+		{Address: "10.0.1.20", IsPrimary: false},
+	})
+	c.Check(iface.Tags, HasLen, 0)
+}
+
+func (s *S) TestAttachNetworkInterfaceExample(c *C) {
+	testServer.Response(200, nil, AttachNetworkInterfaceExample)
+
+	resp, err := s.ec2.AttachNetworkInterface("eni-id", "i-id", 0)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AttachNetworkInterface"})
+	c.Assert(req.Form["NetworkInterfaceId"], DeepEquals, []string{"eni-id"})
+	c.Assert(req.Form["InstanceId"], DeepEquals, []string{"i-id"})
+	c.Assert(req.Form["DeviceIndex"], DeepEquals, []string{"0"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "ace8cd1e-e685-4e44-90fb-92014d907212")
+	c.Assert(resp.AttachmentId, Equals, "eni-attach-d94b09b0")
+}
+
+func (s *S) TestDetachNetworkInterfaceExample(c *C) {
+	testServer.Response(200, nil, DetachNetworkInterfaceExample)
+
+	resp, err := s.ec2.DetachNetworkInterface("eni-attach-id", true)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DetachNetworkInterface"})
+	c.Assert(req.Form["AttachmentId"], DeepEquals, []string{"eni-attach-id"})
+	c.Assert(req.Form["Force"], DeepEquals, []string{"true"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "ce540707-0635-46bc-97da-33a8a362a0e8")
+}
+
+// Network interface tests run against either a local test server or
+// live on EC2.
+
+func (s *ServerTests) TestNetworkInterfaces(c *C) {
+	vpcResp, err := s.ec2.CreateVPC("10.3.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := vpcResp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	subResp := s.createSubnet(c, vpcId, "10.3.1.0/24", "")
+	subId := subResp.Subnet.Id
+	defer s.deleteSubnets(c, []string{subId})
+
+	sg := s.makeTestGroupVPC(c, vpcId, "vpc-sg-1", "vpc test group1")
+	defer s.deleteGroups(c, []ec2.SecurityGroup{sg})
+
+	instList, err := s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:      imageId,
+		InstanceType: "t1.micro",
+		SubnetId:     subId,
+	})
+	c.Assert(err, IsNil)
+	inst := instList.Instances[0]
+	c.Assert(inst, NotNil)
+	instId := inst.InstanceId
+	defer terminateInstances(c, s.ec2, []string{instId})
+
+	ips1 := []ec2.PrivateIP{{Address: "10.3.1.10", IsPrimary: true}}
+	resp1, err := s.ec2.CreateNetworkInterface(ec2.CreateNetworkInterface{
+		SubnetId:    subId,
+		PrivateIPs:  ips1,
+		Description: "My first iface",
+	})
+	c.Assert(err, IsNil)
+	assertNetworkInterface(c, resp1.NetworkInterface, "", subId, ips1)
+	c.Check(resp1.NetworkInterface.Description, Equals, "My first iface")
+	id1 := resp1.NetworkInterface.Id
+
+	ips2 := []ec2.PrivateIP{
+		{Address: "10.3.1.20", IsPrimary: true},
+		{Address: "10.3.1.22", IsPrimary: false},
+	}
+	resp2, err := s.ec2.CreateNetworkInterface(ec2.CreateNetworkInterface{
+		SubnetId:         subId,
+		PrivateIPs:       ips2,
+		SecurityGroupIds: []string{sg.Id},
+	})
+	c.Assert(err, IsNil)
+	assertNetworkInterface(c, resp2.NetworkInterface, "", subId, ips2)
+	c.Assert(resp2.NetworkInterface.Groups, DeepEquals, []ec2.SecurityGroup{sg})
+	id2 := resp2.NetworkInterface.Id
+
+	// We only check for the network interfaces we just created,
+	// because the user might have others in his account (when testing
+	// against the EC2 servers). In some cases it takes a short while
+	// until both interfaces are created, so we need to retry a few
+	// times to make sure.
+	testAttempt := aws.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	var list *ec2.NetworkInterfacesResp
+	done := false
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for %v to be created", []string{id1, id2})
+		list, err = s.ec2.NetworkInterfaces(nil, nil)
+		if err != nil {
+			c.Logf("retrying; NetworkInterfaces returned: %v", err)
+			continue
+		}
+		found := 0
+		for _, iface := range list.Interfaces {
+			c.Logf("found NIC %v", iface)
+			switch iface.Id {
+			case id1:
+				assertNetworkInterface(c, iface, id1, subId, ips1)
+				found++
+			case id2:
+				assertNetworkInterface(c, iface, id2, subId, ips2)
+				found++
+			}
+			if found == 2 {
+				done = true
+				break
+			}
+		}
+		if done {
+			c.Logf("all NICs were created")
+			break
+		}
+	}
+	if !done {
+		c.Fatalf("timeout while waiting for NICs %v", []string{id1, id2})
+	}
+
+	list, err = s.ec2.NetworkInterfaces([]string{id1}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(list.Interfaces, HasLen, 1)
+	assertNetworkInterface(c, list.Interfaces[0], id1, subId, ips1)
+
+	f := ec2.NewFilter()
+	f.Add("network-interface-id", id2)
+	list, err = s.ec2.NetworkInterfaces(nil, f)
+	c.Assert(err, IsNil)
+	c.Assert(list.Interfaces, HasLen, 1)
+	assertNetworkInterface(c, list.Interfaces[0], id2, subId, ips2)
+
+	// Attachment might fail if the instance is not running yet,
+	// so we retry for a while until it succeeds.
+	var attResp *ec2.AttachNetworkInterfaceResp
+	for a := testAttempt.Start(); a.Next(); {
+		attResp, err = s.ec2.AttachNetworkInterface(id2, instId, 1)
+		if err != nil {
+			c.Logf("AttachNetworkInterface returned: %v; retrying...", err)
+			attResp = nil
+			continue
+		}
+		c.Logf("AttachNetworkInterface succeeded")
+		c.Check(attResp.AttachmentId, Not(Equals), "")
+		break
+	}
+	if attResp == nil {
+		c.Fatalf("timeout while waiting for AttachNetworkInterface to succeed")
+	}
+
+	list, err = s.ec2.NetworkInterfaces([]string{id2}, nil)
+	c.Assert(err, IsNil)
+	att := list.Interfaces[0].Attachment
+	c.Check(att.Id, Equals, attResp.AttachmentId)
+	c.Check(att.InstanceId, Equals, instId)
+	c.Check(att.DeviceIndex, Equals, 1)
+	c.Check(att.Status, Matches, "(attaching|in-use)")
+
+	_, err = s.ec2.DetachNetworkInterface(att.Id, true)
+	c.Check(err, IsNil)
+
+	_, err = s.ec2.DeleteNetworkInterface(id1)
+	c.Assert(err, IsNil)
+
+	// We might not be able to delete the interface until the
+	// detachment is completed, so we need to retry here as well.
+	for a := testAttempt.Start(); a.Next(); {
+		_, err = s.ec2.DeleteNetworkInterface(id2)
+		if err != nil {
+			c.Logf("DeleteNetworkInterface returned: %v; retrying...", err)
+			continue
+		}
+		c.Logf("DeleteNetworkInterface succeeded")
+		return
+	}
+	c.Fatalf("timeout while waiting for DeleteNetworkInterface to succeed")
+}
+
+func assertNetworkInterface(c *C, obtained ec2.NetworkInterface, expectId, expectSubId string, expectIPs []ec2.PrivateIP) {
+	if expectId != "" {
+		c.Check(obtained.Id, Equals, expectId)
+	} else {
+		c.Check(obtained.Id, Matches, `^eni-[0-9a-f]+$`)
+	}
+	c.Check(obtained.Status, Matches, "(available|pending|in-use)")
+	if expectSubId != "" {
+		c.Check(obtained.SubnetId, Equals, expectSubId)
+	} else {
+		c.Check(obtained.SubnetId, Matches, `^subnet-[0-9a-f]+$`)
+	}
+	c.Check(obtained.Attachment, DeepEquals, ec2.NetworkInterfaceAttachment{})
+	if len(expectIPs) > 0 {
+		c.Check(obtained.PrivateIPs, DeepEquals, expectIPs)
+		c.Check(obtained.PrivateIPAddress, DeepEquals, expectIPs[0].Address)
+	}
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/privateips.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/privateips.go
@@ -1,0 +1,67 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2
+
+import (
+	"strconv"
+)
+
+// AssignPrivateIPAddresses assigns secondary IP addresses to the
+// network interface interfaceId.
+//
+// If secondaryIPCount is non-zero, ipAddresses must be nil, and the
+// specified number of secondary IP addresses will be allocated within
+// the subnet's CIDR block range.
+//
+// allowReassignment specifies whether to allow reassignment of
+// addresses currently assigned to a different network interface.
+//
+// See http://goo.gl/MoeH0L more details.
+func (ec2 *EC2) AssignPrivateIPAddresses(interfaceId string, ipAddresses []string, secondaryIPCount int, allowReassignment bool) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("AssignPrivateIpAddresses")
+	params["NetworkInterfaceId"] = interfaceId
+	if secondaryIPCount > 0 {
+		params["SecondaryPrivateIpAddressCount"] = strconv.Itoa(secondaryIPCount)
+	} else {
+		for i, ip := range ipAddresses {
+			// PrivateIpAddress is zero indexed.
+			n := strconv.Itoa(i)
+			params["PrivateIpAddress."+n] = ip
+		}
+	}
+	if allowReassignment {
+		params["AllowReassignment"] = "true"
+	}
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// UnassignPrivateIPAddresses unassigns one or more secondary private
+// IP addresses from a network interface.
+//
+// See http://goo.gl/RjGZdB for more details.
+func (ec2 *EC2) UnassignPrivateIPAddresses(interfaceId string, ipAddresses []string) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("UnassignPrivateIpAddresses")
+	params["NetworkInterfaceId"] = interfaceId
+	for i, ip := range ipAddresses {
+		// PrivateIpAddress is zero indexed.
+		n := strconv.Itoa(i)
+		params["PrivateIpAddress."+n] = ip
+	}
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/privateips_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/privateips_test.go
@@ -1,0 +1,157 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2_test
+
+import (
+	"launchpad.net/goamz/aws"
+	"launchpad.net/goamz/ec2"
+	. "launchpad.net/gocheck"
+	"time"
+)
+
+// Private IP tests with example responses
+
+func (s *S) TestAssignPrivateIPAddressesExample(c *C) {
+	testServer.Response(200, nil, AssignPrivateIpAddressesExample)
+
+	resp, err := s.ec2.AssignPrivateIPAddresses("eni-id", []string{"1.2.3.4", "4.3.2.1"}, 0, true)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AssignPrivateIpAddresses"})
+	c.Assert(req.Form["NetworkInterfaceId"], DeepEquals, []string{"eni-id"})
+	c.Assert(req.Form["PrivateIpAddress.0"], DeepEquals, []string{"1.2.3.4"})
+	c.Assert(req.Form["PrivateIpAddress.1"], DeepEquals, []string{"4.3.2.1"})
+	c.Assert(req.Form["SecondaryPrivateIpAddressCount"], HasLen, 0)
+	c.Assert(req.Form["AllowReassignment"], DeepEquals, []string{"true"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestUnassignPrivateIPAddressesExample(c *C) {
+	testServer.Response(200, nil, UnassignPrivateIpAddressesExample)
+
+	resp, err := s.ec2.UnassignPrivateIPAddresses("eni-id", []string{"1.2.3.4", "4.3.2.1"})
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"UnassignPrivateIpAddresses"})
+	c.Assert(req.Form["NetworkInterfaceId"], DeepEquals, []string{"eni-id"})
+	c.Assert(req.Form["PrivateIpAddress.0"], DeepEquals, []string{"1.2.3.4"})
+	c.Assert(req.Form["PrivateIpAddress.1"], DeepEquals, []string{"4.3.2.1"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+// Private IP tests run live against EC2.
+
+func (s *AmazonServerSuite) TestAssignUnassignPrivateIPs(c *C) {
+	vpcResp, err := s.ec2.CreateVPC("10.7.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := vpcResp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	subResp := s.createSubnet(c, vpcId, "10.7.1.0/24", "")
+	subId := subResp.Subnet.Id
+	defer s.deleteSubnets(c, []string{subId})
+
+	// Launch a m1.small instance, so we can later assign up to 4
+	// private IPs.
+	instList, err := s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:      imageId,
+		InstanceType: "m1.small",
+		SubnetId:     subId,
+	})
+	c.Assert(err, IsNil)
+	inst := instList.Instances[0]
+	c.Assert(inst, NotNil)
+	instId := inst.InstanceId
+	defer terminateInstances(c, s.ec2, []string{instId})
+
+	// We need to wait for the instance to change state to 'running',
+	// so its automatically created network interface on the created
+	// subnet will appear.
+	testAttempt := aws.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	var newNIC *ec2.NetworkInterface
+	f := ec2.NewFilter()
+	f.Add("subnet-id", subId)
+	for a := testAttempt.Start(); a.Next(); {
+		resp, err := s.ec2.NetworkInterfaces(nil, f)
+		if err != nil {
+			c.Logf("NetworkInterfaces returned: %v; retrying...", err)
+			continue
+		}
+		for _, iface := range resp.Interfaces {
+			c.Logf("found NIC %v", iface)
+			if iface.Attachment.InstanceId == instId {
+				c.Logf("found instance %v NIC", instId)
+				newNIC = &iface
+				break
+			}
+		}
+		if newNIC != nil {
+			break
+		}
+	}
+	if newNIC == nil {
+		c.Fatalf("timeout while waiting for the NIC to appear")
+	}
+
+	c.Check(newNIC.PrivateIPAddress, Matches, `^10\.7\.1\.\d+$`)
+	c.Check(newNIC.PrivateIPs, HasLen, 1)
+
+	// Now let's try assigning some more private IPs.
+	ips := []string{"10.7.1.25", "10.7.1.30"}
+	_, err = s.ec2.AssignPrivateIPAddresses(newNIC.Id, ips, 0, false)
+	c.Assert(err, IsNil)
+
+	expectIPs := append([]string{newNIC.PrivateIPAddress}, ips...)
+	s.waitForAddresses(c, newNIC.Id, expectIPs)
+
+	// And finally, unassign them.
+	_, err = s.ec2.UnassignPrivateIPAddresses(newNIC.Id, ips)
+	c.Assert(err, IsNil)
+
+	expectIPs = []string{newNIC.PrivateIPAddress}
+	s.waitForAddresses(c, newNIC.Id, expectIPs)
+}
+
+func (s *AmazonServerSuite) waitForAddresses(c *C, nicId string, ips []string) {
+	// Wait for the given IPs to appear on the NIC, retrying if needed.
+	testAttempt := aws.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for %v IPs on NIC %v", ips, nicId)
+		resp, err := s.ec2.NetworkInterfaces([]string{nicId}, nil)
+		if err != nil {
+			c.Logf("NetworkInterfaces returned: %v; retrying...", err)
+			continue
+		}
+		if len(resp.Interfaces) != 1 {
+			c.Logf("found %d NICs; retrying", len(resp.Interfaces))
+			continue
+		}
+		iface := resp.Interfaces[0]
+		if len(iface.PrivateIPs) != len(ips) {
+			c.Logf("addresses in %v: %v; still waiting", iface.Id, iface.PrivateIPs)
+			continue
+		}
+		for i, ip := range iface.PrivateIPs {
+			c.Assert(ip.Address, Equals, ips[i])
+		}
+		c.Logf("all addresses updated")
+		return
+	}
+	c.Fatalf("timeout while waiting for the IPs to get updated")
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/responses_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/responses_test.go
@@ -1,0 +1,923 @@
+package ec2_test
+
+var ErrorDump = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Response><Errors><Error><Code>UnsupportedOperation</Code>
+<Message>AMIs with an instance-store root device are not supported for the instance type 't1.micro'.</Message>
+</Error></Errors><RequestID>0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4</RequestID></Response>
+`
+
+// http://goo.gl/Mcm3b
+var RunInstancesExample = `
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-13/"> 
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <reservationId>r-47a5402e</reservationId> 
+  <ownerId>999988887777</ownerId>
+  <groupSet>
+      <item>
+          <groupId>sg-67ad940e</groupId>
+          <groupName>default</groupName>
+      </item>
+  </groupSet>
+  <instancesSet>
+    <item>
+      <instanceId>i-2ba64342</instanceId>
+      <imageId>ami-60a54009</imageId>
+      <instanceState>
+        <code>0</code>
+        <name>pending</name>
+      </instanceState>
+      <privateDnsName></privateDnsName>
+      <dnsName></dnsName>
+      <keyName>example-key-name</keyName>
+      <amiLaunchIndex>0</amiLaunchIndex>
+      <instanceType>m1.small</instanceType>
+      <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+      <placement>
+        <availabilityZone>us-east-1b</availabilityZone>
+      </placement>
+      <monitoring>
+        <state>enabled</state>
+      </monitoring>
+      <virtualizationType>paravirtual</virtualizationType>
+      <subnetId>subnet-id</subnetId>
+      <vpcId>vpc-id</vpcId>
+      <sourceDestCheck>true</sourceDestCheck>
+      <clientToken/>
+      <tagSet/>
+      <hypervisor>xen</hypervisor>
+      <networkInterfaceSet>
+        <item>
+          <networkInterfaceId>eni-c6bb50ae</networkInterfaceId>
+          <subnetId>subnet-id</subnetId>
+          <vpcId>vpc-id</vpcId>
+          <description>eth0</description>
+          <ownerId>111122223333</ownerId>
+          <status>in-use</status>
+          <privateIpAddress>10.0.0.25</privateIpAddress>
+          <macAddress>11:22:33:44:55:66</macAddress>
+          <sourceDestCheck>true</sourceDestCheck>
+          <groupSet>
+            <item>
+              <groupId>sg-1</groupId>
+              <groupName>vpc sg-1</groupName>
+            </item>
+            <item>
+              <groupId>sg-2</groupId>
+              <groupName>vpc sg-2</groupName>
+            </item>
+          </groupSet>
+          <attachment>
+            <attachmentId>eni-attach-0326646a</attachmentId>
+            <deviceIndex>0</deviceIndex>
+            <status>attaching</status>
+            <attachTime>2011-12-20T08:29:31.000Z</attachTime>
+            <deleteOnTermination>true</deleteOnTermination>
+          </attachment>
+          <privateIpAddressesSet>
+            <item>
+              <privateIpAddress>10.0.0.25</privateIpAddress>
+              <primary>true</primary>
+            </item>
+          </privateIpAddressesSet>
+        </item>
+        <item>
+          <networkInterfaceId>eni-id</networkInterfaceId>
+          <subnetId>subnet-id</subnetId>
+          <vpcId>vpc-id</vpcId>
+          <description/>
+          <ownerId>111122223333</ownerId>
+          <status>in-use</status>
+          <privateIpAddress>10.0.1.10</privateIpAddress>
+          <macAddress>11:22:33:44:55:66</macAddress>
+          <sourceDestCheck>true</sourceDestCheck>
+          <groupSet>
+            <item>
+              <groupId>sg-id</groupId>
+              <groupName>vpc default</groupName>
+            </item>
+          </groupSet>
+          <attachment>
+            <attachmentId>eni-attach-id</attachmentId>
+            <deviceIndex>1</deviceIndex>
+            <status>attaching</status>
+            <attachTime>2011-12-20T08:29:31.000Z</attachTime>
+            <deleteOnTermination>false</deleteOnTermination>
+          </attachment>
+          <privateIpAddressesSet>
+            <item>
+              <privateIpAddress>10.0.1.10</privateIpAddress>
+              <primary>true</primary>
+            </item>
+            <item>
+              <privateIpAddress>10.0.1.20</privateIpAddress>
+              <primary>false</primary>
+            </item>
+          </privateIpAddressesSet>
+        </item>
+      </networkInterfaceSet>
+    </item>
+    <item>
+      <instanceId>i-2bc64242</instanceId>
+      <imageId>ami-60a54009</imageId>
+      <instanceState>
+        <code>0</code>
+        <name>pending</name>
+      </instanceState>
+      <privateDnsName></privateDnsName>
+      <dnsName></dnsName>
+      <keyName>example-key-name</keyName>
+      <amiLaunchIndex>1</amiLaunchIndex>
+      <instanceType>m1.small</instanceType>
+      <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+      <placement>
+         <availabilityZone>us-east-1b</availabilityZone>
+      </placement>
+      <monitoring>
+        <state>enabled</state>
+      </monitoring>
+      <virtualizationType>paravirtual</virtualizationType>
+      <clientToken/>
+      <tagSet/>
+      <hypervisor>xen</hypervisor>
+    </item>
+    <item>
+      <instanceId>i-2be64332</instanceId>
+      <imageId>ami-60a54009</imageId>
+      <instanceState>
+        <code>0</code>
+        <name>pending</name>
+      </instanceState>
+      <privateDnsName></privateDnsName>
+      <dnsName></dnsName>
+      <keyName>example-key-name</keyName>
+      <amiLaunchIndex>2</amiLaunchIndex>
+      <instanceType>m1.small</instanceType>
+      <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+      <placement>
+         <availabilityZone>us-east-1b</availabilityZone>
+      </placement>
+      <monitoring>
+        <state>enabled</state>
+      </monitoring>
+      <virtualizationType>paravirtual</virtualizationType>
+      <clientToken/>
+      <tagSet/>
+      <hypervisor>xen</hypervisor>
+    </item>
+  </instancesSet>
+</RunInstancesResponse>
+`
+
+// http://goo.gl/3BKHj
+var TerminateInstancesExample = `
+<TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <instancesSet>
+    <item>
+      <instanceId>i-3ea74257</instanceId>
+      <currentState>
+        <code>32</code>
+        <name>shutting-down</name>
+      </currentState>
+      <previousState>
+        <code>16</code>
+        <name>running</name>
+      </previousState>
+    </item>
+  </instancesSet>
+</TerminateInstancesResponse>
+`
+
+// http://goo.gl/mLbmw
+var DescribeInstancesExample1 = `
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>98e3c9a4-848c-4d6d-8e8a-b1bdEXAMPLE</requestId>
+  <reservationSet>
+    <item>
+      <reservationId>r-b27e30d9</reservationId>
+      <ownerId>999988887777</ownerId>
+      <groupSet>
+        <item>
+          <groupId>sg-67ad940e</groupId>
+          <groupName>default</groupName>
+        </item>
+      </groupSet>
+      <instancesSet>
+        <item>
+          <instanceId>i-c5cd56af</instanceId>
+          <imageId>ami-1a2b3c4d</imageId>
+          <instanceState>
+            <code>16</code>
+            <name>running</name>
+          </instanceState>
+          <privateDnsName>domU-12-31-39-10-56-34.compute-1.internal</privateDnsName>
+          <dnsName>ec2-174-129-165-232.compute-1.amazonaws.com</dnsName>
+          <reason/>
+          <keyName>GSG_Keypair</keyName>
+          <amiLaunchIndex>0</amiLaunchIndex>
+          <productCodes/>
+          <instanceType>m1.small</instanceType>
+          <launchTime>2010-08-17T01:15:18.000Z</launchTime>
+          <placement>
+            <availabilityZone>us-east-1b</availabilityZone>
+            <groupName/>
+          </placement>
+          <kernelId>aki-94c527fd</kernelId>
+          <ramdiskId>ari-96c527ff</ramdiskId>
+          <monitoring>
+            <state>disabled</state>
+          </monitoring>
+          <privateIpAddress>10.198.85.190</privateIpAddress>
+          <ipAddress>174.129.165.232</ipAddress>
+          <architecture>i386</architecture>
+          <rootDeviceType>ebs</rootDeviceType>
+          <rootDeviceName>/dev/sda1</rootDeviceName>
+          <blockDeviceMapping>
+            <item>
+              <deviceName>/dev/sda1</deviceName>
+              <ebs>
+                <volumeId>vol-a082c1c9</volumeId>
+                <status>attached</status>
+                <attachTime>2010-08-17T01:15:21.000Z</attachTime>
+                <deleteOnTermination>false</deleteOnTermination>
+              </ebs>
+            </item>
+          </blockDeviceMapping>
+          <instanceLifecycle>spot</instanceLifecycle>
+          <spotInstanceRequestId>sir-7a688402</spotInstanceRequestId>
+          <virtualizationType>paravirtual</virtualizationType>
+          <clientToken/>
+          <tagSet/>
+          <hypervisor>xen</hypervisor>
+          <groupSet>
+            <item>
+              <groupId>sg-67ad940e</groupId>
+              <groupName>default</groupName>
+            </item>
+          </groupSet>
+       </item>
+      </instancesSet>
+      <requesterId>854251627541</requesterId>
+    </item>
+    <item>
+      <reservationId>r-b67e30dd</reservationId>
+      <ownerId>999988887777</ownerId>
+      <groupSet>
+        <item>
+          <groupId>sg-67ad940e</groupId>
+          <groupName>default</groupName>
+        </item>
+      </groupSet>
+      <instancesSet>
+        <item>
+          <instanceId>i-d9cd56b3</instanceId>
+          <imageId>ami-1a2b3c4d</imageId>
+          <instanceState>
+            <code>16</code>
+            <name>running</name>
+          </instanceState>
+          <privateDnsName>domU-12-31-39-10-54-E5.compute-1.internal</privateDnsName>
+          <dnsName>ec2-184-73-58-78.compute-1.amazonaws.com</dnsName>
+          <reason/>
+          <keyName>GSG_Keypair</keyName>
+          <amiLaunchIndex>0</amiLaunchIndex>
+          <productCodes/>
+          <instanceType>m1.large</instanceType>
+          <launchTime>2010-08-17T01:15:19.000Z</launchTime>
+          <placement>
+            <availabilityZone>us-east-1b</availabilityZone>
+            <groupName/>
+          </placement>
+          <kernelId>aki-94c527fd</kernelId>
+          <ramdiskId>ari-96c527ff</ramdiskId>
+          <monitoring>
+            <state>disabled</state>
+          </monitoring>
+          <privateIpAddress>10.198.87.19</privateIpAddress>
+          <ipAddress>184.73.58.78</ipAddress>
+          <architecture>i386</architecture>
+          <rootDeviceType>ebs</rootDeviceType>
+          <rootDeviceName>/dev/sda1</rootDeviceName>
+          <blockDeviceMapping>
+            <item>
+              <deviceName>/dev/sda1</deviceName>
+              <ebs>
+                <volumeId>vol-a282c1cb</volumeId>
+                <status>attached</status>
+                <attachTime>2010-08-17T01:15:23.000Z</attachTime>
+                <deleteOnTermination>false</deleteOnTermination>
+              </ebs>
+            </item>
+          </blockDeviceMapping>
+          <instanceLifecycle>spot</instanceLifecycle>
+          <spotInstanceRequestId>sir-55a3aa02</spotInstanceRequestId>
+          <virtualizationType>paravirtual</virtualizationType>
+          <clientToken/>
+          <tagSet/>
+          <hypervisor>xen</hypervisor>
+       </item>
+      </instancesSet>
+      <requesterId>854251627541</requesterId>
+    </item>
+  </reservationSet>
+</DescribeInstancesResponse>
+`
+
+// http://goo.gl/mLbmw
+var DescribeInstancesExample2 = `
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/"> 
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <reservationSet>
+    <item>
+      <reservationId>r-bc7e30d7</reservationId>
+      <ownerId>999988887777</ownerId>
+      <groupSet>
+        <item>
+          <groupId>sg-67ad940e</groupId>
+          <groupName>default</groupName>
+        </item>
+      </groupSet>
+      <instancesSet>
+        <item>
+          <instanceId>i-c7cd56ad</instanceId>
+          <imageId>ami-b232d0db</imageId>
+          <instanceState>
+            <code>16</code>
+            <name>running</name>
+          </instanceState>
+          <privateDnsName>domU-12-31-39-01-76-06.compute-1.internal</privateDnsName>
+          <dnsName>ec2-72-44-52-124.compute-1.amazonaws.com</dnsName>
+          <keyName>GSG_Keypair</keyName>
+          <amiLaunchIndex>0</amiLaunchIndex>
+          <productCodes/>
+          <instanceType>m1.small</instanceType>
+          <launchTime>2010-08-17T01:15:16.000Z</launchTime>
+          <placement>
+              <availabilityZone>us-east-1b</availabilityZone>
+          </placement>
+          <kernelId>aki-94c527fd</kernelId>
+          <ramdiskId>ari-96c527ff</ramdiskId>
+          <monitoring>
+              <state>disabled</state>
+          </monitoring>
+          <privateIpAddress>10.255.121.240</privateIpAddress>
+          <ipAddress>72.44.52.124</ipAddress>
+          <architecture>i386</architecture>
+          <rootDeviceType>ebs</rootDeviceType>
+          <rootDeviceName>/dev/sda1</rootDeviceName>
+          <blockDeviceMapping>
+              <item>
+                 <deviceName>/dev/sda1</deviceName>
+                 <ebs>
+                    <volumeId>vol-a482c1cd</volumeId>
+                    <status>attached</status>
+                    <attachTime>2010-08-17T01:15:26.000Z</attachTime>
+                    <deleteOnTermination>true</deleteOnTermination>
+                </ebs>
+             </item>
+          </blockDeviceMapping>
+          <virtualizationType>paravirtual</virtualizationType>
+          <clientToken/>
+          <tagSet>
+              <item>
+                    <key>webserver</key>
+                    <value></value>
+             </item>
+              <item>
+                    <key>stack</key>
+                    <value>Production</value>
+             </item>
+          </tagSet>
+          <hypervisor>xen</hypervisor>
+        </item>
+      </instancesSet>
+    </item>
+  </reservationSet>
+</DescribeInstancesResponse>
+`
+
+// http://goo.gl/V0U25
+var DescribeImagesExample = `
+<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2012-08-15/">
+         <requestId>4a4a27a2-2e7c-475d-b35b-ca822EXAMPLE</requestId>
+    <imagesSet>
+        <item>
+            <imageId>ami-a2469acf</imageId>
+            <imageLocation>aws-marketplace/example-marketplace-amzn-ami.1</imageLocation>
+            <imageState>available</imageState>
+            <imageOwnerId>123456789999</imageOwnerId>
+            <isPublic>true</isPublic>
+            <productCodes>
+                <item>
+                    <productCode>a1b2c3d4e5f6g7h8i9j10k11</productCode>
+                    <type>marketplace</type>
+                </item>
+            </productCodes>
+            <architecture>i386</architecture>
+            <imageType>machine</imageType>
+            <kernelId>aki-805ea7e9</kernelId>
+            <imageOwnerAlias>aws-marketplace</imageOwnerAlias>
+            <name>example-marketplace-amzn-ami.1</name>
+            <description>Amazon Linux AMI i386 EBS</description>
+            <rootDeviceType>ebs</rootDeviceType>
+            <rootDeviceName>/dev/sda1</rootDeviceName>
+            <blockDeviceMapping>
+                <item>
+                    <deviceName>/dev/sda1</deviceName>
+                    <ebs>
+                        <snapshotId>snap-787e9403</snapshotId>
+                        <volumeSize>8</volumeSize>
+                        <deleteOnTermination>true</deleteOnTermination>
+                    </ebs>
+                </item>
+            </blockDeviceMapping>
+            <virtualizationType>paravirtual</virtualizationType>
+            <hypervisor>xen</hypervisor>
+        </item>
+    </imagesSet>
+</DescribeImagesResponse>
+`
+
+// http://goo.gl/ttcda
+var CreateSnapshotExample = `
+<CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <snapshotId>snap-78a54011</snapshotId>
+  <volumeId>vol-4d826724</volumeId>
+  <status>pending</status>
+  <startTime>2008-05-07T12:51:50.000Z</startTime>
+  <progress>60%</progress>
+  <ownerId>111122223333</ownerId>
+  <volumeSize>10</volumeSize>
+  <description>Daily Backup</description>
+</CreateSnapshotResponse>
+`
+
+// http://goo.gl/vwU1y
+var DeleteSnapshotExample = `
+<DeleteSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <return>true</return>
+</DeleteSnapshotResponse>
+`
+
+// http://goo.gl/nkovs
+var DescribeSnapshotsExample = `
+<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <snapshotSet>
+      <item>
+         <snapshotId>snap-1a2b3c4d</snapshotId>
+         <volumeId>vol-8875daef</volumeId>
+         <status>pending</status>
+         <startTime>2010-07-29T04:12:01.000Z</startTime>
+         <progress>30%</progress>
+         <ownerId>111122223333</ownerId>
+         <volumeSize>15</volumeSize>
+         <description>Daily Backup</description>
+         <tagSet>
+            <item>
+               <key>Purpose</key>
+               <value>demo_db_14_backup</value>
+            </item>
+         </tagSet>
+      </item>
+   </snapshotSet>
+</DescribeSnapshotsResponse>
+`
+
+// http://goo.gl/Eo7Yl
+var CreateSecurityGroupExample = `
+<CreateSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+   <groupId>sg-67ad940e</groupId>
+</CreateSecurityGroupResponse>
+`
+
+// http://goo.gl/k12Uy
+var DescribeSecurityGroupsExample = `
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <securityGroupInfo>
+    <item>
+      <ownerId>999988887777</ownerId>
+      <groupName>WebServers</groupName>
+      <groupId>sg-67ad940e</groupId>
+      <groupDescription>Web Servers</groupDescription>
+      <ipPermissions>
+        <item>
+           <ipProtocol>tcp</ipProtocol>
+           <fromPort>80</fromPort>
+           <toPort>80</toPort>
+           <groups/>
+           <ipRanges>
+             <item>
+               <cidrIp>0.0.0.0/0</cidrIp>
+             </item>
+           </ipRanges>
+        </item>
+      </ipPermissions>
+    </item>
+    <item>
+      <ownerId>999988887777</ownerId>
+      <groupName>RangedPortsBySource</groupName>
+      <groupId>sg-76abc467</groupId>
+      <groupDescription>Group A</groupDescription>
+      <ipPermissions>
+        <item>
+           <ipProtocol>tcp</ipProtocol>
+           <fromPort>6000</fromPort>
+           <toPort>7000</toPort>
+           <groups/>
+           <ipRanges/>
+        </item>
+      </ipPermissions>
+    </item>
+  </securityGroupInfo>
+</DescribeSecurityGroupsResponse>
+`
+
+// A dump which includes groups within ip permissions.
+var DescribeSecurityGroupsDump = `
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+    <requestId>87b92b57-cc6e-48b2-943f-f6f0e5c9f46c</requestId>
+    <securityGroupInfo>
+        <item>
+            <ownerId>12345</ownerId>
+            <groupName>default</groupName>
+            <groupDescription>default group</groupDescription>
+            <ipPermissions>
+                <item>
+                    <ipProtocol>icmp</ipProtocol>
+                    <fromPort>-1</fromPort>
+                    <toPort>-1</toPort>
+                    <groups>
+                        <item>
+                            <userId>12345</userId>
+                            <groupName>default</groupName>
+                            <groupId>sg-67ad940e</groupId>
+                        </item>
+                    </groups>
+                    <ipRanges/>
+                </item>
+                <item>
+                    <ipProtocol>tcp</ipProtocol>
+                    <fromPort>0</fromPort>
+                    <toPort>65535</toPort>
+                    <groups>
+                        <item>
+                            <userId>12345</userId>
+                            <groupName>other</groupName>
+                            <groupId>sg-76abc467</groupId>
+                        </item>
+                    </groups>
+                    <ipRanges/>
+                </item>
+            </ipPermissions>
+        </item>
+    </securityGroupInfo>
+</DescribeSecurityGroupsResponse>
+`
+
+// http://goo.gl/QJJDO
+var DeleteSecurityGroupExample = `
+<DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+</DeleteSecurityGroupResponse>
+`
+
+// http://goo.gl/u2sDJ
+var AuthorizeSecurityGroupIngressExample = `
+<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <return>true</return>
+</AuthorizeSecurityGroupIngressResponse>
+`
+
+// http://goo.gl/Mz7xr
+var RevokeSecurityGroupIngressExample = `
+<RevokeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <return>true</return>
+</RevokeSecurityGroupIngressResponse>
+`
+
+// http://goo.gl/Vmkqc
+var CreateTagsExample = `
+<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+</CreateTagsResponse>
+`
+
+// http://goo.gl/awKeF
+var StartInstancesExample = `
+<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>   
+  <instancesSet>
+    <item>
+      <instanceId>i-10a64379</instanceId>
+      <currentState>
+          <code>0</code>
+          <name>pending</name>
+      </currentState>
+      <previousState>
+          <code>80</code>
+          <name>stopped</name>
+      </previousState>
+    </item>
+  </instancesSet>
+</StartInstancesResponse>
+`
+
+// http://goo.gl/436dJ
+var StopInstancesExample = `
+<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <instancesSet>
+    <item>
+      <instanceId>i-10a64379</instanceId>
+      <currentState>
+          <code>64</code>
+          <name>stopping</name>
+      </currentState>
+      <previousState>
+          <code>16</code>
+          <name>running</name>
+      </previousState>
+    </item>
+  </instancesSet>
+</StopInstancesResponse>
+`
+
+// http://goo.gl/baoUf
+var RebootInstancesExample = `
+<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <return>true</return>
+</RebootInstancesResponse>
+`
+
+// http://goo.gl/nkwjv
+var CreateVpcExample = `
+<CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <vpc>
+      <vpcId>vpc-1a2b3c4d</vpcId>
+      <state>pending</state>
+      <cidrBlock>10.0.0.0/16</cidrBlock>
+      <dhcpOptionsId>dopt-1a2b3c4d2</dhcpOptionsId>
+      <instanceTenancy>default</instanceTenancy>
+      <tagSet/>
+   </vpc>
+</CreateVpcResponse>
+`
+
+// http://goo.gl/bcxtbf
+var DeleteVpcExample = `
+<DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <return>true</return>
+</DeleteVpcResponse>
+`
+
+// http://goo.gl/Y5kHqG
+var DescribeVpcsExample = `
+<DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+  <vpcSet>
+    <item>
+      <vpcId>vpc-1a2b3c4d</vpcId>
+      <state>available</state>
+      <cidrBlock>10.0.0.0/23</cidrBlock>
+      <dhcpOptionsId>dopt-7a8b9c2d</dhcpOptionsId>
+      <instanceTenancy>default</instanceTenancy>
+      <isDefault>false</isDefault>
+      <tagSet/>
+    </item>
+  </vpcSet>
+</DescribeVpcsResponse>
+`
+
+// http://goo.gl/wLPhf
+var CreateSubnetExample = `
+<CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+  <subnet>
+    <subnetId>subnet-9d4a7b6c</subnetId>
+    <state>pending</state>
+    <vpcId>vpc-1a2b3c4d</vpcId>
+    <cidrBlock>10.0.1.0/24</cidrBlock>
+    <availableIpAddressCount>251</availableIpAddressCount>
+    <availabilityZone>us-east-1a</availabilityZone>
+    <tagSet/>
+  </subnet>
+</CreateSubnetResponse>
+`
+
+// http://goo.gl/KmhcBM
+var DeleteSubnetExample = `
+<DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <return>true</return>
+</DeleteSubnetResponse>
+`
+
+// http://goo.gl/NTKQVI
+var DescribeSubnetsExample = `
+<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+  <subnetSet>
+    <item>
+      <subnetId>subnet-9d4a7b6c</subnetId>
+      <state>available</state>
+      <vpcId>vpc-1a2b3c4d</vpcId>
+      <cidrBlock>10.0.1.0/24</cidrBlock>
+      <availableIpAddressCount>251</availableIpAddressCount>
+      <availabilityZone>us-east-1a</availabilityZone>
+      <defaultForAz>false</defaultForAz>
+      <mapPublicIpOnLaunch>false</mapPublicIpOnLaunch>
+      <tagSet/>
+    </item>
+    <item>
+      <subnetId>subnet-6e7f829e</subnetId>
+      <state>available</state>
+      <vpcId>vpc-1a2b3c4d</vpcId>
+      <cidrBlock>10.0.0.0/24</cidrBlock>
+      <availableIpAddressCount>251</availableIpAddressCount>
+      <availabilityZone>us-east-1a</availabilityZone>
+      <defaultForAz>false</defaultForAz>
+      <mapPublicIpOnLaunch>false</mapPublicIpOnLaunch>
+      <tagSet/>
+    </item>
+  </subnetSet>
+</DescribeSubnetsResponse>
+`
+
+// http://goo.gl/ze3VhA
+var CreateNetworkInterfaceExample = `
+<CreateNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+ <requestId>8dbe591e-5a22-48cb-b948-dd0aadd55adf</requestId>
+    <networkInterface>
+        <networkInterfaceId>eni-cfca76a6</networkInterfaceId>
+        <subnetId>subnet-b2a249da</subnetId>
+        <vpcId>vpc-c31dafaa</vpcId>
+        <availabilityZone>ap-southeast-1b</availabilityZone>
+        <description/>
+        <ownerId>251839141158</ownerId>
+        <requesterManaged>false</requesterManaged>
+        <status>available</status>
+        <macAddress>02:74:b0:72:79:61</macAddress>
+        <privateIpAddress>10.0.2.157</privateIpAddress>
+        <sourceDestCheck>true</sourceDestCheck>
+        <groupSet>
+            <item>
+                <groupId>sg-1a2b3c4d</groupId>
+                <groupName>default</groupName>
+            </item>
+        </groupSet>
+        <tagSet/>
+        <privateIpAddressesSet>
+            <item>
+                <privateIpAddress>10.0.2.157</privateIpAddress>
+                <primary>true</primary>
+            </item>
+        </privateIpAddressesSet>
+    </networkInterface>
+</CreateNetworkInterfaceResponse>
+`
+
+// http://goo.gl/MC1yOj
+var DeleteNetworkInterfaceExample = `
+<DeleteNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+    <requestId>e1c6d73b-edaa-4e62-9909-6611404e1739</requestId>
+    <return>true</return>
+</DeleteNetworkInterfaceResponse>
+`
+
+// http://goo.gl/2LcXtM
+var DescribeNetworkInterfacesExample = `
+<DescribeNetworkInterfacesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+    <requestId>fc45294c-006b-457b-bab9-012f5b3b0e40</requestId>
+     <networkInterfaceSet>
+       <item>
+         <networkInterfaceId>eni-0f62d866</networkInterfaceId>
+         <subnetId>subnet-c53c87ac</subnetId>
+         <vpcId>vpc-cc3c87a5</vpcId>
+         <availabilityZone>ap-southeast-1b</availabilityZone>
+         <description/>
+         <ownerId>053230519467</ownerId>
+         <requesterManaged>false</requesterManaged>
+         <status>in-use</status>
+         <macAddress>02:81:60:cb:27:37</macAddress>
+         <privateIpAddress>10.0.0.146</privateIpAddress>
+         <sourceDestCheck>true</sourceDestCheck>
+         <groupSet>
+           <item>
+             <groupId>sg-3f4b5653</groupId>
+             <groupName>default</groupName>
+           </item>
+         </groupSet>
+         <attachment>
+           <attachmentId>eni-attach-6537fc0c</attachmentId>
+           <instanceId>i-22197876</instanceId>
+           <instanceOwnerId>053230519467</instanceOwnerId>
+           <deviceIndex>0</deviceIndex>
+           <status>attached</status>
+           <attachTime>2012-07-01T21:45:27.000Z</attachTime>
+           <deleteOnTermination>true</deleteOnTermination>
+         </attachment>
+         <tagSet/>
+         <privateIpAddressesSet>
+           <item>
+             <privateIpAddress>10.0.0.146</privateIpAddress>
+             <primary>true</primary>
+           </item>
+           <item>
+             <privateIpAddress>10.0.0.148</privateIpAddress>
+             <primary>false</primary>
+           </item>
+           <item>
+             <privateIpAddress>10.0.0.150</privateIpAddress>
+             <primary>false</primary>
+           </item>
+         </privateIpAddressesSet>
+       </item>
+       <item>
+         <networkInterfaceId>eni-a66ed5cf</networkInterfaceId>
+         <subnetId>subnet-cd8a35a4</subnetId>
+         <vpcId>vpc-f28a359b</vpcId>
+         <availabilityZone>ap-southeast-1b</availabilityZone>
+         <description>Primary network interface</description>
+         <ownerId>053230519467</ownerId>
+         <requesterManaged>false</requesterManaged>
+         <status>in-use</status>
+         <macAddress>02:78:d7:00:8a:1e</macAddress>
+         <privateIpAddress>10.0.1.233</privateIpAddress>
+         <sourceDestCheck>true</sourceDestCheck>
+         <groupSet>
+           <item>
+             <groupId>sg-a2a0b2ce</groupId>
+             <groupName>quick-start-1</groupName>
+           </item>
+         </groupSet>
+         <attachment>
+           <attachmentId>eni-attach-a99c57c0</attachmentId>
+           <instanceId>i-886401dc</instanceId>
+           <instanceOwnerId>053230519467</instanceOwnerId>
+           <deviceIndex>0</deviceIndex>
+           <status>attached</status>
+           <attachTime>2012-06-27T20:08:44.000Z</attachTime>
+           <deleteOnTermination>true</deleteOnTermination>
+         </attachment>
+         <tagSet/>
+         <privateIpAddressesSet>
+           <item>
+             <privateIpAddress>10.0.1.233</privateIpAddress>
+             <primary>true</primary>
+           </item>
+           <item>
+             <privateIpAddress>10.0.1.20</privateIpAddress>
+             <primary>false</primary>
+           </item>
+         </privateIpAddressesSet>
+       </item>
+     </networkInterfaceSet>
+</DescribeNetworkInterfacesResponse>
+`
+
+// http://goo.gl/rEbSii
+var AttachNetworkInterfaceExample = `
+<AttachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+    <requestId>ace8cd1e-e685-4e44-90fb-92014d907212</requestId>
+    <attachmentId>eni-attach-d94b09b0</attachmentId>
+</AttachNetworkInterfaceResponse>
+`
+
+// http://goo.gl/0Xc1px
+var DetachNetworkInterfaceExample = `
+<DetachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+    <requestId>ce540707-0635-46bc-97da-33a8a362a0e8</requestId>
+    <return>true</return>
+</DetachNetworkInterfaceResponse>
+`
+
+// http://goo.gl/MoeH0L
+var AssignPrivateIpAddressesExample = `
+<AssignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+</AssignPrivateIpAddresses>
+`
+
+// http://goo.gl/RjGZdB
+var UnassignPrivateIpAddressesExample = `
+<UnassignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+</UnassignPrivateIpAddresses>
+`

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/sign.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/sign.go
@@ -1,0 +1,42 @@
+package ec2
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"sort"
+	"strings"
+)
+
+// ----------------------------------------------------------------------------
+// EC2 signing (http://goo.gl/fQmAN)
+
+var b64 = base64.StdEncoding
+
+func sign(auth aws.Auth, method, path string, params map[string]string, host string) {
+	params["AWSAccessKeyId"] = auth.AccessKey
+	params["SignatureVersion"] = "2"
+	params["SignatureMethod"] = "HmacSHA256"
+
+	// AWS specifies that the parameters in a signed request must
+	// be provided in the natural order of the keys. This is distinct
+	// from the natural order of the encoded value of key=value.
+	// Percent and equals affect the sorting order.
+	var keys, sarray []string
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		sarray = append(sarray, aws.Encode(k)+"="+aws.Encode(params[k]))
+	}
+	joined := strings.Join(sarray, "&")
+	payload := method + "\n" + host + "\n" + path + "\n" + joined
+	hash := hmac.New(sha256.New, []byte(auth.SecretKey))
+	hash.Write([]byte(payload))
+	signature := make([]byte, b64.EncodedLen(hash.Size()))
+	b64.Encode(signature, hash.Sum(nil))
+
+	params["Signature"] = string(signature)
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/sign_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/sign_test.go
@@ -1,0 +1,68 @@
+package ec2_test
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	. "launchpad.net/gocheck"
+)
+
+// EC2 ReST authentication docs: http://goo.gl/fQmAN
+
+var testAuth = aws.Auth{"user", "secret"}
+
+func (s *S) TestBasicSignature(c *C) {
+	params := map[string]string{}
+	ec2.Sign(testAuth, "GET", "/path", params, "localhost")
+	c.Assert(params["SignatureVersion"], Equals, "2")
+	c.Assert(params["SignatureMethod"], Equals, "HmacSHA256")
+	expected := "6lSe5QyXum0jMVc7cOUz32/52ZnL7N5RyKRk/09yiK4="
+	c.Assert(params["Signature"], Equals, expected)
+}
+
+func (s *S) TestParamSignature(c *C) {
+	params := map[string]string{
+		"param1": "value1",
+		"param2": "value2",
+		"param3": "value3",
+	}
+	ec2.Sign(testAuth, "GET", "/path", params, "localhost")
+	expected := "XWOR4+0lmK8bD8CGDGZ4kfuSPbb2JibLJiCl/OPu1oU="
+	c.Assert(params["Signature"], Equals, expected)
+}
+
+func (s *S) TestManyParams(c *C) {
+	params := map[string]string{
+		"param1":  "value10",
+		"param2":  "value2",
+		"param3":  "value3",
+		"param4":  "value4",
+		"param5":  "value5",
+		"param6":  "value6",
+		"param7":  "value7",
+		"param8":  "value8",
+		"param9":  "value9",
+		"param10": "value1",
+	}
+	ec2.Sign(testAuth, "GET", "/path", params, "localhost")
+	expected := "di0sjxIvezUgQ1SIL6i+C/H8lL+U0CQ9frLIak8jkVg="
+	c.Assert(params["Signature"], Equals, expected)
+}
+
+func (s *S) TestEscaping(c *C) {
+	params := map[string]string{"Nonce": "+ +"}
+	ec2.Sign(testAuth, "GET", "/path", params, "localhost")
+	c.Assert(params["Nonce"], Equals, "+ +")
+	expected := "bqffDELReIqwjg/W0DnsnVUmfLK4wXVLO4/LuG+1VFA="
+	c.Assert(params["Signature"], Equals, expected)
+}
+
+func (s *S) TestSignatureExample1(c *C) {
+	params := map[string]string{
+		"Timestamp": "2009-02-01T12:53:20+00:00",
+		"Version":   "2007-11-07",
+		"Action":    "ListDomains",
+	}
+	ec2.Sign(aws.Auth{"access", "secret"}, "GET", "/", params, "sdb.amazonaws.com")
+	expected := "okj96/5ucWBSc1uR2zXVfm6mDHtgfNv657rRtt/aunQ="
+	c.Assert(params["Signature"], Equals, expected)
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/subnets.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/subnets.go
@@ -1,0 +1,109 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2
+
+import (
+	"strconv"
+)
+
+// Subnet describes an Amazon VPC subnet.
+//
+// See http://goo.gl/CdkvO2 for more details.
+type Subnet struct {
+	Id                  string `xml:"subnetId"`
+	State               string `xml:"state"`
+	VPCId               string `xml:"vpcId"`
+	CIDRBlock           string `xml:"cidrBlock"`
+	AvailableIPCount    int    `xml:"availableIpAddressCount"`
+	AvailZone           string `xml:"availabilityZone"`
+	DefaultForAZ        bool   `xml:"defaultForAz"`
+	MapPublicIPOnLaunch bool   `xml:"mapPublicIpOnLaunch"`
+	Tags                []Tag  `xml:"tagSet>item"`
+}
+
+// CreateSubnetResp is the response to a CreateSubnet request.
+//
+// See http://goo.gl/wLPhfI for more details.
+type CreateSubnetResp struct {
+	RequestId string `xml:"requestId"`
+	Subnet    Subnet `xml:"subnet"`
+}
+
+// CreateSubnet creates a subnet in an existing VPC.
+//
+// The vpcId and cidrBlock parameters specify the VPC id and CIDR
+// block respectively - these cannot be changed after creation. The
+// subnet's CIDR block can be the same as the VPC's CIDR block
+// (assuming a single subnet is wanted), or a subset of the VPC's CIDR
+// block. If more than one subnet is created in a VPC, their CIDR
+// blocks must not overlap. The smallest subnet (and VPC) that can be
+// created uses a /28 netmask (16 IP addresses), and the largest uses
+// a /16 netmask (65,536 IP addresses).
+//
+// availZone may be empty, an availability zone is automatically
+// selected.
+//
+// See http://goo.gl/wLPhfI for more details.
+func (ec2 *EC2) CreateSubnet(vpcId, cidrBlock, availZone string) (resp *CreateSubnetResp, err error) {
+	params := makeParamsVPC("CreateSubnet")
+	params["VpcId"] = vpcId
+	params["CidrBlock"] = cidrBlock
+	if availZone != "" {
+		params["AvailabilityZone"] = availZone
+	}
+	resp = &CreateSubnetResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteSubnet deletes the specified subnet. All running instances in
+// the subnet must have been terminated.
+//
+// See http://goo.gl/KmhcBM for more details.
+func (ec2 *EC2) DeleteSubnet(id string) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("DeleteSubnet")
+	params["SubnetId"] = id
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// SubnetsResp is the response to a Subnets request.
+//
+// See http://goo.gl/NTKQVI for more details.
+type SubnetsResp struct {
+	RequestId string   `xml:"requestId"`
+	Subnets   []Subnet `xml:"subnetSet>item"`
+}
+
+// Subnets returns one or more subnets. Both parameters are optional,
+// and if specified will limit the returned subnets to the matching
+// ids or filtering rules.
+//
+// See http://goo.gl/NTKQVI for more details.
+func (ec2 *EC2) Subnets(ids []string, filter *Filter) (resp *SubnetsResp, err error) {
+	params := makeParamsVPC("DescribeSubnets")
+	for i, id := range ids {
+		params["SubnetId."+strconv.Itoa(i+1)] = id
+	}
+	filter.addParams(params)
+
+	resp = &SubnetsResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/subnets_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/subnets_test.go
@@ -1,0 +1,247 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2_test
+
+import (
+	"launchpad.net/goamz/aws"
+	"launchpad.net/goamz/ec2"
+	. "launchpad.net/gocheck"
+	"time"
+)
+
+// Subnet tests with example responses
+
+func (s *S) TestCreateSubnetExample(c *C) {
+	testServer.Response(200, nil, CreateSubnetExample)
+
+	resp, err := s.ec2.CreateSubnet("vpc-1a2b3c4d", "10.0.1.0/24", "us-east-1a")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateSubnet"})
+	c.Assert(req.Form["VpcId"], DeepEquals, []string{"vpc-1a2b3c4d"})
+	c.Assert(req.Form["CidrBlock"], DeepEquals, []string{"10.0.1.0/24"})
+	c.Assert(req.Form["AvailabilityZone"], DeepEquals, []string{"us-east-1a"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	subnet := resp.Subnet
+	c.Check(subnet.Id, Equals, "subnet-9d4a7b6c")
+	c.Check(subnet.State, Equals, "pending")
+	c.Check(subnet.VPCId, Equals, "vpc-1a2b3c4d")
+	c.Check(subnet.CIDRBlock, Equals, "10.0.1.0/24")
+	c.Check(subnet.AvailableIPCount, Equals, 251)
+	c.Check(subnet.AvailZone, Equals, "us-east-1a")
+	c.Check(subnet.Tags, HasLen, 0)
+}
+
+func (s *S) TestDeleteSubnetExample(c *C) {
+	testServer.Response(200, nil, DeleteSubnetExample)
+
+	resp, err := s.ec2.DeleteSubnet("subnet-id")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteSubnet"})
+	c.Assert(req.Form["SubnetId"], DeepEquals, []string{"subnet-id"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+}
+
+func (s *S) TestSubnetsExample(c *C) {
+	testServer.Response(200, nil, DescribeSubnetsExample)
+
+	ids := []string{"subnet-9d4a7b6c", "subnet-6e7f829e"}
+	resp, err := s.ec2.Subnets(ids, nil)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSubnets"})
+	c.Assert(req.Form["SubnetId.1"], DeepEquals, []string{ids[0]})
+	c.Assert(req.Form["SubnetId.2"], DeepEquals, []string{ids[1]})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	c.Check(resp.Subnets, HasLen, 2)
+	subnet := resp.Subnets[0]
+	c.Check(subnet.Id, Equals, "subnet-9d4a7b6c")
+	c.Check(subnet.State, Equals, "available")
+	c.Check(subnet.VPCId, Equals, "vpc-1a2b3c4d")
+	c.Check(subnet.CIDRBlock, Equals, "10.0.1.0/24")
+	c.Check(subnet.AvailableIPCount, Equals, 251)
+	c.Check(subnet.AvailZone, Equals, "us-east-1a")
+	c.Check(subnet.DefaultForAZ, Equals, false)
+	c.Check(subnet.MapPublicIPOnLaunch, Equals, false)
+	c.Check(subnet.Tags, HasLen, 0)
+	subnet = resp.Subnets[1]
+	c.Check(subnet.Id, Equals, "subnet-6e7f829e")
+	c.Check(subnet.State, Equals, "available")
+	c.Check(subnet.VPCId, Equals, "vpc-1a2b3c4d")
+	c.Check(subnet.CIDRBlock, Equals, "10.0.0.0/24")
+	c.Check(subnet.AvailableIPCount, Equals, 251)
+	c.Check(subnet.AvailZone, Equals, "us-east-1a")
+	c.Check(subnet.DefaultForAZ, Equals, false)
+	c.Check(subnet.MapPublicIPOnLaunch, Equals, false)
+	c.Check(subnet.Tags, HasLen, 0)
+}
+
+// Subnet tests run against either a local test server or live on EC2.
+
+func (s *ServerTests) TestSubnets(c *C) {
+	resp, err := s.ec2.CreateVPC("10.2.0.0/16", "")
+	c.Assert(err, IsNil)
+	vpcId := resp.VPC.Id
+	defer s.deleteVPCs(c, []string{vpcId})
+
+	resp1 := s.createSubnet(c, vpcId, "10.2.1.0/24", "")
+	assertSubnet(c, resp1.Subnet, "", vpcId, "10.2.1.0/24")
+	id1 := resp1.Subnet.Id
+
+	resp2, err := s.ec2.CreateSubnet(vpcId, "10.2.2.0/24", "")
+	c.Assert(err, IsNil)
+	assertSubnet(c, resp2.Subnet, "", vpcId, "10.2.2.0/24")
+	id2 := resp2.Subnet.Id
+
+	// We only check for the subnets we just created, because the user
+	// might have others in his account (when testing against the EC2
+	// servers). In some cases it takes a short while until both
+	// subnets are created, so we need to retry a few times to make
+	// sure.
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	var list *ec2.SubnetsResp
+	done := false
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for %v to be created", []string{id1, id2})
+		list, err = s.ec2.Subnets(nil, nil)
+		if err != nil {
+			c.Logf("retrying; Subnets returned: %v", err)
+			continue
+		}
+		found := 0
+		for _, subnet := range list.Subnets {
+			c.Logf("found subnet %v", subnet)
+			switch subnet.Id {
+			case id1:
+				assertSubnet(c, subnet, id1, vpcId, resp1.Subnet.CIDRBlock)
+				found++
+			case id2:
+				assertSubnet(c, subnet, id2, vpcId, resp2.Subnet.CIDRBlock)
+				found++
+			}
+			if found == 2 {
+				done = true
+				break
+			}
+		}
+		if done {
+			c.Logf("all subnets were created")
+			break
+		}
+	}
+	if !done {
+		c.Fatalf("timeout while waiting for subnets %v", []string{id1, id2})
+	}
+
+	list, err = s.ec2.Subnets([]string{id1}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(list.Subnets, HasLen, 1)
+	assertSubnet(c, list.Subnets[0], id1, vpcId, resp1.Subnet.CIDRBlock)
+
+	f := ec2.NewFilter()
+	f.Add("cidr", resp2.Subnet.CIDRBlock)
+	list, err = s.ec2.Subnets(nil, f)
+	c.Assert(err, IsNil)
+	c.Assert(list.Subnets, HasLen, 1)
+	assertSubnet(c, list.Subnets[0], id2, vpcId, resp2.Subnet.CIDRBlock)
+
+	_, err = s.ec2.DeleteSubnet(id1)
+	c.Assert(err, IsNil)
+	_, err = s.ec2.DeleteSubnet(id2)
+	c.Assert(err, IsNil)
+}
+
+// createSubnet ensures a subnet with the given vpcId and cidrBlock
+// gets created, retrying a few times with a timeout. This needs to be
+// done when testing against EC2 servers, because if the VPC was just
+// created it might take some time for it to show up, so the subnet
+// can be created.
+func (s *ServerTests) createSubnet(c *C, vpcId, cidrBlock, availZone string) *ec2.CreateSubnetResp {
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		resp, err := s.ec2.CreateSubnet(vpcId, cidrBlock, availZone)
+		if errorCode(err) == "InvalidVpcID.NotFound" {
+			c.Logf("VPC %v not created yet; retrying", vpcId)
+			continue
+		}
+		if err != nil {
+			c.Logf("retrying; CreateSubnet returned: %v", err)
+			continue
+		}
+		return resp
+	}
+	c.Fatalf("timeout while waiting for VPC and subnet")
+	return nil
+}
+
+// deleteSubnets ensures the given subnets are deleted, by retrying
+// until a timeout or all subnets cannot be found anymore.  This
+// should be used to make sure tests leave no subnets around.
+func (s *ServerTests) deleteSubnets(c *C, ids []string) {
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		deleted := 0
+		c.Logf("deleting subnets %v", ids)
+		for _, id := range ids {
+			_, err := s.ec2.DeleteSubnet(id)
+			if err == nil || errorCode(err) == "InvalidSubnetID.NotFound" {
+				c.Logf("subnet %s deleted", id)
+				deleted++
+				continue
+			}
+			if err != nil {
+				c.Logf("retrying; DeleteSubnet returned: %v", err)
+			}
+		}
+		if deleted == len(ids) {
+			c.Logf("all subnets deleted")
+			return
+		}
+	}
+	c.Fatalf("timeout while waiting %v subnets to get deleted!", ids)
+}
+
+func assertSubnet(c *C, obtained ec2.Subnet, expectId, expectVpcId, expectCidr string) {
+	if expectId != "" {
+		c.Check(obtained.Id, Equals, expectId)
+	} else {
+		c.Check(obtained.Id, Matches, `^subnet-[0-9a-f]+$`)
+	}
+	c.Check(obtained.State, Matches, "(available|pending)")
+	if expectVpcId != "" {
+		c.Check(obtained.VPCId, Equals, expectVpcId)
+	} else {
+		c.Check(obtained.VPCId, Matches, `^vpc-[0-9a-f]+$`)
+	}
+	if expectCidr != "" {
+		c.Check(obtained.CIDRBlock, Equals, expectCidr)
+	} else {
+		c.Check(obtained.CIDRBlock, Matches, `^\d+\.\d+\.\d+\.\d+/\d+$`)
+	}
+	c.Check(obtained.AvailZone, Not(Equals), "")
+	c.Check(obtained.AvailableIPCount, Not(Equals), 0)
+	c.Check(obtained.DefaultForAZ, Equals, false)
+	c.Check(obtained.MapPublicIPOnLaunch, Equals, false)
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/vpc.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/vpc.go
@@ -1,0 +1,105 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2
+
+import (
+	"strconv"
+)
+
+// VPC describes a Virtual Private Cloud (VPC).
+//
+// See http://goo.gl/Uy6ZLL for more details.
+type VPC struct {
+	Id              string `xml:"vpcId"`
+	State           string `xml:"state"`
+	CIDRBlock       string `xml:"cidrBlock"`
+	DHCPOptionsId   string `xml:"dhcpOptionsId"`
+	Tags            []Tag  `xml:"tagSet>item"`
+	InstanceTenancy string `xml:"instanceTenancy"`
+	IsDefault       bool   `xml:"isDefault"`
+}
+
+// CreateVPCResp is the response to a CreateVPC request.
+//
+// See http://goo.gl/nkwjvN for more details.
+type CreateVPCResp struct {
+	RequestId string `xml:"requestId"`
+	VPC       VPC    `xml:"vpc"`
+}
+
+// CreateVPC creates a VPC with the specified CIDR block.
+//
+// The smallest VPC that can be created uses a /28 netmask (16 IP
+// addresses), and the largest uses a /16 netmask (65,536 IP
+// addresses).
+//
+// The instanceTenancy value holds the tenancy options for instances
+// launched into the VPC - either "default" or "dedicated".
+//
+// See http://goo.gl/nkwjvN for more details.
+func (ec2 *EC2) CreateVPC(CIDRBlock, instanceTenancy string) (resp *CreateVPCResp, err error) {
+	params := makeParamsVPC("CreateVpc")
+	params["CidrBlock"] = CIDRBlock
+	if instanceTenancy == "" {
+		instanceTenancy = "default"
+	}
+	params["InstanceTenancy"] = instanceTenancy
+	resp = &CreateVPCResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteVPC deletes the VPC with the specified id. All gateways and
+// resources that are associated with the VPC must have been
+// previously deleted, including instances running in the VPC, and
+// non-default security groups and route tables associated with the
+// VPC.
+//
+// See http://goo.gl/bcxtbf for more details.
+func (ec2 *EC2) DeleteVPC(id string) (resp *SimpleResp, err error) {
+	params := makeParamsVPC("DeleteVpc")
+	params["VpcId"] = id
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// VPCsResp is the response to a VPCs request.
+//
+// See http://goo.gl/Y5kHqG for more details.
+type VPCsResp struct {
+	RequestId string `xml:"requestId"`
+	VPCs      []VPC  `xml:"vpcSet>item"`
+}
+
+// VPCs describes one or more VPCs. Both parameters are optional, and
+// if specified will limit the returned VPCs to the matching ids or
+// filtering rules.
+//
+// See http://goo.gl/Y5kHqG for more details.
+func (ec2 *EC2) VPCs(ids []string, filter *Filter) (resp *VPCsResp, err error) {
+	params := makeParamsVPC("DescribeVpcs")
+	for i, id := range ids {
+		params["VpcId."+strconv.Itoa(i+1)] = id
+	}
+	filter.addParams(params)
+
+	resp = &VPCsResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/vpc_test.go
+++ b/Godeps/_workspace/src/github.com/cupcake/goamz/ec2/vpc_test.go
@@ -1,0 +1,196 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2014 Canonical Ltd.
+//
+
+package ec2_test
+
+import (
+	"launchpad.net/goamz/aws"
+	"launchpad.net/goamz/ec2"
+	. "launchpad.net/gocheck"
+	"time"
+)
+
+// VPC tests with example responses
+
+func (s *S) TestCreateVPCExample(c *C) {
+	testServer.Response(200, nil, CreateVpcExample)
+
+	resp, err := s.ec2.CreateVPC("10.0.0.0/16", "default")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateVpc"})
+	c.Assert(req.Form["CidrBlock"], DeepEquals, []string{"10.0.0.0/16"})
+	c.Assert(req.Form["InstanceTenancy"], DeepEquals, []string{"default"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	vpc := resp.VPC
+	c.Check(vpc.Id, Equals, "vpc-1a2b3c4d")
+	c.Check(vpc.State, Equals, "pending")
+	c.Check(vpc.CIDRBlock, Equals, "10.0.0.0/16")
+	c.Check(vpc.DHCPOptionsId, Equals, "dopt-1a2b3c4d2")
+	c.Check(vpc.Tags, HasLen, 0)
+	c.Check(vpc.IsDefault, Equals, false)
+	c.Check(vpc.InstanceTenancy, Equals, "default")
+}
+
+func (s *S) TestDeleteVPCExample(c *C) {
+	testServer.Response(200, nil, DeleteVpcExample)
+
+	resp, err := s.ec2.DeleteVPC("vpc-id")
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DeleteVpc"})
+	c.Assert(req.Form["VpcId"], DeepEquals, []string{"vpc-id"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+}
+
+func (s *S) TestVPCsExample(c *C) {
+	testServer.Response(200, nil, DescribeVpcsExample)
+
+	resp, err := s.ec2.VPCs([]string{"vpc-1a2b3c4d"}, nil)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeVpcs"})
+	c.Assert(req.Form["VpcId.1"], DeepEquals, []string{"vpc-1a2b3c4d"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	c.Assert(resp.VPCs, HasLen, 1)
+	vpc := resp.VPCs[0]
+	c.Check(vpc.Id, Equals, "vpc-1a2b3c4d")
+	c.Check(vpc.State, Equals, "available")
+	c.Check(vpc.CIDRBlock, Equals, "10.0.0.0/23")
+	c.Check(vpc.DHCPOptionsId, Equals, "dopt-7a8b9c2d")
+	c.Check(vpc.Tags, HasLen, 0)
+	c.Check(vpc.IsDefault, Equals, false)
+	c.Check(vpc.InstanceTenancy, Equals, "default")
+}
+
+// VPC tests to run against either a local test server or live on EC2.
+
+func (s *ServerTests) TestVPCs(c *C) {
+	resp1, err := s.ec2.CreateVPC("10.0.0.0/16", "")
+	c.Assert(err, IsNil)
+	assertVPC(c, resp1.VPC, "", "10.0.0.0/16")
+	id1 := resp1.VPC.Id
+
+	resp2, err := s.ec2.CreateVPC("10.1.0.0/16", "default")
+	c.Assert(err, IsNil)
+	assertVPC(c, resp2.VPC, "", "10.1.0.0/16")
+	id2 := resp2.VPC.Id
+
+	// We only check for the VPCs we just created, because the user
+	// might have others in his account (when testing against the EC2
+	// servers). In some cases it takes a short while until both VPCs
+	// are created, so we need to retry a few times to make sure.
+	var list *ec2.VPCsResp
+	done := false
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		c.Logf("waiting for %v to be created", []string{id1, id2})
+		list, err = s.ec2.VPCs(nil, nil)
+		if err != nil {
+			c.Logf("retrying; VPCs returned: %v", err)
+			continue
+		}
+		found := 0
+		for _, vpc := range list.VPCs {
+			c.Logf("found VPC %v", vpc)
+			switch vpc.Id {
+			case id1:
+				assertVPC(c, vpc, id1, resp1.VPC.CIDRBlock)
+				found++
+			case id2:
+				assertVPC(c, vpc, id2, resp2.VPC.CIDRBlock)
+				found++
+			}
+			if found == 2 {
+				done = true
+				break
+			}
+		}
+		if done {
+			c.Logf("all VPCs were created")
+			break
+		}
+	}
+	if !done {
+		c.Fatalf("timeout while waiting for VPCs %v", []string{id1, id2})
+	}
+
+	list, err = s.ec2.VPCs([]string{id1}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(list.VPCs, HasLen, 1)
+	assertVPC(c, list.VPCs[0], id1, resp1.VPC.CIDRBlock)
+
+	f := ec2.NewFilter()
+	f.Add("cidr", resp2.VPC.CIDRBlock)
+	list, err = s.ec2.VPCs(nil, f)
+	c.Assert(err, IsNil)
+	c.Assert(list.VPCs, HasLen, 1)
+	assertVPC(c, list.VPCs[0], id2, resp2.VPC.CIDRBlock)
+
+	_, err = s.ec2.DeleteVPC(id1)
+	c.Assert(err, IsNil)
+	_, err = s.ec2.DeleteVPC(id2)
+	c.Assert(err, IsNil)
+}
+
+// deleteVPCs ensures the given VPCs are deleted, by retrying until a
+// timeout or all VPC cannot be found anymore.  This should be used to
+// make sure tests leave no VPCs around.
+func (s *ServerTests) deleteVPCs(c *C, ids []string) {
+	testAttempt := aws.AttemptStrategy{
+		Total: 2 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	for a := testAttempt.Start(); a.Next(); {
+		deleted := 0
+		c.Logf("deleting VPCs %v", ids)
+		for _, id := range ids {
+			_, err := s.ec2.DeleteVPC(id)
+			if err == nil || errorCode(err) == "InvalidVpcID.NotFound" {
+				c.Logf("VPC %s deleted", id)
+				deleted++
+				continue
+			}
+			if err != nil {
+				c.Logf("retrying; DeleteVPC returned: %v", err)
+			}
+		}
+		if deleted == len(ids) {
+			c.Logf("all VPCs deleted")
+			return
+		}
+	}
+	c.Fatalf("timeout while waiting %v VPCs to get deleted!", ids)
+}
+
+func assertVPC(c *C, obtained ec2.VPC, expectId, expectCidr string) {
+	if expectId != "" {
+		c.Check(obtained.Id, Equals, expectId)
+	} else {
+		c.Check(obtained.Id, Matches, `^vpc-[0-9a-f]+$`)
+	}
+	c.Check(obtained.State, Matches, "(available|pending)")
+	if expectCidr != "" {
+		c.Check(obtained.CIDRBlock, Equals, expectCidr)
+	} else {
+		c.Check(obtained.CIDRBlock, Matches, `^\d+\.\d+\.\d+\.\d+/\d+$`)
+	}
+	c.Check(obtained.DHCPOptionsId, Matches, `^dopt-[0-9a-f]+$`)
+	c.Check(obtained.IsDefault, Equals, false)
+	c.Check(obtained.Tags, HasLen, 0)
+	c.Check(obtained.InstanceTenancy, Matches, "(default|dedicated)")
+}

--- a/script/release-vm-images
+++ b/script/release-vm-images
@@ -25,6 +25,7 @@ source "${ROOT}/script/lib/aws.sh"
 UBUNTU_BOX_NAME="ubuntu-trusty-20141016" # used in filenames for caching, bump at the same time as UBUNTU_BOX_URL
 UBUNTU_BOX_URL="http://cloud-images.ubuntu.com/vagrant/trusty/20141016/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 UBUNTU_BOX_SHA="c6623a4850c4d61bc6b96c3b2d2150eb60ca1e4a38f2cb2a8087370139b08d30"
+UBUNTU_USEAST_AMI="ami-9eaa1cf6" # us-east-1 | trusty | 14.04 LTS | amd64 | hvm:ebs-ssd | 20140927 | ami-9eaa1cf6 | hvm
 
 usage() {
   cat <<USAGE >&2
@@ -35,11 +36,17 @@ OPTIONS:
   -b BUCKET     The S3 bucket to upload vagrant images to [default: flynn]
   -d DOMAIN     The CloudFront domain [default: dl.flynn.io]
   -r DIR        Resume the release using DIR
+
+Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set
 USAGE
 }
 
 main() {
   local bucket dir domain
+
+  if [[ -z "${AWS_ACCESS_KEY_ID}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+    fail "Both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set"
+  fi
 
   while getopts "hb:d:r:" opt; do
     case $opt in
@@ -80,8 +87,9 @@ main() {
 
   info "using base dir: ${dir}"
 
+  local amis="$(cat "${dir}/amis.txt" 2>/dev/null)"
   local box=$(ls "${dir}"/*_virtualbox.box 2>/dev/null)
-  if [[ -z "${box}" ]]; then
+  if [[ -z "${box}" ]] || [[ -z "${amis}" ]]; then
     local ubuntu_box="/tmp/${UBUNTU_BOX_NAME}.box"
     if [[ ! -f "${ubuntu_box}" ]]; then
       info "fetching base Ubuntu box"
@@ -100,19 +108,39 @@ main() {
       tar --delete Vagrantfile < "${ubuntu_box}" > "${ova_path}"
     fi
 
-    info "building virtualbox image"
+    info "building VirtualBox and EC2 images"
     pushd "${ROOT}/util/packer/ubuntu-14.04" >/dev/null
-    packer build \
-      -only="virtualbox-ovf" \
+    local output=$(packer build \
+      -machine-readable \
+      -only="amazon-ebs,virtualbox-ovf" \
       -var "flynn_deb_url=${deb_url}" \
       -var "headless=true" \
       -var "output_dir=${dir}" \
       -var "ova_path=${ova_path}" \
+      -var "source_ami=${UBUNTU_USEAST_AMI}" \
       -var "version=${version}" \
-      vagrant.json
+      template.json | parse_packer)
     popd >/dev/null
 
-    box=$(ls "${dir}"/*_virtualbox.box 2>/dev/null)
+    info "parsing build output"
+    while read line; do
+      IFS="|" read builder artifacts <<< "${line}"
+
+      case "${builder}" in
+        virtualbox-ovf)
+          box="${artifacts}"
+          ;;
+        amazon-ebs)
+          amis="${artifacts}"
+          ;;
+      esac
+    done <<< "${output}"
+
+    if [[ -z "${box}" ]] || [[ -z "${amis}" ]]; then
+      fail "failed to parse build output"
+    fi
+
+    echo -n "${amis}" > "${dir}/amis.txt"
   fi
 
   local box_name="$(basename "${box}")"
@@ -135,17 +163,31 @@ main() {
   fi
 
   info "updating vagrant manifest"
-  mkdir -p "${dir}/manifest"
+  mkdir -p "${dir}/manifests/vagrant"
   "${ROOT}/util/release/flynn-release" vagrant \
     "https://${domain}/vagrant/boxes/${box_name}" \
     "${checksum}" \
     "${version}" \
     "virtualbox" \
     <<< "${manifest}" \
-    > "${dir}/manifest/flynn-base.json"
+    > "${dir}/manifests/vagrant/flynn-base.json"
 
-  info "releasing vagrant manifest"
-  sync_cloudfront "${dir}/manifest/" "s3://${bucket}/vagrant/"
+  info "fetching current EC2 manifest"
+  local manifest="$(s3cmd --no-progress get "s3://${bucket}/ec2/images.json" - 2>/dev/null)"
+  if [[ -z "${manifest}" ]]; then
+    manifest='{"name":"flynn-base"}'
+  fi
+
+  info "updating EC2 manifest"
+  mkdir -p "${dir}/manifests/ec2"
+  "${ROOT}/util/release/flynn-release" amis \
+    "${version}" \
+    "${amis}" \
+    <<< "${manifest}" \
+    > "${dir}/manifests/ec2/images.json"
+
+  info "releasing manifests"
+  sync_cloudfront "${dir}/manifests/" "s3://${bucket}/"
 
   info "cleaning up"
   rm -rf "${dir}"
@@ -156,6 +198,33 @@ main() {
 sha256() {
   local file=$1
   sha256sum "${file}" | cut -d ' ' -f 1
+}
+
+# parse_packer reads machine readable packer output, prints the
+# ui messages to stderr and prints the artifacts to stdout.
+#
+# example artifact output:
+#
+#   virtualbox-ovf|/tmp/tmp.FhRkEcY9YJ/flynn-base_20141021.1_virtualbox.box
+#   amazon-ebs|eu-west-1:ami-4c832d3b,us-east-1:ami-fea92d96
+#
+parse_packer() {
+  sed 's/%!(PACKER_COMMA)/,/g' | while read -r line; do
+    IFS="," read -r _ target type data <<< "${line}"
+
+    case "${type}" in
+      ui)
+        echo -e "$(cut -d "," -f 2 <<< "${data}")" >&2
+        ;;
+      artifact)
+        if [[ "${target}" == "virtualbox-ovf" ]] && [[ "${data:0:9}" == "0,file,0," ]]; then
+          echo "virtualbox-ovf|${data:9}"
+        elif [[ "${target}" == "amazon-ebs" ]] && [[ "${data:0:5}" == "0,id," ]]; then
+          echo "amazon-ebs|${data:5}"
+        fi
+        ;;
+    esac
+  done
 }
 
 main $@

--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -84,7 +84,8 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "{{ user `output_dir` }}/flynn-base_{{ user `version` }}_{{ .Provider }}.box"
+      "output": "{{ user `output_dir` }}/flynn-base_{{ user `version` }}_{{ .Provider }}.box",
+      "except": ["amazon-ebs"]
     }
   ]
 }

--- a/util/release/amis.go
+++ b/util/release/amis.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+)
+
+func amis(args *docopt.Args) {
+	auth, err := aws.EnvAuth()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	manifest := &EC2Manifest{}
+
+	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
+		log.Fatal(err)
+	}
+
+	for _, s := range strings.Split(args.String["<ids>"], ",") {
+		regionID := strings.SplitN(s, ":", 2)
+		resp, err := ec2.New(auth, aws.Regions[regionID[0]]).Images([]string{regionID[1]}, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(resp.Images) < 1 {
+			log.Fatalln("Could not find image", regionID[1])
+		}
+		image := resp.Images[0]
+
+		var snapshotID string
+		for _, mapping := range image.BlockDevices {
+			if mapping.DeviceName == image.RootDeviceName {
+				snapshotID = mapping.SnapshotId
+			}
+		}
+		if snapshotID == "" {
+			log.Fatalln("Could not determine RootDeviceSnapshotID for", regionID[1])
+		}
+
+		manifest.Add(args.String["<version>"], &EC2Image{
+			ID:                   image.Id,
+			Name:                 image.Name,
+			Region:               regionID[0],
+			OwnerID:              image.OwnerId,
+			RootDeviceType:       image.RootDeviceType,
+			RootDeviceName:       image.RootDeviceName,
+			RootDeviceSnapshotID: snapshotID,
+			VirtualizationType:   image.VirtualizationType,
+			Hypervisor:           image.Hypervisor,
+		})
+
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type EC2Manifest struct {
+	Name     string        `json:"name"`
+	Versions []*EC2Version `json:"versions"`
+}
+
+// Add adds an image to the manifest.
+//
+// If the version is already in the manifest, the given image either
+// replaces any existing image with the same region, or is appended to
+// the existing list of images for that version.
+//
+// If the version is not already in the manifest a new version is added
+// containing the image.
+func (m *EC2Manifest) Add(version string, image *EC2Image) {
+	for _, v := range m.Versions {
+		if v.Version == version {
+			images := make([]*EC2Image, len(v.Images))
+			added := false
+			for n, i := range v.Images {
+				if i.Region == image.Region {
+					// replace existing image
+					images[n] = image
+					added = true
+					continue
+				}
+				images[n] = i
+			}
+			if !added {
+				images = append(images, image)
+			}
+			v.Images = images
+			return
+		}
+	}
+
+	m.Versions = append(m.Versions, &EC2Version{
+		Version: version,
+		Images:  []*EC2Image{image},
+	})
+}
+
+type EC2Version struct {
+	Version string      `json:"version"`
+	Images  []*EC2Image `json:"images"`
+}
+
+type EC2Image struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Region               string `json:"region"`
+	OwnerID              string `json:"owner_id"`
+	RootDeviceType       string `json:"root_device_type"`
+	RootDeviceName       string `json:"root_device_name"`
+	RootDeviceSnapshotID string `json:"root_device_snapshot_id"`
+	VirtualizationType   string `json:"virtualization_type"`
+	Hypervisor           string `json:"hypervisor"`
+}

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -13,6 +13,7 @@ Usage:
   flynn-release download [--driver=<name>] [--root=<path>] <manifest>
   flynn-release upload <manifest> [<tag>]
   flynn-release vagrant <url> <checksum> <version> <provider>
+  flynn-release amis <version> <ids>
 
 Options:
   -o --output=<dest>   output destination file ("-" for stdout) [default: -]
@@ -33,5 +34,7 @@ Options:
 		upload(args)
 	case args.Bool["vagrant"]:
 		vagrant(args)
+	case args.Bool["amis"]:
+		amis(args)
 	}
 }

--- a/util/release/vagrant.go
+++ b/util/release/vagrant.go
@@ -9,13 +9,13 @@ import (
 )
 
 func vagrant(args *docopt.Args) {
-	manifest := &Manifest{}
+	manifest := &VagrantManifest{}
 
 	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
 		log.Fatal(err)
 	}
 
-	manifest.Add(args.String["<version>"], &Provider{
+	manifest.Add(args.String["<version>"], &VagrantProvider{
 		Name:         args.String["<provider>"],
 		URL:          args.String["<url>"],
 		Checksum:     args.String["<checksum>"],
@@ -27,9 +27,9 @@ func vagrant(args *docopt.Args) {
 	}
 }
 
-type Manifest struct {
-	Name     string     `json:"name"`
-	Versions []*Version `json:"versions"`
+type VagrantManifest struct {
+	Name     string            `json:"name"`
+	Versions []*VagrantVersion `json:"versions"`
 }
 
 // Add adds a provider to the manifest.
@@ -40,10 +40,10 @@ type Manifest struct {
 //
 // If the version is not already in the manifest a new version is added
 // containing the provider.
-func (m *Manifest) Add(version string, provider *Provider) {
+func (m *VagrantManifest) Add(version string, provider *VagrantProvider) {
 	for _, v := range m.Versions {
 		if v.Version == version {
-			providers := make([]*Provider, len(v.Providers))
+			providers := make([]*VagrantProvider, len(v.Providers))
 			added := false
 			for i, p := range v.Providers {
 				if p.Name == provider.Name {
@@ -62,18 +62,18 @@ func (m *Manifest) Add(version string, provider *Provider) {
 		}
 	}
 
-	m.Versions = append(m.Versions, &Version{
+	m.Versions = append(m.Versions, &VagrantVersion{
 		Version:   version,
-		Providers: []*Provider{provider},
+		Providers: []*VagrantProvider{provider},
 	})
 }
 
-type Version struct {
-	Version   string      `json:"version"`
-	Providers []*Provider `json:"providers"`
+type VagrantVersion struct {
+	Version   string             `json:"version"`
+	Providers []*VagrantProvider `json:"providers"`
 }
 
-type Provider struct {
+type VagrantProvider struct {
 	Name         string `json:"name"`
 	URL          string `json:"url"`
 	ChecksumType string `json:"checksum_type"`


### PR DESCRIPTION
This builds EC2 AMIs using packer and releases a manifest similar to the vagrant one, e.g.:

``` json
{
  "name": "flynn-base",
  "versions": [
    {
      "version": "20141021.2",
      "images": [
        {
          "hypervisor": "xen",
          "id": "ami-aa6bc5dd",
          "name": "flynn-20141021.2-ubuntu-14.04-1413920729",
          "region": "eu-west-1",
          "owner_id": "061747782411",
          "root_device_type": "ebs",
          "root_device_name": "/dev/sda1",
          "root_device_snapshot_id": "snap-f3c0550e",
          "virtualization_type": "hvm"
        },
        {
          "hypervisor": "xen",
          "id": "ami-765eda1e",
          "name": "flynn-20141021.2-ubuntu-14.04-1413920729",
          "region": "us-east-1",
          "owner_id": "061747782411",
          "root_device_type": "ebs",
          "root_device_name": "/dev/sda1",
          "root_device_snapshot_id": "snap-1893f6a1",
          "virtualization_type": "hvm"
        }
      ]
    }
  ]
}
```
