### PR TITLE
test/cluster: Use virtio network interface

### DIFF
--- a/test/cluster/instance.go
+++ b/test/cluster/instance.go
@@ -134,8 +134,8 @@ func (i *Instance) Start() error {
 		"-enable-kvm",
 		"-kernel", i.Kernel,
 		"-append", `"root=/dev/sda"`,
-		"-net", "nic,macaddr="+macaddr,
-		"-net", "tap,ifname="+i.tap.Name+",script=no,downscript=no",
+		"-netdev", "tap,id=vmnic,ifname="+i.tap.Name+",script=no,downscript=no",
+		"-device", "virtio-net,netdev=vmnic,mac="+macaddr,
 		"-virtfs", "fsdriver=local,path="+i.netFS+",security_model=passthrough,readonly,mount_tag=netfs",
 		"-nographic",
 	)


### PR DESCRIPTION
Refs #753

This resolves a long-standing networking instability issue on CI. The default qemu NIC driver is apparently broken and was dropping/mangling packets right and left. This patch changes the NIC driver to virtio which is used by everybody and works correctly.

The problem and fix were extensively verified by running a program that exercised the network by making many connections and transferring many bytes.

Unfortunately this does not appear to resolve all of the intermittent CI failures, but it's a step forward.