### PR TITLE
script: Run make dev in run-integration-tests

### DIFF
--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -9,7 +9,7 @@ main() {
   local flynn="${ROOT}/cli/flynn-cli"
 
   pushd "${ROOT}" >/dev/null
-  make
+  make dev
   popd >/dev/null
 
   cluster_add=$("${ROOT}/script/bootstrap-flynn" &> >(tee /dev/stderr) | tail -1)


### PR DESCRIPTION
It’s rare that I actually want this to happen.
