### PR TITLE
Avoid duplicate releases

### DIFF
--- a/script/release-flynn
+++ b/script/release-flynn
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+# A script to do a full release of Flynn (packages + VM images)
+#
+# PREREQUISITES:
+#
+# - A recent version of jq (which has the --exit-status flag)
+#   sudo curl -sLo /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq
+#   sudo chmod +x /usr/local/bin/jq
 
 set -eo pipefail
 
@@ -8,11 +16,12 @@ source "${ROOT}/script/lib/aws.sh"
 
 usage() {
   cat <<USAGE >&2
-usage: $0 [options] COMMIT
+usage: $0 [options]
 
 OPTIONS:
   -h            Show this message
   -b BUCKET     The S3 bucket to upload packages and vm images to [default: flynn]
+  -c COMMIT     The commit to build [default: the master branch of https://github.com/flynn/flynn.git]
   -d DOMAIN     The CloudFront domain [default: dl.flynn.io]
   -r DIR        Resume the release using DIR
 
@@ -21,15 +30,16 @@ USAGE
 }
 
 main() {
-  local bucket dir domain
+  local bucket commit dir domain
 
-  while getopts "hb:d:r:" opt; do
+  while getopts "hb:c:d:r:" opt; do
     case $opt in
       h)
         usage
         exit 1
         ;;
       b) bucket=${OPTARG} ;;
+      c) commit=${OPTARG} ;;
       d) domain=${OPTARG} ;;
       r)
         dir=${OPTARG}
@@ -52,10 +62,28 @@ main() {
 
   check_aws_keys
 
-  local commit=$1
   bucket="${bucket:-"flynn"}"
   dir="${dir:-$(mktemp -d)}"
   domain="${domain:-"dl.flynn.io"}"
+
+  if [[ -z "${commit}" ]]; then
+    info "determining commit"
+    commit=$(curl -s https://api.github.com/repos/flynn/flynn/git/refs/heads/master | jq --raw-output .object.sha)
+    if [[ -z "${commit}" ]]; then
+      fail "could not determine commit"
+    fi
+  fi
+
+  info "getting flynn release manifest"
+  local manifest="$(s3cmd --no-progress get "s3://${bucket}/release/manifest.json" - 2>/dev/null)"
+  if [[ -z "${manifest}" ]]; then
+    manifest='{}'
+  fi
+
+  info "checking for existing release"
+  if jq --exit-status ".versions[] | select(.commit==\"${commit}\")" <<< "${manifest}"; then
+    fail "commit ${commit} has already been released"
+  fi
 
   # release-packages prints results to fd 3, so create a pipe to read them
   results="$(mktemp -u)"
@@ -98,6 +126,16 @@ main() {
     -r "${dir}" \
     "${version}" \
     "${deb_url}"
+
+  info "updating flynn release manifest"
+  "${ROOT}/util/release/flynn-release" version \
+    "${version}" \
+    "${commit}" \
+    <<< "${manifest}" \
+    > "${dir}/manifest.json"
+
+  info "uploading flynn release manifest"
+  s3cmd put --acl-public "${dir}/manifest.json" "s3://${bucket}/release/manifest.json"
 
   info "successfully released Flynn version ${version}"
 

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -14,6 +14,7 @@ Usage:
   flynn-release upload <manifest> [<tag>]
   flynn-release vagrant <url> <checksum> <version> <provider>
   flynn-release amis <version> <ids>
+  flynn-release version <version> <commit>
 
 Options:
   -o --output=<dest>              output destination file ("-" for stdout) [default: -]
@@ -37,5 +38,7 @@ Options:
 		vagrant(args)
 	case args.Bool["amis"]:
 		amis(args)
+	case args.Bool["version"]:
+		version(args)
 	}
 }

--- a/util/release/version.go
+++ b/util/release/version.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+)
+
+func version(args *docopt.Args) {
+	manifest := &FlynnManifest{}
+
+	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := manifest.Add(args.String["<version>"], args.String["<commit>"]); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type FlynnManifest struct {
+	Current  *FlynnVersion   `json:"current"`
+	Versions []*FlynnVersion `json:"versions"`
+}
+
+func (m *FlynnManifest) Add(version, commit string) error {
+	for _, v := range m.Versions {
+		if v.Version == version {
+			return errors.New("version already in manifest")
+		}
+	}
+	v := &FlynnVersion{Version: version, Commit: commit}
+	// prepend the version so it's at the top
+	m.Versions = append([]*FlynnVersion{v}, m.Versions...)
+	m.Current = v
+	return nil
+}
+
+type FlynnVersion struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}


### PR DESCRIPTION
This adds a version manifest matching commits to versions and checks that before doing the release.

The manifest also includes a `current` object which is the current release for convenience.

For example:

``` json
{
  "current": {
    "version": "20141103.0",
    "commit": "51075aa45801a395d34a631c6d61c588"
  },
  "versions": [
    {
      "version": "20141103.0",
      "commit": "51075aa45801a395d34a631c6d61c588"
    },
    {
      "version": "20141102.0",
      "commit": "3eec6a22e2add1f5ea41c0555cfdd90e"
    },
    {
      "version": "20141101.0",
      "commit": "185e0f6b95fff32cad965c932e1b90ec"
    }
  ]
}
```
