### PR TITLE
util/commit-validator: Fix DCO link

### DIFF
--- a/util/commit-validator/validate-dco
+++ b/util/commit-validator/validate-dco
@@ -38,7 +38,7 @@ else
       echo 'Please amend each commit to include a properly formatted DCO sign-off.'
       echo
       echo "Visit the following URL for information about the Developer's Certificate of Origin:"
-      echo ' https://flynn.io/docs/contributing#developers-certificate-of-origin'
+      echo ' https://flynn.io/docs/contributing#developer’s-certificate-of-origin'
       echo
     } >&2
     false


### PR DESCRIPTION
At some point the sanitizer for anchor generation changed, this adds a missing apostrophe to the anchor.