### PR TITLE
host,pkg/rpcplus: Use os.File instead of ClosingFD

### DIFF
--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -220,7 +220,7 @@ func (c *ContainerInit) GetStdout(arg struct{}, fds *[]fdrpc.FD) error {
 	return nil
 }
 
-func (c *ContainerInit) GetStdin(arg struct{}, fd *fdrpc.ClosingFD) error {
+func (c *ContainerInit) GetStdin(arg struct{}, f *os.File) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -228,7 +228,7 @@ func (c *ContainerInit) GetStdin(arg struct{}, fd *fdrpc.ClosingFD) error {
 		return errors.New("stdin is closed")
 	}
 
-	fd.FD = int(c.stdin.Fd())
+	*f = *c.stdin
 	c.stdin = nil
 
 	return nil


### PR DESCRIPTION
This prevents the `c.stdin` file from being double closed by the finalizer in containerinit by closing it explicitly in fdrpc.

Closes #402
Closes #384 

@lmars please review and verify this fix.
