### PR TITLE
pkg/httpclient: Close stream http response body when stopping

### DIFF
--- a/pkg/httpclient/stream.go
+++ b/pkg/httpclient/stream.go
@@ -25,8 +25,17 @@ func Stream(res *http.Response, outputCh interface{}) stream.Stream {
 	stopChanValue := reflect.ValueOf(stream.StopCh)
 	msgType := chanValue.Type().Elem().Elem()
 	go func() {
+		done := make(chan struct{})
 		defer func() {
 			chanValue.Close()
+			close(done)
+		}()
+
+		go func() {
+			select {
+			case <-stream.StopCh:
+			case <-done:
+			}
 			res.Body.Close()
 		}()
 


### PR DESCRIPTION
This unblocks the SSE decoder if the stop request comes in while we are blocked in a read.