### PR TITLE
router: Strip port from Host header when looking up route

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -287,6 +287,9 @@ func (s *HTTPListener) listenAndServeTLS(started chan<- error) {
 
 func (s *HTTPListener) findRouteForHost(host string) *httpRoute {
 	host = strings.ToLower(host)
+	if strings.Contains(host, ":") {
+		host, _, _ = net.SplitHostPort(host)
+	}
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	if backend, ok := s.domains[host]; ok {


### PR DESCRIPTION
It is totally valid for a Host header to look like:

    Host: example.com:80

or

    Host: example.com:443

This will cause a 404, as the route doesn't contain the port. So when doing the backend lookup, we need to strip the port off if it is included.

This fixes the "controller: resource not found" error that slipped through broken CI.

Closes #789.

/cc @bgentry @benburkert