### PR TITLE
all: Fix os.Signal chan buffering

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -95,7 +95,7 @@ func runRun(args *docopt.Args, client *controller.Client) error {
 		// Restore the terminal if we return without calling os.Exit
 		defer term.RestoreTerminal(os.Stdin.Fd(), termState)
 		go func() {
-			ch := make(chan os.Signal)
+			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, SIGWINCH)
 			for range ch {
 				ws, err := term.GetWinsize(os.Stdin.Fd())
@@ -109,7 +109,7 @@ func runRun(args *docopt.Args, client *controller.Client) error {
 	}
 
 	go func() {
-		ch := make(chan os.Signal)
+		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 		sig := <-ch
 		attachClient.Signal(int(sig.(syscall.Signal)))

--- a/host/cli/run.go
+++ b/host/cli/run.go
@@ -59,7 +59,7 @@ func runRun(args *docopt.Args, client *cluster.Client) error {
 		// Restore the terminal if we return without calling os.Exit
 		defer term.RestoreTerminal(os.Stdin.Fd(), termState)
 		go func() {
-			ch := make(chan os.Signal)
+			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, syscall.SIGWINCH)
 			for range ch {
 				ws, err := term.GetWinsize(os.Stdin.Fd())
@@ -73,7 +73,7 @@ func runRun(args *docopt.Args, client *cluster.Client) error {
 	}
 
 	go func() {
-		ch := make(chan os.Signal)
+		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 		sig := <-ch
 		cmd.Signal(int(sig.(syscall.Signal)))

--- a/test/apps/signal/main.go
+++ b/test/apps/signal/main.go
@@ -14,7 +14,7 @@ const service = "signal-service"
 
 func main() {
 	log.SetFlags(log.Lmicroseconds)
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	log.Println("setting signal handler")
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	log.Println("registering service")


### PR DESCRIPTION
> Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate.

Closes #590
