### PR TITLE
Fix stack depth in shutdown log

### DIFF
--- a/pkg/shutdown/handler.go
+++ b/pkg/shutdown/handler.go
@@ -31,10 +31,6 @@ func IsActive() bool {
 }
 
 func BeforeExit(f func()) {
-	h.BeforeExit(f)
-}
-
-func (h *handler) BeforeExit(f func()) {
 	h.mtx.Lock()
 	h.stack = append(h.stack, f)
 	h.mtx.Unlock()
@@ -49,10 +45,6 @@ func ExitWithCode(code int) {
 }
 
 func Fatal(v ...interface{}) {
-	h.Fatal(v)
-}
-
-func (h *handler) Fatal(v ...interface{}) {
 	h.exit(errors.New(fmt.Sprint(v...)), 1, recover())
 }
 


### PR DESCRIPTION
Just remove the remaining indirections of methods on the singleton struct.  Stack depth is now uniform again (the '3' offset for the log output is thus again correct).