### PR TITLE
util/packer: Handle existing fuse group

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -100,7 +100,7 @@ enable_cgroups() {
 
 create_groups() {
   groupadd docker
-  groupadd fuse
+  groupadd fuse || true
   usermod -a -G docker,fuse "${SUDO_USER}"
 }
 


### PR DESCRIPTION
The Ubuntu Vagrant cloud image already has the `fuse` group.
