### PR TITLE
host: Fix libvirt network XML

### DIFF
--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -111,8 +111,8 @@ type Network struct {
 	Name    string   `xml:"name"`
 	Bridge  Bridge   `xml:"bridge"`
 	Forward Forward  `xml:"forward"`
-	IP      IP       `xml:"ip"`
-	MAC     MAC      `xml:"mac"`
+	IP      *IP      `xml:"ip,omitempty"`
+	MAC     *MAC     `xml:"mac,omitempty"`
 }
 
 func (n *Network) XML() []byte {


### PR DESCRIPTION
The empty fields were causing the following error:

```
[Code-27] [Domain-19] XML error: Missing required address attribute in network 'flynn'
```