### PR TITLE
test/scripts: Disable network debug logging

### DIFF
--- a/test/scripts/debug-info.sh
+++ b/test/scripts/debug-info.sh
@@ -42,5 +42,3 @@ trace() {
     echo "+ ${cmd}"
     $cmd
 }
-
-netdebug


### PR DESCRIPTION
We’ve eliminated most of the network instability, so this output is not useful.