### PR TITLE
test: Output stderr of `flynn-host ps` when dumping logs

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -524,7 +524,7 @@ func (c *Cluster) DumpLogs(w io.Writer) {
 	}
 
 	var out bytes.Buffer
-	if err := c.Run("flynn-host ps -a -q", &Streams{Stdout: &out}); err != nil {
+	if err := c.Run("flynn-host ps -a -q", &Streams{Stdout: &out, Stderr: w}); err != nil {
 		io.Copy(w, &out)
 		fallback()
 		return


### PR DESCRIPTION
The command sometimes hangs in CI, so we want to be able to see the output when sending SIGQUIT.