### PR TITLE
test/rootfs: Disable memory overcommit

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -134,7 +134,5 @@ rm godeb
 apt-get autoremove -y
 apt-get clean
 
-echo "vm.overcommit_memory = 1" >> /etc/sysctl.conf
-
 # recreate resolv.conf symlink
 ln -nsf ../run/resolvconf/resolv.conf /etc/resolv.conf


### PR DESCRIPTION
Setting this to `1` effectively prevents errors from being returned from `malloc()` and the OOM killer is never triggered. Thus, the CI VMs tend to hang when they encounter memory leaks instead of causing issues that would show up in the logs. Removing this customization reverts us back to the Linux default of `0` which behaves as expected.
