### PR TITLE
util/packer: Don't attempt to copy AMI to eu-central-1

### DIFF
--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -60,7 +60,6 @@
         "ap-northeast-1",
         "ap-southeast-1",
         "ap-southeast-2",
-        "eu-central-1",
         "eu-west-1",
         "sa-east-1",
         "us-west-1",


### PR DESCRIPTION
The eu-central-1 region requires v4 signatures, which are unsupported by packer and its fork of goamz. Trying to copy to this region results in an AuthError and the release does not continue.

See https://github.com/mitchellh/packer/issues/1646 for the upstream issue tracking this.