### PR TITLE
Vagrantfile: Avoid DNS rebind protection by using TEST-NET-1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "https://dl.flynn.io/vagrant/flynn-base.json"
   config.vm.box_version = "> 0"
 
-  config.vm.network "private_network", ip: "192.168.96.48"
+  # RFC 5737 TEST-NET-1 used to avoid DNS rebind protection
+  config.vm.network "private_network", ip: "192.0.2.100"
 
   config.vm.provider "virtualbox" do |v|
     v.memory = ENV["VAGRANT_MEMORY"] || 1024

--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -17,7 +17,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "https://dl.flynn.io/vagrant/flynn-base.json"
   config.vm.box_version = "> 0"
 
-  config.vm.network "private_network", ip: "192.168.84.42"
+  # RFC 5737 TEST-NET-1 used to avoid DNS rebind protection
+  config.vm.network "private_network", ip: "192.0.2.200"
+
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provision "shell", privileged: false, inline: <<SCRIPT


### PR DESCRIPTION
The [TEST-NET subnets](http://vektra.com/blog/test-net) are specified in RFC 5737 for use in documentation, and should be fine for our host-only networking uses.

dnsmasq (used in many home/prosumer/smb routers) rebind protection uses this list which notably excludes all three TEST-NETs:
- 127.0.0.0/8    (loopback)
- 192.168.0.0/16 (private)
- 10.0.0.0/8     (private)
- 172.16.0.0/12  (private)
- 169.254.0.0/16 (zeroconf)

I will update the DNS entries as soon as this is merged.
