### PR TITLE
Clean up context-based Handler type, move context setters/getters to ctxhelper pkg

### DIFF
--- a/controller/app.go
+++ b/controller/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/controller/name"
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
@@ -235,7 +236,7 @@ func (r *AppRepo) GetRelease(id string) (*ct.Release, error) {
 }
 
 func (c *controllerAPI) UpdateApp(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 
 	var data appUpdate
 	if err := httphelper.DecodeJSON(req, &data); err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,6 +21,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/shutdown"
@@ -233,7 +234,8 @@ func (c *controllerAPI) getApp(ctx context.Context) *ct.App {
 }
 
 func (c *controllerAPI) getRelease(ctx context.Context) (*ct.Release, error) {
-	data, err := c.releaseRepo.Get(httphelper.ParamsFromContext(ctx).ByName("releases_id"))
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	data, err := c.releaseRepo.Get(params.ByName("releases_id"))
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +243,8 @@ func (c *controllerAPI) getRelease(ctx context.Context) (*ct.Release, error) {
 }
 
 func (c *controllerAPI) getProvider(ctx context.Context) (*ct.Provider, error) {
-	data, err := c.providerRepo.Get(httphelper.ParamsFromContext(ctx).ByName("providers_id"))
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	data, err := c.providerRepo.Get(params.ByName("providers_id"))
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +253,8 @@ func (c *controllerAPI) getProvider(ctx context.Context) (*ct.Provider, error) {
 
 func (c *controllerAPI) appLookup(handler httphelper.Handle) httphelper.Handle {
 	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-		data, err := c.appRepo.Get(httphelper.ParamsFromContext(ctx).ByName("apps_id"))
+		params, _ := ctxhelper.ParamsFromContext(ctx)
+		data, err := c.appRepo.Get(params.ByName("apps_id"))
 		if err != nil {
 			respondWithError(w, err)
 			return
@@ -269,7 +273,8 @@ func routeID(params httprouter.Params) string {
 }
 
 func (c *controllerAPI) getRoute(ctx context.Context) (*router.Route, error) {
-	route, err := c.routerc.GetRoute(routeID(httphelper.ParamsFromContext(ctx)))
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	route, err := c.routerc.GetRoute(routeID(params))
 	if err == routerc.ErrNotFound || err == nil && route.ParentRef != routeParentRef(c.getApp(ctx).ID) {
 		err = ErrNotFound
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -251,7 +251,7 @@ func (c *controllerAPI) getProvider(ctx context.Context) (*ct.Provider, error) {
 	return data.(*ct.Provider), nil
 }
 
-func (c *controllerAPI) appLookup(handler httphelper.Handle) httphelper.Handle {
+func (c *controllerAPI) appLookup(handler httphelper.HandlerFunc) httphelper.HandlerFunc {
 	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		params, _ := ctxhelper.ParamsFromContext(ctx)
 		data, err := c.appRepo.Get(params.ByName("apps_id"))

--- a/controller/crud.go
+++ b/controller/crud.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/controller/schema"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 )
 
@@ -44,7 +45,8 @@ func crud(r *httprouter.Router, resource string, example interface{}, repo Repos
 	}))
 
 	lookup := func(ctx context.Context) (interface{}, error) {
-		return repo.Get(httphelper.ParamsFromContext(ctx).ByName(resource + "_id"))
+		params, _ := ctxhelper.ParamsFromContext(ctx)
+		return repo.Get(params.ByName(resource + "_id"))
 	}
 
 	singletonPath := prefix + "/:" + resource + "_id"
@@ -73,7 +75,7 @@ func crud(r *httprouter.Router, resource string, example interface{}, repo Repos
 				respondWithError(rw, err)
 				return
 			}
-			params := httphelper.ParamsFromContext(ctx)
+			params, _ := ctxhelper.ParamsFromContext(ctx)
 			if err = remover.Remove(params.ByName(resource + "_id")); err != nil {
 				respondWithError(rw, err)
 				return

--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
@@ -76,7 +77,7 @@ func scanDeployment(s postgres.Scanner) (*ct.Deployment, error) {
 }
 
 func (c *controllerAPI) GetDeployment(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 	deployment, err := c.deploymentRepo.Get(params.ByName("deployment_id"))
 	if err != nil {
 		respondWithError(w, err)

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/sse"
@@ -297,7 +298,7 @@ func (c *controllerAPI) PutFormation(ctx context.Context, w http.ResponseWriter,
 }
 
 func (c *controllerAPI) GetFormation(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 
 	app := c.getApp(ctx)
 	formation, err := c.formationRepo.Get(app.ID, params.ByName("releases_id"))
@@ -309,7 +310,7 @@ func (c *controllerAPI) GetFormation(ctx context.Context, w http.ResponseWriter,
 }
 
 func (c *controllerAPI) DeleteFormation(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 
 	app := c.getApp(ctx)
 	formation, err := c.formationRepo.Get(app.ID, params.ByName("releases_id"))

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -19,6 +19,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/schedutil"
@@ -188,7 +189,7 @@ type clusterClient interface {
 }
 
 func (c *controllerAPI) connectHost(ctx context.Context) (cluster.Host, string, error) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 	hostID, jobID, err := cluster.ParseJobID(params.ByName("jobs_id"))
 	if err != nil {
 		log.Printf("Unable to parse hostID from %q", params.ByName("jobs_id"))
@@ -219,7 +220,7 @@ func (c *controllerAPI) ListJobs(ctx context.Context, w http.ResponseWriter, req
 }
 
 func (c *controllerAPI) GetJob(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 	job, err := c.jobRepo.Get(params.ByName("jobs_id"))
 	if err != nil {
 		respondWithError(w, err)

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
@@ -218,7 +219,7 @@ func (c *controllerAPI) GetProviderResources(ctx context.Context, w http.Respons
 }
 
 func (c *controllerAPI) GetResource(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 
 	_, err := c.getProvider(ctx)
 	if err != nil {
@@ -235,7 +236,7 @@ func (c *controllerAPI) GetResource(ctx context.Context, w http.ResponseWriter, 
 }
 
 func (c *controllerAPI) PutResource(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	params := httphelper.ParamsFromContext(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
 
 	p, err := c.getProvider(ctx)
 	if err != nil {

--- a/pkg/ctxhelper/ctxhelper.go
+++ b/pkg/ctxhelper/ctxhelper.go
@@ -1,0 +1,52 @@
+package ctxhelper
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+)
+
+type ctxKey int
+
+const (
+	ctxKeyComponent ctxKey = iota
+	ctxKeyReqID
+	ctxKeyParams
+	ctxKeyLogger
+)
+
+func NewContextComponentName(ctx context.Context, componentName string) context.Context {
+	return context.WithValue(ctx, ctxKeyComponent, componentName)
+}
+
+func ComponentNameFromContext(ctx context.Context) (componentName string, ok bool) {
+	componentName, ok = ctx.Value(ctxKeyComponent).(string)
+	return
+}
+
+func NewContextLogger(ctx context.Context, logger log.Logger) context.Context {
+	return context.WithValue(ctx, ctxKeyLogger, logger)
+}
+
+func LoggerFromContext(ctx context.Context) (logger log.Logger, ok bool) {
+	logger, ok = ctx.Value(ctxKeyLogger).(log.Logger)
+	return
+}
+
+func NewContextParams(ctx context.Context, params httprouter.Params) context.Context {
+	return context.WithValue(ctx, ctxKeyParams, params)
+}
+
+func ParamsFromContext(ctx context.Context) (params httprouter.Params, ok bool) {
+	params, ok = ctx.Value(ctxKeyParams).(httprouter.Params)
+	return
+}
+
+func NewContextRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKeyReqID, id)
+}
+
+func RequestIDFromContext(ctx context.Context) (id string, ok bool) {
+	id, ok = ctx.Value(ctxKeyReqID).(string)
+	return
+}

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -50,9 +50,9 @@ var CORSAllowAllHandler = cors.Allow(&cors.Options{
 	MaxAge:           time.Hour,
 })
 
-type Handle func(context.Context, http.ResponseWriter, *http.Request)
+type HandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
 
-func WrapHandler(handler Handle) httprouter.Handle {
+func WrapHandler(handler HandlerFunc) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		ctx := contextFromResponseWriter(w)
 		ctx = ctxhelper.NewContextParams(ctx, params)

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -50,13 +50,27 @@ var CORSAllowAllHandler = cors.Allow(&cors.Options{
 	MaxAge:           time.Hour,
 })
 
+// Handler is an extended version of http.Handler that also takes a context
+// argument ctx.
+type Handler interface {
+	ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request)
+}
+
+// The HandlerFunc type is an adapter to allow the use of ordinary functions as
+// Handlers.  If f is a function with the appropriate signature, HandlerFunc(f)
+// is a Handler object that calls f.
 type HandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
+
+// ServeHTTP calls f(ctx, w, r).
+func (f HandlerFunc) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	f(ctx, w, r)
+}
 
 func WrapHandler(handler HandlerFunc) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		ctx := contextFromResponseWriter(w)
 		ctx = ctxhelper.NewContextParams(ctx, params)
-		handler(ctx, w, req)
+		handler.ServeHTTP(ctx, w, req)
 	}
 }
 

--- a/pkg/httphelper/request_logger.go
+++ b/pkg/httphelper/request_logger.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 )
 
 func NewRequestLogger(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		rw := w.(*ResponseWriter)
 
-		reqID, _ := rw.Context().Value(CtxKeyReqID).(string)
-		componentName, _ := rw.Context().Value(CtxKeyComponent).(string)
+		reqID, _ := ctxhelper.RequestIDFromContext(rw.Context())
+		componentName, _ := ctxhelper.ComponentNameFromContext(rw.Context())
 		logger := log.New(log.Ctx{"component": componentName, "req_id": reqID})
-		rw.ctx = context.WithValue(rw.Context(), CtxKeyLogger, logger)
+		rw.ctx = ctxhelper.NewContextLogger(rw.Context(), logger)
 
 		start := time.Now()
 		var clientIP string


### PR DESCRIPTION
Following the conventions outlined in the [context blog post](https://blog.golang.org/context#TOC_3.2.), I've moved to context getters and setters to a separate subpackage. This allows the context keys to be internal, unexported types, and provides users of the package with stronger type guarantees (since you can't set something on a context with a key whose type you can't access).

I also renamed the `Handle` type to `HandlerFunc` since it is analogous to `http.HandlerFunc`.

Finally, I introduced an `httphelper.Handler` type that is analogous to `http.Handler`.

I plan to use all this stuff to bring context into the router.