### PR TITLE
test/runner: Redirect local log requests to log URL

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -424,6 +424,10 @@ func (r *Runner) serveBuildLog(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+	if b.LogFile == "" {
+		http.Redirect(w, req, b.LogUrl, http.StatusMovedPermanently)
+		return
+	}
 	t, err := tail.TailFile(b.LogFile, tail.Config{Follow: true, MustExist: true})
 	if err != nil {
 		http.Error(w, err.Error(), 500)


### PR DESCRIPTION
If we've uploaded the log, the local log file will not be available, but we can redirect to the copy on S3.

Closes #877