### PR TITLE
test: Increase VM RAM to 2GB

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -209,7 +209,7 @@ func (c *Cluster) startVMs(rootFS string, initial bool, count int) ([]*Instance,
 			Kernel: c.bc.Kernel,
 			User:   uid,
 			Group:  gid,
-			Memory: "1024",
+			Memory: "2048",
 			Cores:  2,
 			Drives: map[string]*VMDrive{
 				"hda": {FS: rootFS, COW: true, Temp: true},


### PR DESCRIPTION
After upgrading to etcd v2, CI was frequently stalling due to high RAM usage. We do not know the root cause but bumping the RAM solves the problem.
