### PR TITLE
controller: Remove "_id" suffixes from deployment json

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -101,9 +101,9 @@ type NewJob struct {
 
 type Deployment struct {
 	ID           string     `json:"id,omitempty"`
-	AppID        string     `json:"app_id,omitempty"`
-	OldReleaseID string     `json:"old_release_id,omitempty"`
-	NewReleaseID string     `json:"new_release_id,omitempty"`
+	AppID        string     `json:"app,omitempty"`
+	OldReleaseID string     `json:"old_release,omitempty"`
+	NewReleaseID string     `json:"new_release,omitempty"`
 	Strategy     string     `json:"strategy,omitempty"`
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
 	FinishedAt   *time.Time `json:"finished_at,omitempty"`
@@ -115,8 +115,8 @@ type DeployID struct {
 
 type DeploymentEvent struct {
 	ID           int64      `json:"id"`
-	DeploymentID string     `json:"deployment_id"`
-	ReleaseID    string     `json:"release_id"`
+	DeploymentID string     `json:"deployment"`
+	ReleaseID    string     `json:"release"`
 	Status       string     `json:"status"`
 	JobType      string     `json:"job_type"`
 	JobState     string     `json:"job_state"`


### PR DESCRIPTION
This makes the JSON consistent with other controller resources