### PR TITLE
slugbuilder: Revert "Proxy support"

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -89,13 +89,13 @@ selected_buildpack=
 
 if [[ -n "${BUILDPACK_URL}" ]]; then
   echo_title "Fetching custom buildpack"
+
   buildpack="${buildpack_root}/custom"
   rm -rf "${buildpack}"
   /tmp/builder/install-buildpack \
     "${buildpack_root}" \
     "${BUILDPACK_URL}" \
     custom \
-    "${env_dir}" \
     &> /dev/null
   selected_buildpack="${buildpack}"
   buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_root}")

--- a/slugbuilder/builder/install-buildpack
+++ b/slugbuilder/builder/install-buildpack
@@ -4,24 +4,6 @@ set -eo pipefail
 buildpacks_dir="$1"
 buildpack_url="$2"
 buildpack_name="$3"
-env_dir="$4"
-
-export_env_dir() {
-  env_dir=$1
-  whitelist_regex=${2:-''}
-  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
-  if [ -d "${env_dir}" ]; then
-    for e in $(ls $env_dir); do
-      echo "$e" | grep -Ei "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
-      export "$e=$(cat $env_dir/$e)"
-      :
-    done
-  fi
-}
-
-#Only import proxy related environment variables to support 'git clone'
-export_env_dir "${env_dir}" '(HTTP_PROXY|HTTPS_PROXY|NO_PROXY)$'
-
 
 if [[ "${buildpack_name}" == "" ]]; then
   buildpack_name="$(basename "${buildpack_url}")"


### PR DESCRIPTION
Reverts flynn/flynn#546

@tlperkins Do you mind re-opening another pull request with the commits squashed and a [DCO sign-off](https://flynn.io/docs/contributing#developer%E2%80%99s-certificate-of-origin) added? For silly IP reasons we can't have commits in the tree that are not signed.
