### PR TITLE
 test/runner: Send SIGQUIT to test binary after timeout

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -204,7 +204,7 @@ cmd="bin/flynn-test \
   --debug \
   --dump-logs"
 
-timeout --kill-after=10 20m $cmd
+timeout --signal=QUIT --kill-after=10 20m $cmd
 `[1:]))
 
 func formatDuration(d time.Duration) string {


### PR DESCRIPTION
This ensures that we get a stack trace from the binary which will help debug if it has hung somewhere.
