### PR TITLE
util/release: Drop minimum commit statuses to one

### DIFF
--- a/util/release/status.go
+++ b/util/release/status.go
@@ -29,8 +29,8 @@ func status(args *docopt.Args) {
 	if err := json.NewDecoder(res.Body).Decode(status); err != nil {
 		log.Fatal("error decoding Github response:", err)
 	}
-	if status.Count < 2 {
-		log.Fatalf("commit does not have enough statuses (expected 2, got %d)", status.Count)
+	if status.Count < 1 {
+		log.Fatalf("commit does not have enough statuses (expected 1, got %d)", status.Count)
 	}
 	fmt.Println(status.State)
 	if status.State != "success" {


### PR DESCRIPTION
We are no longer using Travis, so the only commit status will be from Flynn CI.