### PR TITLE
simplify httpclient.Stream invocation

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -109,7 +109,7 @@ func (c *Client) StreamFormations(since *time.Time, output chan<- *ct.ExpandedFo
 	if err != nil {
 		return nil, err
 	}
-	return httpclient.Stream(res, func() interface{} { return &ct.ExpandedFormation{} }, output), nil
+	return httpclient.Stream(res, output), nil
 }
 
 // CreateArtifact creates a new artifact.
@@ -289,7 +289,7 @@ func (c *Client) StreamJobEvents(appID string, lastID int64, output chan<- *ct.J
 	if err != nil {
 		return nil, err
 	}
-	return httpclient.Stream(res, func() interface{} { return &ct.JobEvent{} }, output), nil
+	return httpclient.Stream(res, output), nil
 }
 
 // GetJobLog returns a ReadCloser stream of the job with id of jobID, running

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -185,7 +185,7 @@ func (c *Client) RegisterHost(h *host.Host, jobs chan *host.Job) (stream.Stream,
 		return nil, err
 	}
 
-	return httpclient.Stream(res, func() interface{} { return &host.Job{} }, jobs), nil
+	return httpclient.Stream(res, jobs), nil
 }
 
 // RemoveJob is used by flynn-host to delete jobs from the cluster state. It
@@ -203,5 +203,5 @@ func (c *Client) StreamHostEvents(output chan<- *host.HostEvent) (stream.Stream,
 		return nil, err
 	}
 
-	return httpclient.Stream(res, func() interface{} { return &host.HostEvent{} }, output), nil
+	return httpclient.Stream(res, output), nil
 }

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -78,7 +78,7 @@ func (c *hostClient) StreamEvents(id string, ch chan<- *host.Event) (stream.Stre
 		return nil, err
 	}
 
-	return httpclient.Stream(res, func() interface{} { return &host.Event{} }, ch), nil
+	return httpclient.Stream(res, ch), nil
 }
 
 func (c *hostClient) Close() error {


### PR DESCRIPTION
This makes creating http client streams significantly terser at the cost of a tiny bit more reflection, by automatically producing message objects based on the output channel's element type.