### PR TITLE
Add default manifest paths to download and bootstrap

### DIFF
--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -41,8 +41,13 @@ func runBootstrap(args *docopt.Args) {
 		logf = jsonLogger
 	}
 
+	manifestFile := args.String["<manifest>"]
+	if manifestFile == "" {
+		manifestFile = "/etc/flynn/bootstrap-manifest.json"
+	}
+
 	var err error
-	manifest, err = readBootstrapManifest(args.String["<manifest>"])
+	manifest, err = readBootstrapManifest(manifestFile)
 	if err != nil {
 		log.Fatalln("Error reading manifest:", err)
 	}

--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -30,8 +30,13 @@ func runDownload(args *docopt.Args) error {
 		return fmt.Errorf("error creating root dir: %s", err)
 	}
 
+	manifestFile := args.String["<manifest>"]
+	if manifestFile == "" {
+		manifestFile = "/etc/flynn/version.json"
+	}
+
 	var manifest map[string]string
-	if err := cliutil.DecodeJSONArg(args.String["<manifest>"], &manifest); err != nil {
+	if err := cliutil.DecodeJSONArg(manifestFile, &manifest); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is much less confusing than hanging waiting for STDIN.