### PR TITLE
util/packer,test/rootfs: Install kernel 3.16.0

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -62,11 +62,11 @@ echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
 # update packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get dist-upgrade \
+apt-get install --install-recommends linux-generic-lts-utopic \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"
-apt-get install linux-generic-lts-trusty \
+apt-get dist-upgrade \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"

--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -4,6 +4,10 @@ set -xeo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
+apt-get install --install-recommends linux-generic-lts-utopic \
+  -y \
+  -o Dpkg::Options::="--force-confdef" \
+  -o Dpkg::Options::="--force-confold"
 apt-get dist-upgrade -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
The default trusty kernel is 3.13, but the backported “LTS Enablement” package is already available and will be the default in 14.04.2