### PR TITLE
router: switch to from net/http/httputil to net/http

### DIFF
--- a/router/handlers.go
+++ b/router/handlers.go
@@ -1,19 +1,21 @@
 package main
 
 import (
+	"net"
 	"net/http"
 	"strings"
 )
 
 const (
+	fwdForHeaderName   = "X-Forwarded-For"
 	fwdProtoHeaderName = "X-Forwarded-Proto"
 	fwdPortHeaderName  = "X-Forwarded-Port"
 )
 
-// fwdProtoHandler is an http.Handler that sets X-Forwarded-Proto and
-// X-Forwarded-Port headers on inbound requests to match the values in Proto
-// and Port. If those headers already exist, the Proto and Port values will be
-// appended.
+// fwdProtoHandler is an http.Handler that sets the X-Forwarded-For header on
+// inbound requests to match the remote IP address, and sets X-Forwarded-Proto
+// and X-Forwarded-Port headers to match the values in Proto and Port. If those
+// headers already exist, the new values will be appended.
 type fwdProtoHandler struct {
 	http.Handler
 	Proto string
@@ -21,11 +23,16 @@ type fwdProtoHandler struct {
 }
 
 func (h fwdProtoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// If we aren't the first proxy retain prior X-Forwarded-Proto and
-	// X-Forwarded-Port information as a comma+space separated list and fold
-	// multiple headers into one.
-	proto, port := h.Proto, h.Port
+	// If we aren't the first proxy retain prior X-Forwarded-* information as a
+	// comma+space separated list and fold multiple headers into one.
+	if clientIP, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if prior, ok := r.Header[fwdForHeaderName]; ok {
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
+		}
+		r.Header.Set(fwdForHeaderName, clientIP)
+	}
 
+	proto, port := h.Proto, h.Port
 	if prior, ok := r.Header[fwdProtoHeaderName]; ok {
 		proto = strings.Join(prior, ", ") + ", " + proto
 	}

--- a/router/handlers.go
+++ b/router/handlers.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	fwdProtoHeaderName = "X-Forwarded-Proto"
+	fwdPortHeaderName  = "X-Forwarded-Port"
+)
+
+// fwdProtoHandler is an http.Handler that sets X-Forwarded-Proto and
+// X-Forwarded-Port headers on inbound requests to match the values in Proto
+// and Port. If those headers already exist, the Proto and Port values will be
+// appended.
+type fwdProtoHandler struct {
+	http.Handler
+	Proto string
+	Port  string
+}
+
+func (h fwdProtoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If we aren't the first proxy retain prior X-Forwarded-Proto and
+	// X-Forwarded-Port information as a comma+space separated list and fold
+	// multiple headers into one.
+	proto, port := h.Proto, h.Port
+
+	if prior, ok := r.Header[fwdProtoHeaderName]; ok {
+		proto = strings.Join(prior, ", ") + ", " + proto
+	}
+	if prior, ok := r.Header[fwdPortHeaderName]; ok {
+		port = strings.Join(prior, ", ") + ", " + port
+	}
+	r.Header.Set(fwdProtoHeaderName, proto)
+	r.Header.Set(fwdPortHeaderName, port)
+
+	h.Handler.ServeHTTP(w, r)
+}

