### PR TITLE
demo: Don’t update flynn by default when starting

### DIFF
--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -23,9 +23,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provision "shell", privileged: false, inline: <<SCRIPT
-    sudo apt-get update -qq
-    sudo apt-get install -y flynn-host
-    sudo flynn-host download /etc/flynn/version.json
+    ## Uncomment these lines to update flynn before starting
+    # sudo apt-get update -qq
+    # sudo apt-get install -y flynn-host
+    # sudo flynn-host download /etc/flynn/version.json
+
     sudo start flynn-host
 
     CLUSTER_DOMAIN=demo.localflynn.com \


### PR DESCRIPTION
Nightly builds remove the need for this on first start.
