### PR TITLE
bootstrap: Log dashboard link and token

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -325,6 +325,6 @@
   {
     "id": "log-complete",
     "action": "log",
-    "output": "\n\nFlynn bootstrapping complete. Install flynn-cli and paste the line below into a terminal window:\n\nflynn cluster add -g {{ getenv \"CLUSTER_DOMAIN\" }}:2222 -p {{ (index .StepData \"controller-cert\").Pin }} default https://controller.{{ getenv \"CLUSTER_DOMAIN\" }} {{ (index .StepData \"controller-key\").Data }}"
+    "output": "\n\nFlynn bootstrapping complete. Install the flynn-cli (see https://cli.flynn.io for instructions) and paste the line below into a terminal window:\n\nflynn cluster add -g {{ getenv \"CLUSTER_DOMAIN\" }}:2222 -p {{ (index .StepData \"controller-cert\").Pin }} default https://controller.{{ getenv \"CLUSTER_DOMAIN\" }} {{ (index .StepData \"controller-key\").Data }}\n\nThe built-in dashboard can be accessed at http://dashboard.{{ getenv \"CLUSTER_DOMAIN\" }} with login token {{ (index .StepData \"dashboard-login-token\").Data }}"
   }
 ]


### PR DESCRIPTION
This adds the dashboard link and token to the log message, and a link to the CLI installation page:

```
12:47:19.635648 log log-complete
12:47:19.635819 log log-complete 

Flynn bootstrapping complete. Install the flynn-cli (see https://cli.flynn.io for instructions) and paste the line below into a terminal window:

flynn cluster add -g dev.localflynn.com:2222 -p tMq6CLHmv2g9ys2Zf/2n4WnC63tdscFsNMflk91538k= default https://controller.dev.localflynn.com aa01ab76e5a68bb33e2678e67813baa4

The built-in dashboard can be accessed at http://dashboard.dev.localflynn.com with login token 3daf12f05c20f88edcf201f386f8818f
```