--- a/router/handlers_test.go
+++ b/router/handlers_test.go
@@ -14,8 +14,12 @@ func TestFwdProtoHandler(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	request, _ := http.NewRequest("GET", "http://test.com", nil)
+	request.RemoteAddr = "1.2.3.4:5678"
 	h := fwdProtoHandler{Handler: nopHandler, Proto: "https", Port: "443"}
 	h.ServeHTTP(rec, request)
+	if v := request.Header.Get("X-Forwarded-For"); v != "1.2.3.4" {
+		t.Errorf("want X-Forwarded-For %s, got %s", "1.2.3.4", v)
+	}
 	if v := request.Header.Get("X-Forwarded-Proto"); v != "https" {
 		t.Errorf("want X-Forwarded-Proto %s, got %s", "https", v)
 	}

--- a/router/handlers_test.go
+++ b/router/handlers_test.go
@@ -3,12 +3,13 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"testing"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 )
 
 var nopHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-func TestFwdProtoHandler(t *testing.T) {
+func (s *S) TestFwdProtoHandler(c *C) {
 	prevForwardedProto := "fakeproto"
 	prevForwardedPort := "8080"
 
@@ -17,15 +18,9 @@ func TestFwdProtoHandler(t *testing.T) {
 	request.RemoteAddr = "1.2.3.4:5678"
 	h := fwdProtoHandler{Handler: nopHandler, Proto: "https", Port: "443"}
 	h.ServeHTTP(rec, request)
-	if v := request.Header.Get("X-Forwarded-For"); v != "1.2.3.4" {
-		t.Errorf("want X-Forwarded-For %s, got %s", "1.2.3.4", v)
-	}
-	if v := request.Header.Get("X-Forwarded-Proto"); v != "https" {
-		t.Errorf("want X-Forwarded-Proto %s, got %s", "https", v)
-	}
-	if v := request.Header.Get("X-Forwarded-Port"); v != "443" {
-		t.Errorf("want X-Forwarded-Port %s, got %s", "443", v)
-	}
+	c.Assert(request.Header.Get("X-Forwarded-For"), Equals, "1.2.3.4")
+	c.Assert(request.Header.Get("X-Forwarded-Proto"), Equals, "https")
+	c.Assert(request.Header.Get("X-Forwarded-Port"), Equals, "443")
 
 	// test with headers already set, make sure we append correctly
 	rec = httptest.NewRecorder()
@@ -34,14 +29,6 @@ func TestFwdProtoHandler(t *testing.T) {
 	request.Header.Set("X-Forwarded-Port", prevForwardedPort)
 
 	h.ServeHTTP(rec, request)
-	want := prevForwardedProto + ", https"
-	got := request.Header.Get("X-Forwarded-Proto")
-	if want != got {
-		t.Errorf("want X-Forwarded-Proto %q, got %q", want, got)
-	}
-	want = prevForwardedPort + ", 443"
-	got = request.Header.Get("X-Forwarded-Port")
-	if want != got {
-		t.Errorf("want X-Forwarded-Port %q, got %q", want, got)
-	}
+	c.Assert(request.Header.Get("X-Forwarded-Proto"), Equals, prevForwardedProto+", https")
+	c.Assert(request.Header.Get("X-Forwarded-Port"), Equals, prevForwardedPort+", 443")
 }

--- a/router/handlers_test.go
+++ b/router/handlers_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var nopHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+func TestFwdProtoHandler(t *testing.T) {
+	prevForwardedProto := "fakeproto"
+	prevForwardedPort := "8080"
+
+	rec := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "http://test.com", nil)
+	h := fwdProtoHandler{Handler: nopHandler, Proto: "https", Port: "443"}
+	h.ServeHTTP(rec, request)
+	if v := request.Header.Get("X-Forwarded-Proto"); v != "https" {
+		t.Errorf("want X-Forwarded-Proto %s, got %s", "https", v)
+	}
+	if v := request.Header.Get("X-Forwarded-Port"); v != "443" {
+		t.Errorf("want X-Forwarded-Port %s, got %s", "443", v)
+	}
+
+	// test with headers already set, make sure we append correctly
+	rec = httptest.NewRecorder()
+	request, _ = http.NewRequest("GET", "http://test.com", nil)
+	request.Header.Set("X-Forwarded-Proto", prevForwardedProto)
+	request.Header.Set("X-Forwarded-Port", prevForwardedPort)
+
+	h.ServeHTTP(rec, request)
+	want := prevForwardedProto + ", https"
+	got := request.Header.Get("X-Forwarded-Proto")
+	if want != got {
+		t.Errorf("want X-Forwarded-Proto %q, got %q", want, got)
+	}
+	want = prevForwardedPort + ", 443"
+	got = request.Header.Get("X-Forwarded-Port")
+	if want != got {
+		t.Errorf("want X-Forwarded-Port %q, got %q", want, got)
+	}
+}

--- a/router/http.go
+++ b/router/http.go
@@ -299,6 +299,12 @@ func fail(sc *httputil.ServerConn, req *http.Request, code int, msg string) {
 	sc.Write(req, resp)
 }
 
+func failw(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Length", strconv.Itoa(len(msg)))
+	w.WriteHeader(code)
+	w.Write([]byte(msg))
+}
+
 var errMissingTLS = errors.New("router: route not found or TLS not configured")
 
 func (s *HTTPListener) handle(conn net.Conn, isTLS bool) {

--- a/router/http.go
+++ b/router/http.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/tls"
@@ -9,11 +8,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"strconv"
 	"strings"
 	"sync"
@@ -248,6 +245,8 @@ func (s *HTTPListener) listenAndServe(started chan<- error) {
 	_ = server.Serve(s.listener)
 }
 
+var errMissingTLS = errors.New("router: route not found or TLS not configured")
+
 func (s *HTTPListener) listenAndServeTLS(started chan<- error) {
 	_, port, err := net.SplitHostPort(s.TLSAddr)
 	if err != nil {
@@ -303,50 +302,10 @@ func (s *HTTPListener) findRouteForHost(host string) *httpRoute {
 	return nil
 }
 
-func fail(sc *httputil.ServerConn, req *http.Request, code int, msg string) {
-	resp := &http.Response{
-		StatusCode:    code,
-		ProtoMajor:    1,
-		ProtoMinor:    0,
-		Request:       req,
-		Body:          ioutil.NopCloser(bytes.NewBufferString(msg)),
-		ContentLength: int64(len(msg)),
-	}
-	sc.Write(req, resp)
-}
-
-func failw(w http.ResponseWriter, code int, msg string) {
+func fail(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(msg)))
 	w.WriteHeader(code)
 	w.Write([]byte(msg))
-}
-
-var errMissingTLS = errors.New("router: route not found or TLS not configured")
-
-func (s *HTTPListener) handle(conn net.Conn, isTLS bool) {
-	defer conn.Close() // TODO(benburkert): for TLS, check that closing this conn sends the TLS "close notify"
-
-	sc := httputil.NewServerConn(conn, nil)
-	for {
-		req, err := sc.Read()
-		if err != nil {
-			if err != io.EOF && err != httputil.ErrPersistEOF && err != errMissingTLS {
-				log.Println("client read err:", err)
-			}
-			return
-		}
-
-		r := s.findRouteForHost(req.Host)
-		if r == nil {
-			fail(sc, req, 404, "Not Found")
-			continue
-		}
-
-		req.RemoteAddr = conn.RemoteAddr().String()
-		if r.service.handle(req, sc, isTLS, r.Sticky) {
-			return
-		}
-	}
 }
 
 const hdrUseStickySessions = "Flynn-Use-Sticky-Sessions"
@@ -354,7 +313,7 @@ const hdrUseStickySessions = "Flynn-Use-Sticky-Sessions"
 func (s *HTTPListener) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r := s.findRouteForHost(req.Host)
 	if r == nil {
-		failw(w, 404, "Not Found")
+		fail(w, 404, "Not Found")
 		return
 	}
 
@@ -450,180 +409,6 @@ func (s *httpService) pickNewBackendSticky() (string, *http.Cookie) {
 	return backend, &http.Cookie{Name: stickyCookie, Value: base64.StdEncoding.EncodeToString(out), Path: "/"}
 }
 
-func (s *httpService) getBackend() *httputil.ClientConn {
-	backend, _ := s.connectBackend()
-	return backend
-}
-
-func (s *httpService) connectBackend() (*httputil.ClientConn, string) {
-	for _, addr := range shuffle(s.ss.Addrs()) {
-		// TODO: set connection timeout
-		backend, err := net.Dial("tcp", addr)
-		if err != nil {
-			// TODO: log error
-			// TODO: limit number of backends tried
-			// TODO: temporarily quarantine failing backends
-			log.Println("backend error", err)
-			continue
-		}
-		return httputil.NewClientConn(backend, nil), addr
-	}
-	// TODO: log no backends found error
-	return nil, ""
-}
-
-func (s *httpService) getNewBackendSticky() (*httputil.ClientConn, *http.Cookie) {
-	backend, addr := s.connectBackend()
-	if backend == nil {
-		return nil, nil
-	}
-
-	var nonce [24]byte
-	_, err := io.ReadFull(rand.Reader, nonce[:])
-	if err != nil {
-		panic(err)
-	}
-	out := make([]byte, len(nonce), len(nonce)+len(addr)+secretbox.Overhead)
-	copy(out, nonce[:])
-	out = secretbox.Seal(out, []byte(addr), &nonce, s.cookieKey)
-
-	return backend, &http.Cookie{Name: stickyCookie, Value: base64.StdEncoding.EncodeToString(out), Path: "/"}
-}
-
-func (s *httpService) getBackendSticky(req *http.Request) (*httputil.ClientConn, *http.Cookie) {
-	cookie, err := req.Cookie(stickyCookie)
-	if err != nil {
-		return s.getNewBackendSticky()
-	}
-
-	data, err := base64.StdEncoding.DecodeString(cookie.Value)
-	if err != nil {
-		return s.getNewBackendSticky()
-	}
-	var nonce [24]byte
-	if len(data) < len(nonce) {
-		return s.getNewBackendSticky()
-	}
-	copy(nonce[:], data)
-	res, ok := secretbox.Open(nil, data[len(nonce):], &nonce, s.cookieKey)
-	if !ok {
-		return s.getNewBackendSticky()
-	}
-
-	addr := string(res)
-	ok = false
-	for _, a := range s.ss.Addrs() {
-		if a == addr {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return s.getNewBackendSticky()
-	}
-
-	backend, err := net.Dial("tcp", string(addr))
-	if err != nil {
-		return s.getNewBackendSticky()
-	}
-	return httputil.NewClientConn(backend, nil), nil
-}
-
-func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, isTLS, sticky bool) (done bool) {
-	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
-	req.Header.Set("X-Request-Id", random.UUID())
-
-	var backend *httputil.ClientConn
-	var stickyCookie *http.Cookie
-	if sticky {
-		backend, stickyCookie = s.getBackendSticky(req)
-	} else {
-		backend = s.getBackend()
-	}
-	if backend == nil {
-		log.Println("no backend found")
-		fail(sc, req, 503, "Service Unavailable")
-		return
-	}
-	defer backend.Close()
-
-	req.Proto = "HTTP/1.1"
-	req.ProtoMajor = 1
-	req.ProtoMinor = 1
-	delete(req.Header, "Te")
-	delete(req.Header, "Transfer-Encoding")
-
-	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
-		// If we aren't the first proxy retain prior
-		// X-Forwarded-For information as a comma+space
-		// separated list and fold multiple headers into one.
-		if prior, ok := req.Header["X-Forwarded-For"]; ok {
-			clientIP = strings.Join(prior, ", ") + ", " + clientIP
-		}
-		req.Header.Set("X-Forwarded-For", clientIP)
-	}
-	if isTLS {
-		req.Header.Set("X-Forwarded-Proto", "https")
-	} else {
-		req.Header.Set("X-Forwarded-Proto", "http")
-	}
-	// TODO: Set X-Forwarded-Port
-
-	// Pass the Request-URI verbatim without any modifications
-	req.URL.Opaque = strings.Split(strings.TrimPrefix(req.RequestURI, req.URL.Scheme+":"), "?")[0]
-
-	if err := backend.Write(req); err != nil {
-		log.Println("server write err:", err)
-		// TODO: return error to client here
-		return true
-	}
-	res, err := backend.Read(req)
-	if res != nil {
-		if stickyCookie != nil {
-			res.Header.Add("Set-Cookie", stickyCookie.String())
-		}
-		if res.StatusCode == http.StatusSwitchingProtocols {
-			res.Body = nil
-		}
-		if err := sc.Write(req, res); err != nil {
-			if err != io.EOF && err != httputil.ErrPersistEOF {
-				log.Println("client write err:", err)
-				// TODO: log error
-			}
-			return true
-		}
-	}
-	if err != nil {
-		if err != io.EOF && err != httputil.ErrPersistEOF {
-			log.Println("server read err:", err)
-			// TODO: log error
-			fail(sc, req, 502, "Bad Gateway")
-		}
-		return
-	}
-
-	// TODO: Proxy HTTP CONNECT? (example: Go RPC over HTTP)
-	if res.StatusCode == http.StatusSwitchingProtocols {
-		serverW, serverR := backend.Hijack()
-		clientW, clientR := sc.Hijack()
-		defer serverW.Close()
-		done := make(chan struct{})
-		go func() {
-			serverR.WriteTo(clientW)
-			if cw, ok := clientW.(writeCloser); ok {
-				cw.CloseWrite()
-			}
-			close(done)
-		}()
-		clientR.WriteTo(serverW)
-		serverW.(writeCloser).CloseWrite()
-		<-done
-		return true
-	}
-
-	return
-}
-
 func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
 	req.Header.Set("X-Request-Id", random.UUID())
@@ -644,7 +429,7 @@ func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if backend == "" {
 		log.Println("no backend found")
-		failw(w, 503, "Service Unavailable")
+		fail(w, 503, "Service Unavailable")
 		return
 	}
 
@@ -715,7 +500,7 @@ func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (s *httpService) forwardAndProxyTCP(w http.ResponseWriter, req *http.Request) {
 	upconn, err := net.Dial("tcp", req.URL.Host)
 	if err != nil {
-		failw(w, 503, http.StatusText(503))
+		fail(w, 503, http.StatusText(503))
 		return
 	}
 	defer upconn.Close()
@@ -723,13 +508,13 @@ func (s *httpService) forwardAndProxyTCP(w http.ResponseWriter, req *http.Reques
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		log.Println("not a hijacker")
-		failw(w, 500, http.StatusText(500))
+		fail(w, 500, http.StatusText(500))
 		return
 	}
 	downconn, _, err := hj.Hijack()
 	if err != nil {
 		log.Println("hijack failed:", err)
-		failw(w, 500, http.StatusText(500))
+		fail(w, 500, http.StatusText(500))
 		return
 	}
 	defer downconn.Close()

--- a/router/http.go
+++ b/router/http.go
@@ -426,7 +426,7 @@ func (s *httpService) getBackendSticky(req *http.Request) (*httputil.ClientConn,
 	return httputil.NewClientConn(backend, nil), nil
 }
 
-func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, tls, sticky bool) (done bool) {
+func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, isTLS, sticky bool) (done bool) {
 	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
 	req.Header.Set("X-Request-Id", random.UUID())
 
@@ -459,7 +459,7 @@ func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, tls, st
 		}
 		req.Header.Set("X-Forwarded-For", clientIP)
 	}
-	if tls {
+	if isTLS {
 		req.Header.Set("X-Forwarded-Proto", "https")
 	} else {
 		req.Header.Set("X-Forwarded-Proto", "http")

--- a/router/http.go
+++ b/router/http.go
@@ -241,6 +241,11 @@ func (s *HTTPListener) listenAndServe(started chan<- error) {
 }
 
 func (s *HTTPListener) listenAndServeTLS(started chan<- error) {
+	_, port, err := net.SplitHostPort(s.TLSAddr)
+	if err != nil {
+		started <- err
+		return
+	}
 	certForHandshake := func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		r := s.findRouteForHost(hello.ServerName)
 		if r == nil {
@@ -253,20 +258,23 @@ func (s *HTTPListener) listenAndServeTLS(started chan<- error) {
 		Certificates:   []tls.Certificate{s.keypair},
 	})
 
+	server := &http.Server{
+		Addr: s.TLSAddr,
+		Handler: fwdProtoHandler{
+			Handler: s,
+			Proto:   "https",
+			Port:    port,
+		},
+	}
+
 	l, err := reuseport.NewReusablePortListener("tcp4", s.TLSAddr)
 	started <- err
 	if err != nil {
 		return
 	}
 	s.tlsListener = tls.NewListener(l, tlsConfig)
-	for {
-		conn, err := s.tlsListener.Accept()
-		if err != nil {
-			// TODO: log error
-			break
-		}
-		go s.handle(conn, true)
-	}
+	// TODO: log error
+	_ = server.Serve(s.tlsListener)
 }
 
 func (s *HTTPListener) findRouteForHost(host string) *httpRoute {
@@ -331,6 +339,16 @@ func (s *HTTPListener) handle(conn net.Conn, isTLS bool) {
 			return
 		}
 	}
+}
+
+func (s *HTTPListener) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r := s.findRouteForHost(req.Host)
+	if r == nil {
+		failw(w, 404, "Not Found")
+		return
+	}
+
+	r.service.ServeHTTP(w, req)
 }
 
 // A domain served by a listener, associated TLS certs,
@@ -525,6 +543,13 @@ func (s *httpService) handle(req *http.Request, sc *httputil.ServerConn, isTLS, 
 	}
 
 	return
+}
+
+func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+	req.Header.Set("X-Request-Id", random.UUID())
+
+	// TODO(bgentry): implement rest of this from handle above
 }
 
 type writeCloser interface {

--- a/router/http.go
+++ b/router/http.go
@@ -96,14 +96,14 @@ func (s *HTTPListener) Start() error {
 		return err
 	}
 
-	go s.serve(started)
+	go s.listenAndServe(started)
 	if err := <-started; err != nil {
 		s.ds.StopSync()
 		return err
 	}
 	s.Addr = s.listener.Addr().String()
 
-	go s.serveTLS(started)
+	go s.listenAndServeTLS(started)
 	if err := <-started; err != nil {
 		s.ds.StopSync()
 		s.listener.Close()
@@ -223,7 +223,7 @@ func (h *httpSyncHandler) Remove(id string) error {
 	return nil
 }
 
-func (s *HTTPListener) serve(started chan<- error) {
+func (s *HTTPListener) listenAndServe(started chan<- error) {
 	var err error
 	s.listener, err = reuseport.NewReusablePortListener("tcp4", s.Addr)
 	started <- err
@@ -240,7 +240,7 @@ func (s *HTTPListener) serve(started chan<- error) {
 	}
 }
 
-func (s *HTTPListener) serveTLS(started chan<- error) {
+func (s *HTTPListener) listenAndServeTLS(started chan<- error) {
 	var err error
 	s.tlsListener, err = reuseport.NewReusablePortListener("tcp4", s.TLSAddr)
 	started <- err

--- a/router/http.go
+++ b/router/http.go
@@ -512,15 +512,13 @@ func sortStringFirst(ss []string, s string) {
 	}
 }
 
-// TODO(bgentry): these are defaults from DefaultTransport. Ask about
-// changing them.
 var transport http.RoundTripper = &http.Transport{
 	Dial:                customDial,
-	TLSHandshakeTimeout: 10 * time.Second,
+	TLSHandshakeTimeout: 10 * time.Second, // unused, but safer to leave default in place
 }
 
 var dialer = &net.Dialer{
-	Timeout:   30 * time.Second,
+	Timeout:   1 * time.Second,
 	KeepAlive: 30 * time.Second,
 }
 

--- a/router/http.go
+++ b/router/http.go
@@ -487,7 +487,7 @@ func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if isSticky && stickyAddr != backend {
-		res.Header.Add("Set-Cookie", s.newStickyCookie(backend).String())
+		http.SetCookie(w, s.newStickyCookie(backend))
 	}
 
 	for _, h := range hopHeaders {

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/websocket"
@@ -286,6 +287,11 @@ func (s *S) TestHTTPServiceHandlerBackendConnectionClosed(c *C) {
 	// the backend server's connection gets closed, but router is
 	// able to recover
 	srv.CloseClientConnections()
+	// Though we've closed the conn on the server, the client might not have
+	// handled the FIN yet. The Transport offers no way to safely retry in those
+	// scenarios, so instead we just sleep long enough to handle the FIN.
+	// https://golang.org/issue/4677
+	time.Sleep(500 * time.Microsecond)
 	assertGet(c, "http://"+l.Addr, "example.com", "1")
 }
 

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -290,8 +290,9 @@ func (s *S) TestHTTPServiceHandlerBackendConnectionClosed(c *C) {
 }
 
 // Act as an app to test HTTP headers
-func httpHeaderTestHandler(c *C, ip string) http.Handler {
+func httpHeaderTestHandler(c *C, ip, port string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c.Assert(req.Header["X-Forwarded-Port"][0], Equals, port)
 		c.Assert(req.Header["X-Forwarded-Proto"][0], Equals, "http")
 		c.Assert(len(req.Header["X-Request-Start"][0]), Equals, 13)
 		c.Assert(req.Header["X-Forwarded-For"][0], Equals, ip)
@@ -302,7 +303,7 @@ func httpHeaderTestHandler(c *C, ip string) http.Handler {
 
 // issue #105
 func (s *S) TestHTTPHeaders(c *C) {
-	srv := httptest.NewServer(httpHeaderTestHandler(c, "127.0.0.1"))
+	srv := httptest.NewServer(httpHeaderTestHandler(c, "127.0.0.1", "0"))
 
 	l, discoverd := newHTTPListener(c)
 	defer l.Close()
@@ -316,7 +317,7 @@ func (s *S) TestHTTPHeaders(c *C) {
 }
 
 func (s *S) TestHTTPHeadersFromClient(c *C) {
-	srv := httptest.NewServer(httpHeaderTestHandler(c, "192.168.1.1, 127.0.0.1"))
+	srv := httptest.NewServer(httpHeaderTestHandler(c, "192.168.1.1, 127.0.0.1", "0"))
 
 	l, discoverd := newHTTPListener(c)
 	defer l.Close()


### PR DESCRIPTION
This PR switches Flynn's router away from using the somewhat-deprecated `httputil.ClientConn` and `httputil.ServerConn` to using `net/http` HTTP parsers and handlers.

Because there are subtle differences between handling protocol upgrades (i.e. for websockets) and regular request proxying, there's a lot of duplicated logic between the functions that handle these paths. I think we'll be able to clean that up a lot, but would rather this doesn't spend too much more time in a side branch :)

We pretty quickly had to move away from `httputil.ReverseProxy` as it makes it basically impossible to do some of the stuff we want to do with trying conns to multiple backends, and it also wouldn't work for the websocket upgrade. In doing so, we've currently lost some of the nice parts of that package like periodic flushing of buffers (see [ReverseProxy.FlushInterval](http://golang.org/pkg/net/http/httputil/#ReverseProxy)). I've left a couple of TODOs for that in the code and intend to bring it in in a future PR. I also think that we can better package up some of the stuff we've done into a nice encapsulation similar to `httputil.ReverseProxy`, but again, didn't want to branch off for too long.

Finally, the way we pass down the sticky session setting from the route to the service is pretty ugly (using a temporary internal header). I didn't see an obvious way to access this bool (`r.Sticky`) from the part of the code where I needed to use it, so this was a compromise for expediency. I suspect we can find a much better way to do this, either by refactoring to make the setting available where we need it or by storing that setting inside of [a request context](https://blog.golang.org/context).

Fixes #61. Fixes #64. Makes some progress on #67 by setting some sane defaults for TCP timeouts.