### PR TITLE
httphelper: Fix marshalling of JSONError

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -110,7 +110,7 @@ func respondWithError(w http.ResponseWriter, err error) {
 			Message: fmt.Sprintf("%s %s", v.Field, v.Message),
 			Detail:  detail,
 		}
-		httphelper.JSON(w, 400, err)
+		httphelper.Error(w, err)
 	default:
 		if err == ErrNotFound {
 			w.WriteHeader(404)

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -97,17 +97,17 @@ func (jsonError JSONError) Error() string {
 }
 
 func Error(w http.ResponseWriter, err error) {
-	var jsonError JSONError
-	switch err.(type) {
+	var jsonError *JSONError
+	switch v := err.(type) {
 	case *json.SyntaxError, *json.UnmarshalTypeError:
-		jsonError = JSONError{
+		jsonError = &JSONError{
 			Code:    SyntaxError,
 			Message: "The provided JSON input is invalid",
 		}
 	case JSONError:
-		jsonError = err.(JSONError)
+		jsonError = &v
 	case *JSONError:
-		jsonError = *err.(*JSONError)
+		jsonError = v
 	default:
 		rw, ok := w.(*ResponseWriter)
 		if ok {
@@ -115,7 +115,7 @@ func Error(w http.ResponseWriter, err error) {
 		} else {
 			log.Println(err)
 		}
-		jsonError = JSONError{
+		jsonError = &JSONError{
 			Code:    UnknownError,
 			Message: "Something went wrong",
 		}


### PR DESCRIPTION
Calling `json.Marshal` on `JSONError` instead of `*JSONError` causes the
detail field to be base64 encoded.

https://play.golang.org/p/xzPIPOrfoO
https://play.golang.org/p/55jQt2QD_e