### PR TITLE
host: Increase container connect timeout

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -554,7 +554,7 @@ func (c *libvirtContainer) watch(ready chan<- error) error {
 	var err error
 	symlink := "/tmp/containerinit-rpc." + c.job.ID
 	socketPath := path.Join(c.RootPath, containerinit.SocketPath)
-	for startTime := time.Now(); time.Since(startTime) < 5*time.Second; time.Sleep(time.Millisecond) {
+	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; time.Sleep(time.Millisecond) {
 		if !symlinked {
 			// We can't connect to the socket file directly because
 			// the path to it is longer than 108 characters (UNIX_PATH_MAX).


### PR DESCRIPTION
See [this CI log](https://s3.amazonaws.com/flynn-ci-logs/flynn-build-20141207033407-c5108ef7-0ff9479eee0af94fb23a1af11194f6bea0b67c68-2014-12-07-03-42-24.txt) for an example of a job which did not start quickly enough (the job with ID `63414bd61c0149eebddae3e982bbc98f`).

I suspect the slowness is because the scheduler / receiver are overloading particular hosts.
