### PR TITLE
Vagrantfile: add a configuration patch to fix slow networking on some hosts.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.cpus = ENV["VAGRANT_CPUS"] || 2
   end
 
+  # Address issues some hosts experience with networking (specifically, DNS latency) inside the development environment VM.
+  # See also https://github.com/mitchellh/vagrant/issues/1172 for a description of the problem.
+  config.vm.provision :shell, inline: <<SCRIPT
+    if [ ! $(grep single-request-reopen /etc/resolvconf/resolv.conf.d/base) ]; then
+      echo "options single-request-reopen" >> /etc/resolvconf/resolv.conf.d/base && resolvconf -u
+    fi
+SCRIPT
+
   config.vm.provision "shell", privileged: false, inline: <<SCRIPT
     grep '^export GOPATH' ~/.bashrc || echo export GOPATH=~/go >> ~/.bashrc
     grep '^export PATH' ~/.bashrc || echo export PATH=\\\$PATH:~/go/bin:/vagrant/script >> ~/.bashrc

--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -22,6 +22,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
+  # Address issues some hosts experience with networking (specifically, DNS latency) inside the development environment VM.
+  # See also https://github.com/mitchellh/vagrant/issues/1172 for a description of the problem.
+  config.vm.provision :shell, inline: <<SCRIPT
+    if [ ! $(grep single-request-reopen /etc/resolvconf/resolv.conf.d/base) ]; then
+      echo "options single-request-reopen" >> /etc/resolvconf/resolv.conf.d/base && resolvconf -u
+    fi
+SCRIPT
+
   config.vm.provision "shell", privileged: false, inline: <<SCRIPT
     ## Uncomment these lines to update flynn before starting
     # sudo apt-get update -qq


### PR DESCRIPTION
Some hosts experience issues with networking (specifically, DNS latency) inside the development environment VM.

See also https://github.com/mitchellh/vagrant/issues/1172 and https://gist.github.com/simono/73e37d8c3a45664c7045 for a description of the problem and the origins of this fix.

This fixes issues with a number of integration tests which can fail on timeouts due to absurdly high (i.e. many seconds) DNS latency.  Another workaround that fixes the troublesome tests is `echo 192.0.2.100 dev.localflynn.com controller.dev.localflynn.com >> /etc/hosts`; this fix appears to get at the general purpose issue.  Not all hosts experience this issue; I don't know what the discriminating factor is, but I haven't seen any reports that this change could cause any detrumental behavior for those already unaffected.

(p.s. @lmars this is the stuff you suggested in IRC -- I just tested it, and afaict it works as advertised)
