### PR TITLE
httpclient: Remove Dial and DialClose.

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -67,7 +67,6 @@ func NewClientWithPin(uri, key string, pin []byte) (*Client, error) {
 	d := &pinned.Config{Pin: pin}
 	httpClient := &http.Client{Transport: &http.Transport{Dial: d.Dial}}
 	c := newClient(key, u.String(), httpClient)
-	c.Dial = d.Dial
 	return c, nil
 }
 

--- a/host/cli/cli.go
+++ b/host/cli/cli.go
@@ -49,7 +49,6 @@ func Run(name string, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer client.Close()
 		return f(parsedArgs, client)
 	case func(*docopt.Args):
 		f(parsedArgs)

--- a/host/cli/upload-debug-info.go
+++ b/host/cli/upload-debug-info.go
@@ -87,7 +87,6 @@ func captureJobs(gist *Gist) error {
 	if err != nil {
 		return err
 	}
-	defer client.Close()
 
 	jobs, err := jobList(client, true)
 	if err != nil {

--- a/host/host.go
+++ b/host/host.go
@@ -272,7 +272,6 @@ func runDaemon(args *docopt.Args) {
 	if err != nil {
 		shutdown.Fatal(err)
 	}
-	shutdown.BeforeExit(func() { cluster.Close() })
 
 	g.Log(grohl.Data{"at": "sampi_connected"})
 

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -89,7 +89,6 @@ func (c *Client) followLeader(firstErr chan<- error) {
 		if leader == nil {
 			if firstErr != nil {
 				firstErr <- ErrNoServers
-				c.Close()
 				return
 			}
 			continue
@@ -107,7 +106,6 @@ func (c *Client) followLeader(firstErr chan<- error) {
 			firstErr <- c.err
 			if c.err != nil {
 				c.c = nil
-				c.Close()
 				return
 			}
 			firstErr = nil
@@ -123,17 +121,6 @@ func (c *Client) NewLeaderSignal() <-chan struct{} {
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
 	return c.leaderChange
-}
-
-// Close disconnects from the server and cleans up internal resources used by
-// the client.
-func (c *Client) Close() error {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	if c.c != nil {
-		c.c.Close()
-	}
-	return nil
 }
 
 // LeaderID returns the identifier of the current leader.

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -272,9 +272,6 @@ func (c *Cmd) close() {
 	if c.attachClient != nil {
 		c.attachClient.Close()
 	}
-	if c.closeCluster {
-		c.cluster.(*cluster.Client).Close()
-	}
 }
 
 func (c *Cmd) Wait() error {

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -33,16 +33,6 @@ type Client struct {
 	URL         string
 	Key         string
 	HTTP        *http.Client
-	Dial        DialFunc
-	DialClose   io.Closer
-}
-
-// Close closes the underlying transport connection.
-func (c *Client) Close() error {
-	if c.DialClose != nil {
-		c.DialClose.Close()
-	}
-	return nil
 }
 
 func ToJSON(v interface{}) (io.Reader, error) {
@@ -119,11 +109,7 @@ func (c *Client) Hijack(method, path string, header http.Header, in interface{})
 	if err != nil {
 		return nil, err
 	}
-	dial := c.Dial
-	if dial == nil {
-		dial = net.Dial
-	}
-	conn, err := dial("tcp", uri.Host)
+	conn, err := net.Dial("tcp", uri.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/router/api_test.go
+++ b/router/api_test.go
@@ -44,7 +44,6 @@ func (s *testAPIServer) Close() error {
 	for _, cleanup := range s.cleanup {
 		cleanup()
 	}
-	s.Client.Close()
 	return nil
 }
 

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -4,7 +4,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -44,7 +43,6 @@ func newRouterClient() *client {
 func NewWithAddr(addr string) Client {
 	c := newRouterClient()
 	c.URL = fmt.Sprintf("http://%s", addr)
-	c.HTTP = http.DefaultClient
 	return c
 }
 
@@ -62,8 +60,6 @@ type Client interface {
 	// ListRoutes returns a list of routes. If parentRef is not empty, routes
 	// are filtered by the reference (ex: "controller/apps/myapp").
 	ListRoutes(parentRef string) ([]*router.Route, error)
-	// Closer allows closing the underlying transport connection.
-	io.Closer
 }
 
 // HTTPError is returned when the server returns a status code that is different

--- a/test/helper.go
+++ b/test/helper.go
@@ -188,18 +188,6 @@ func (h *Helper) TearDownSuite(t *c.C) {
 }
 
 func (h *Helper) cleanup() {
-	h.clusterMtx.Lock()
-	if h.cluster != nil {
-		h.cluster.Close()
-	}
-	h.clusterMtx.Unlock()
-
-	h.controllerMtx.Lock()
-	if h.controller != nil {
-		h.controller.Close()
-	}
-	h.controllerMtx.Unlock()
-
 	h.sshMtx.Lock()
 	if h.ssh != nil {
 		h.ssh.Cleanup()

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -285,7 +285,6 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 	// kill the first controller and check the scheduler brings it back online
 	cc, err := cluster.NewClientWithServices(s.discoverdClient(t).Service)
 	t.Assert(err, c.IsNil)
-	defer cc.Close()
 	hc, err := cc.DialHost(hostID)
 	t.Assert(err, c.IsNil)
 	debug(t, "stopping job ", jobID)


### PR DESCRIPTION
Primarily used for the way old discoverd managed service discovery.

Because of this simplification, we can now get rid of Close().

Signed-off-by: Blaž Hrastnik <blaz.hrast@gmail.com>