### PR TITLE
test: Track memory usage in /tmp/memwatch.log

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -334,6 +334,10 @@ git merge origin/master
 
 make dev
 
+if [[ -f test/scripts/debug-info.sh ]]; then
+  sudo cp test/scripts/debug-info.sh /usr/local/bin/debug-info.sh
+fi
+
 sudo cp host/bin/flynn-* /usr/bin
 sudo cp host/bin/manifest.json /etc/flynn-host.json
 sudo cp bootstrap/bin/manifest.json /etc/flynn-bootstrap.json
@@ -359,6 +363,10 @@ type hostScriptData struct {
 
 var flynnHostScripts = map[string]*template.Template{
 	"libvirt-lxc": template.Must(template.New("flynn-host-libvirt").Parse(`
+if [[ -f /usr/local/bin/debug-info.sh ]]; then
+  /usr/local/bin/debug-info.sh &>/tmp/debug-info.log &
+fi
+
 sudo start-stop-daemon \
   --start \
   --background \
@@ -497,6 +505,7 @@ func (c *Cluster) DumpLogs(w io.Writer) {
 	for _, inst := range c.Instances {
 		run(inst, "ps faux")
 		run(inst, "cat /tmp/flynn-host.log")
+		run(inst, "cat /tmp/debug-info.log")
 	}
 
 	var out bytes.Buffer

--- a/test/scripts/debug-info.sh
+++ b/test/scripts/debug-info.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This script is run by the CI runner to collect debugging information
+# which will be printed if any tests fail.
+
+memwatch() {
+  interests=("$@")
+
+  echo -n $(date "+%H:%M:%S.%3N")
+  for x in "${interests[@]}"; do
+    echo -ne "\t${x}"
+  done
+  echo
+
+  while true; do
+    snap="$(ps -A -o rss -o cmd)" # downgrade to '-a' or leave it out entirely for confined scope
+    echo -n $(date "+%H:%M:%S.%3N")
+    for x in "${interests[@]}"; do
+      mem="$(echo "$snap" | grep "$x" | grep -v "$0" | awk '{ SUM += $1 } END { print SUM+0 }')"
+      echo -ne "\t${mem}"
+    done
+    echo
+
+    sleep 1
+  done
+}
+
+memwatch "etcd" "discoverd"


### PR DESCRIPTION
Output looks like this:

```
HostID: cafd72ba - cat /tmp/memwatch.log

15:36:33.870    etcd    discoverd
15:36:33.883    0       0
15:36:34.902    8920    2280
15:36:35.917    19128   11088
15:36:36.932    19128   11088
15:36:37.946    19652   11612
15:36:38.962    19912   11612
15:36:39.978    19912   11612
...
```

Thanks to @heavenlyhash for the script.
