### PR TITLE
website: Fix swiftype section annotation

### DIFF
--- a/website/lib/markdown_html.rb
+++ b/website/lib/markdown_html.rb
@@ -53,7 +53,7 @@ class Middleman::Renderers::MiddlemanRedcarpetHTML
       attrs['data-swiftype-name'] = 'title'
       attrs['data-swiftype-type'] = 'string'
     elsif level == 2
-      attrs['data-swiftype-name'] = 'section'
+      attrs['data-swiftype-name'] = 'sections'
       attrs['data-swiftype-type'] = 'string'
     end
     wrapped_text = el('span', text, attrs)


### PR DESCRIPTION
There was a typo in their docs, it’s ‘sections’, not ‘section’.