### PR TITLE
host:Centos 7 ,using devicemapper driver by default.

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -46,8 +46,11 @@ func NewLibvirtLXCBackend(state *State, volPath, logPath, initPath string) (Back
 	if err != nil {
 		return nil, err
 	}
-
-	pinkertonCtx, err := pinkerton.BuildContext("aufs", "/var/lib/docker")
+	default_driver := os.Getenv("DOCKER_DRIVER")
+	if default_driver == "" {
+		default_driver = "aufs"
+	}
+	pinkertonCtx, err := pinkerton.BuildContext(default_driver, "/var/lib/docker")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In Centos 7,Use XFS default,and docker should using devicemapper  driver.
export DOCKER_DRIVER=devicemapper

Signed-off-by: Hpgood <hpgoodggx@gmail.com>