### PR TITLE
test: Update github commit status context

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -213,7 +213,7 @@ func (r *Runner) build(b *Build) (err error) {
 	}
 	b.LogFile = logFile.Name()
 
-	r.updateStatus(b, "pending", "")
+	r.updateStatus(b, "pending", fmt.Sprintf("https://ci.flynn.io/builds/%s.log", b.Id))
 
 	<-r.buildCh
 	defer func() {


### PR DESCRIPTION
This matches the string convention used by Travis CI, and adds a link to the log stream.
