### PR TITLE
Manifests and named volumes

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -208,6 +208,7 @@ func runDaemon(args *docopt.Args) {
 		bindAddr:     bindAddr,
 		backend:      backend,
 		state:        state,
+		vman:         vman,
 		ports:        portAlloc,
 	}
 

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -4,7 +4,7 @@
     "image": "$image_url_prefix/etcd?id=$image_id[etcd]",
     "expose_env": ["ETCD_INITIAL_CLUSTER", "ETCD_INITIAL_CLUSTER_STATE", "ETCD_NAME", "ETCD_DISCOVERY", "ETCD_PROXY"],
     "args": [
-      "-data-dir={{ .Volume \"/data\" }}",
+      "-data-dir={{ .Volume \"flynn-etcd-data\" \"/data\" }}",
       "-advertise-client-urls=http://{{ .ExternalIP }}:{{ .TCPPort 0 }}",
       "-listen-client-urls=http://0.0.0.0:{{ .TCPPort 0 }}",
       "-initial-advertise-peer-urls=http://{{ .ExternalIP }}:{{ .TCPPort 1 }}",

--- a/host/volume/manager.go
+++ b/host/volume/manager.go
@@ -64,7 +64,7 @@ func (m *Manager) Volumes() map[string]Volume {
 func (m *Manager) NewVolume() (Volume, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return managerProviderProxy{m.defaultProvider, m}.NewVolume()
+	return m.newVolumeFromProviderLocked("")
 }
 
 /*
@@ -74,6 +74,13 @@ func (m *Manager) NewVolume() (Volume, error) {
 func (m *Manager) NewVolumeFromProvider(providerID string) (Volume, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
+	return m.newVolumeFromProviderLocked(providerID)
+}
+
+func (m *Manager) newVolumeFromProviderLocked(providerID string) (Volume, error) {
+	if providerID == "" {
+		return managerProviderProxy{m.defaultProvider, m}.NewVolume()
+	}
 	if p, ok := m.providers[providerID]; ok {
 		return managerProviderProxy{p, m}.NewVolume()
 	} else {


### PR DESCRIPTION
Create persistent volumes when evaluating manifests.  Add simple name->volume mapping so if the manifest is run again, services get the same volumes again if were created previously.

Using etcd appliance as canary.

Once this and other `volume.Manager` state is persisted via boltdb, this will allow etcd appliances to keep their disk state across flynn-host daemon reboots.