### PR TITLE
all: Move pkg/migrate into pkg/postgres

### DIFF
--- a/blobstore/postgres_filesystem.go
+++ b/blobstore/postgres_filesystem.go
@@ -9,11 +9,11 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq/oid"
-	"github.com/flynn/flynn/pkg/migrate"
+	"github.com/flynn/flynn/pkg/postgres"
 )
 
 func NewPostgresFilesystem(db *sql.DB) (Filesystem, error) {
-	m := migrate.NewMigrations()
+	m := postgres.NewMigrations()
 	m.Add(1,
 		`CREATE TABLE files (
 	file_id oid PRIMARY KEY DEFAULT lo_create(0),

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
-	"github.com/flynn/flynn/pkg/migrate"
+	"github.com/flynn/flynn/pkg/postgres"
 )
 
 func migrateDB(db *sql.DB) error {
-	m := migrate.NewMigrations()
+	m := postgres.NewMigrations()
 	m.Add(1,
 		`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`,
 		`CREATE EXTENSION IF NOT EXISTS "hstore"`,

--- a/pkg/postgres/migrate.go
+++ b/pkg/postgres/migrate.go
@@ -1,4 +1,4 @@
-package migrate
+package postgres
 
 import "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
 


### PR DESCRIPTION
Since `pkg/migrate` depends on postgres, there's no reason for it to be in a separate package.
