### PR TITLE
Run unit tests in flynn CI

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -119,6 +119,13 @@ apt-get install -y \
   libvirt-dev \
   libvirt-bin
 
+# install flynn test dependencies: postgres
+# (normally this is used via an appliance; this is for unit tests)
+apt-get install -y postgresql postgresql-contrib
+sudo -u postgres createuser --superuser ubuntu
+update-rc.d postgresql disable
+service postgresql stop
+
 # make tup suid root so that we can build in chroots
 chmod ug+s /usr/bin/tup
 

--- a/test/scripts/test-unit.sh
+++ b/test/scripts/test-unit.sh
@@ -5,4 +5,9 @@ util/commit-validator/validate-dco
 
 util/commit-validator/validate-gofmt
 
+export PGHOST=/var/run/postgresql
+sudo service postgresql start
+
 go test -race -cover ./...
+
+sudo service postgresql stop

--- a/test/scripts/test-unit.sh
+++ b/test/scripts/test-unit.sh
@@ -5,6 +5,9 @@ util/commit-validator/validate-dco
 
 util/commit-validator/validate-gofmt
 
+GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false tup appliance/etcd discoverd
+PATH=$PATH:$PWD/appliance/etcd/bin:$PWD/discoverd/bin
+
 export PGHOST=/var/run/postgresql
 sudo service postgresql start
 

--- a/test/scripts/test-unit.sh
+++ b/test/scripts/test-unit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exo pipefail
+
+util/commit-validator/validate-dco
+
+util/commit-validator/validate-gofmt
+
+go test -race -cover ./...


### PR DESCRIPTION
Move unit tests into flynn CI.  Will deprecate travis.

Adds dependencies of unit tests to the rootfs used in CI.

Adds a script 'test/scripts/test-unit.sh' which can drive unit tests.  In the future, this script can be modified without requiring updates to the main CI binary.

If unit tests fail, the entire run will be halted; cluster bootstrapping and integration tests will not be run.