### PR TITLE
discoverd2: Implement etcd backend

### DIFF
--- a/discoverd2/server/backend.go
+++ b/discoverd2/server/backend.go
@@ -1,0 +1,15 @@
+package server
+
+type Backend interface {
+	AddInstance(service string, inst *Instance) error
+	RemoveInstance(service, id string) error
+	StartSync() error
+	Close() error
+}
+
+type SyncHandler interface {
+	AddInstance(service string, inst *Instance)
+	RemoveInstance(service, id string)
+	SetService(service string, data []*Instance)
+	ListServices() []string
+}

--- a/discoverd2/server/etcd_backend.go
+++ b/discoverd2/server/etcd_backend.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
+)
+
+type etcdClient interface {
+	Create(key string, value string, ttl uint64) (*etcd.Response, error)
+	Set(key string, value string, ttl uint64) (*etcd.Response, error)
+	Get(key string, sort, recursive bool) (*etcd.Response, error)
+	Delete(key string, recursive bool) (*etcd.Response, error)
+	Watch(prefix string, waitIndex uint64, recursive bool, receiver chan *etcd.Response, stop chan bool) (*etcd.Response, error)
+}
+
+func NewEtcdBackend(client etcdClient, prefix string, h SyncHandler) Backend {
+	return &etcdBackend{
+		prefix:   prefix,
+		etcd:     client,
+		h:        h,
+		stopSync: make(chan bool),
+		done:     make(chan struct{}),
+	}
+}
+
+type etcdBackend struct {
+	prefix   string
+	etcd     etcdClient
+	h        SyncHandler
+	stopSync chan bool
+	done     chan struct{}
+}
+
+const defaultTTL = 10
+
+type NotFoundError struct {
+	Service  string
+	Instance string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("discoverd: %s/%s not found", e.Service, e.Instance)
+}
+
+func (b *etcdBackend) instanceKey(service, id string) string {
+	return path.Join(b.prefix, "instances", service, id)
+}
+
+func (b *etcdBackend) AddInstance(service string, inst *Instance) error {
+	data, err := json.Marshal(inst)
+	if err != nil {
+		return err
+	}
+	_, err = b.etcd.Set(b.instanceKey(service, inst.ID), string(data), defaultTTL)
+	return err
+}
+
+func (b *etcdBackend) RemoveInstance(service, id string) error {
+	_, err := b.etcd.Delete(b.instanceKey(service, id), true)
+	if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == 100 {
+		return NotFoundError{Service: service, Instance: id}
+	}
+	return err
+}
+
+func (b *etcdBackend) Close() error {
+	close(b.stopSync)
+	<-b.done
+	return nil
+}
+
+func (b *etcdBackend) StartSync() error {
+	started := make(chan error)
+	go func() {
+		defer close(b.done)
+	outer:
+		for {
+			nextIndex, err := b.fullSync()
+			if err != nil {
+				if started != nil {
+					started <- err
+					return
+				}
+				log.Printf("Error while performing etcd fullsync: %s", err)
+				// TODO: backoff/sleep
+				continue
+			}
+
+			if started != nil {
+				started <- nil
+				started = nil
+			}
+
+			for {
+				stream := make(chan *etcd.Response)
+				watchDone := make(chan error)
+				keyPrefix := path.Join(b.prefix, "instances")
+
+				go func() {
+					_, err := b.etcd.Watch(keyPrefix, nextIndex, true, stream, b.stopSync)
+					watchDone <- err
+				}()
+
+				for res := range stream {
+					nextIndex = res.EtcdIndex + 1
+
+					// ensure we have a key like /foo/bar/instances/service/id
+					if strings.Count(res.Node.Key[len(keyPrefix):], "/") != 2 {
+						continue
+					}
+					serviceName := path.Base(path.Dir(res.Node.Key))
+					instanceID := path.Base(res.Node.Key)
+
+					if res.Action == "delete" {
+						b.h.RemoveInstance(serviceName, instanceID)
+					} else {
+						inst := &Instance{}
+						if err := json.Unmarshal([]byte(res.Node.Value), inst); err != nil {
+							log.Printf("Error decoding JSON for instance %s/%s: %s", instanceID, serviceName, err)
+							continue
+						}
+						b.h.AddInstance(serviceName, inst)
+					}
+				}
+
+				watchErr := <-watchDone
+				select {
+				case <-b.stopSync:
+					return
+				default:
+				}
+
+				if e, ok := watchErr.(*etcd.EtcdError); ok && e.ErrorCode == 401 {
+					// event log has been pruned beyond our waitIndex, force fullSync
+					log.Printf("Got etcd error 401, doing full sync")
+					continue outer
+				}
+				log.Printf("Restarting etcd watch %s due to error: %s", keyPrefix, watchErr)
+				// TODO: add sleep/backoff
+			}
+		}
+	}()
+	return <-started
+}
+
+func (b *etcdBackend) fullSync() (uint64, error) {
+	data, err := b.etcd.Get(path.Join(b.prefix, "instances"), false, true)
+	if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == 100 {
+		// key not found, remove existing services
+		for _, name := range b.h.ListServices() {
+			b.h.SetService(name, nil)
+		}
+		return e.Index + 1, nil
+	}
+	if err != nil {
+		return 1, err
+	}
+
+	added := make(map[string]struct{}, len(data.Node.Nodes))
+	for _, serviceNode := range data.Node.Nodes {
+		serviceName := path.Base(serviceNode.Key)
+		added[serviceName] = struct{}{}
+
+		var instances []*Instance
+		for _, instNode := range serviceNode.Nodes {
+			inst := &Instance{}
+			if err := json.Unmarshal([]byte(instNode.Value), inst); err != nil {
+				log.Printf("Error decoding JSON for instance %s: %s", instNode.Key, err)
+				continue
+			}
+			instances = append(instances, inst)
+		}
+		b.h.SetService(serviceName, instances)
+	}
+	// remove any services that weren't found in the response
+	for _, name := range b.h.ListServices() {
+		if _, ok := added[name]; !ok {
+			b.h.SetService(name, nil)
+		}
+	}
+
+	return data.Node.ModifiedIndex, nil
+}

