### PR TITLE
router: enable pprof handler via build flag

### DIFF
--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -3,11 +3,12 @@ export GIT_COMMIT
 export GIT_BRANCH
 export GIT_TAG
 export GIT_DIRTY
+export GO_BUILD_TAGS
 
 VPKG = github.com/flynn/flynn/pkg/version
 ROOT = $(TUP_CWD)
 
-!go = |> ^c go build %o^ go build -o %o -ldflags="-X $(VPKG).commit $GIT_COMMIT -X $(VPKG).branch $GIT_BRANCH -X $(VPKG).tag $GIT_TAG -X $(VPKG).dirty $GIT_DIRTY" |>
+!go = |> ^c go build %o^ go build -o %o -ldflags="-X $(VPKG).commit $GIT_COMMIT -X $(VPKG).branch $GIT_BRANCH -X $(VPKG).tag $GIT_TAG -X $(VPKG).dirty $GIT_DIRTY" -tags="$GO_BUILD_TAGS" |>
 !docker = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-%d.log <docker>
 !docker-layer0 = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-layer0/%d.log $(ROOT)/<layer0>
 !docker-layer1 = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-layer1/%d.log $(ROOT)/<layer1>

--- a/pkg/pprof/nopprof.go
+++ b/pkg/pprof/nopprof.go
@@ -1,0 +1,11 @@
+// +build !pprof
+
+package pprof
+
+import (
+	"net/http"
+)
+
+const Enabled = false
+
+var Handler = http.HandlerFunc(http.NotFound)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,19 @@
+// +build pprof
+
+package pprof
+
+import (
+	"net/http"
+	hpprof "net/http/pprof"
+)
+
+const Enabled = true
+
+var Handler = http.NewServeMux()
+
+func init() {
+	Handler.Handle("/debug/pprof/", http.HandlerFunc(hpprof.Index))
+	Handler.Handle("/debug/pprof/cmdline", http.HandlerFunc(hpprof.Cmdline))
+	Handler.Handle("/debug/pprof/profile", http.HandlerFunc(hpprof.Profile))
+	Handler.Handle("/debug/pprof/symbol", http.HandlerFunc(hpprof.Symbol))
+}

--- a/router/api.go
+++ b/router/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/go-martini/martini"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/binding"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/render"
+	"github.com/flynn/flynn/pkg/pprof"
 	"github.com/flynn/flynn/router/types"
 )
 
@@ -30,6 +31,7 @@ func apiHandler(rtr *Router) http.Handler {
 	r.Get("/routes", getRoutes)
 	r.Get("/routes/:route_type/:route_id", getRoute)
 	r.Delete("/routes/:route_type/:route_id", deleteRoute)
+	r.Any("/debug/**", pprof.Handler.ServeHTTP)
 	return m
 }
 

--- a/router/server.go
+++ b/router/server.go
@@ -135,6 +135,7 @@ func main() {
 	}
 
 	go func() { shutdown.Fatal(r.ListenAndServe(nil)) }()
+
 	listener, err := reuseport.NewReusablePortListener("tcp4", *apiAddr)
 	if err != nil {
 		shutdown.Fatal(err)


### PR DESCRIPTION
Profiling the router with the `net/http/pprof` handler is useful for debugging the router, but it has a lot of baggage. Pulling in the `runtime/pprof` dependency should not be done by default. This adds a `pkg/pprof` package that only pulls in the `runtime/pprof`/`net/http/pprof` packages when the `pprof` build tag is set (`go build -tags=pprof`).