### PR TITLE
shutdown handler should be a singleton.

### DIFF
--- a/host/http.go
+++ b/host/http.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/httphelper"
-	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/sse"
 )
 
@@ -99,12 +98,11 @@ func (h *jobAPI) RegisterRoutes(r *httprouter.Router) error {
 	return nil
 }
 
-func serveHTTP(host *Host, attach *attachHandler, sh *shutdown.Handler) (*httprouter.Router, error) {
+func serveHTTP(host *Host, attach *attachHandler) (*httprouter.Router, error) {
 	l, err := net.Listen("tcp", ":1113")
 	if err != nil {
 		return nil, err
 	}
-	sh.BeforeExit(func() { l.Close() })
 
 	r := httprouter.New()
 

--- a/host/sampi/http.go
+++ b/host/sampi/http.go
@@ -10,7 +10,6 @@ import (
 	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/httphelper"
-	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/sse"
 )
 
@@ -219,7 +218,7 @@ func (c *HTTPAPI) StreamHostEvents(w http.ResponseWriter, r *http.Request, ps ht
 	}
 }
 
-func (c *HTTPAPI) RegisterRoutes(r *httprouter.Router, sh *shutdown.Handler) error {
+func (c *HTTPAPI) RegisterRoutes(r *httprouter.Router) error {
 	r.GET("/cluster/hosts", c.ListHosts)
 	r.PUT("/cluster/hosts/:id", c.RegisterHost)
 	r.POST("/cluster/jobs", c.AddJobs)

--- a/pkg/shutdown/handler.go
+++ b/pkg/shutdown/handler.go
@@ -7,26 +7,27 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 )
 
 var h = newHandler()
 
 type handler struct {
-	Active bool
-
-	mtx   sync.Mutex
-	stack []func()
+	active atomic.Value
+	mtx    sync.Mutex
+	stack  []func()
 }
 
 func newHandler() *handler {
 	h := &handler{}
+	h.active.Store(false)
 	go h.wait()
 	return h
 }
 
 func IsActive() bool {
-	return h.Active
+	return h.active.Load().(bool)
 }
 
 func BeforeExit(f func()) {
@@ -56,7 +57,7 @@ func (h *handler) wait() {
 
 func (h *handler) exit(err error) {
 	h.mtx.Lock()
-	h.Active = true
+	h.active.Store(true)
 	for i := len(h.stack) - 1; i > 0; i-- {
 		h.stack[i]()
 	}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -118,8 +118,6 @@ func (r *Runner) start() error {
 		return err
 	}
 
-	sh := shutdown.NewHandler()
-
 	bc := r.bc
 	bc.Network, err = r.allocateNet()
 	if err != nil {
@@ -129,14 +127,14 @@ func (r *Runner) start() error {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 	r.releaseNet(bc.Network)
-	sh.BeforeExit(func() { removeRootFS(r.rootFS) })
+	shutdown.BeforeExit(func() { removeRootFS(r.rootFS) })
 
 	db, err := bolt.Open(args.DBPath, 0600, &bolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		return fmt.Errorf("could not open db: %s", err)
 	}
 	r.db = db
-	sh.BeforeExit(func() { r.db.Close() })
+	shutdown.BeforeExit(func() { r.db.Close() })
 
 	if err := r.db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(dbBucket)


### PR DESCRIPTION
Use of multiple handlers as written will result in the first one of them to finish exiting the whole process without waiting for other handler instances, which may result in incomplete cleanup.  There is now only one allowed handler instance.