### PR TITLE
slugrunner: exec command

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -75,4 +75,4 @@ fi
 ## Run!
 
 chown -R nobody:nogroup .
-setuidgid nobody ${runner} "${command}"
+exec setuidgid nobody ${runner} "${command}"


### PR DESCRIPTION
There’s no reason to leave bash lying around in the process tree, so exec right away instead of forking first.
