### PR TITLE
router: add default tls keypair to server

### DIFF
--- a/router/http_test.go
+++ b/router/http_test.go
@@ -27,27 +27,28 @@ var httpClient = &http.Client{
 // "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end
 // of ASN.1 time).
 // generated from src/pkg/crypto/tls:
-// go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+// go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com,*.example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
 var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
-MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
-bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
-bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
-IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
-AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
-EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
-AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
-Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+MIIBmjCCAUagAwIBAgIRAP5DRqWA/pgvAnbC6gnl82kwCwYJKoZIhvcNAQELMBIx
+EDAOBgNVBAoTB0FjbWUgQ28wIBcNNzAwMTAxMDAwMDAwWhgPMjA4NDAxMjkxNjAw
+MDBaMBIxEDAOBgNVBAoTB0FjbWUgQ28wXDANBgkqhkiG9w0BAQEFAANLADBIAkEA
+t9JXJg6fCMxvBKfLCukH7dnF1nIdCBuurjXxVM69E2+97G3aDBTIm7rXtxilAYib
+BwzBtgqPzUVngbmK25cguQIDAQABo3cwdTAOBgNVHQ8BAf8EBAMCAKQwEwYDVR0l
+BAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zA9BgNVHREENjA0ggtleGFt
+cGxlLmNvbYINKi5leGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATAL
+BgkqhkiG9w0BAQsDQQBJxy1zotHYLZpyoockAlJWRa88hs1PrroUNMlueRtzNkpx
+9heaebvotwUkFlnNYJZsfPnO23R0lUlzLJ3p1RNz
 -----END CERTIFICATE-----`)
 
 // localhostKey is the private key for localhostCert.
 var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
-0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
-NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
-AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
-MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
-EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
-1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+MIIBOQIBAAJBALfSVyYOnwjMbwSnywrpB+3ZxdZyHQgbrq418VTOvRNvvext2gwU
+yJu617cYpQGImwcMwbYKj81FZ4G5ituXILkCAwEAAQJAXvmhp3skdkJSFgCv6qou
+O5kqG7uH/nl3DnG2iA/tJw3SlEPftQyzNk5jcIFSxvr8pu1pj+L1vw5pR68/7fre
+xQIhAMM0/bYtVbzW+PPjqAev3TKhMyWkY3t9Qvw5OtgmBQ+PAiEA8RGk9OvMxBbR
+8zJmOXminEE2VVE1VF0K0OiFLDG+JzcCIHurptE0B42L5E0ffeTg1hKtben7K8ug
+oD+LQmyOKcahAiB05Btab2QQyQfwpsWOpP5GShCwefoj+CGgfr7kWRJdLQIgTMZe
+++SKD8ascROyDnZ0Td8wbrFnO0YRPEkwlhn6h0U=
 -----END RSA PRIVATE KEY-----`)
 
 func init() {

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -73,7 +73,13 @@ func newHTTPListenerClients(t etcdrunner.TestingT, etcd EtcdClient, discoverd di
 		t.Fatal(err)
 	}
 	l := &httpListener{
-		NewHTTPListener("127.0.0.1:0", "127.0.0.1:0", nil, pair, NewEtcdDataStore(etcd, "/router/http/"), discoverd),
+		&HTTPListener{
+			Addr:      "127.0.0.1:0",
+			TLSAddr:   "127.0.0.1:0",
+			keypair:   pair,
+			ds:        NewEtcdDataStore(etcd, "/router/http/"),
+			discoverd: discoverd,
+		},
 		cleanup,
 	}
 	if err := l.Start(); err != nil {

--- a/router/server.go
+++ b/router/server.go
@@ -74,10 +74,17 @@ func main() {
 	flag.Parse()
 
 	keypair := tls.Certificate{}
+	var err error
 	if *certFile != "" {
-		var err error
 		if keypair, err = tls.LoadX509KeyPair(*certFile, *keyFile); err != nil {
 			log.Fatal(err)
+		}
+	} else if tlsCert := os.Getenv("TLSCERT"); tlsCert != "" {
+		if tlsKey := os.Getenv("TLSKEY"); tlsKey != "" {
+			os.Setenv("TLSKEY", fmt.Sprintf("md5^(%s)", md5sum(tlsKey)))
+			if keypair, err = tls.X509KeyPair([]byte(tlsCert), []byte(tlsKey)); err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 

--- a/router/server.go
+++ b/router/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -67,8 +68,18 @@ func main() {
 	tcpIP := flag.String("tcpip", "", "tcp router listen ip")
 	tcpRangeStart := flag.Int("tcp-range-start", 3000, "tcp port range start")
 	tcpRangeEnd := flag.Int("tcp-range-end", 3500, "tcp port range end")
+	certFile := flag.String("tlscert", "", "TLS (SSL) cert file in pem format")
+	keyFile := flag.String("tlskey", "", "TLS (SSL) key file in pem format")
 	apiAddr := flag.String("apiaddr", ":"+apiPort, "api listen address")
 	flag.Parse()
+
+	keypair := tls.Certificate{}
+	if *certFile != "" {
+		var err error
+		if keypair, err = tls.LoadX509KeyPair(*certFile, *keyFile); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	// Will use DISCOVERD environment variable
 	d, err := discoverd.NewClient()
@@ -108,7 +119,7 @@ func main() {
 	}
 	var r Router
 	r.TCP = NewTCPListener(*tcpIP, *tcpRangeStart, *tcpRangeEnd, NewEtcdDataStore(etcdc, path.Join(prefix, "tcp/")), d)
-	r.HTTP = NewHTTPListener(*httpAddr, *httpsAddr, cookieKey, NewEtcdDataStore(etcdc, path.Join(prefix, "http/")), d)
+	r.HTTP = NewHTTPListener(*httpAddr, *httpsAddr, cookieKey, keypair, NewEtcdDataStore(etcdc, path.Join(prefix, "http/")), d)
 
 	go func() { log.Fatal(r.ListenAndServe(nil)) }()
 	listener, err := reuseport.NewReusablePortListener("tcp4", *apiAddr)

--- a/router/server.go
+++ b/router/server.go
@@ -117,9 +117,23 @@ func main() {
 	if prefix == "" {
 		prefix = "/router"
 	}
-	var r Router
-	r.TCP = NewTCPListener(*tcpIP, *tcpRangeStart, *tcpRangeEnd, NewEtcdDataStore(etcdc, path.Join(prefix, "tcp/")), d)
-	r.HTTP = NewHTTPListener(*httpAddr, *httpsAddr, cookieKey, keypair, NewEtcdDataStore(etcdc, path.Join(prefix, "http/")), d)
+	r := Router{
+		TCP: &TCPListener{
+			IP:        *tcpIP,
+			startPort: *tcpRangeStart,
+			endPort:   *tcpRangeEnd,
+			ds:        NewEtcdDataStore(etcdc, path.Join(prefix, "tcp/")),
+			discoverd: d,
+		},
+		HTTP: &HTTPListener{
+			Addr:      *httpAddr,
+			TLSAddr:   *httpsAddr,
+			cookieKey: cookieKey,
+			keypair:   keypair,
+			ds:        NewEtcdDataStore(etcdc, path.Join(prefix, "http/")),
+			discoverd: d,
+		},
+	}
 
 	go func() { log.Fatal(r.ListenAndServe(nil)) }()
 	listener, err := reuseport.NewReusablePortListener("tcp4", *apiAddr)

--- a/router/tcp_test.go
+++ b/router/tcp_test.go
@@ -63,7 +63,13 @@ func (l *tcpListener) Close() error {
 func newTCPListenerClients(t etcdrunner.TestingT, etcd EtcdClient, discoverd discoverdClient) (*tcpListener, discoverdClient) {
 	discoverd, etcd, cleanup := setup(t, etcd, discoverd)
 	l := &tcpListener{
-		NewTCPListener("127.0.0.1", firstTCPPort, lastTCPPort, NewEtcdDataStore(etcd, "/router/tcp/"), discoverd),
+		&TCPListener{
+			IP:        "127.0.0.1",
+			startPort: firstTCPPort,
+			endPort:   lastTCPPort,
+			ds:        NewEtcdDataStore(etcd, "/router/tcp/"),
+			discoverd: discoverd,
+		},
 		cleanup,
 	}
 	if err := l.Start(); err != nil {


### PR DESCRIPTION
This is an initial attempt at implementing #267. I'm still getting up to speed on the code base so I'd love to get some feedback on this approach & any style issues.

The keypair passed into the new `HTTPListener` is used as the default `tls.Certificate` for SNI & non-SNI clients alike. This is handled by `tls.Config`'s `NameToCertificate` map, which is populated in the `tls.Server` call.