### PR TITLE
script: Remove variable in tag_release

### DIFF
--- a/script/release-flynn
+++ b/script/release-flynn
@@ -156,19 +156,11 @@ tag_release() {
   local commit=$1
   local version=$2
 
-  read -d "" payload <<EOF
-{
-  "ref": "refs/tags/v${version}",
-  "sha": "${commit}"
-}
-EOF
-
   curl \
     --header "Content-Type: application/json" \
     --header "Authorization: token ${GITHUB_TOKEN}" \
-    --data @- \
-    "https://api.github.com/repos/flynn/flynn/git/refs" \
-    <<< "${payload}"
+    --data "{\"ref\":\"refs/tags/v${version}\",\"sha\":\"${commit}\"}" \
+    "https://api.github.com/repos/flynn/flynn/git/refs"
 }
 
 main $@


### PR DESCRIPTION
The read call was failing when running the script unattended.

Fixes #452 
