### PR TITLE
Vagrantfile: Fix escaping of environment variables in dev vm bashrc initialization

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "shell", privileged: false, inline: <<SCRIPT
     grep '^export GOPATH' ~/.bashrc || echo export GOPATH=~/go >> ~/.bashrc
-    grep '^export PATH' ~/.bashrc || echo export PATH=\$PATH:~/go/bin:/vagrant/script >> ~/.bashrc
+    grep '^export PATH' ~/.bashrc || echo export PATH=\\\$PATH:~/go/bin:/vagrant/script >> ~/.bashrc
     GOPATH=~/go go get github.com/tools/godep
 
     # For controller tests


### PR DESCRIPTION
Vagrantfile: Fix escaping of environment variables in dev vm bashrc initialization

Previously, the hardcoded $PATH was ending up in the bashrc file.  The "$PATH" variable is now placed in the bashrc file, thus doing the more correct thing with chaining changes to that variable.
