### PR TITLE
Vagrantfile: Provision using an optional script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 .vagrant
 /version.json
 /log
+script/custom-vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,4 +39,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ln -s /vagrant ~/go/src/github.com/flynn/flynn
     grep ^cd ~/.bashrc || echo cd ~/go/src/github.com/flynn/flynn >> ~/.bashrc
 SCRIPT
+
+  if File.exists?("script/custom-vagrant")
+    config.vm.provision "shell", path: "script/custom-vagrant"
+  end
 end


### PR DESCRIPTION
Every time I upgrade my vagrant box, I notice things are missing and re-install them, but they are pretty custom to me (e.g. settings in `~/.inputrc`), so with this I can just keep those modifications in `script/custom-vagrant`, which is git ignored.
