### PR TITLE
util/cedarish: Add new upstream packages

### DIFF
--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -39,6 +39,8 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.li
       libxml2-dev \
       libxslt-dev \
       netcat-openbsd \
+      openjdk-7-jdk \
+      openjdk-7-jre-headless \
       openssh-client \
       openssh-server \
       python \

--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -43,6 +43,7 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.li
       openjdk-7-jre-headless \
       openssh-client \
       openssh-server \
+      postgresql-server-dev-9.3 \
       python \
       python-dev \
       ruby \


### PR DESCRIPTION
Heroku added these packages to their official cedar-14 stack, which we track:

OpenJDK:
https://devcenter.heroku.com/changelog-items/585
heroku/stack-images@2d3932e431f2f8c165d9ec8c1b7a016fa6de5e11

Postgres headers:
https://github.com/heroku/stack-images/commit/d15c442831ac39d4c7a952d833127369af209569