--- a/discoverd2/server/etcd_backend_test.go
+++ b/discoverd2/server/etcd_backend_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/discoverd/testutil/etcdrunner"
+)
+
+type EtcdSuite struct {
+	state   *State
+	backend Backend
+	cleanup func()
+}
+
+func (s *EtcdSuite) SetUpTest(c *C) {
+	var addr string
+	addr, s.cleanup = etcdrunner.RunEtcdServer(c)
+	s.state = NewState()
+	s.backend = NewEtcdBackend(etcd.NewClient([]string{addr}), "/test/discoverd", s.state)
+}
+
+func (s *EtcdSuite) TearDownTest(c *C) {
+	if s.backend != nil {
+		s.backend.Close()
+	}
+	if s.cleanup != nil {
+		s.cleanup()
+	}
+}
+
+var _ = Suite(&EtcdSuite{})
+
+// Sync starting with a clean slate
+func (s *EtcdSuite) TestBasicSync(c *C) {
+	events := make(chan *Event, 1)
+	s.state.Subscribe("a", false, EventKindAll, events)
+
+	c.Assert(s.backend.StartSync(), IsNil)
+
+	s.testBasicSync(c, events)
+}
+
+func (s *EtcdSuite) testBasicSync(c *C, events chan *Event) {
+	// create instance
+	inst := fakeInstance()
+	err := s.backend.AddInstance("a", inst)
+	c.Assert(err, IsNil)
+	assertEvent(c, events, "a", EventKindUp, inst)
+
+	// Update instance
+	inst2 := *inst
+	inst2.Meta = map[string]string{"a": "b"}
+	err = s.backend.AddInstance("a", &inst2)
+	c.Assert(err, IsNil)
+	assertEvent(c, events, "a", EventKindUpdate, &inst2)
+
+	// Remove instance
+	err = s.backend.RemoveInstance("a", inst.ID)
+	c.Assert(err, IsNil)
+	assertEvent(c, events, "a", EventKindDown, &inst2)
+}
+
+// Sync starting with empty etcd, but services in local state
+func (s *EtcdSuite) TestNoServiceSync(c *C) {
+	inst := fakeInstance()
+	s.state.AddInstance("a", inst)
+
+	events := make(chan *Event, 1)
+	s.state.Subscribe("a", false, EventKindAll, events)
+
+	c.Assert(s.backend.StartSync(), IsNil)
+
+	assertEvent(c, events, "a", EventKindDown, inst)
+
+	s.testBasicSync(c, events)
+}
+
+// Sync starting with existing, updated, deleted, added, etc services
+func (s *EtcdSuite) TestLocalDiffSync(c *C) {
+	existing := fakeInstance()
+	updated := fakeInstance()
+	deleted := fakeInstance()
+	added := fakeInstance()
+	missingService := fakeInstance()
+
+	s.state.AddInstance("a", existing)
+	s.state.AddInstance("a", updated)
+	s.state.AddInstance("a", deleted)
+	s.state.AddInstance("b", missingService)
+
+	updated2 := *updated
+	updated2.Meta = map[string]string{"a": "b"}
+	c.Assert(s.backend.AddInstance("a", existing), IsNil)
+	c.Assert(s.backend.AddInstance("a", &updated2), IsNil)
+	c.Assert(s.backend.AddInstance("a", added), IsNil)
+
+	aEvents := make(chan *Event, 3)
+	bEvents := make(chan *Event, 1)
+	s.state.Subscribe("a", false, EventKindAll, aEvents)
+	s.state.Subscribe("b", false, EventKindAll, bEvents)
+
+	c.Assert(s.backend.StartSync(), IsNil)
+
+	// Ensure that a service that is not in etcd is removed
+	assertEvent(c, bEvents, "b", EventKindDown, missingService)
+
+	res := receiveEvents(c, aEvents, 3)
+	c.Assert(res[updated.ID], DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUpdate,
+		Instance: &updated2,
+	})
+	c.Assert(res[deleted.ID], DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindDown,
+		Instance: deleted,
+	})
+	c.Assert(res[added.ID], DeepEquals, &Event{
+		Service:  "a",
+		Kind:     EventKindUp,
+		Instance: added,
+	})
+
+	s.testBasicSync(c, aEvents)
+}

