### PR TITLE
slugbuilder: Update multi buildpack URL

### DIFF
--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,4 +1,4 @@
-https://github.com/ddollar/heroku-buildpack-multi.git#6e790943
+https://github.com/heroku/heroku-buildpack-multi.git#cddec34c
 https://github.com/heroku/heroku-buildpack-ruby.git#v129
 https://github.com/heroku/heroku-buildpack-nodejs.git#v60
 https://github.com/heroku/heroku-buildpack-clojure.git#eb4ff18a


### PR DESCRIPTION
No code changes, Heroku is now maintaining the buildpack.
