### PR TITLE
discoverd2: Add healthcheck package

### DIFF
--- a/discoverd2/health/check.go
+++ b/discoverd2/health/check.go
@@ -1,0 +1,103 @@
+package health
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+const defaultTimeout = 2 * time.Second
+
+type Check interface {
+	Check() error
+}
+
+var _ Check = &TCPCheck{}
+var _ Check = &HTTPCheck{}
+
+type TCPCheck struct {
+	Addr    string
+	Timeout time.Duration
+}
+
+func (c *TCPCheck) Check() error {
+	d := &net.Dialer{
+		Timeout: c.Timeout,
+	}
+	if d.Timeout == 0 {
+		d.Timeout = defaultTimeout
+	}
+	conn, err := d.Dial("tcp", c.Addr)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}
+
+type HTTPCheck struct {
+	// URL is the URL that will be requested
+	URL string
+
+	// Host specifies the host to be used in the Host header as well as the TLS
+	// SNI extension. It is optional, if unset the host from the URL will be
+	// used.
+	Host string
+
+	Timeout    time.Duration
+	StatusCode int
+	MatchBytes []byte
+}
+
+func (c *HTTPCheck) Check() error {
+	req, err := http.NewRequest("GET", c.URL, nil)
+	if err != nil {
+		return err
+	}
+	req.Host = c.Host
+
+	client := &http.Client{
+		Timeout: c.Timeout,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				// Don't verify TLS certificates since this is just a health check,
+				// not a connection that needs confidentiality or authenticity.
+				InsecureSkipVerify: true,
+				ServerName:         c.Host,
+			},
+		},
+	}
+	if client.Timeout == 0 {
+		client.Timeout = defaultTimeout
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	expectedStatus := c.StatusCode
+	if expectedStatus == 0 {
+		expectedStatus = 200
+	}
+	if res.StatusCode != expectedStatus {
+		return fmt.Errorf("healthcheck: expected HTTP status %d, got %d", expectedStatus, res.StatusCode)
+	}
+	if len(c.MatchBytes) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(io.LimitReader(res.Body, 5120)); err != nil {
+		return err
+	}
+	if !bytes.Contains(buf.Bytes(), c.MatchBytes) {
+		return fmt.Errorf("healthcheck: response did not match expected bytes")
+	}
+	return nil
+}

--- a/discoverd2/health/check_test.go
+++ b/discoverd2/health/check_test.go
@@ -1,0 +1,148 @@
+package health
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type CheckSuite struct{}
+
+var _ = Suite(&CheckSuite{})
+
+func (CheckSuite) TestTCPSuccess(c *C) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, IsNil)
+	defer l.Close()
+
+	go func() {
+		conn, err := l.Accept()
+		c.Assert(err, IsNil)
+		conn.Close()
+	}()
+
+	err = (&TCPCheck{Addr: l.Addr().String()}).Check()
+	c.Assert(err, IsNil)
+}
+
+func (CheckSuite) TestTCPFailure(c *C) {
+	err := (&TCPCheck{
+		Addr:    "127.0.0.1:65535",
+		Timeout: 10 * time.Millisecond,
+	}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "connection refused"), Equals, true)
+}
+
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if r.Host == "example.com" {
+		w.WriteHeader(400)
+	}
+	if r.RequestURI == "/ok" {
+		w.Write([]byte("ok"))
+	}
+})
+
+func (CheckSuite) TestHTTPSuccess(c *C) {
+	srv := httptest.NewServer(okHandler)
+	defer srv.Close()
+
+	err := (&HTTPCheck{URL: srv.URL}).Check()
+	c.Assert(err, IsNil)
+}
+
+func (CheckSuite) TestHTTPS(c *C) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS.ServerName != "example.com" {
+			w.WriteHeader(400)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	err := (&HTTPCheck{
+		URL:  srv.URL,
+		Host: "example.com",
+	}).Check()
+	c.Assert(err, IsNil)
+
+	err = (&HTTPCheck{
+		URL:  srv.URL,
+		Host: "foo.com",
+	}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "400"), Equals, true)
+}
+
+func (CheckSuite) TestHTTPCustomStatusHost(c *C) {
+	srv := httptest.NewServer(okHandler)
+	defer srv.Close()
+
+	err := (&HTTPCheck{
+		URL:        srv.URL,
+		StatusCode: 400,
+		Host:       "example.com",
+	}).Check()
+	c.Assert(err, IsNil)
+
+	err = (&HTTPCheck{URL: srv.URL}).Check()
+	c.Assert(err, IsNil)
+}
+
+func (CheckSuite) TestHTTPMatch(c *C) {
+	srv := httptest.NewServer(okHandler)
+	defer srv.Close()
+
+	err := (&HTTPCheck{
+		URL:        srv.URL + "/ok",
+		MatchBytes: []byte("ok"),
+	}).Check()
+	c.Assert(err, IsNil)
+
+	err = (&HTTPCheck{
+		URL:        srv.URL + "/ok",
+		MatchBytes: []byte("notok"),
+	}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "did not match"), Equals, true)
+}
+
+func (CheckSuite) TestHTTPReadTimeout(c *C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	err := (&HTTPCheck{
+		URL:        srv.URL,
+		Timeout:    50 * time.Millisecond,
+		MatchBytes: []byte("foo"),
+	}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "use of closed network connection"), Equals, true)
+}
+
+func (CheckSuite) TestHTTPConnectRefused(c *C) {
+	err := (&HTTPCheck{
+		URL:     "http://127.0.0.1:65535",
+		Timeout: 10 * time.Millisecond,
+	}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "connection refused"), Equals, true)
+}
+
+func (CheckSuite) TestHTTPInvalidURL(c *C) {
+	err := (&HTTPCheck{URL: "http%:"}).Check()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "invalid URL escape"), Equals, true)
+}


### PR DESCRIPTION
Incremental patch for #145.

This adds a simple package that can check the health of HTTP(S) and TCP endpoints, it will be used to automatically register/unregister services (probably from containerinit). The tests cover 100% of the statements.