### PR TITLE
Zfs file vdev recovery

### DIFF
--- a/host/volume/zfs/zpool.go
+++ b/host/volume/zfs/zpool.go
@@ -1,0 +1,24 @@
+package zfs
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func zpoolImportFile(fileVdevPath string) error {
+	// make tmpdir with symlink to make it possible to actually look at a single file with 'zpool import'
+	tempDir, err := ioutil.TempDir("/tmp/", "zfs-import-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+	if err := os.Symlink(fileVdevPath, filepath.Join(tempDir, filepath.Base(fileVdevPath))); err != nil {
+		return err
+	}
+	if err := exec.Command("zpool", "import", "-d", tempDir, "-a").Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/host/volume/zfs/zpool_test.go
+++ b/host/volume/zfs/zpool_test.go
@@ -2,8 +2,11 @@ package zfs
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
+	"os/exec"
+	"path"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	gzfs "github.com/flynn/flynn/Godeps/_workspace/src/github.com/mistifyio/go-zfs"
@@ -104,4 +107,83 @@ func (ZpoolTests) TestProviderExistingZpoolDetection(c *C) {
 	_, err = os.Stat(badFilePath)
 	c.Assert(err, NotNil)
 	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (ZpoolTests) TestOrphanedZpoolFileAdoption(c *C) {
+	dataset := "testpool-bananagram"
+
+	backingFilePath := fmt.Sprintf("/tmp/zfs-%s", random.String(12))
+	defer os.Remove(backingFilePath)
+
+	provider, err := NewProvider(&ProviderConfig{
+		DatasetName: dataset,
+		Make: &MakeDev{
+			BackingFilename: backingFilePath,
+			Size:            one_gig,
+		},
+	})
+	defer func() {
+		pool, _ := gzfs.GetZpool(dataset)
+		if pool != nil {
+			pool.Destroy()
+		}
+	}()
+	c.Assert(err, IsNil)
+	c.Assert(provider, NotNil)
+
+	// add a dataset to this zpool, so we can check for it on the flip side
+	markerDatasetName := path.Join(dataset, "testfs")
+	_, err = gzfs.CreateFilesystem(markerDatasetName, nil)
+	c.Assert(err, IsNil)
+
+	// do a 'zpool export'
+	// this roughly approximates what we see after a host reboot
+	// (though host reboots may leave it in an even more unclean state than this)
+	err = exec.Command("zpool", "export", "-f", dataset).Run()
+	c.Assert(err, IsNil)
+
+	// sanity check that our test is doing the right thing: zpool forgot about these
+	_, err = gzfs.GetDataset(dataset)
+	c.Assert(err, NotNil)
+	_, err = gzfs.GetDataset(markerDatasetName)
+	c.Assert(err, NotNil)
+
+	// if we create another provider with the same file vdev path, it should
+	// pick up that file again without wrecking the dataset
+	provider, err = NewProvider(&ProviderConfig{
+		DatasetName: dataset,
+		Make: &MakeDev{
+			BackingFilename: backingFilePath,
+			Size:            one_gig,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(provider, NotNil)
+	_, err = gzfs.GetDataset(markerDatasetName)
+	c.Assert(err, IsNil)
+}
+
+func (ZpoolTests) TestNonZpoolFilesFailImport(c *C) {
+	dataset := "testpool-landslide"
+
+	backingFile, err := ioutil.TempFile("/tmp/", "zfs-")
+	c.Assert(err, IsNil)
+	backingFile.Write([]byte{'a', 'b', 'c'})
+	backingFile.Close()
+
+	provider, err := NewProvider(&ProviderConfig{
+		DatasetName: dataset,
+		Make: &MakeDev{
+			BackingFilename: backingFile.Name(),
+			Size:            one_gig,
+		},
+	})
+	defer func() {
+		pool, _ := gzfs.GetZpool(dataset)
+		if pool != nil {
+			pool.Destroy()
+		}
+	}()
+	c.Assert(err, NotNil)
+	c.Assert(provider, IsNil)
 }


### PR DESCRIPTION
ZFS volume providers should re-import file vdevs if already existing.

This makes it possible for the system to easily reassemble itself after a host reboot in which zfs has forgotten about the zpools based on file vdevs.
