### PR TITLE
appliance/postgresql: Remove some dead follower code

### DIFF
--- a/appliance/postgresql/runner.go
+++ b/appliance/postgresql/runner.go
@@ -3,10 +3,8 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"io"
 	"log"
-	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -18,7 +16,6 @@ import (
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
 	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq"
-	da "github.com/flynn/flynn/discoverd/agent"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/random"
 )
@@ -197,19 +194,6 @@ func runCmd(cmd *exec.Cmd) {
 	}
 }
 
-func pullBaseBackup(s *discoverd.Service) {
-	log.Println("Running pg_basebackup...")
-	runCmd(exec.Command(
-		"pg_basebackup",
-		"-D", *dataDir,
-		"-d", fmt.Sprintf("host=%s port=%s user=%s password=%s", s.Host, s.Port, s.Attrs["username"], s.Attrs["password"]),
-		"--xlog-method=stream",
-		"--progress",
-		"--verbose",
-	))
-	log.Println("pg_basebackup complete.")
-}
-
 var recoveryTempl = template.Must(template.New("recovery").Parse(`
 standby_mode = 'on'
 primary_conninfo = 'host={{.Host}} port={{.Port}} user={{.Username}} password={{.Password}}'
@@ -222,93 +206,6 @@ type recoveryConfig struct {
 	Username string
 	Password string
 	Trigger  string
-}
-
-func writeRecoveryConf(dir string, leader *discoverd.Service) {
-	f, err := os.Create(filepath.Join(dir, "recovery.conf"))
-	if err != nil {
-		log.Fatalln("Error creating recovery.conf:", err)
-	}
-	defer f.Close()
-
-	err = recoveryTempl.Execute(f, &recoveryConfig{
-		Host:     leader.Host,
-		Port:     leader.Port,
-		Username: leader.Attrs["username"],
-		Password: leader.Attrs["password"],
-		Trigger:  filepath.Join(dir, "promote.trigger"),
-	})
-	if err != nil {
-		log.Fatalln("Error writing recovery.conf:", err)
-	}
-}
-
-func updateToService(u *da.ServiceUpdate) *discoverd.Service {
-	host, port, _ := net.SplitHostPort(u.Addr)
-	return &discoverd.Service{
-		Created: u.Created,
-		Name:    u.Name,
-		Addr:    u.Addr,
-		Attrs:   u.Attrs,
-		Host:    host,
-		Port:    port,
-	}
-}
-
-func waitForLeaderUp(leader *discoverd.Service, set discoverd.ServiceSet) *discoverd.Service {
-	if leader.Attrs["up"] == "true" {
-		return leader
-	}
-	log.Println("Waiting for leader to come up...")
-	watch := set.Watch(true)
-	defer set.Unwatch(watch)
-	for update := range watch {
-		if update.Addr == set.Leader().Addr && update.Attrs["up"] == "true" && update.Attrs["username"] != "" && update.Attrs["password"] != "" {
-			return updateToService(update)
-		}
-	}
-	return nil
-}
-
-func startFollower(leader *discoverd.Service, set discoverd.ServiceSet) *follower {
-	log.Println("Starting as follower...")
-	leader = waitForLeaderUp(leader, set)
-	if err := dirIsEmpty(*dataDir); err == nil {
-		pullBaseBackup(leader)
-	} else if err != ErrNotEmpty {
-		log.Fatal(err)
-	}
-
-	writeRecoveryConf(*dataDir, leader)
-	cmd, err := startPostgres(*dataDir)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	waitForPostgres(time.Minute).Close()
-	register(map[string]string{"up": "true"})
-	log.Println("Follower started.")
-
-	// TODO: if data and insufficient WAL, pg_basebackup
-	return newFollower(cmd)
-}
-
-func switchLeader(leader *discoverd.Service, set discoverd.ServiceSet, follower *follower) *follower {
-	log.Println("Switching leaders...")
-	leader = waitForLeaderUp(leader, set)
-	register(map[string]string{"up": "false"})
-	writeRecoveryConf(*dataDir, leader)
-	follower.Stop()
-
-	cmd, err := startPostgres(*dataDir)
-	if err != nil {
-		log.Fatal(err)
-	}
-	waitForPostgres(time.Minute).Close()
-	// TODO: check for insufficient WAL, then pg_basebackup
-	register(map[string]string{"up": "true"})
-	log.Println("Leader switch complete.")
-	return newFollower(cmd)
 }
 
 func newFollower(cmd *exec.Cmd) *follower {


### PR DESCRIPTION
Follow-up to b95e7ad5 / #772.

Remove code that references discoverd and is unused after disabling the follower code. This will make landing discoverd2 easier.