### PR TITLE
test/scripts: Remove debug-info.sh memory logging script

### DIFF
--- a/test/scripts/debug-info.sh
+++ b/test/scripts/debug-info.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script is run by the CI runner to collect debugging information
-# which will be printed if any tests fail.
+# which will be printed if any tests fail. It currently runs no code.
 
 memwatch() {
   interests=("$@")
@@ -24,5 +24,3 @@ memwatch() {
     sleep 1
   done
 }
-
-memwatch "etcd" "discoverd"


### PR DESCRIPTION
This script is no longer necessary, as it has not discovered any memory issues on CI.
