### PR TITLE
discoverd/health: Increase timeout in tests.

### DIFF
--- a/discoverd/health/check_test.go
+++ b/discoverd/health/check_test.go
@@ -135,7 +135,7 @@ func (CheckSuite) TestHTTPReadTimeout(c *C) {
 func (CheckSuite) TestHTTPConnectRefused(c *C) {
 	err := (&HTTPCheck{
 		URL:     "http://127.0.0.1:65535",
-		Timeout: 10 * time.Millisecond,
+		Timeout: 100 * time.Millisecond,
 	}).Check()
 	c.Assert(err, NotNil)
 	c.Assert(strings.Contains(err.Error(), "connection refused"), Equals, true, Commentf("err = %s", err))


### PR DESCRIPTION
Small test fix for timeout seen several times (https://s3.amazonaws.com/flynn-ci-logs/20150126220052-213c7255-build-98a56e88f4541c015c91954c7438e3748ad9239f-2015-01-26-22-02-27.txt an example).