### PR TITLE
controller/examples: Send log output to STDERR by default

### DIFF
--- a/controller/examples/config.go
+++ b/controller/examples/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -25,12 +24,13 @@ func loadConfigFromEnv() (*config, error) {
 	}
 	c.ourPort = port
 
-	logPath := os.Getenv("LOGFILE")
-	c.logOut = ioutil.Discard
-	if logPath != "" {
+	if logPath := os.Getenv("LOGFILE"); logPath != "" {
 		if f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err == nil {
 			c.logOut = f
 		}
+	}
+	if c.logOut == nil {
+		c.logOut = os.Stderr
 	}
 	return c, nil
 }

--- a/controller/examples/config.go
+++ b/controller/examples/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 )
 
@@ -10,6 +11,10 @@ type config struct {
 	controllerKey string
 	ourPort       string
 	logOut        io.Writer
+}
+
+func init() {
+	log.SetFlags(log.Lshortfile | log.Lmicroseconds)
 }
 
 func loadConfigFromEnv() (*config, error) {


### PR DESCRIPTION
The previous default was to discard any messages, which will suppress errors.