### PR TITLE
slugrunner: Follow redirects when downloading SLUG_URL

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -9,7 +9,7 @@ mkdir -p "${HOME}"
 if [[ -n $(ls -A "${HOME}") ]]; then
   true
 elif ! [[ -z "${SLUG_URL}" ]]; then
-  curl -s "${SLUG_URL}" | tar -xzC "${HOME}"
+  curl -s -L "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL
 else
   cat | tar -xzC "${HOME}"


### PR DESCRIPTION
I was wondering if it would be possible to follow redirects when downloading the SLUG_URL. 

In our case, we would like the SLUG_URL to point to a service which generates S3 authenticated URLs for slugs stored in an S3 bucket and returns those URLs as a redirect.
