### PR TITLE
discoverd: Use current etcd index for watch after full sync

### DIFF
--- a/discoverd/server/etcd_backend.go
+++ b/discoverd/server/etcd_backend.go
@@ -284,5 +284,5 @@ func (b *etcdBackend) fullSync() (uint64, error) {
 		}
 	}
 
-	return data.Node.ModifiedIndex, nil
+	return data.EtcdIndex, nil
 }


### PR DESCRIPTION
Previously we were using the `ModifiedIndex` of the returned node, which is incorrect, as we can enter an infinite loop if that index is old. Instead we use the `EtcdIndex` which is the current index of the server and will be the most recent index.