### PR TITLE
Download images from a TUF repository

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -259,18 +259,18 @@
 		},
 		{
 			"ImportPath": "github.com/flynn/docker-utils/registry",
-			"Comment": "1.1.1-5-g97f04d8",
-			"Rev": "97f04d814b31f35fa978cb0e4bc042025cca0848"
+			"Comment": "1.1.1-7-g2bfd558",
+			"Rev": "2bfd558e1d0eb036d930957dc3bbd8c38ab1fae1"
 		},
 		{
 			"ImportPath": "github.com/flynn/docker-utils/sum",
-			"Comment": "1.1.1-5-g97f04d8",
-			"Rev": "97f04d814b31f35fa978cb0e4bc042025cca0848"
+			"Comment": "1.1.1-7-g2bfd558",
+			"Rev": "2bfd558e1d0eb036d930957dc3bbd8c38ab1fae1"
 		},
 		{
 			"ImportPath": "github.com/flynn/docker-utils/version",
-			"Comment": "1.1.1-5-g97f04d8",
-			"Rev": "97f04d814b31f35fa978cb0e4bc042025cca0848"
+			"Comment": "1.1.1-7-g2bfd558",
+			"Rev": "2bfd558e1d0eb036d930957dc3bbd8c38ab1fae1"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-check",

--- a/Godeps/_workspace/src/github.com/flynn/docker-utils/registry/registry.go
+++ b/Godeps/_workspace/src/github.com/flynn/docker-utils/registry/registry.go
@@ -74,11 +74,12 @@ func (r Registry) EnsureRepoReady(name string) error {
 }
 
 func (r Registry) CreateAncestry(hashid string) error {
-	hashes := []string{}
-	// Unmarshal the json for the layer, get the parent
+	// the ancestry starts at the given ID and ends at the scratch layer
+	hashes := []string{hashid}
 
 	thisHash := hashid
 	for {
+		// Unmarshal the json for the layer, get the parent
 		imageJson, err := ioutil.ReadFile(r.JsonFileName(thisHash))
 		if err != nil {
 			return err

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -13,4 +13,4 @@ ROOT = $(TUP_CWD)
 !docker-layer1 = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-layer1/%d.log $(ROOT)/<layer1>
 !docker-cedarish = |> ^ docker build %d^ cat $(ROOT)/log/docker-cedarish.log > /dev/null && docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-layer1/%d.log $(ROOT)/<layer1>
 !cp = |> cp %f %o |>
-!manifest = | $(ROOT)/util/release/flynn-release |> $(ROOT)/util/release/flynn-release manifest --output=%o --image-url-prefix=@(IMAGE_URL_PREFIX) manifest_template.json |> bin/manifest.json
+!manifest = | $(ROOT)/util/release/flynn-release |> $(ROOT)/util/release/flynn-release manifest --output=%o --image-repository=@(IMAGE_REPOSITORY) manifest_template.json |> bin/manifest.json

--- a/bootstrap/Tupfile
+++ b/bootstrap/Tupfile
@@ -1,3 +1,3 @@
 include_rules
 : | $(ROOT)/<layer1> |> ^ LAYER 1^ cat $(ROOT)/log/docker-layer1/* > %o |> $(ROOT)/log/docker-layer1.log
-: $(ROOT)/util/release/flynn-release $(ROOT)/log/docker-layer1.log |> ^ bootstrap_manifest.json^ cat $(ROOT)/log/docker-layer1.log > /dev/null && $(ROOT)/util/release/flynn-release manifest --output=%o --image-url-prefix=@(IMAGE_URL_PREFIX) manifest_template.json |> bin/manifest.json <manifest>
+: $(ROOT)/util/release/flynn-release $(ROOT)/log/docker-layer1.log |> ^ bootstrap_manifest.json^ cat $(ROOT)/log/docker-layer1.log > /dev/null && $(ROOT)/util/release/flynn-release manifest --output=%o --image-repository=@(IMAGE_REPOSITORY) manifest_template.json |> bin/manifest.json <manifest>

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -25,7 +25,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/postgresql?id=$image_id[postgresql]"
+      "uri": "$image_repository?name=flynn/postgresql&id=$image_id[postgresql]"
     },
     "processes": {
       "postgres": 1,
@@ -85,7 +85,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/controller?id=$image_id[controller]"
+      "uri": "$image_repository?name=flynn/controller&id=$image_id[controller]"
     },
     "processes": {
       "web": 1
@@ -150,7 +150,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/blobstore?id=$image_id[blobstore]"
+      "uri": "$image_repository?name=flynn/blobstore&id=$image_id[blobstore]"
     },
     "release": {
       "processes": {
@@ -173,7 +173,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/router?id=$image_id[router]"
+      "uri": "$image_repository?name=flynn/router&id=$image_id[router]"
     },
     "release": {
       "processes": {
@@ -201,7 +201,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/receiver?id=$image_id[receiver]"
+      "uri": "$image_repository?name=flynn/receiver&id=$image_id[receiver]"
     },
     "release": {
       "processes": {
@@ -210,8 +210,8 @@
           "env": {
             "SSH_PRIVATE_KEYS": "{{ (index .StepData \"gitreceive-key\").PrivateKeys }}",
             "CONTROLLER_AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
-            "SLUGBUILDER_IMAGE_URI": "$image_url_prefix/slugbuilder?id=$image_id[slugbuilder]",
-            "SLUGRUNNER_IMAGE_URI": "$image_url_prefix/slugrunner?id=$image_id[slugrunner]"
+            "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
+            "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
           }
         }
       }
@@ -268,13 +268,13 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/taffy?id=$image_id[taffy]"
+      "uri": "$image_repository?name=flynn/taffy&id=$image_id[taffy]"
     },
     "release": {
       "env": {
         "CONTROLLER_AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
-        "SLUGBUILDER_IMAGE_URI": "$image_url_prefix/slugbuilder?id=$image_id[slugbuilder]",
-        "SLUGRUNNER_IMAGE_URI": "$image_url_prefix/slugrunner?id=$image_id[slugrunner]"
+        "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
+        "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
       }
     }
   },
@@ -287,7 +287,7 @@
     },
     "artifact": {
       "type": "docker",
-      "uri": "$image_url_prefix/dashboard?id=$image_id[dashboard]"
+      "uri": "$image_repository?name=flynn/dashboard&id=$image_id[dashboard]"
     },
     "release": {
       "env": {

--- a/host/Tupfile
+++ b/host/Tupfile
@@ -2,4 +2,4 @@ include_rules
 : |> !go |> bin/flynn-host
 : |> !go ./flynn-init |> bin/flynn-init
 : | $(ROOT)/<layer0> |> ^ LAYER 0^ cat $(ROOT)/log/docker-layer0/* > %o |> $(ROOT)/log/docker-layer0.log
-: $(ROOT)/util/release/flynn-release $(ROOT)/log/docker-layer0.log |> ^ host_manifest.json^ cat $(ROOT)/log/docker-layer0.log > /dev/null && $(ROOT)/util/release/flynn-release manifest --output=%o --image-url-prefix=@(IMAGE_URL_PREFIX) manifest_template.json |> bin/manifest.json
+: $(ROOT)/util/release/flynn-release $(ROOT)/log/docker-layer0.log |> ^ host_manifest.json^ cat $(ROOT)/log/docker-layer0.log > /dev/null && $(ROOT)/util/release/flynn-release manifest --output=%o --image-repository=@(IMAGE_REPOSITORY) manifest_template.json |> bin/manifest.json

--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -1,28 +1,39 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/url"
+	"io"
 	"os"
+	"path/filepath"
 
-	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/graphdriver/aufs"
-	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/graphdriver/btrfs"
-	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/graphdriver/devmapper"
-	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/graphdriver/vfs"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+	tufdata "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/data"
 	"github.com/flynn/flynn/pinkerton"
-	"github.com/flynn/flynn/pkg/cliutil"
+	"github.com/flynn/flynn/pkg/tufutil"
 )
 
+const rootKeysJSON = `[{"keytype":"ed25519","keyval":{"public":"5c14a2ca78bc556f29fbd4a1eca7fbfcef0600e2d329dfb02a39886c706a740a"}}]`
+
+var rootKeys []*tufdata.Key
+
 func init() {
+	if err := json.Unmarshal([]byte(rootKeysJSON), &rootKeys); err != nil {
+		panic("error decoding root keys")
+	}
+
 	Register("download", runDownload, `
-usage: flynn-host download [--driver=<name>] [--root=<path>] [<manifest>]
+usage: flynn-host download [--driver=<name>] [--root=<path>] [--repository=<uri>] [--tuf-db=<path>] [--manifest-dir=<dir>]
 
 Options:
-  -d --driver=<name>  image storage driver [default: aufs]
-  -r --root=<path>    image storage root [default: /var/lib/docker]
+  -d --driver=<name>       image storage driver [default: aufs]
+  -r --root=<path>         image storage root [default: /var/lib/docker]
+  -u --repository=<uri>    image repository URI [default: https://dl.flynn.io/images]
+  -t --tuf-db=<path>       local TUF file [default: /etc/flynn/tuf.db]
+  -m --manifest-dir=<dir>  directory to copy manifests into [default: /etc/flynn]
 
-Download container images listed in a manifest`)
+Download container images from a TUF repository`)
 }
 
 func runDownload(args *docopt.Args) error {
@@ -30,33 +41,63 @@ func runDownload(args *docopt.Args) error {
 		return fmt.Errorf("error creating root dir: %s", err)
 	}
 
-	manifestFile := args.String["<manifest>"]
-	if manifestFile == "" {
-		manifestFile = "/etc/flynn/version.json"
+	// create a TUF client, initialize it if the DB doesn't exist and update it
+	tufDB := args.String["--tuf-db"]
+	needsInit := false
+	if _, err := os.Stat(tufDB); os.IsNotExist(err) {
+		needsInit = true
 	}
-
-	var manifest map[string]string
-	if err := cliutil.DecodeJSONArg(manifestFile, &manifest); err != nil {
-		return err
-	}
-
-	ctx, err := pinkerton.BuildContext(args.String["--driver"], args.String["--root"])
+	local, err := tuf.FileLocalStore(tufDB)
 	if err != nil {
 		return err
 	}
-
-	for image, id := range manifest {
-		parsedURL, err := url.Parse(image)
-		if err != nil {
+	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], nil)
+	if err != nil {
+		return err
+	}
+	client := tuf.NewClient(local, remote)
+	if needsInit {
+		if err := client.Init(rootKeys, len(rootKeys)); err != nil {
 			return err
 		}
-		// Hide login info from printing.
-		parsedURL.User = nil
-		fmt.Printf("Downloading %s %s...\n", parsedURL, id)
-		image += "?id=" + id
-		if err := ctx.PullDocker(image, pinkerton.InfoPrinter(false)); err != nil {
+	}
+	if _, err := client.Update(); err != nil && !tuf.IsLatestSnapshot(err) {
+		return err
+	}
+
+	// pull images from the TUF repo
+	if err := pinkerton.PullImagesWithClient(
+		client,
+		args.String["--repository"],
+		args.String["--driver"],
+		args.String["--root"],
+		pinkerton.InfoPrinter(false),
+	); err != nil {
+		return err
+	}
+
+	// download the host and bootstrap manifests
+	if err := os.MkdirAll(args.String["--manifest-dir"], 0755); err != nil {
+		return fmt.Errorf("error creating manifest dir: %s", err)
+	}
+	for _, path := range []string{"/host-manifest.json", "/bootstrap-manifest.json"} {
+		if err := downloadManifest(client, path, args.String["--manifest-dir"]); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func downloadManifest(client *tuf.Client, path, dir string) error {
+	file, err := tufutil.Download(client, path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	out, err := os.Create(filepath.Join(dir, path))
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(out, file)
+	return err
 }

--- a/host/cli/update.go
+++ b/host/cli/update.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pkg/cluster"
+)
+
+func init() {
+	Register("update", runUpdate, `
+usage: flynn-host update [--driver=<name>] [--root=<path>] [--repository=<uri>] [--tuf-db=<path>]
+
+Options:
+  -d --driver=<name>       image storage driver [default: aufs]
+  -r --root=<path>         image storage root [default: /var/lib/docker]
+  -u --repository=<uri>    image repository URI [default: https://dl.flynn.io/images]
+  -t --tuf-db=<path>       local TUF file [default: /etc/flynn/tuf.db]
+
+Update Flynn components`)
+}
+
+func runUpdate(args *docopt.Args) error {
+	// create and update a TUF client
+	local, err := tuf.FileLocalStore(args.String["--tuf-db"])
+	if err != nil {
+		return err
+	}
+	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], nil)
+	if err != nil {
+		return err
+	}
+	client := tuf.NewClient(local, remote)
+	if _, err := client.Update(); err != nil && !tuf.IsLatestSnapshot(err) {
+		return err
+	}
+
+	// read the TUF db so we can pass it to hosts
+	tufDB, err := ioutil.ReadFile(args.String["--tuf-db"])
+	if err != nil {
+		return err
+	}
+
+	// get list of hosts
+	clusterClient, err := cluster.NewClient()
+	if err != nil {
+		return err
+	}
+	hosts, err := clusterClient.ListHosts()
+	if err != nil {
+		return err
+	}
+	if len(hosts) == 0 {
+		return errors.New("no hosts found")
+	}
+
+	hostErrs := make(chan error)
+	for _, h := range hosts {
+		go func(hostID string) {
+			host, err := clusterClient.DialHost(hostID)
+			if err != nil {
+				hostErrs <- err
+				return
+			}
+			ch := make(chan *pinkerton.LayerPullInfo)
+			stream, err := host.PullImages(
+				args.String["--repository"],
+				args.String["--driver"],
+				args.String["--root"],
+				bytes.NewReader(tufDB),
+				ch,
+			)
+			if err != nil {
+				hostErrs <- err
+				return
+			}
+			defer stream.Close()
+			for info := range ch {
+				fmt.Printf("==> %s : %s %s %s\n", hostID, info.Repo, info.ID, info.Status)
+			}
+			hostErrs <- stream.Err()
+		}(h.ID)
+	}
+	var hostErr error
+	for _, h := range hosts {
+		if err := <-hostErrs; err != nil {
+			fmt.Printf("update: error running update on host %s: %s\n", h.ID, err)
+			hostErr = err
+		}
+	}
+	return hostErr
+}

--- a/host/host.go
+++ b/host/host.go
@@ -38,7 +38,7 @@ usage: flynn-host daemon [options] [--meta=<KEY=VAL>...]
 
 options:
   --external=IP          external IP of host
-  --manifest=PATH        path to manifest file [default: /etc/flynn-host.json]
+  --manifest=PATH        path to manifest file [default: /etc/flynn/host-manifest.json]
   --state=PATH           path to state file [default: /var/lib/flynn/host-state.bolt]
   --id=ID                host id
   --force                kill all containers booted by flynn-host before starting

--- a/host/host.go
+++ b/host/host.go
@@ -62,6 +62,7 @@ Commands:
   help                       Show usage for a specific command
   init                       Create cluster configuration for daemon
   daemon                     Start the daemon
+  update                     Update Flynn components
   download                   Download container images
   bootstrap                  Bootstrap layer 1
   inspect                    Get low-level information about a job

--- a/host/http.go
+++ b/host/http.go
@@ -3,12 +3,16 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pinkerton"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sse"
 )
@@ -91,10 +95,67 @@ func (h *jobAPI) StopJob(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	w.WriteHeader(200)
 }
 
+func (h *jobAPI) PullImages(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	tufDB, err := extractTufDB(r)
+	if err != nil {
+		httphelper.Error(w, err)
+	}
+	defer os.Remove(tufDB)
+
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.WriteHeader(200)
+	w.(http.Flusher).Flush()
+
+	ws := sse.NewWriter(w)
+	info := make(chan pinkerton.LayerPullInfo)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		enc := json.NewEncoder(ws)
+		for {
+			select {
+			case l, ok := <-info:
+				if !ok {
+					return
+				}
+				if err := enc.Encode(l); err != nil {
+					ws.Error(err)
+					return
+				}
+				w.(http.Flusher).Flush()
+			}
+		}
+	}()
+	if err := pinkerton.PullImages(
+		tufDB,
+		r.URL.Query().Get("repository"),
+		r.URL.Query().Get("driver"),
+		r.URL.Query().Get("root"),
+		info,
+	); err != nil {
+		ws.Error(err)
+	}
+	<-done
+}
+
+func extractTufDB(r *http.Request) (string, error) {
+	defer r.Body.Close()
+	tmp, err := ioutil.TempFile("", "tuf-db")
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+	if _, err := io.Copy(tmp, r.Body); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
 func (h *jobAPI) RegisterRoutes(r *httprouter.Router) error {
 	r.GET("/host/jobs", h.ListJobs)
 	r.GET("/host/jobs/:id", h.GetJob)
 	r.DELETE("/host/jobs/:id", h.StopJob)
+	r.POST("/host/pull-images", h.PullImages)
 	return nil
 }
 

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "etcd",
-    "image": "$image_url_prefix/etcd?id=$image_id[etcd]",
+    "image": "$image_repository?name=flynn/etcd&id=$image_id[etcd]",
     "expose_env": ["ETCD_INITIAL_CLUSTER", "ETCD_INITIAL_CLUSTER_STATE", "ETCD_NAME", "ETCD_DISCOVERY", "ETCD_PROXY"],
     "args": [
       "-data-dir={{ .Volume \"/data\" }}",
@@ -15,7 +15,7 @@
   },
   {
     "id": "flannel",
-    "image": "$image_url_prefix/flannel?id=$image_id[flannel]",
+    "image": "$image_repository?name=flynn/flannel&id=$image_id[flannel]",
     "env": {
       "FLANNEL_NETWORK": "100.100.0.0/16",
       "ETCD_ADDR": "{{ .Services.etcd.ExternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"
@@ -23,7 +23,7 @@
   },
   {
     "id": "discoverd",
-    "image": "$image_url_prefix/discoverd?id=$image_id[discoverd]",
+    "image": "$image_repository?name=flynn/discoverd&id=$image_id[discoverd]",
     "args": ["-bind=:{{ .TCPPort 0 }}", "-etcd=http://{{ .Services.etcd.ExternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"],
     "args": [
 		"-http-addr=:{{ .TCPPort 0 }}", 

--- a/pinkerton/context.go
+++ b/pinkerton/context.go
@@ -173,6 +173,18 @@ func ImageID(s string) (string, error) {
 	return id, nil
 }
 
+func PullImages(tufDB, repository, driver, root string, progress chan<- LayerPullInfo) error {
+	local, err := tuf.FileLocalStore(tufDB)
+	if err != nil {
+		return err
+	}
+	remote, err := tuf.HTTPRemoteStore(repository, nil)
+	if err != nil {
+		return err
+	}
+	return PullImagesWithClient(tuf.NewClient(local, remote), repository, driver, root, progress)
+}
+
 func PullImagesWithClient(client *tuf.Client, repository, driver, root string, progress chan<- LayerPullInfo) error {
 	tmp, err := tufutil.Download(client, "/version.json")
 	if err != nil {

--- a/pinkerton/registry/docker.go
+++ b/pinkerton/registry/docker.go
@@ -27,6 +27,10 @@ func (s *dockerSession) ImageID() string {
 	return s.ref.imageID
 }
 
+func (s *dockerSession) Repo() string {
+	return s.ref.repo
+}
+
 func (s *dockerSession) GetImage() (*Image, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repositories/%s/images", s.index, s.ref.repo), nil)
 	if err != nil {

--- a/pinkerton/registry/registry.go
+++ b/pinkerton/registry/registry.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Session interface {
+	Repo() string
 	ImageID() string
 	GetImage() (*Image, error)
 	GetLayer(string) (io.ReadCloser, error)

--- a/pinkerton/registry/tuf.go
+++ b/pinkerton/registry/tuf.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
 	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+	"github.com/flynn/flynn/pkg/tufutil"
 )
 
 func NewTUFSession(client *tuf.Client, ref *Ref) Session {
@@ -22,6 +22,10 @@ type tufSession struct {
 
 func (s *tufSession) ImageID() string {
 	return s.ref.imageID
+}
+
+func (s *tufSession) Repo() string {
+	return s.ref.repo
 }
 
 func (s *tufSession) GetImage() (*Image, error) {
@@ -60,26 +64,12 @@ func (s *tufSession) tags() (map[string]string, error) {
 	return tags, err
 }
 
-type tmpFile struct {
-	*os.File
-}
-
-func (t *tmpFile) Delete() error {
-	t.File.Close()
-	return os.Remove(t.Name())
-}
-
-func (t *tmpFile) Close() error {
-	return t.Delete()
-}
-
 func (s *tufSession) get(name string, out interface{}) (io.ReadCloser, error) {
-	file, err := ioutil.TempFile("", "pinkerton")
+	tmp, err := tufutil.NewTempFile()
 	if err != nil {
 		return nil, err
 	}
 	name = path.Join("v1", name)
-	tmp := &tmpFile{file}
 	if err := s.client.Download(name, tmp); err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -155,7 +155,11 @@ func (c *Client) Hijack(method, path string, header http.Header, in interface{})
 // optional json object to be sent to the server via the body, and out is a
 // required channel, to which the output will be streamed.
 func (c *Client) Stream(method, path string, in, out interface{}) (stream.Stream, error) {
-	header := http.Header{"Accept": []string{"text/event-stream"}}
+	return c.StreamWithHeader(method, path, make(http.Header), in, out)
+}
+
+func (c *Client) StreamWithHeader(method, path string, header http.Header, in, out interface{}) (stream.Stream, error) {
+	header.Set("Accept", "text/event-stream")
 	res, err := c.RawReq(method, path, header, in, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/sse/sse.go
+++ b/pkg/sse/sse.go
@@ -33,6 +33,8 @@ func (w *Writer) Write(p []byte) (int, error) {
 }
 
 func (w *Writer) Error(err error) (int, error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
 	_, e := w.w.Write([]byte("event: error\n"))
 	if e != nil {
 		return 0, e

--- a/pkg/tufutil/tufutil.go
+++ b/pkg/tufutil/tufutil.go
@@ -1,0 +1,44 @@
+package tufutil
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+)
+
+func Download(client *tuf.Client, path string) (io.ReadCloser, error) {
+	tmp, err := NewTempFile()
+	if err != nil {
+		return nil, err
+	}
+	if err := client.Download(path, tmp); err != nil {
+		return nil, err
+	}
+	if _, err := tmp.Seek(0, os.SEEK_SET); err != nil {
+		return nil, err
+	}
+	return tmp, nil
+}
+
+func NewTempFile() (*TempFile, error) {
+	file, err := ioutil.TempFile("", "flynn-tuf")
+	if err != nil {
+		return nil, err
+	}
+	return &TempFile{file}, nil
+}
+
+type TempFile struct {
+	*os.File
+}
+
+func (t *TempFile) Delete() error {
+	t.File.Close()
+	return os.Remove(t.Name())
+}
+
+func (t *TempFile) Close() error {
+	return t.Delete()
+}

--- a/script/release-packages
+++ b/script/release-packages
@@ -167,6 +167,8 @@ main() {
   pushd "${tuf_dir}" >/dev/null
   tuf clean
   cp "${src}/version.json" "staged/targets"
+  cp "${src}/host/bin/manifest.json" "staged/targets/host-manifest.json"
+  cp "${src}/bootstrap/bin/manifest.json" "staged/targets/bootstrap-manifest.json"
   "${flynn_release}" export "${src}/version.json" "staged/targets"
   tuf add
   tuf snapshot

--- a/tup.config
+++ b/tup.config
@@ -1,1 +1,1 @@
-CONFIG_IMAGE_URL_PREFIX=https://registry.hub.docker.com/flynn
+CONFIG_IMAGE_REPOSITORY=https://dl.flynn.io/images

--- a/util/release/Tupfile
+++ b/util/release/Tupfile
@@ -1,3 +1,3 @@
 include_rules
 : |> !go |> flynn-release
-: flynn-release | $(ROOT)/bootstrap/<manifest> |> ^ version.json^ cat $(ROOT)/log/docker-layer1.log > /dev/null && ./flynn-release manifest --output=%o --image-url-prefix=@(IMAGE_URL_PREFIX) version_template.json |> $(ROOT)/version.json
+: flynn-release | $(ROOT)/bootstrap/<manifest> |> ^ version.json^ cat $(ROOT)/log/docker-layer1.log > /dev/null && ./flynn-release manifest --output=%o --image-repository=@(IMAGE_REPOSITORY) version_template.json |> $(ROOT)/version.json

--- a/util/release/export.go
+++ b/util/release/export.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"net/url"
 	"os"
 	"os/exec"
 
@@ -31,15 +30,8 @@ func export(args *docopt.Args) {
 	}
 
 	images := make([]string, 0, len(manifest))
-	for uri, id := range manifest {
-		// assuming the path is the name of the repo won't work in all cases, but
-		// this is going to get replaced very soon as the manifest will just
-		// include mappings of name -> id
-		u, err := url.Parse(uri)
-		if err != nil {
-			log.Fatal(err)
-		}
-		tagged := u.Path[1:] + ":latest"
+	for name, id := range manifest {
+		tagged := name + ":latest"
 		run(exec.Command("docker", "tag", "--force", id, tagged))
 		images = append(images, tagged)
 	}

--- a/util/release/export.go
+++ b/util/release/export.go
@@ -11,6 +11,14 @@ import (
 	"github.com/flynn/flynn/pkg/cliutil"
 )
 
+func run(cmd *exec.Cmd) {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
 func export(args *docopt.Args) {
 	var manifest map[string]string
 	if err := cliutil.DecodeJSONArg(args.String["<manifest>"], &manifest); err != nil {

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -9,16 +9,16 @@ func main() {
 
 Usage:
   flynn-release status <commit>
-  flynn-release manifest [--output=<dest>] [--image-url-prefix=<prefix>] [--id-file=<file>] <template>
+  flynn-release manifest [--output=<dest>] [--image-repository=<url>] [--id-file=<file>] <template>
   flynn-release vagrant <url> <checksum> <version> <provider>
   flynn-release amis <version> <ids>
   flynn-release version <version> <commit>
   flynn-release export <manifest> <dir>
 
 Options:
-  -o --output=<dest>              output destination file ("-" for stdout) [default: -]
-  -i --id-file=<file>             JSON file containing ID mappings
-  -s --image-url-prefix=<prefix>  the image URL prefix [default: https://registry.hub.docker.com/flynn]
+  -o --output=<dest>           output destination file ("-" for stdout) [default: -]
+  -i --id-file=<file>          JSON file containing ID mappings
+  -r --image-repository=<url>  the image repository URL [default: https://dl.flynn.io/images]
 `
 	args, _ := docopt.Parse(usage, nil, true, "", false)
 

--- a/util/release/manifest.go
+++ b/util/release/manifest.go
@@ -46,19 +46,19 @@ func manifest(args *docopt.Args) {
 		log.Fatal(err)
 	}
 
-	if err := interpolateManifest(lookup, args.String["--image-url-prefix"], src, dest); err != nil {
+	if err := interpolateManifest(lookup, args.String["--image-repository"], src, dest); err != nil {
 		log.Fatal(err)
 	}
 }
 
 var imageIDPattern = regexp.MustCompile(`\$image_id\[[^\]]+\]`)
 
-func interpolateManifest(lookup idLookupFunc, imageURLPrefix string, src io.Reader, dest io.Writer) error {
+func interpolateManifest(lookup idLookupFunc, imageRepository string, src io.Reader, dest io.Writer) error {
 	manifest, err := ioutil.ReadAll(src)
 	if err != nil {
 		return err
 	}
-	manifest = bytes.Replace(manifest, []byte("$image_url_prefix"), []byte(imageURLPrefix), -1)
+	manifest = bytes.Replace(manifest, []byte("$image_repository"), []byte(imageRepository), -1)
 	var replaceErr interface{}
 	func() {
 		defer func() {

--- a/util/release/version_template.json
+++ b/util/release/version_template.json
@@ -1,14 +1,14 @@
 {
-  "$image_url_prefix/etcd": "$image_id[etcd]",
-  "$image_url_prefix/flannel": "$image_id[flannel]",
-  "$image_url_prefix/discoverd": "$image_id[discoverd]",
-  "$image_url_prefix/postgresql": "$image_id[postgresql]",
-  "$image_url_prefix/controller": "$image_id[controller]",
-  "$image_url_prefix/blobstore": "$image_id[blobstore]",
-  "$image_url_prefix/router": "$image_id[router]",
-  "$image_url_prefix/receiver": "$image_id[receiver]",
-  "$image_url_prefix/slugbuilder": "$image_id[slugbuilder]",
-  "$image_url_prefix/slugrunner": "$image_id[slugrunner]",
-  "$image_url_prefix/taffy": "$image_id[taffy]",
-  "$image_url_prefix/dashboard": "$image_id[dashboard]"
+  "flynn/etcd": "$image_id[etcd]",
+  "flynn/flannel": "$image_id[flannel]",
+  "flynn/discoverd": "$image_id[discoverd]",
+  "flynn/postgresql": "$image_id[postgresql]",
+  "flynn/controller": "$image_id[controller]",
+  "flynn/blobstore": "$image_id[blobstore]",
+  "flynn/router": "$image_id[router]",
+  "flynn/receiver": "$image_id[receiver]",
+  "flynn/slugbuilder": "$image_id[slugbuilder]",
+  "flynn/slugrunner": "$image_id[slugrunner]",
+  "flynn/taffy": "$image_id[taffy]",
+  "flynn/dashboard": "$image_id[dashboard]"
 }


### PR DESCRIPTION
Summary of changes:

* Modify manifest URIs to point at a TUF repo
* Modify `flynn-host download` to initialize the local TUF db using embedded root keys, download the version, host and bootstrap manifests from a TUF repo, and download all necessary images
* Add `flynn-host update` which updates the local TUF db then calls `PullImages` on each host in the cluster via HTTP, passing the updated TUF db in the request body (so that each host downloads the same images)

The root keys here are for a test repo at `https://s3.amazonaws.com/flynn-test/images` so will need changing before merging this into master.

An example download:

```
$ sudo flynn-host download \
  --repository https://s3.amazonaws.com/flynn-test/images \
  --tuf-db /tmp/tuf.db \
  --manifest-dir /tmp
flynn/receiver 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 exists
flynn/receiver ed53cd6f7f21a7ddb8b8b36f19b4b145eefe0bf744f57a33562641c40910f3b5 exists
...
flynn/receiver b3ddaeec65ed65b9a645c96449e115b11f8dfef44e243c47a0fc31c912014b79 downloaded
flynn/receiver 0a473907997f27e0b91028780adf1ad3522de042f4af66c037da4c5f39f2a0cb downloaded
flynn/discoverd 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 exists
flynn/discoverd a643fa1f27423cb7d426d52aed06d846fd6a4518b44da74ab03fc78cbfae6a04 exists
...
flynn/discoverd dcfad9f682b3e153c8b8a4cdfea30d3121fa2978ba7753c3b4802343dfb591d6 downloaded
flynn/discoverd 6bb9a43a7f88c048735be043099f8c3b35988f1846e63a5ff03f14dde6deaabb downloaded
```

An example update:

```
$ sudo flynn-host update --repository https://s3.amazonaws.com/flynn-test/images
==> ip17231528 : flynn/receiver 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 exists
==> ip17231528 : flynn/receiver ed53cd6f7f21a7ddb8b8b36f19b4b145eefe0bf744f57a33562641c40910f3b5 exists
...
==> ip17231528 : flynn/receiver b3ddaeec65ed65b9a645c96449e115b11f8dfef44e243c47a0fc31c912014b79 downloaded
==> ip17231528 : flynn/receiver 0a473907997f27e0b91028780adf1ad3522de042f4af66c037da4c5f39f2a0cb downloaded
==> ip17231528 : flynn/discoverd 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 exists
==> ip17231528 : flynn/discoverd a643fa1f27423cb7d426d52aed06d846fd6a4518b44da74ab03fc78cbfae6a04 exists
...
==> ip17231528 : flynn/discoverd dcfad9f682b3e153c8b8a4cdfea30d3121fa2978ba7753c3b4802343dfb591d6 downloaded
==> ip17231528 : flynn/discoverd 6bb9a43a7f88c048735be043099f8c3b35988f1846e63a5ff03f14dde6deaabb downloaded
```

I plan to add a test for updating images across the cluster, but I will do that in a subsequent PR as there are already a lot of changes here.

Incremental patch for #617.