### PR TITLE
cli: Adding --remote flag on "flynn create" command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -99,7 +99,7 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 		if r == remote {
 			fmt.Println("There is already a git remote called", remote)
 			if !promptYesNo("Are you sure you want to replace it?") {
-				log.Println("Please, declare the desired local git remote name with --remote flag.")
+				log.Println("The app was not created. Please, declare the desired local git remote name with --remote flag.")
 				return nil
 			}
 		}

--- a/cli/app.go
+++ b/cli/app.go
@@ -84,7 +84,10 @@ func promptYesNo(msg string) (result bool) {
 func runCreate(args *docopt.Args, client *controller.Client) error {
 	app := &ct.App{}
 	app.Name = args.String["<name>"]
-	remote := args.String["<remote>"] || "flynn"
+	remote := args.String["<remote>"]
+	if remote == "" {
+		remote = "flynn"
+	}
 
 	// Test if remote name exists and prompt user
 	remotes, err = gitRemoteNames()

--- a/cli/app.go
+++ b/cli/app.go
@@ -111,8 +111,10 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 	}
 
 	// Register git remote
-	exec.Command("git", "remote", "remove", remote).Run()
-	exec.Command("git", "remote", "add", remote, gitURLPre(clusterConf.GitHost)+app.Name+gitURLSuf).Run()
+	if remote != "" {
+		exec.Command("git", "remote", "remove", remote).Run()
+		exec.Command("git", "remote", "add", remote, gitURLPre(clusterConf.GitHost)+app.Name+gitURLSuf).Run()
+	}
 	log.Printf("Created %s", app.Name)
 	return nil
 }

--- a/cli/app.go
+++ b/cli/app.go
@@ -23,7 +23,7 @@ allows deploying the application via git.
 
 Options:
 	-r, --remote <remote>  Name of git remote to create, empty string for none. [default: flynn]
-	-y, --yes              Skip the confirmation prompt if there is already a "flynn" git remote.
+	-y, --yes              Skip the confirmation prompt if the git remote already exists.
 
 Examples:
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -23,6 +23,7 @@ allows deploying the application via git.
 
 Options:
 	-r, --remote <remote>  Name of git remote to create, empty string for none. [default: flynn]
+	-y, --yes              Skip the confirmation prompt if there is already a "flynn" git remote.
 
 Examples:
 
@@ -92,12 +93,14 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 		return err
 	}
 
