### PR TITLE
host: Check error from reading flannel config

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -231,16 +231,20 @@ func (l *LibvirtLXCBackend) ConfigureNetworking(strategy NetworkStrategy, job st
 
 	path := filepath.Join(container.RootPath, "/run/flannel/subnet.env")
 	var data []byte
-	networkConfigAttempts.Run(func() error {
+	err = networkConfigAttempts.Run(func() error {
 		select {
 		case <-container.done:
 			return errors.New("host: networking container unexpectedly gone")
 		default:
 		}
 
+		var err error
 		data, err = ioutil.ReadFile(path)
 		return err
 	})
+	if err != nil {
+		return err
+	}
 
 	for _, line := range bytes.Split(data, []byte("\n")) {
 		if bytes.HasPrefix(line, []byte("FLANNEL_MTU=")) {


### PR DESCRIPTION
If we don’t do this, and there is an error, we’ll end up panicking later.