### PR TITLE
Improved upstart configuration

### DIFF
--- a/host/upstart.conf
+++ b/host/upstart.conf
@@ -6,5 +6,6 @@ respawn limit 1000 60
 
 script
   IP_ADDR=$(/sbin/ifconfig eth0 | grep -oP 'inet addr:\S+' | cut -d: -f2)
+  [ -r /etc/default/etcd-discovery ] && . /etc/default/etcd-discovery && export ETCD_DISCOVERY
   flynn-host daemon --manifest /etc/flynn/host-manifest.json --external $IP_ADDR --state /tmp/flynn-host-state.bolt
 end script


### PR DESCRIPTION
Instead of having the sysadmin edit the `/etc/init/flynn-host.conf` file during installation, source the `ETCD_DISCOVERY` variable from a single-line `/etc/default/etcd-discovery` shell source file. If that source file doesn't exist, behavior is the same as when the env directive was not added to the upstart conf file.

The `/etc/default/etcd-discovery` file can then be easily generated or copied around during host/cluster provisioning with a command like:

``` bash
echo ETCD_DISCOVERY=$(curl -s "https://discovery.etcd.io/new") > /etc/default/etcd-discovery
```

The key point is to only update the value when booting the whole cluster. I have it in my own Vagrantfile script provisioner. Suggestions on where to put that in your existing initialization artifacts would be good (e.g. the Vagrantfile, Packer scripts, etc).
