### PR TITLE
discoverd2: Add state implementation

### DIFF
--- a/discoverd2/server/state.go
+++ b/discoverd2/server/state.go
@@ -1,0 +1,333 @@
+package server
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type EventKind uint
+
+const (
+	EventKindUp EventKind = 1 << iota
+	EventKindUpdate
+	EventKindDown
+	EventKindLeader
+)
+
+func (k EventKind) String() string {
+	switch k {
+	case EventKindUp:
+		return "up"
+	case EventKindUpdate:
+		return "update"
+	case EventKindDown:
+		return "down"
+	case EventKindLeader:
+		return "leader"
+	default:
+		return "unknown"
+	}
+}
+
+type Event struct {
+	Service string
+	Kind    EventKind
+	*Instance
+}
+
+func eventKindUpdate(existing bool) EventKind {
+	if existing {
+		return EventKindUpdate
+	}
+	return EventKindUp
+}
+
+// Instance is a single running instance of a service.
+type Instance struct {
+	// ID is unique within the service, and is currently defined as
+	// Hex(SHA256(Proto + "-" + Addr)) but this may change in the future.
+	ID string `json:"id"`
+
+	// Addr is the IP/port address that can be used to communicate with the
+	// service. It must be valid to dial this address.
+	Addr string `json:"addr"`
+
+	// Proto is the protocol used to connect to the service, examples include:
+	// tcp, udp, http, https. It must be lowercase alphanumeric.
+	Proto string `json:"proto"`
+
+	// Meta is arbitrary metadata specified when registering the instance.
+	Meta map[string]string `json:"meta,omitempty"`
+
+	// Leader is true if the instance is the leader of the service. Exactly one
+	// instance per service has this set to true at any point in time.
+	Leader bool `json:"leader,omitempty"`
+
+	// Index is the logical epoch of the initial registration of the instance.
+	// It is guaranteed to be unique, not change as long as the instance does
+	// not expire, and sort with other indexes in the order of instance
+	// creation.
+	Index uint `json:"index"`
+}
+
+func (inst *Instance) Equal(other *Instance) bool {
+	return inst.Addr == other.Addr &&
+		inst.Proto == other.Proto &&
+		inst.Index == other.Index &&
+		mapEqual(inst.Meta, other.Meta)
+}
+
+func mapEqual(x, y map[string]string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for k, v := range x {
+		if yv, ok := y[k]; !ok || yv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func NewState() *State {
+	return &State{
+		services:    make(map[string]map[string]*Instance),
+		subscribers: make(map[string]*list.List),
+	}
+}
+
+type State struct {
+	// service name -> instance ID -> instance
+	services map[string]map[string]*Instance
+	// TODO: change to atomic.Value and CoW for the services map, and a RWMutex
+	// for each service map
+	mtx sync.RWMutex
+
+	// service name -> list of *subscriber
+	subscribers    map[string]*list.List
+	subscribersMtx sync.Mutex
+}
+
+func (s *State) AddInstance(service string, inst *Instance) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	data, ok := s.services[service]
+	if !ok {
+		data = make(map[string]*Instance)
+		s.services[service] = data
+	}
+	old, existing := data[inst.ID]
+	data[inst.ID] = inst
+
+	if !existing || !inst.Equal(old) {
+		s.broadcast(&Event{
+			Service:  service,
+			Kind:     eventKindUpdate(existing),
+			Instance: inst,
+		})
+	}
+}
+
+func (s *State) RemoveInstance(service, id string) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	data, ok := s.services[service]
+	if !ok {
+		return
+	}
+	inst, exists := data[id]
+	if !exists {
+		return
+	}
+	delete(data, id)
+
+	s.broadcast(&Event{
+		Service:  service,
+		Kind:     EventKindDown,
+		Instance: inst,
+	})
+}
+
+func (s *State) SetService(service string, data []*Instance) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	oldData, ok := s.services[service]
+	if len(data) == 0 {
+		delete(s.services, service)
+	} else {
+		newData := make(map[string]*Instance, len(data))
+		for _, inst := range data {
+			newData[inst.ID] = inst
+		}
+		s.services[service] = newData
+	}
+	if !ok {
+		// Service doesn't currently exist, send updates for each instance
+		for _, inst := range data {
+			s.broadcast(&Event{
+				Service:  service,
+				Kind:     EventKindUp,
+				Instance: inst,
+			})
+		}
+		return
+	}
+
+	// diff existing
+	for _, inst := range data {
+		if old, existing := oldData[inst.ID]; !existing || !inst.Equal(old) {
+			s.broadcast(&Event{
+				Service:  service,
+				Kind:     eventKindUpdate(existing),
+				Instance: inst,
+			})
+		}
+	}
+
+	// find deleted
+	for k, v := range oldData {
+		if _, ok := s.services[service][k]; !ok {
+			s.broadcast(&Event{
+				Service:  service,
+				Kind:     EventKindDown,
+				Instance: v,
+			})
+		}
+	}
+}
+
+func (s *State) Get(service string) []*Instance {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.getLocked(service)
+}
+
+func (s *State) getLocked(service string) []*Instance {
+	data, ok := s.services[service]
+	if !ok {
+		return nil
+	}
+
+	res := make([]*Instance, 0, len(data))
+	for _, inst := range data {
+		res = append(res, inst)
+	}
+	return res
+}
+
+type subscription struct {
+	kinds EventKind
+	ch    chan *Event
+	err   error
+
+	// the following fields are used by Close to clean up
+	el      *list.Element
+	service string
+	state   *State
+}
+
+func (s *subscription) Err() error {
+	return s.err
+}
+
+func (s *subscription) Close() error {
+	go func() {
+		// drain channel to prevent deadlocks
+		for range s.ch {
+		}
+	}()
+
+	s.close()
+	return nil
+}
+
+func (s *subscription) close() {
+	s.state.subscribersMtx.Lock()
+	defer s.state.subscribersMtx.Unlock()
+	l := s.state.subscribers[s.service]
+	l.Remove(s.el)
+	if l.Len() == 0 {
+		delete(s.state.subscribers, s.service)
+	}
+	close(s.ch)
+}
+
+func (s *State) Subscribe(service string, sendCurrent bool, kinds EventKind, ch chan *Event) stream.Stream {
+	// Grab a copy of the state if we need it. If we do this later we risk
+	// a deadlock as updates are broadcast with mtx and subscribersMtx both
+	// locked.
+	var current []*Instance
+	sendCurrent = sendCurrent && kinds&(EventKindUp|EventKindUpdate) != 0
+	if sendCurrent {
+		s.mtx.RLock()
+		current = s.getLocked(service)
+	}
+
+	s.subscribersMtx.Lock()
+	defer s.subscribersMtx.Unlock()
+
+	if sendCurrent {
+		// Make sure we unlock this *after* locking subscribersMtx to prevent any
+		// changes from being applied before we send the current state
+		s.mtx.RUnlock()
+	}
+
+	l, ok := s.subscribers[service]
+	if !ok {
+		l = list.New()
+		s.subscribers[service] = l
+	}
+	sub := &subscription{
+		kinds:   kinds,
+		ch:      ch,
+		state:   s,
+		service: service,
+	}
+	sub.el = l.PushBack(sub)
+
+	for _, inst := range current {
+		ch <- &Event{
+			Service:  service,
+			Kind:     EventKindUp,
+			Instance: inst,
+		}
+		// TODO: add a timeout here so that clients can't slow things down too much
+	}
+
+	return sub
+}
+
+var ErrSendBlocked = errors.New("discoverd: channel send failed due to blocked receiver")
+
+func (s *State) broadcast(event *Event) {
+	s.subscribersMtx.Lock()
+	defer s.subscribersMtx.Unlock()
+
+	l, ok := s.subscribers[event.Service]
+	if !ok {
+		return
+	}
+
+	for e := l.Front(); e != nil; e = e.Next() {
+		sub := e.Value.(*subscription)
+
+		// skip if kinds bitmap doesn't include this event type
+		if sub.kinds&event.Kind == 0 {
+			continue
+		}
+
+		select {
+		case sub.ch <- event:
+		default:
+			sub.err = ErrSendBlocked
+			// run in a goroutine as it requires a lock on subscribersMtx
+			go sub.Close()
+		}
+	}
+}

