### PR TITLE
pkg/httpclient: Decode JSON errors

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -35,7 +35,6 @@ var ErrNotFound = errors.New("controller: resource not found")
 func newClient(key string, url string, http *http.Client) *Client {
 	c := &Client{
 		Client: &httpclient.Client{
-			ErrPrefix:   "controller",
 			ErrNotFound: ErrNotFound,
 			Key:         key,
 			URL:         url,

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -59,7 +59,6 @@ func newClient(services ServiceSetFunc) (*Client, error) {
 		return nil, err
 	}
 	c := &httpclient.Client{
-		ErrPrefix:   "cluster",
 		ErrNotFound: ErrNotFound,
 		HTTP:        http.DefaultClient,
 	}

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -40,7 +40,6 @@ func NewHostClient(addr string, h *http.Client) Host {
 		h = http.DefaultClient
 	}
 	return &hostClient{c: &httpclient.Client{
-		ErrPrefix:   "host",
 		ErrNotFound: ErrNotFound,
 		URL:         addr,
 		HTTP:        h,

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -18,7 +18,6 @@ type DialFunc func(network, addr string) (net.Conn, error)
 
 type Client struct {
 	ErrNotFound error
-	ErrPrefix   string
 	URL         string
 	Key         string
 	HTTP        *http.Client

--- a/router/api.go
+++ b/router/api.go
@@ -46,7 +46,7 @@ func createRoute(req *http.Request, route router.Route, router *Router, r render
 
 	if err := l.AddRoute(&route); err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 	res := formatRoute(&route)
@@ -66,7 +66,7 @@ func createOrReplaceRoute(req *http.Request, route router.Route, router *Router,
 
 	if err := l.SetRoute(&route); err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 	res := formatRoute(&route)
@@ -108,13 +108,13 @@ func getRoutes(req *http.Request, rtr *Router, r render.Render) {
 	routes, err := rtr.HTTP.List()
 	if err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 	tcpRoutes, err := rtr.TCP.List()
 	if err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 	routes = append(routes, tcpRoutes...)
@@ -139,18 +139,18 @@ func getRoutes(req *http.Request, rtr *Router, r render.Render) {
 func getRoute(params martini.Params, router *Router, r render.Render) {
 	l := listenerFor(router, params["route_type"])
 	if l == nil {
-		r.JSON(404, struct{}{})
+		r.JSON(404, "not found")
 		return
 	}
 
 	route, err := l.Get(params["route_id"])
 	if err == ErrNotFound {
-		r.JSON(404, struct{}{})
+		r.JSON(404, "not found")
 		return
 	}
 	if err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 
@@ -160,20 +160,20 @@ func getRoute(params martini.Params, router *Router, r render.Render) {
 func deleteRoute(params martini.Params, router *Router, r render.Render) {
 	l := listenerFor(router, params["route_type"])
 	if l == nil {
-		r.JSON(404, struct{}{})
+		r.JSON(404, "not found")
 		return
 	}
 
 	err := l.RemoveRoute(params["route_id"])
 	if err == ErrNotFound {
-		r.JSON(404, struct{}{})
+		r.JSON(404, "not found")
 		return
 	}
 	if err != nil {
 		log.Println(err)
-		r.JSON(500, struct{}{})
+		r.JSON(500, "unknown error")
 		return
 	}
 
-	r.JSON(200, struct{}{})
+	r.JSON(200, "unknown error")
 }

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -46,7 +46,6 @@ func NewWithHTTP(http *http.Client) (Client, error) {
 
 func newRouterClient() *client {
 	c := &httpclient.Client{
-		ErrPrefix:   "router",
 		ErrNotFound: ErrNotFound,
 	}
 	return &client{Client: c}
@@ -71,7 +70,6 @@ func newWithDiscoverd(name string, dc dialer.DiscoverdClient) *client {
 	}
 	dialer := dialer.New(dc, nil)
 	c := newRouterClient()
-	c.ErrPrefix = name
 	c.Dial = dialer.Dial
 	c.DialClose = dialer
 	c.URL = fmt.Sprintf("http://%s-api", name)


### PR DESCRIPTION
If a non-200 response has an `application/json` Content-Type and decodes successfully into a `JSONError`, return it. If not, fallback to the old behavior of returning generic errors.