### PR TITLE
flannel: Use RFC 6598 shared address space

### DIFF
--- a/flannel/runner.go
+++ b/flannel/runner.go
@@ -33,7 +33,7 @@ var networkConfigAttempts = attempt.Strategy{
 func main() {
 	var config Config
 	config.Backend.Type = "vxlan"
-	flag.StringVar(&config.Network, "network", "172.16.0.0/12", "container network")
+	flag.StringVar(&config.Network, "network", "100.100.0.0/16", "container network")
 	flag.StringVar(&config.SubnetMin, "subnet-min", "", "container network min subnet")
 	flag.StringVar(&config.SubnetMax, "subnet-max", "", "container network max subnet")
 	flag.UintVar(&config.SubnetLen, "subnet-len", 0, "container network subnet length")

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -17,7 +17,7 @@
     "id": "flannel",
     "image": "$image_url_prefix/flannel?id=$image_id[flannel]",
     "env": {
-      "FLANNEL_NETWORK": "172.16.0.0/12",
+      "FLANNEL_NETWORK": "100.100.0.0/16",
       "ETCD_ADDR": "{{ .Services.etcd.ExternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"
     }
   },


### PR DESCRIPTION
[RFC 6598](https://tools.ietf.org/html/rfc6598) defines 100.64.0.0/10 as shared address space to be used for carrier-grade NAT, but it also allows its use as private address space.

Using this instead of 172.16.0.0/12 will avoid a ton of conflicts.

Closes #724