### PR TITLE
router: make domain name lookup case insensitive

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -194,7 +194,7 @@ func (h *httpSyncHandler) Set(data *router.Route) error {
 	service.refs++
 	r.service = service
 	h.l.routes[data.ID] = r
-	h.l.domains[r.Domain] = r
+	h.l.domains[strings.ToLower(r.Domain)] = r
 
 	go h.l.wm.Send(&router.Event{Event: "set", ID: r.Domain})
 	return nil
@@ -258,6 +258,7 @@ func (s *HTTPListener) serveTLS(started chan<- error) {
 }
 
 func (s *HTTPListener) findRouteForHost(host string) *httpRoute {
+	host = strings.ToLower(host)
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	if backend, ok := s.domains[host]; ok {


### PR DESCRIPTION
Some http clients do not down-case the hostname in the Host header of the HTTP request and the servername in the TLS client-hello. Matching route domains in a case-insensitive way prevents 404 and TLS handshake errors for such clients. The request's Host header is not altered and keeps the original casing.