### PR TITLE
router: add proxy package

### DIFF
--- a/router/http_test.go
+++ b/router/http_test.go
@@ -434,7 +434,7 @@ func (s *S) TestConnectionHeaders(c *C) {
 		{
 			// tcp/websocket path, all headers should be sent to backend (except
 			// Transfer-Encoding)
-			conn:              "upgrade, custom-conn-header,   ,another-option   ",
+			conn:              "upGrade, custom-Conn-header,   ,Another-option   ",
 			upgradeFromClient: true,
 			emptyHeaders:      []string{"Transfer-Encoding"},
 			presentHeaders:    []string{"Another-Option", "Custom-Conn-Header", "Keep-Alive", "Upgrade"},

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -24,6 +24,18 @@ const (
 // flushLoop() goroutine.
 var onExitFlushLoop func()
 
+// Hop-by-hop headers. These are removed when sent to the backend.
+// https://tools.ietf.org/html/rfc7230#section-6.1
+var (
+	hopHeaders = []string{
+		"Te", // canonicalized version of "TE"
+		"Trailers",
+		"Transfer-Encoding",
+	}
+
+	serviceUnavailable = []byte("Service Unavailable\n")
+)
+
 // ReverseProxy is an HTTP Handler that takes an incoming request and
 // sends it to another server, proxying the response back to the
 // client.
@@ -44,6 +56,9 @@ type ReverseProxy struct {
 	ErrorLog *log.Logger
 }
 
+// NewReverseProxy initializes a new ReverseProxy with a callback to get
+// backends, a stickyKey for encrypting sticky session cookies, and a flag
+// sticky to enable sticky sessions.
 func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky bool) *ReverseProxy {
 	return &ReverseProxy{
 		transport: &transport{
@@ -55,26 +70,7 @@ func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky bool) *Reve
 	}
 }
 
-func copyHeader(dst, src http.Header) {
-	for k, vv := range src {
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
-	}
-}
-
-// Hop-by-hop headers. These are removed when sent to the backend.
-// https://tools.ietf.org/html/rfc7230#section-6.1
-var (
-	hopHeaders = []string{
-		"Te", // canonicalized version of "TE"
-		"Trailers",
-		"Transfer-Encoding",
-	}
-
-	serviceUnavailable = []byte("Service Unavailable\n")
-)
-
+// ServeHTTP implements http.Handler.
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	transport := p.transport
 	if transport == nil {
@@ -100,6 +96,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	p.writeResponse(rw, res)
 }
 
+// ServeConn takes an inbound conn and proxies it to a backend.
 func (p *ReverseProxy) ServeConn(conn net.Conn) {
 	transport := p.transport
 	if transport == nil {
@@ -208,6 +205,14 @@ func (p *ReverseProxy) logf(format string, args ...interface{}) {
 		p.ErrorLog.Printf(format, args...)
 	} else {
 		log.Printf(format, args...)
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
 	}
 }
 

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -1,0 +1,225 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP reverse proxy handler
+
+package proxy
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// onExitFlushLoop is a callback set by tests to detect the state of the
+// flushLoop() goroutine.
+var onExitFlushLoop func()
+
+// ReverseProxy is an HTTP Handler that takes an incoming request and
+// sends it to another server, proxying the response back to the
+// client.
+type ReverseProxy struct {
+	// Director must be a function which modifies
+	// the request into a new request to be sent
+	// using Transport. Its response is then copied
+	// back to the original client unmodified.
+	Director func(*http.Request)
+
+	// The transport used to perform proxy requests.
+	// If nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+
+	// FlushInterval specifies the flush interval
+	// to flush to the client while copying the
+	// response body.
+	// If zero, no periodic flushing is done.
+	FlushInterval time.Duration
+
+	// ErrorLog specifies an optional logger for errors
+	// that occur when attempting to proxy the request.
+	// If nil, logging goes to os.Stderr via the log package's
+	// standard logger.
+	ErrorLog *log.Logger
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+// NewSingleHostReverseProxy returns a new ReverseProxy that rewrites
+// URLs to the scheme, host, and base path provided in target. If the
+// target's path is "/base" and the incoming request was for "/dir",
+// the target request will be for /base/dir.
+func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
+	targetQuery := target.RawQuery
+	director := func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+	}
+	return &ReverseProxy{Director: director}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te", // canonicalized version of "TE"
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	transport := p.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	outreq := new(http.Request)
+	*outreq = *req // includes shallow copies of maps, but okay
+
+	p.Director(outreq)
+	outreq.Proto = "HTTP/1.1"
+	outreq.ProtoMajor = 1
+	outreq.ProtoMinor = 1
+	outreq.Close = false
+
+	// Remove hop-by-hop headers to the backend.  Especially
+	// important is "Connection" because we want a persistent
+	// connection, regardless of what the client sent to us.  This
+	// is modifying the same underlying map from req (shallow
+	// copied above) so we only copy it if necessary.
+	copiedHeaders := false
+	for _, h := range hopHeaders {
+		if outreq.Header.Get(h) != "" {
+			if !copiedHeaders {
+				outreq.Header = make(http.Header)
+				copyHeader(outreq.Header, req.Header)
+				copiedHeaders = true
+			}
+			outreq.Header.Del(h)
+		}
+	}
+
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		// If we aren't the first proxy retain prior
+		// X-Forwarded-For information as a comma+space
+		// separated list and fold multiple headers into one.
+		if prior, ok := outreq.Header["X-Forwarded-For"]; ok {
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
+		}
+		outreq.Header.Set("X-Forwarded-For", clientIP)
+	}
+
+	res, err := transport.RoundTrip(outreq)
+	if err != nil {
+		p.logf("http: proxy error: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer res.Body.Close()
+
+	for _, h := range hopHeaders {
+		res.Header.Del(h)
+	}
+
+	copyHeader(rw.Header(), res.Header)
+
+	rw.WriteHeader(res.StatusCode)
+	p.copyResponse(rw, res.Body)
+}
+
+func (p *ReverseProxy) copyResponse(dst io.Writer, src io.Reader) {
+	if p.FlushInterval != 0 {
+		if wf, ok := dst.(writeFlusher); ok {
+			mlw := &maxLatencyWriter{
+				dst:     wf,
+				latency: p.FlushInterval,
+				done:    make(chan bool),
+			}
+			go mlw.flushLoop()
+			defer mlw.stop()
+			dst = mlw
+		}
+	}
+
+	io.Copy(dst, src)
+}
+
+func (p *ReverseProxy) logf(format string, args ...interface{}) {
+	if p.ErrorLog != nil {
+		p.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+type writeFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+type maxLatencyWriter struct {
+	dst     writeFlusher
+	latency time.Duration
+
+	lk   sync.Mutex // protects Write + Flush
+	done chan bool
+}
+
+func (m *maxLatencyWriter) Write(p []byte) (int, error) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+	return m.dst.Write(p)
+}
+
+func (m *maxLatencyWriter) flushLoop() {
+	t := time.NewTicker(m.latency)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.done:
+			if onExitFlushLoop != nil {
+				onExitFlushLoop()
+			}
+			return
+		case <-t.C:
+			m.lk.Lock()
+			m.dst.Flush()
+			m.lk.Unlock()
+		}
+	}
+}
+
+func (m *maxLatencyWriter) stop() { m.done <- true }

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -71,6 +71,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	outreq := new(http.Request)
 	*outreq = *req // includes shallow copies of maps, but okay
 
+	outreq.URL.Scheme = "http"
 	outreq.Proto = "HTTP/1.1"
 	outreq.ProtoMajor = 1
 	outreq.ProtoMinor = 1

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -25,12 +24,6 @@ var onExitFlushLoop func()
 // sends it to another server, proxying the response back to the
 // client.
 type ReverseProxy struct {
-	// Director must be a function which modifies
-	// the request into a new request to be sent
-	// using Transport. Its response is then copied
-	// back to the original client unmodified.
-	Director func(*http.Request)
-
 	// The transport used to perform proxy requests.
 	// If nil, http.DefaultTransport is used.
 	Transport http.RoundTripper
@@ -46,37 +39,6 @@ type ReverseProxy struct {
 	// If nil, logging goes to os.Stderr via the log package's
 	// standard logger.
 	ErrorLog *log.Logger
-}
-
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
-	}
-	return a + b
-}
-
-// NewSingleHostReverseProxy returns a new ReverseProxy that rewrites
-// URLs to the scheme, host, and base path provided in target. If the
-// target's path is "/base" and the incoming request was for "/dir",
-// the target request will be for /base/dir.
-func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
-	targetQuery := target.RawQuery
-	director := func(req *http.Request) {
-		req.URL.Scheme = target.Scheme
-		req.URL.Host = target.Host
-		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
-		if targetQuery == "" || req.URL.RawQuery == "" {
-			req.URL.RawQuery = targetQuery + req.URL.RawQuery
-		} else {
-			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
-		}
-	}
-	return &ReverseProxy{Director: director}
 }
 
 func copyHeader(dst, src http.Header) {
@@ -109,7 +71,6 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	outreq := new(http.Request)
 	*outreq = *req // includes shallow copies of maps, but okay
 
-	p.Director(outreq)
 	outreq.Proto = "HTTP/1.1"
 	outreq.ProtoMajor = 1
 	outreq.ProtoMinor = 1

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -16,6 +16,10 @@ import (
 	"time"
 )
 
+const (
+	stickyCookie = "_backend"
+)
+
 // onExitFlushLoop is a callback set by tests to detect the state of the
 // flushLoop() goroutine.
 var onExitFlushLoop func()
@@ -25,8 +29,7 @@ var onExitFlushLoop func()
 // client.
 type ReverseProxy struct {
 	// The transport used to perform proxy requests.
-	// If nil, http.DefaultTransport is used.
-	Transport http.RoundTripper
+	transport *transport
 
 	// FlushInterval specifies the flush interval
 	// to flush to the client while copying the
@@ -60,9 +63,9 @@ var (
 )
 
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	transport := p.Transport
+	transport := p.transport
 	if transport == nil {
-		transport = http.DefaultTransport
+		panic("router: nil transport for proxy")
 	}
 
 	outreq := prepareRequest(req)

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -89,6 +89,22 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	p.writeResponse(rw, res)
 }
 
+func (p *ReverseProxy) ServeConn(conn net.Conn) {
+	transport := p.transport
+	if transport == nil {
+		panic("router: nil transport for proxy")
+	}
+	defer conn.Close()
+
+	dconn, err := transport.Connect(conn.RemoteAddr())
+	if err != nil {
+		p.logf("router: proxy error: %v", err)
+		return
+	}
+
+	joinConns(conn, dconn)
+}
+
 func (p *ReverseProxy) serveUpgrade(rw http.ResponseWriter, req *http.Request) {
 	transport := p.transport
 	if transport == nil {

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -44,6 +44,17 @@ type ReverseProxy struct {
 	ErrorLog *log.Logger
 }
 
+func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky bool) *ReverseProxy {
+	return &ReverseProxy{
+		transport: &transport{
+			getBackends:       bf,
+			stickyCookieKey:   stickyKey,
+			useStickySessions: sticky,
+		},
+		FlushInterval: 10 * time.Millisecond,
+	}
+}
+
 func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
 		for _, v := range vv {

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -174,6 +174,8 @@ func prepareRequest(req *http.Request) *http.Request {
 	outreq := new(http.Request)
 	*outreq = *req // includes shallow copies of maps, but okay
 
+	// Pass the Request-URI verbatim without any modifications
+	outreq.URL.Opaque = strings.Split(strings.TrimPrefix(req.RequestURI, req.URL.Scheme+":"), "?")[0]
 	outreq.URL.Scheme = "http"
 	outreq.Proto = "HTTP/1.1"
 	outreq.ProtoMajor = 1

--- a/router/proxy/stream_conn.go
+++ b/router/proxy/stream_conn.go
@@ -1,0 +1,16 @@
+package proxy
+
+import (
+	"bufio"
+	"net"
+)
+
+// streamConn buffers reads but not writes.
+type streamConn struct {
+	*bufio.Reader
+	net.Conn
+}
+
+func (c *streamConn) Read(b []byte) (int, error) {
+	return c.Reader.Read(b)
+}

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -1,0 +1,156 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/nacl/secretbox"
+	"github.com/flynn/flynn/pkg/random"
+)
+
+var (
+	errNoBackends = errors.New("router: no backends available")
+
+	httpTransport = &http.Transport{
+		Dial:                customDial,
+		TLSHandshakeTimeout: 10 * time.Second, // unused, but safer to leave default in place
+	}
+
+	dialer = &net.Dialer{
+		Timeout:   1 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+)
+
+// BackendListFunc returns a slice of backend hosts (hostname:port).
+type BackendListFunc func() []string
+
+type transport struct {
+	getBackends BackendListFunc
+
+	stickyCookieKey   *[32]byte
+	useStickySessions bool
+}
+
+func (t *transport) getOrderedBackends(stickyBackend string) []string {
+	backends := t.getBackends()
+	shuffle(backends)
+
+	if stickyBackend != "" {
+		swapToFront(backends, stickyBackend)
+	}
+	return backends
+}
+
+func (t *transport) getStickyBackend(req *http.Request) string {
+	if t.useStickySessions {
+		return getStickyCookieBackend(req, *t.stickyCookieKey)
+	}
+	return ""
+}
+
+func (t *transport) setStickyBackend(res *http.Response, originalStickyBackend string) {
+	if !t.useStickySessions {
+		return
+	}
+	if backend := res.Request.URL.Host; backend != originalStickyBackend {
+		setStickyCookieBackend(res, backend, *t.stickyCookieKey)
+	}
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	stickyBackend := t.getStickyBackend(req)
+	backends := t.getOrderedBackends(stickyBackend)
+	for _, backend := range backends {
+		req.URL.Host = backend
+		res, err := httpTransport.RoundTrip(req)
+		if err == nil {
+			t.setStickyBackend(res, stickyBackend)
+			return res, nil
+		}
+		if _, ok := err.(dialErr); !ok {
+			return nil, err
+		}
+		// retry, maybe log a message about it
+	}
+	return nil, errNoBackends
+}
+
+func customDial(network, addr string) (net.Conn, error) {
+	conn, err := dialer.Dial(network, addr)
+	if err != nil {
+		return nil, dialErr{err}
+	}
+	return conn, nil
+}
+
+type dialErr struct {
+	error
+}
+
+func shuffle(s []string) {
+	for i := len(s) - 1; i > 0; i-- {
+		j := random.Math.Intn(i + 1)
+		s[i], s[j] = s[j], s[i]
+	}
+}
+
+func swapToFront(ss []string, s string) {
+	for i := range ss {
+		if ss[i] == s {
+			ss[0], ss[i] = ss[i], ss[0]
+			return
+		}
+	}
+}
+func getStickyCookieBackend(req *http.Request, cookieKey [32]byte) string {
+	cookie, err := req.Cookie(stickyCookie)
+	if err != nil {
+		return ""
+	}
+
+	data, err := base64.StdEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return ""
+	}
+	return string(decrypt(data, cookieKey))
+}
+
+func setStickyCookieBackend(res *http.Response, backend string, cookieKey [32]byte) {
+	cookie := http.Cookie{
+		Name:  stickyCookie,
+		Value: base64.StdEncoding.EncodeToString(encrypt([]byte(backend), cookieKey)),
+		Path:  "/",
+	}
+	res.Header.Add("Set-Cookie", cookie.String())
+}
+
+func encrypt(data []byte, key [32]byte) []byte {
+	var nonce [24]byte
+	_, err := io.ReadFull(rand.Reader, nonce[:])
+	if err != nil {
+		panic(err)
+	}
+
+	out := make([]byte, len(nonce), len(nonce)+len(data)+secretbox.Overhead)
+	copy(out, nonce[:])
+	return secretbox.Seal(out, data, &nonce, &key)
+}
+
+func decrypt(data []byte, key [32]byte) []byte {
+	var nonce [24]byte
+	if len(data) < len(nonce) {
+		return nil
+	}
+	copy(nonce[:], data)
+	res, ok := secretbox.Open(nil, data[len(nonce):], &nonce, &key)
+	if !ok {
+		return nil
+	}
+	return res
+}

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -96,12 +96,12 @@ func (t *transport) Connect(remoteAddr net.Addr) (net.Conn, error) {
 func (t *transport) UpgradeHTTP(req *http.Request) (*http.Response, net.Conn, error) {
 	stickyBackend := t.getStickyBackend(req)
 	backends := t.getOrderedBackends(stickyBackend)
-	c, addr, err := dialTCP(backends)
+	upconn, addr, err := dialTCP(backends)
 	if err != nil {
 		return nil, nil, err
 	}
+	conn := &streamConn{bufio.NewReader(upconn), upconn}
 	req.URL.Host = addr
-	conn := &streamConn{bufio.NewReader(c), c}
 
 	if err := req.Write(conn); err != nil {
 		conn.Close()

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -64,6 +64,8 @@ func (t *transport) setStickyBackend(res *http.Response, originalStickyBackend s
 	}
 }
 
+// always sets the response.Request.URL.Host to the last backend that was
+// connected to.
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// http.Transport closes the request body on a failed dial, issue #875
 	req.Body = &fakeCloseReadCloser{req.Body}
@@ -87,8 +89,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (t *transport) Connect(remoteAddr net.Addr) (net.Conn, error) {
-	backends := t.getBackends()
-	shuffle(backends)
+	backends := t.getOrderedBackends("")
 	conn, _, err := dialTCP(backends)
 	return conn, err
 }

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -86,6 +86,13 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return nil, errNoBackends
 }
 
+func (t *transport) Connect(remoteAddr net.Addr) (net.Conn, error) {
+	backends := t.getBackends()
+	shuffle(backends)
+	conn, _, err := dialTCP(backends)
+	return conn, err
+}
+
 func (t *transport) UpgradeHTTP(req *http.Request) (*http.Response, net.Conn, error) {
 	stickyBackend := t.getStickyBackend(req)
 	backends := t.getOrderedBackends(stickyBackend)


### PR DESCRIPTION
The `router/proxy` package contains the (reverse)proxy functionality extracted from `router/http.go` & `router/tcp.go`. The package is broken up into two main types: `ReverseProxy` & `transporter`. They are broken up this way to keep features (like sticky-sessions) orthogonal to protocols (like HTTP & TCP) and out of `ReverseProxy`.

The `ReverseProxy` is a modified version of `httputil.ReverseProxy` from stdlib. There are a few changes to how it behaves internally that differ from the stdlib implementation. Additionally, support for generic TCP proxying has also been added via `ServeConn`. `ReverseProxy` is able to handle HTTP upgrades internally by using the same dialing logic as `ServeConn`. `transport` is based off `http.Transport` and implements the `http.RoundTripper` interface, but is also modified to support raw `net.Conn` connections via `Connect` and HTTP upgrades via `UpgradeHTTP`.

#### TODO

- [x] godoc all exported types & funcs.
- [x] rewrite tests to not use `StickyCookie`, then stop exporting it.
- [x] fix backend list fetching/updating mechanism in `ReverseProxy`.
- [x] cleanup, squash & reorder commits.

#### For Later PRs

- move `router/*_test.go` tests that assert internal proxy behavior into the `router/proxy` package.
- toggle stickiness on existing services.
- context & request logging.
- request/response timeouts.

/cc @bgentry