### PR TITLE
Testable host restarts

### DIFF
--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -74,6 +74,10 @@ func (c *Client) RemoveHost(host *tc.Instance) error {
 	return c.Delete("/" + host.ID)
 }
 
+func (c *Client) BounceHost(host *tc.Instance) error {
+	return c.Post("/"+host.ID+"/reboot", nil, nil)
+}
+
 func (c *Client) DumpLogs(out io.Writer) error {
 	res, err := c.RawReq("GET", "/dump-logs", nil, nil, nil)
 	if err != nil {

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -241,6 +241,26 @@ loop:
 	return nil
 }
 
+func (c *Cluster) BounceHost(id string) error {
+	inst, err := c.Instances.Get(id)
+	if err != nil {
+		return err
+	}
+
+	// send reboot to the host, and wait for new ssh
+	c.log("bouncing host", id)
+	if err := inst.Reboot(); err != nil {
+		return err
+	}
+
+	// restart the flynn-host
+	c.log("restarting flynn-host process", id)
+	if err := c.startHostProcess(inst); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *Cluster) Size() int {
 	return len(c.Instances)
 }

--- a/test/cluster/instance.go
+++ b/test/cluster/instance.go
@@ -203,6 +203,17 @@ func (i *Instance) Wait(timeout time.Duration) error {
 	}
 }
 
+func (i *Instance) Reboot() error {
+	if err := i.Run("sudo reboot && sleep 60", nil); err != nil {
+		return i.Kill()
+	}
+	i.sshMtx.Lock()
+	i.ssh.Close()
+	i.ssh = nil
+	i.sshMtx.Unlock()
+	return i.Run("uptime", nil)
+}
+
 func (i *Instance) Shutdown() error {
 	if err := i.Run("sudo poweroff", nil); err != nil {
 		return i.Kill()

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -168,6 +168,7 @@ func (r *Runner) start() error {
 	router.POST("/cluster/:key/:cluster", r.clusterAPI(r.addHost))
 	router.DELETE("/cluster/:key/:cluster/:host", r.clusterAPI(r.removeHost))
 	router.GET("/cluster/:key/:cluster/dump-logs", r.clusterAPI(r.dumpLogs))
+	router.POST("/cluster/:key/:cluster/:host/reboot", r.clusterAPI(r.rebootHost))
 
 	srv := &http.Server{
 		Addr:      args.ListenAddr,
@@ -636,6 +637,15 @@ func (r *Runner) addHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values
 func (r *Runner) removeHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {
 	hostID := ps.ByName("host")
 	if err := c.RemoveHost(hostID); err != nil {
+		return err
+	}
+	w.WriteHeader(200)
+	return nil
+}
+
+func (r *Runner) rebootHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {
+	hostID := ps.ByName("host")
+	if err := c.BounceHost(hostID); err != nil {
 		return err
 	}
 	w.WriteHeader(200)

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -170,6 +170,12 @@ func (r *Runner) start() error {
 	router.GET("/cluster/:key/:cluster/dump-logs", r.clusterAPI(r.dumpLogs))
 	router.POST("/cluster/:key/:cluster/:host/reboot", r.clusterAPI(r.rebootHost))
 
+	router.NotFound = func(w http.ResponseWriter, r *http.Request) {
+		msg := fmt.Sprintf("no route matched for query path %s %q\n", r.Method, r.URL.Path)
+		log.Printf("testrunner: WARN: %s\n", msg)
+		http.Error(w, "testrunner: 404 page not found: "+msg, http.StatusNotFound)
+	}
+
 	srv := &http.Server{
 		Addr:      args.ListenAddr,
 		Handler:   router,

--- a/test/test_bounce.go
+++ b/test/test_bounce.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/host/types"
+)
+
+/*
+	Sanity check over our CI system to make sure we can in fact bounce hosts,
+	and that does what we think it does.
+
+	Note that any tests that involve raising or destroying hosts that join the
+	main test bootstrap cluster cannot be run concurrently.
+*/
+type BounceSuite struct {
+	Helper
+}
+
+var _ = c.Suite(&BounceSuite{})
+
+func (BounceSuite) SetUpSuite(t *c.C) {
+	if testCluster == nil {
+		t.Skip("cannot boot new hosts")
+	}
+}
+
+func (s *BounceSuite) TestHostUpDown(t *c.C) {
+	// get host event stream to watch
+	ch := make(chan *host.HostEvent)
+	stream, err := s.clusterClient(t).StreamHostEvents(ch)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+	// request a new host; use stream to await its availability
+	instance, err := testCluster.AddHost(ch, false)
+	t.Assert(err, c.IsNil)
+
+	// destroy that host to clean up
+	err = testCluster.RemoveHost(instance)
+	t.Assert(err, c.IsNil)
+}
+
+func (s *BounceSuite) TestBounceHostProcess(t *c.C) {
+	// TODO
+}
+
+func (s *BounceSuite) TestBounceHostVM(t *c.C) {
+	// TODO
+}

--- a/test/test_bounce.go
+++ b/test/test_bounce.go
@@ -40,10 +40,23 @@ func (s *BounceSuite) TestHostUpDown(t *c.C) {
 	t.Assert(err, c.IsNil)
 }
 
-func (s *BounceSuite) TestBounceHostProcess(t *c.C) {
-	// TODO
-}
-
 func (s *BounceSuite) TestBounceHostVM(t *c.C) {
-	// TODO
+	// get host event stream to watch
+	ch := make(chan *host.HostEvent)
+	stream, err := s.clusterClient(t).StreamHostEvents(ch)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+	// request a new host; use stream to await its availability
+	instance, err := testCluster.AddHost(ch, false)
+	t.Assert(err, c.IsNil)
+
+	// bounce that host
+	// this includes VM reboot and then relaunching of the host daemon
+	err = testCluster.BounceHost(instance)
+	t.Assert(err, c.IsNil)
+
+	// destroy that host to clean up
+	err = testCluster.RemoveHost(instance)
+	t.Assert(err, c.IsNil)
 }


### PR DESCRIPTION
Add features to the test cluter API to support the rebooting of both flynn-host processes, and whole test VMs.

Some of this is refactor to extract existing api code from tests that were previously the only consumers of it.

Still WIP.