### PR TITLE
pkg/httpclient: Consolidate HTTP hijacking.

### DIFF
--- a/host/attach.go
+++ b/host/attach.go
@@ -25,11 +25,14 @@ func (h *attachHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, _ ht
 		http.Error(w, "invalid JSON", 400)
 		return
 	}
+	w.Header().Set("Content-Type", "application/vnd.flynn.attach")
+	w.Header().Set("Content-Length", "0")
+	w.WriteHeader(http.StatusSwitchingProtocols)
+
 	conn, _, err := w.(http.Hijacker).Hijack()
 	if err != nil {
 		return
 	}
-	conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Type: application/vnd.flynn.attach-hijack\r\n\r\n"))
 	h.attach(&attachReq, conn)
 }
 

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -1,12 +1,14 @@
 package httpclient
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 
@@ -15,6 +17,16 @@ import (
 )
 
 type DialFunc func(network, addr string) (net.Conn, error)
+
+type writeCloser interface {
+	io.WriteCloser
+	CloseWrite() error
+}
+
+type ReadWriteCloser interface {
+	io.ReadWriteCloser
+	CloseWrite() error
+}
 
 type Client struct {
 	ErrNotFound error
@@ -38,7 +50,7 @@ func ToJSON(v interface{}) (io.Reader, error) {
 	return bytes.NewBuffer(data), err
 }
 
-func (c *Client) RawReq(method, path string, header http.Header, in, out interface{}) (*http.Response, error) {
+func (c *Client) prepareReq(method, path string, header http.Header, in interface{}) (*http.Request, error) {
 	var payload io.Reader
 	switch v := in.(type) {
 	case io.Reader:
@@ -66,6 +78,14 @@ func (c *Client) RawReq(method, path string, header http.Header, in, out interfa
 	if c.Key != "" {
 		req.SetBasicAuth("", c.Key)
 	}
+	return req, nil
+}
+
+func (c *Client) RawReq(method, path string, header http.Header, in, out interface{}) (*http.Response, error) {
+	req, err := c.prepareReq(method, path, header, in)
+	if err != nil {
+		return nil, err
+	}
 	res, err := c.HTTP.Do(req)
 	if err != nil {
 		return nil, err
@@ -92,6 +112,51 @@ func (c *Client) RawReq(method, path string, header http.Header, in, out interfa
 		return res, json.NewDecoder(res.Body).Decode(out)
 	}
 	return res, nil
+}
+
+func (c *Client) Hijack(method, path string, header http.Header, in interface{}) (ReadWriteCloser, error) {
+	uri, err := url.Parse(c.URL)
+	if err != nil {
+		return nil, err
+	}
+	dial := c.Dial
+	if dial == nil {
+		dial = net.Dial
+	}
+	conn, err := dial("tcp", uri.Host)
+	if err != nil {
+		return nil, err
+	}
+	clientconn := httputil.NewClientConn(conn, nil)
+	req, err := c.prepareReq(method, path, header, in)
+	if err != nil {
+		return nil, err
+	}
+	res, err := clientconn.Do(req)
+	if err != nil && err != httputil.ErrPersistEOF {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusSwitchingProtocols {
+		res.Body.Close()
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: fmt.Errorf("httpclient: unexpected status %d", res.StatusCode),
+		}
+	}
+	var rwc io.ReadWriteCloser
+	var buf *bufio.Reader
+	rwc, buf = clientconn.Hijack()
+	if buf.Buffered() > 0 {
+		rwc = struct {
+			io.Reader
+			writeCloser
+		}{
+			io.MultiReader(io.LimitReader(buf, int64(buf.Buffered())), rwc),
+			rwc.(writeCloser),
+		}
+	}
+	return rwc.(ReadWriteCloser), nil
 }
 
 // Stream returns a stream.Stream for a specific method and path. in is an


### PR DESCRIPTION
Since we're using an uniform client for doing http requests, we can provide a
convenience method for hijacking. This also standardises hijacking -- the attach
endpoint used status 200, but http.SwitchingProtocols seems more appropriate.

Whereas Stream is defined as a SSE stream of JSON objects, Hijack is more
general and unspecified, allowing for custom protocols where SSE would not work
well.

Signed-off-by: Blaž Hrastnik <blaz.hrast@gmail.com>