### PR TITLE
discoverd2: Implement health monitor

### DIFF
--- a/discoverd2/health/check.go
+++ b/discoverd2/health/check.go
@@ -48,8 +48,12 @@ type HTTPCheck struct {
 	// used.
 	Host string
 
-	Timeout    time.Duration
+	Timeout time.Duration
+	// The response must respond with StatusCode for the check to pass. It
+	// defaults to 200.
 	StatusCode int
+	// If set, MatchBytes must be a subset present in the first 5120 bytes of
+	// the response for the check to pass.
 	MatchBytes []byte
 }
 

--- a/discoverd2/health/monitor.go
+++ b/discoverd2/health/monitor.go
@@ -1,0 +1,114 @@
+package health
+
+import (
+	"time"
+
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type MonitorConfig struct {
+	// StartInterval is the check interval to use when waiting for the service
+	// to transition from created -> up. It defaults to 100ms.
+	StartInterval time.Duration
+
+	// Interval is the check interval to use when the service is up or down. It
+	// defaults to two seconds.
+	Interval time.Duration
+
+	// Threshold is the number of consecutive checks of the same status before
+	// a service will transition up -> down or down -> up. It defaults to 2.
+	Threshold int
+}
+
+type MonitorStatus int
+
+const (
+	MonitorStatusUnknown MonitorStatus = iota
+	MonitorStatusCreated
+	MonitorStatusUp
+	MonitorStatusDown
+)
+
+type MonitorEvent struct {
+	Status MonitorStatus
+	// If Status is MonitorStatusDown, Err is the last failure
+	Err error
+	// Check is included to identify the monitor.
+	Check Check
+}
+
+const (
+	defaultStartInterval = 100 * time.Millisecond
+	defaultInterval      = 2 * time.Second
+	defaultThreshold     = 2
+)
+
+// Monitor monitors a service using Check and sends up/down transitions to ch
+func Monitor(cfg MonitorConfig, check Check, ch chan MonitorEvent) stream.Stream {
+	if cfg.StartInterval == 0 {
+		cfg.StartInterval = defaultStartInterval
+	}
+	if cfg.Interval == 0 {
+		cfg.Interval = defaultInterval
+	}
+	if cfg.Threshold == 0 {
+		cfg.Threshold = defaultThreshold
+	}
+
+	stream := stream.New()
+	go func() {
+		t := time.NewTicker(cfg.StartInterval)
+		defer close(ch)
+
+		status := MonitorStatusCreated
+		var upCount, downCount int
+		up := func() {
+			downCount = 0
+			upCount++
+			if status == MonitorStatusCreated || status == MonitorStatusDown && upCount >= cfg.Threshold {
+				if status == MonitorStatusCreated {
+					t.Stop()
+					t = time.NewTicker(cfg.Interval)
+				}
+				status = MonitorStatusUp
+				ch <- MonitorEvent{
+					Status: status,
+					Check:  check,
+				}
+			}
+		}
+		down := func(err error) {
+			upCount = 0
+			downCount++
+			if status == MonitorStatusUp && downCount >= cfg.Threshold {
+				status = MonitorStatusDown
+				ch <- MonitorEvent{
+					Status: status,
+					Err:    err,
+					Check:  check,
+				}
+			}
+		}
+		check := func() {
+			if err := check.Check(); err != nil {
+				down(err)
+			} else {
+				up()
+			}
+		}
+
+		check()
+	outer:
+		for {
+			select {
+			case <-t.C:
+				check()
+			case <-stream.StopCh:
+				break outer
+			}
+		}
+		t.Stop()
+	}()
+
+	return stream
+}

--- a/discoverd2/health/monitor_test.go
+++ b/discoverd2/health/monitor_test.go
@@ -1,0 +1,164 @@
+package health
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type MonitorSuite struct{}
+
+var _ = Suite(&MonitorSuite{})
+
+type CheckFunc func() error
+
+func (f CheckFunc) Check() error { return f() }
+
+func (MonitorSuite) TestMonitor(c *C) {
+	type step struct {
+		up    bool
+		event MonitorStatus
+	}
+
+	var stream stream.Stream
+	checker := func(steps []step) (chan MonitorEvent, Check) {
+		var i int
+		events := make(chan MonitorEvent, 1)
+		return events, CheckFunc(func() error {
+			defer func() {
+				if i >= len(steps) {
+					stream.Close()
+				}
+			}()
+
+			step := steps[i]
+			i++
+
+			if !step.up {
+				err := errors.New("check failure")
+				if step.event > 0 {
+					events <- MonitorEvent{
+						Status: step.event,
+						Err:    err,
+					}
+				}
+				return err
+			}
+			if step.event > 0 {
+				events <- MonitorEvent{Status: step.event}
+			}
+			return nil
+		})
+	}
+
+	for _, t := range []struct {
+		name      string
+		steps     []step
+		threshold int
+	}{
+		{
+			name:  "service doesn't come up",
+			steps: []step{{}, {}, {}},
+		},
+		{
+			name: "service comes up right away",
+			steps: []step{
+				{event: MonitorStatusUp, up: true},
+				{up: true},
+				{up: true},
+			},
+		},
+		{
+			name: "service comes up after a few checks",
+			steps: []step{
+				{}, {}, {},
+				{event: MonitorStatusUp, up: true},
+			},
+		},
+		{
+			name: "up/down/up - default threshold",
+			steps: []step{
+				{event: MonitorStatusUp, up: true},
+				{},
+				{event: MonitorStatusDown},
+				{up: true},
+				{event: MonitorStatusUp, up: true},
+			},
+		},
+		{
+			name:      "up/down/up - custom threshold",
+			threshold: 3,
+			steps: []step{
+				{event: MonitorStatusUp, up: true},
+				{},
+				{},
+				{event: MonitorStatusDown},
+				{up: true},
+				{up: true},
+				{event: MonitorStatusUp, up: true},
+			},
+		},
+		{
+			name: "flapping - alternate",
+			steps: []step{
+				{event: MonitorStatusUp, up: true},
+				{},
+				{up: true},
+				{},
+				{up: true},
+				{},
+				{event: MonitorStatusDown},
+				{up: true},
+				{},
+				{up: true},
+				{},
+			},
+		},
+		{
+			name:      "flapping - consecutive",
+			threshold: 3,
+			steps: []step{
+				{event: MonitorStatusUp, up: true},
+				{},
+				{},
+				{up: true},
+				{},
+				{},
+				{up: true},
+				{},
+				{},
+				{event: MonitorStatusDown},
+				{up: true},
+				{up: true},
+				{},
+				{up: true},
+				{up: true},
+				{},
+			},
+		},
+	} {
+		c.Log(t.name)
+
+		expectedEvents, check := checker(t.steps)
+		actualEvents := make(chan MonitorEvent)
+		stream = Monitor(MonitorConfig{
+			Threshold:     t.threshold,
+			StartInterval: time.Nanosecond,
+			Interval:      time.Nanosecond,
+		}, check, actualEvents)
+
+		for actual := range actualEvents {
+			select {
+			case expected := <-expectedEvents:
+				// functions are not comparable, so we check it and then nil it
+				c.Assert(actual.Check, FitsTypeOf, CheckFunc(nil))
+				actual.Check = nil
+				c.Assert(actual, DeepEquals, expected)
+			default:
+				c.Fatalf("unexpected event %#v", actual)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Incremental patch for #145.

This builds on the health check capabilities to provide a monitor that runs checks on a regular basis and signals a channel when a check changes state.