--- a/discoverd2/server/state.go
+++ b/discoverd2/server/state.go
@@ -208,6 +208,16 @@ func (s *State) Get(service string) []*Instance {
 	return s.getLocked(service)
 }
 
+func (s *State) ListServices() []string {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	res := make([]string, 0, len(s.services))
+	for name := range s.services {
+		res = append(res, name)
+	}
+	return res
+}
+
 func (s *State) getLocked(service string) []*Instance {
 	data, ok := s.services[service]
 	if !ok {

--- a/discoverd2/server/state.go
+++ b/discoverd2/server/state.go
@@ -3,6 +3,7 @@ package server
 import (
 	"container/list"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/flynn/flynn/pkg/stream"
@@ -15,6 +16,7 @@ const (
 	EventKindUpdate
 	EventKindDown
 	EventKindLeader
+	EventKindAll = ^EventKind(0)
 )
 
 func (k EventKind) String() string {
@@ -36,6 +38,10 @@ type Event struct {
 	Service string
 	Kind    EventKind
 	*Instance
+}
+
+func (e *Event) String() string {
+	return fmt.Sprintf("[%s] %s %#v", e.Service, e.Kind, e.Instance)
 }
 
 func eventKindUpdate(existing bool) EventKind {

--- a/discoverd2/server/state_test.go
+++ b/discoverd2/server/state_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"sync/atomic"
 	"testing"
 
@@ -257,4 +258,13 @@ func (StateSuite) TestBlockedSubscription(c *C) {
 	_, open := <-events
 	c.Assert(open, Equals, false)
 	c.Assert(stream.Err(), Equals, ErrSendBlocked)
+}
+
+func (StateSuite) TestListServices(c *C) {
+	state := NewState()
+	state.AddInstance("a", fakeInstance())
+	state.AddInstance("b", fakeInstance())
+	services := state.ListServices()
+	sort.Strings(services)
+	c.Assert(services, DeepEquals, []string{"a", "b"})
 }


### PR DESCRIPTION
This implements the etcd backend for discoverd2, and is an incremental patch for #145.

The unit test coverage is at 89.2% with only some simple error paths left untested.