--- a/discoverd2/server/state_test.go
+++ b/discoverd2/server/state_test.go
@@ -1,0 +1,260 @@
+package server
+
+import (
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/pkg/random"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type StateSuite struct{}
+
+var _ = Suite(&StateSuite{})
+
+var instanceIdx uint64
+
+func fakeInstance() *Instance {
+	octet := func() int { return random.Math.Intn(255) + 1 }
+	return &Instance{
+		ID:    random.String(16),
+		Addr:  fmt.Sprintf("%d.%d.%d.%d:%d", octet(), octet(), octet(), octet(), random.Math.Intn(65535)+1),
+		Proto: "tcp",
+		Meta:  map[string]string{"foo": "bar"},
+		Index: uint(atomic.AddUint64(&instanceIdx, 1)),
+	}
+}
+
+func assertHasInstance(c *C, list []*Instance, want ...*Instance) {
+	for _, want := range want {
+		for _, have := range list {
+			if reflect.DeepEqual(have, want) {
+				return
+			}
+		}
+		c.Errorf("couldn't find %#v in %#v", want, list)
+	}
+}
+
+func assertNoEvent(c *C, events chan *Event) {
+	select {
+	case e := <-events:
+		c.Errorf("unexpected event %v %#v", e, e.Instance)
+	default:
+	}
+}
+
+func receiveEvents(c *C, events chan *Event, count int) map[string]*Event {
+	res := make(map[string]*Event, count)
+	for i := 0; i < count; i++ {
+		select {
+		case e := <-events:
+			c.Logf("+ event %v %#v", e, e.Instance)
+			res[e.Instance.ID] = e
+		default:
+			c.Errorf("expected %d events, got %d", count, len(res))
+		}
+	}
+	assertNoEvent(c, events)
+	return res
+}
+
+func (StateSuite) TestAddInstance(c *C) {
+	state := NewState()
+	events := make(chan *Event, 1)
+	state.Subscribe("a", false, EventKindUpdate|EventKindUp, events)
+
+	// + with service that doesn't exist
+	inst1 := fakeInstance()
+	state.AddInstance("a", inst1)
+	data := state.Get("a")
+	c.Assert(data, HasLen, 1)
+	c.Assert(data[0], DeepEquals, inst1)
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUp,
+		Instance: inst1,
+	})
+
+	// + with new instance
+	inst2 := fakeInstance()
+	state.AddInstance("a", inst2)
+	data = state.Get("a")
+	c.Assert(data, HasLen, 2)
+	assertHasInstance(c, data, inst2)
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUp,
+		Instance: inst2,
+	})
+
+	// + with updated instance
+	inst3 := *inst2
+	inst3.Meta = map[string]string{"test": "b"}
+	state.AddInstance("a", &inst3)
+	data = state.Get("a")
+	c.Assert(data, HasLen, 2)
+	assertHasInstance(c, data, &inst3)
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUpdate,
+		Instance: &inst3,
+	})
+
+	// + with unchanged instance
+	inst4 := inst3
+	state.AddInstance("a", &inst4)
+	c.Assert(data, HasLen, 2)
+	assertHasInstance(c, data, &inst4)
+	assertNoEvent(c, events)
+}
+
+func (StateSuite) TestDeleteInstance(c *C) {
+	state := NewState()
+	events := make(chan *Event, 1)
+	state.Subscribe("a", false, EventKindDown, events)
+
+	// + with service that doesn't exist
+	state.RemoveInstance("a", "b")
+	assertNoEvent(c, events)
+
+	// + with instance that doesn't exist
+	inst := fakeInstance()
+	state.AddInstance("a", inst)
+	state.RemoveInstance("a", "b")
+	c.Assert(state.Get("a"), HasLen, 1)
+	assertNoEvent(c, events)
+
+	// + with instance that exists
+	state.RemoveInstance("a", inst.ID)
+	c.Assert(state.Get("a"), HasLen, 0)
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindDown,
+		Instance: inst,
+	})
+}
+
+func (StateSuite) TestSetService(c *C) {
+	state := NewState()
+	events := make(chan *Event, 3)
+	state.Subscribe("a", false, EventKindDown|EventKindUp|EventKindUpdate, events)
+
+	// + with service that doesn't exist
+	newData := []*Instance{fakeInstance(), fakeInstance()}
+	state.SetService("a", newData)
+	data := state.Get("a")
+	c.Assert(data, HasLen, 2)
+	assertHasInstance(c, data, newData...)
+	for _, expected := range newData {
+		c.Assert(<-events, DeepEquals, &Event{
+			Service:  "a",
+			Kind:     EventKindUp,
+			Instance: expected,
+		})
+	}
+	assertNoEvent(c, events)
+
+	// + with service that exists and zero-length new
+	state.SetService("a", nil)
+	c.Assert(state.Get("a"), HasLen, 0)
+	// make sure we get exactly two down events, one for each existing instance
+	down := receiveEvents(c, events, 2)
+	for _, e := range down {
+		c.Assert(e.Kind, Equals, EventKindDown)
+		c.Assert(e.Service, Equals, "a")
+	}
+	c.Assert(down[newData[0].ID].Instance, DeepEquals, newData[0])
+	c.Assert(down[newData[1].ID].Instance, DeepEquals, newData[1])
+
+	// + one existing, one updated, one new, one deleted
+	initial := []*Instance{fakeInstance(), fakeInstance(), fakeInstance()}
+	state.SetService("a", initial)
+	// eat the three up events
+	receiveEvents(c, events, 3)
+
+	existing := initial[0]
+	deleted := initial[1]
+	modified := *initial[2]
+	modified.Meta = map[string]string{"a": "b"}
+	added := fakeInstance()
+
+	state.SetService("a", []*Instance{existing, &modified, added})
+	data = state.Get("a")
+	c.Assert(data, HasLen, 3)
+	assertHasInstance(c, data, existing, &modified, added)
+
+	changes := receiveEvents(c, events, 3)
+
+	modifiedEvent := changes[modified.ID]
+	c.Assert(modifiedEvent.Kind, Equals, EventKindUpdate)
+	c.Assert(modifiedEvent.Service, Equals, "a")
+	c.Assert(modifiedEvent.Instance, DeepEquals, &modified)
+
+	deletedEvent := changes[deleted.ID]
+	c.Assert(deletedEvent.Kind, Equals, EventKindDown)
+	c.Assert(deletedEvent.Service, Equals, "a")
+	c.Assert(deletedEvent.Instance, DeepEquals, deleted)
+
+	addedEvent := changes[added.ID]
+	c.Assert(addedEvent.Kind, Equals, EventKindUp)
+	c.Assert(addedEvent.Service, Equals, "a")
+	c.Assert(addedEvent.Instance, DeepEquals, added)
+}
+
+func (StateSuite) TestGetNilService(c *C) {
+	state := NewState()
+	c.Assert(state.Get("a"), HasLen, 0)
+}
+
+func (StateSuite) TestSubscribe(c *C) {
+	state := NewState()
+
+	inst1 := fakeInstance()
+	state.AddInstance("a", inst1)
+
+	events := make(chan *Event, 1)
+	stream := state.Subscribe("a", true, EventKindDown|EventKindUp|EventKindUpdate, events)
+
+	// initial instance
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUp,
+		Instance: inst1,
+	})
+
+	inst2 := fakeInstance()
+	state.AddInstance("a", inst2)
+
+	// subsequent event
+	c.Assert(<-events, DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUp,
+		Instance: inst2,
+	})
+
+	stream.Close()
+	_, open := <-events
+	c.Assert(open, Equals, false)
+
+	// create another update to confirm nothing is blocked
+	state.AddInstance("a", fakeInstance())
+}
+
+func (StateSuite) TestBlockedSubscription(c *C) {
+	state := NewState()
+	events := make(chan *Event)
+	stream := state.Subscribe("a", true, EventKindUp, events)
+
+	// send to the channel will fail immediately because there is no receiver
+	state.AddInstance("a", fakeInstance())
+
+	_, open := <-events
+	c.Assert(open, Equals, false)
+	c.Assert(stream.Err(), Equals, ErrSendBlocked)
+}


### PR DESCRIPTION
This implements the core list of services and instances that will be hooked up to a consensus/communication backend like etcd as well as the HTTP and DNS read APIs.

I'm trying to send review-sized PRs instead of just the final result, so this is an intermediate (working, with 84% test coverage) patch for #145.