### PR TITLE
router: Add wait between retries if connection to etcd fails

### DIFF
--- a/router/data_store.go
+++ b/router/data_store.go
@@ -225,7 +225,7 @@ watch:
 			goto fullSync
 		}
 		log.Printf("Restarting etcd watch %s due to error: %s", s.prefix, watchErr)
-		// TODO: backoff here
+		time.Sleep(time.Second)
 	}
 }
 


### PR DESCRIPTION
Without this patch, if/when etcd goes down it will fill up the logs with errors due to a tight retry loop.