### PR TITLE
test: Improve cluster HTTP API

### DIFF
--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -1,0 +1,77 @@
+package testcluster
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/httpclient"
+	tc "github.com/flynn/flynn/test/cluster"
+)
+
+type Client struct {
+	*httpclient.Client
+	cluster *tc.Cluster
+}
+
+var ErrNotFound = errors.New("testcluster: resource not found")
+
+func NewClient(endpoint string) (*Client, error) {
+	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: "ci.flynn.io"}}}
+	client := &Client{
+		Client: &httpclient.Client{
+			ErrNotFound: ErrNotFound,
+			URL:         endpoint,
+			HTTP:        httpClient,
+		},
+	}
+	var cluster tc.Cluster
+	if err := client.Get("", &cluster); err != nil {
+		return nil, err
+	}
+	client.cluster = &cluster
+	return client, nil
+}
+
+func (c *Client) Size() int {
+	return c.cluster.Size()
+}
+
+func (c *Client) BackoffPeriod() time.Duration {
+	return c.cluster.BackoffPeriod
+}
+
+func (c *Client) AddHost(ch chan *host.HostEvent) (string, error) {
+	var instance tc.Instance
+	if err := c.Post("", nil, &instance); err != nil {
+		return "", err
+	}
+	c.cluster.Instances = append(c.cluster.Instances, &instance)
+	for {
+		select {
+		case event := <-ch:
+			if event.HostID == instance.ID {
+				return instance.ID, nil
+			}
+		case <-time.After(60 * time.Second):
+			return "", fmt.Errorf("timed out waiting for new host")
+		}
+	}
+}
+
+func (c *Client) RemoveHost(id string) error {
+	return c.Delete("/" + id)
+}
+
+func (c *Client) DumpLogs(out io.Writer) error {
+	res, err := c.RawReq("GET", "/dump-logs", nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(out, res.Body)
+	return err
+}

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -135,7 +135,7 @@ func (c *Cluster) BuildFlynn(rootFS, commit string, merge bool, runTests bool) (
 	return build.Drive("hda").FS, nil
 }
 
-func (c *Cluster) Boot(rootFS string, count int, dumpLogs io.Writer) error {
+func (c *Cluster) Boot(rootFS string, count int, dumpLogs io.Writer, killOnFailure bool) error {
 	if err := c.setup(); err != nil {
 		return err
 	}
@@ -146,7 +146,9 @@ func (c *Cluster) Boot(rootFS string, count int, dumpLogs io.Writer) error {
 		if dumpLogs != nil && len(c.Instances) > 0 {
 			c.DumpLogs(dumpLogs)
 		}
-		c.Shutdown()
+		if killOnFailure {
+			c.Shutdown()
+		}
 		return err
 	}
 
@@ -155,7 +157,9 @@ func (c *Cluster) Boot(rootFS string, count int, dumpLogs io.Writer) error {
 		if dumpLogs != nil {
 			c.DumpLogs(dumpLogs)
 		}
-		c.Shutdown()
+		if killOnFailure {
+			c.Shutdown()
+		}
 		return err
 	}
 	c.rootFS = rootFS

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -36,6 +37,9 @@ type Cluster struct {
 	ControllerKey string        `json:"controller_key"`
 	RouterIP      string        `json:"router_ip"`
 
+	discMtx sync.Mutex
+	disc    *discoverd.Client
+
 	bc     BootConfig
 	vm     *VMManager
 	out    io.Writer
@@ -56,6 +60,15 @@ func (i instances) Get(id string) (*Instance, error) {
 		}
 	}
 	return nil, fmt.Errorf("no such host: %s", id)
+}
+
+func (c *Cluster) discoverdClient() *discoverd.Client {
+	c.discMtx.Lock()
+	defer c.discMtx.Unlock()
+	if c.disc == nil {
+		c.disc = discoverd.NewClientWithURL(fmt.Sprintf("http://%s:1111", c.RouterIP))
+	}
+	return c.disc
 }
 
 type Streams struct {
@@ -191,12 +204,40 @@ func (c *Cluster) RemoveHost(id string) error {
 	}
 	c.log("removing host", id)
 
+	// Clean shutdown requires waiting for that host to unadvertise on discoverd.
+	// Specifically: Wait for router-api services to disappear to indicate host
+	// removal (rather than using StreamHostEvents), so that other
+	// tests won't try and connect to this host via service discovery.
+	events := make(chan *discoverd.Event)
+	stream, err := c.discoverdClient().Service("router-api").Watch(events)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	// ssh into the host and tell the flynn-host daemon to stop
 	var cmd string
 	switch c.bc.Backend {
 	case "libvirt-lxc":
 		cmd = "sudo start-stop-daemon --stop --pidfile /var/run/flynn-host.pid --retry 15"
 	}
-	return inst.Run(cmd, nil)
+	if err := inst.Run(cmd, nil); err != nil {
+		return err
+	}
+
+loop:
+	for {
+		select {
+		case event := <-events:
+			if event.Kind == discoverd.EventKindDown {
+				break loop
+			}
+		case <-time.After(20 * time.Second):
+			return fmt.Errorf("timed out waiting for host removal")
+		}
+	}
+
+	return nil
 }
 
 func (c *Cluster) Size() int {

--- a/test/main.go
+++ b/test/main.go
@@ -79,7 +79,9 @@ func main() {
 		testCluster = cluster.New(args.BootConfig, os.Stdout)
 		rootFS, err = testCluster.BuildFlynn(args.RootFS, "origin/master", false, false)
 		if err != nil {
-			testCluster.Shutdown()
+			if args.Kill {
+				testCluster.Shutdown()
+			}
 			log.Println("could not build flynn: ", err)
 			if rootFS != "" {
 				os.RemoveAll(rootFS)
@@ -93,7 +95,7 @@ func main() {
 		} else {
 			defer os.RemoveAll(rootFS)
 		}
-		if err = testCluster.Boot(rootFS, 3, nil); err != nil {
+		if err = testCluster.Boot(rootFS, 3, nil, args.Kill); err != nil {
 			log.Println("could not boot cluster: ", err)
 			return
 		}

--- a/test/main.go
+++ b/test/main.go
@@ -87,8 +87,9 @@ func main() {
 			return
 		}
 		if args.BuildRootFS {
+			testCluster.Shutdown()
 			fmt.Println("Built Flynn in rootfs:", rootFS)
-			os.Exit(0)
+			return
 		} else {
 			defer os.RemoveAll(rootFS)
 		}

--- a/test/main.go
+++ b/test/main.go
@@ -4,15 +4,12 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -27,6 +24,7 @@ import (
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/test/arg"
 	"github.com/flynn/flynn/test/cluster"
+	"github.com/flynn/flynn/test/cluster/client"
 )
 
 var sshWrapper = template.Must(template.New("ssh").Parse(`
@@ -38,8 +36,7 @@ ssh -o LogLevel=FATAL -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o S
 var args *arg.Args
 var flynnrc string
 var routerIP string
-var testCluster *cluster.Cluster
-var httpClient *http.Client
+var testCluster *testcluster.Client
 
 func init() {
 	args = arg.Parse()
@@ -75,12 +72,12 @@ func main() {
 	flynnrc = args.Flynnrc
 	routerIP = args.RouterIP
 	if flynnrc == "" {
+		c := cluster.New(args.BootConfig, os.Stdout)
 		var rootFS string
-		testCluster = cluster.New(args.BootConfig, os.Stdout)
-		rootFS, err = testCluster.BuildFlynn(args.RootFS, "origin/master", false, false)
+		rootFS, err = c.BuildFlynn(args.RootFS, "origin/master", false, false)
 		if err != nil {
 			if args.Kill {
-				testCluster.Shutdown()
+				c.Shutdown()
 			}
 			log.Println("could not build flynn: ", err)
 			if rootFS != "" {
@@ -89,40 +86,31 @@ func main() {
 			return
 		}
 		if args.BuildRootFS {
-			testCluster.Shutdown()
+			c.Shutdown()
 			fmt.Println("Built Flynn in rootfs:", rootFS)
 			return
 		} else {
 			defer os.RemoveAll(rootFS)
 		}
-		if err = testCluster.Boot(rootFS, 3, nil, args.Kill); err != nil {
+		if err = c.Boot(rootFS, 3, nil, args.Kill); err != nil {
 			log.Println("could not boot cluster: ", err)
 			return
 		}
 		if args.Kill {
-			defer testCluster.Shutdown()
+			defer c.Shutdown()
 		}
 
-		if err = createFlynnrc(); err != nil {
+		if err = createFlynnrc(c); err != nil {
 			log.Println(err)
 			return
 		}
 		defer os.RemoveAll(flynnrc)
 
-		routerIP = testCluster.RouterIP
+		routerIP = c.RouterIP
 	}
 
 	if args.ClusterAPI != "" {
-		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: "ci.flynn.io"}}}
-
-		res, err := httpClient.Get(args.ClusterAPI)
-		if err != nil {
-			log.Println(err)
-			return
-		}
-		testCluster = &cluster.Cluster{}
-		err = json.NewDecoder(res.Body).Decode(testCluster)
-		res.Body.Close()
+		testCluster, err = testcluster.NewClient(args.ClusterAPI)
 		if err != nil {
 			log.Println(err)
 			return
@@ -221,14 +209,14 @@ func genSSHKey() (*sshData, error) {
 	}, nil
 }
 
-func createFlynnrc() error {
+func createFlynnrc(c *cluster.Cluster) error {
 	tmpfile, err := ioutil.TempFile("", "flynnrc-")
 	if err != nil {
 		return err
 	}
 	path := tmpfile.Name()
 
-	config, err := testCluster.CLIConfig()
+	config, err := c.CLIConfig()
 	if err != nil {
 		os.RemoveAll(path)
 		return err

--- a/test/runner/assets/index.html
+++ b/test/runner/assets/index.html
@@ -60,8 +60,7 @@
         </td>
         <td><span class="label <%= label_class %>"><%= state %></span></td>
         <td>
-          <form action="/builds/" method="POST">
-            <input type="hidden" name="id" value="<%= id %>" />
+          <form action="/builds/<%= id %>/restart" method="POST">
             <button type="submit" class="btn btn-primary">
               <i class="fa fa-refresh"></i>
             </button>

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -265,7 +265,7 @@ func (r *Runner) build(b *Build) (err error) {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 
-	if err := c.Boot(rootFS, 3, out); err != nil {
+	if err := c.Boot(rootFS, 3, out, true); err != nil {
 		return fmt.Errorf("could not boot cluster: %s", err)
 	}
 


### PR DESCRIPTION
Use `httprouter` in the test runner and create a client for making HTTP requests from the test builds.

This is an extraction of changes in #840, and that PR will be rebased on top of these changes once merged.