### PR TITLE
util/release: Add flannel to version.json

### DIFF
--- a/util/release/version_template.json
+++ b/util/release/version_template.json
@@ -1,5 +1,6 @@
 {
   "$image_url_prefix/etcd": "$image_id[etcd]",
+  "$image_url_prefix/flannel": "$image_id[flannel]",
   "$image_url_prefix/discoverd": "$image_id[discoverd]",
   "$image_url_prefix/postgresql": "$image_id[postgresql]",
   "$image_url_prefix/controller": "$image_id[controller]",


### PR DESCRIPTION
Without this the image is not uploaded or downloaded, causing errors in the `flynn-host` log that look like:

```
fn=run job.id=flynn-flannel-50f85431d7924d689c9e8724bb1759ab status=error err="registry: repo not found" at=pull_image app=host backend=libvirt-lxc
```
