### PR TITLE
Bump nodejs buildpack

### DIFF
--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,6 +1,6 @@
 https://github.com/heroku/heroku-buildpack-multi.git#cddec34c
 https://github.com/heroku/heroku-buildpack-ruby.git#v129
-https://github.com/heroku/heroku-buildpack-nodejs.git#fae41898
+https://github.com/heroku/heroku-buildpack-nodejs.git#1ebb095a
 https://github.com/heroku/heroku-buildpack-clojure.git#v63
 https://github.com/heroku/heroku-buildpack-python.git#v54
 https://github.com/heroku/heroku-buildpack-java.git#e99a5f80

--- a/slugbuilder/builder/install-buildpack
+++ b/slugbuilder/builder/install-buildpack
@@ -44,3 +44,6 @@ else
 fi
 
 popd > /dev/null
+
+# Ensure buildpack directories are writeable (see https://github.com/heroku/heroku-buildpack-nodejs/issues/152)
+chmod -R ugo+w "${buildpacks_dir}"


### PR DESCRIPTION
This adds support for specifying the npm version in `package.json`, among other things.

https://github.com/heroku/heroku-buildpack-nodejs/compare/fae41898...1ebb095a