### PR TITLE
all: Fix attach HTTP upgrade protocol

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -315,10 +315,7 @@ func (c *Client) GetJobLogWithWait(appID, jobID string, tail bool) (io.ReadClose
 // and returning a ReadWriteCloser stream, which can then be used for
 // communicating with the job.
 func (c *Client) RunJobAttached(appID string, job *ct.NewJob) (utils.ReadWriteCloser, error) {
-	header := http.Header{
-		"Accept": []string{"application/vnd.flynn.attach"},
-	}
-	return c.Hijack("POST", fmt.Sprintf("/apps/%s/jobs", appID), header, job)
+	return c.Hijack("POST", fmt.Sprintf("/apps/%s/jobs", appID), http.Header{"Upgrade": {"flynn-attach/0"}}, job)
 }
 
 // RunJobDetached runs a new job under the specified app, returning the job's

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -454,7 +454,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 		return
 	}
 	artifact := data.(*ct.Artifact)
-	attach := strings.Contains(req.Header.Get("Accept"), "application/vnd.flynn.attach")
+	attach := strings.Contains(req.Header.Get("Upgrade"), "flynn-attach/0")
 
 	env := make(map[string]string, len(release.Env)+len(newJob.Env))
 	for k, v := range release.Env {
@@ -533,8 +533,8 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 			respondWithError(w, fmt.Errorf("attach wait failed: %s", err.Error()))
 			return
 		}
-		w.Header().Set("Content-Type", "application/vnd.flynn.attach")
-		w.Header().Set("Content-Length", "0")
+		w.Header().Set("Connection", "upgrade")
+		w.Header().Set("Upgrade", "flynn-attach/0")
 		w.WriteHeader(http.StatusSwitchingProtocols)
 		conn, _, err := w.(http.Hijacker).Hijack()
 		if err != nil {

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -298,7 +298,7 @@ func (s *S) TestRunJobAttached(c *C) {
 	c.Assert(err, IsNil)
 	req.SetBasicAuth("", authKey)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/vnd.flynn.attach")
+	req.Header.Set("Upgrade", "flynn-attach/0")
 	_, rwc, err := utils.HijackRequest(req, nil)
 	c.Assert(err, IsNil)
 

--- a/controller/utils/hijack.go
+++ b/controller/utils/hijack.go
@@ -29,6 +29,7 @@ func HijackRequest(req *http.Request, dial func(string, string) (net.Conn, error
 		return nil, nil, err
 	}
 	clientconn := httputil.NewClientConn(conn, nil)
+	req.Header.Set("Connection", "upgrade")
 	res, err := clientconn.Do(req)
 	if err != nil && err != httputil.ErrPersistEOF {
 		return nil, nil, err

--- a/host/attach.go
+++ b/host/attach.go
@@ -25,8 +25,8 @@ func (h *attachHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, _ ht
 		http.Error(w, "invalid JSON", 400)
 		return
 	}
-	w.Header().Set("Content-Type", "application/vnd.flynn.attach")
-	w.Header().Set("Content-Length", "0")
+	w.Header().Set("Connection", "upgrade")
+	w.Header().Set("Upgrade", "flynn-attach/0")
 	w.WriteHeader(http.StatusSwitchingProtocols)
 
 	conn, _, err := w.(http.Hijacker).Hijack()

--- a/pkg/cluster/attach.go
+++ b/pkg/cluster/attach.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"sync"
 
 	"github.com/flynn/flynn/host/types"
@@ -21,7 +22,7 @@ var ErrWouldWait = errors.New("cluster: attach would wait")
 // first bytes. If wait is false and the job is not running, ErrWouldWait is
 // returned.
 func (c *hostClient) Attach(req *host.AttachReq, wait bool) (AttachClient, error) {
-	rwc, err := c.c.Hijack("POST", "/attach", nil, req)
+	rwc, err := c.c.Hijack("POST", "/attach", http.Header{"Upgrade": {"flynn-attach/0"}}, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -132,6 +132,7 @@ func (c *Client) Hijack(method, path string, header http.Header, in interface{})
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Connection", "upgrade")
 	res, err := clientconn.Do(req)
 	if err != nil && err != httputil.ErrPersistEOF {
 		return nil, err


### PR DESCRIPTION
The previous implementation was not compliant with the HTTP spec, and broke when the router was refactored. The new protocol dance looks like:

    POST /attach
    Connection: upgrade
    Upgrade: flynn-attach/0

    ...

    101 Switching Protocols
    Connection: upgrade
    Upgrade: flynn-attach/0

    <attach frames>