### PR TITLE
script: Don’t store fs attributes in S3 release files

### DIFF
--- a/script/release-flynn
+++ b/script/release-flynn
@@ -130,7 +130,7 @@ main() {
     > "${dir}/manifest.json"
 
   info "uploading flynn release manifest"
-  s3cmd put --acl-public "${dir}/manifest.json" "s3://${bucket}/release/manifest.json"
+  s3cmd put --acl-public --no-preserve "${dir}/manifest.json" "s3://${bucket}/release/manifest.json"
 
   info "tagging release"
   tag_release "${commit}" "${version}"

--- a/script/release-packages
+++ b/script/release-packages
@@ -106,7 +106,7 @@ main() {
   # NOTE: the trailing slash is necessary
   apt_dir="${dir}/apt/"
   mkdir -p "${apt_dir}"
-  s3cmd sync --delete-removed "s3://${bucket}/ubuntu/" "${apt_dir}"
+  s3cmd sync --delete-removed --no-preserve "s3://${bucket}/ubuntu/" "${apt_dir}"
 
   info "determining version"
   local date=$(date +%Y%m%d)

--- a/script/release-vm-images
+++ b/script/release-vm-images
@@ -154,7 +154,7 @@ main() {
   local box_name="$(basename "${box}")"
   if ! s3cmd info "s3://${bucket}/vagrant/boxes/${box_name}" &>/dev/null; then
     info "uploading ${box_name} to s3://${bucket}/vagrant/boxes"
-    s3cmd put --acl-public "${box}" "s3://${bucket}/vagrant/boxes/"
+    s3cmd put --acl-public --no-preserve "${box}" "s3://${bucket}/vagrant/boxes/"
   fi
 
   info "calculating SHA256 checksum of ${box_name}"


### PR DESCRIPTION
ping @lmars

This avoids headers like this in S3:

``` text
x-amz-meta-s3cmd-attrs: uid:1002/gname:release/uname:release/gid:1002/mode:33204/mtime:1415983624/atime:1415983518/md5:1a32a3dd85edd79127dbf4aca862f94c/ctime:1415983624
```