-	for _, r := range remotes {
-		if r == remote {
-			fmt.Println("There is already a git remote called", remote)
-			if !promptYesNo("Are you sure you want to replace it?") {
-				log.Println("The app was not created. Please, declare the desired local git remote name with --remote flag.")
-				return nil
+	if !args.Bool["--yes"] {
+		for _, r := range remotes {
+			if r == remote {
+				fmt.Println("There is already a git remote called", remote)
+				if !promptYesNo("Are you sure you want to replace it?") {
+					log.Println("The app was not created. Please, declare the desired local git remote name with --remote flag.")
+					return nil
+				}
 			}
 		}
 	}

--- a/cli/app.go
+++ b/cli/app.go
@@ -121,19 +121,8 @@ func runDelete(args *docopt.Args, client *controller.Client) error {
 	appName := mustApp()
 
 	if !args.Bool["--yes"] {
-		fmt.Printf("Are you sure you want to delete the app %q? (yes/no): ", appName)
-	loop:
-		for {
-			var answer string
-			fmt.Scanln(&answer)
-			switch answer {
-			case "y", "yes":
-				break loop
-			case "n", "no":
-				return nil
-			default:
-				fmt.Print("Please type 'yes' or 'no': ")
-			}
+		if !promptYesNo(fmt.Sprintf("Are you sure you want to delete the app %q?", appName)) {
+			return nil
 		}
 	}
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -97,7 +97,7 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 
 	for _, r := range remotes {
 		if r == remote {
-			fmt.Println("There is one git remote called", remote)
+			fmt.Println("There is already a git remote called", remote)
 			if !promptYesNo("Are you sure you want to replace it?") {
 				log.Println("Please, declare the desired local git remote name with --remote flag.")
 				return nil

--- a/cli/app.go
+++ b/cli/app.go
@@ -90,7 +90,7 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 	}
 
 	// Test if remote name exists and prompt user
-	remotes, err = gitRemoteNames()
+	remotes, err := gitRemoteNames()
 	if err != nil {
 		return err
 	}

--- a/cli/app.go
+++ b/cli/app.go
@@ -87,13 +87,13 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 	app.Name = args.String["<name>"]
 	remote := args.String["<remote>"]
 
-	// Test if remote name exists and prompt user
-	remotes, err := gitRemoteNames()
-	if err != nil {
-		return err
-	}
-
 	if !args.Bool["--yes"] {
+		// Test if remote name exists and prompt user
+		remotes, err := gitRemoteNames()
+		if err != nil {
+			return err
+		}
+
 		for _, r := range remotes {
 			if r == remote {
 				fmt.Println("There is already a git remote called", remote)

--- a/cli/app.go
+++ b/cli/app.go
@@ -22,7 +22,7 @@ If run from a git repository, a 'flynn' remote will be created or replaced that
 allows deploying the application via git.
 
 Options:
-	-r, --remote <remote>  Name of git remote on local repo.
+	-r, --remote <remote>  Name of git remote to create, empty string for none. [default: flynn]
 
 Examples:
 
@@ -85,9 +85,6 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 	app := &ct.App{}
 	app.Name = args.String["<name>"]
 	remote := args.String["<remote>"]
-	if remote == "" {
-		remote = "flynn"
-	}
 
 	// Test if remote name exists and prompt user
 	remotes, err := gitRemoteNames()

--- a/cli/app.go
+++ b/cli/app.go
@@ -113,7 +113,7 @@ func runCreate(args *docopt.Args, client *controller.Client) error {
 	// Register git remote
 	if remote != "" {
 		exec.Command("git", "remote", "remove", remote).Run()
-		exec.Command("git", "remote", "add", remote, gitURLPre(clusterConf.GitHost)+app.Name+gitURLSuf).Run()
+		exec.Command("git", "remote", "add", "--", remote, gitURLPre(clusterConf.GitHost)+app.Name+gitURLSuf).Run()
 	}
 	log.Printf("Created %s", app.Name)
 	return nil

--- a/cli/git.go
+++ b/cli/git.go
@@ -34,6 +34,31 @@ type remoteApp struct {
 	Name    string
 }
 
+func gitRemoteNames() (results []string, err error) {
+	b, err := exec.Command("git", "remote").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	s := bufio.NewScanner(bytes.NewBuffer(b))
+	s.Split(bufio.ScanWords)
+
+	results = make([]string, 1)
+
+	for s.Scan() {
+		by := s.Bytes()
+		f := bytes.Fields(by)
+
+		results = append(results, string(f[0]))
+	}
+
+	if err = s.Err(); err != nil {
+		return nil, err
+	}
+
+	return
+}
+
 func gitRemotes() (map[string]remoteApp, error) {
 	b, err := exec.Command("git", "remote", "-v").Output()
 	if err != nil {

--- a/cli/git.go
+++ b/cli/git.go
@@ -43,8 +43,6 @@ func gitRemoteNames() (results []string, err error) {
 	s := bufio.NewScanner(bytes.NewBuffer(b))
 	s.Split(bufio.ScanWords)
 
-	results = make([]string, 1)
-
 	for s.Scan() {
 		by := s.Bytes()
 		f := bytes.Fields(by)


### PR DESCRIPTION
Hello guys,

Closes #700.

This is my first Go code contribution, so, apologize for any formatting/style/logic issues. I'm open to listen suggestions!

This option allow us to set the local git remote name, or "flynn" if not provided. It checks if the remote name is used and warn user about conflict.