### PR TITLE
fix bootstrap success detection in integration test kickoff script

### DIFF
--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -40,7 +40,7 @@ main() {
   make dev
   popd >/dev/null
 
-  cluster_add=$("${ROOT}/script/bootstrap-flynn" &> >(tee /dev/stderr) | tail -1)
+  cluster_add=$("${ROOT}/script/bootstrap-flynn" &> >(tee /dev/stderr) | tail -3 | head -1)
 
   if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then
     echo Bootstrap failed >&2


### PR DESCRIPTION
The integration scripts run test checks against output which was changed in the "Log dashboard link and token" commit ( https://github.com/flynn/flynn/pull/699 ), so this is changing to match.