### PR TITLE
script: Fix signing packages with no TTY

### DIFF
--- a/script/release-packages
+++ b/script/release-packages
@@ -5,7 +5,7 @@
 # PREREQUISITES:
 #
 # - Install required packages
-#   sudo apt-get install -y reprepro dpkg-sig
+#   sudo apt-get install -y reprepro dpkg-sig gnupg-agent
 #
 # - Install up-to-date s3cmd so CloudFront invalidation works:
 #   sudo apt-get install -y python-dateutil
@@ -19,9 +19,15 @@
 # - Import GPG key used to sign packages
 #   gpg --import < /path/to/key.gpg
 #
-# - Store the passphrase
-#   echo "the-passphrase" > ~/.gnupg/passphrase
-#   chmod 440 ~/.gnupg/passphrase
+# - Set large gpg-agent cache expiry
+#   echo -e "default-cache-ttl 4294967295\nmax-cache-ttl 4294967295" | tee ~/.gnupg/gpg-agent.conf
+#
+# - Start gpg-agent
+#   eval $(gpg-agent --daemon)
+#
+# - Trigger cache of passphrase by signing something
+#   export GPG_TTY=`tty`
+#   echo | gpg --sign --yes --use-agent --output /dev/null /dev/stdin
 #
 # - Log in to Docker to push images
 #   docker login
@@ -40,23 +46,21 @@ OPTIONS:
   -h            Show this message
   -k            Keep release directory
   -b BUCKET     The S3 bucket to sync the apt repo with [default: flynn]
-  -g FILE       Path to the GPG passphrase file [default: $HOME/.gnupg/passphrase]
   -p PREFIX     The image URL prefix
   -r DIR        Resume the release using DIR
 USAGE
 }
 
 main() {
-  local bucket dir image_prefix passphrase_file
+  local bucket dir image_prefix
   local keep=false
 
-  while getopts "hkb:p:r:g:" opt; do
+  while getopts "hkb:p:r:" opt; do
     case $opt in
       h)
         usage
         exit 1
         ;;
-      g) passphrase_file=${OPTARG} ;;
       k) keep=true ;;
       b) bucket=${OPTARG} ;;
       p) image_prefix=${OPTARG} ;;
@@ -89,8 +93,6 @@ main() {
 
   bucket="${bucket:-"flynn"}"
   dir="${dir:-$(mktemp -d)}"
-  passphrase_file="${passphrase_file:-"$HOME/.gnupg/passphrase"}"
-
   info "using base dir: ${dir}"
 
   export GOPATH="${dir}"
@@ -144,7 +146,7 @@ main() {
 
   info "signing deb package"
   local deb=$(ls "${src}"/*.deb)
-  dpkg-sig -g "--passphrase-file \"${passphrase_file}\" --batch --no-tty" --sign builder "${deb}"
+  dpkg-sig -g "--use-agent --batch --no-tty" --sign builder "${deb}"
 
   info "adding deb to apt repo"
   reprepro -b "${apt_dir}" includedeb flynn "${deb}"


### PR DESCRIPTION
I am running a release via cron with this change now, so will merge if it succeeds.
