### PR TITLE
host: Fix exit status attach return with no stdin

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -798,12 +798,9 @@ func (l *LibvirtLXCBackend) Signal(id string, sig int) error {
 }
 
 func (l *LibvirtLXCBackend) Attach(req *AttachRequest) (err error) {
-	var client *libvirtContainer
-	if req.Stdin != nil || req.Job.Job.Config.TTY {
-		client, err = l.getContainer(req.Job.Job.ID)
-		if err != nil {
-			return err
-		}
+	client, err := l.getContainer(req.Job.Job.ID)
+	if err != nil && (req.Job.Job.Config.TTY || req.Stdin != nil) {
+		return err
 	}
 
 	defer func() {

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -60,6 +60,20 @@ func (s *HostSuite) TestAttachFinishedInteractiveJob(t *c.C) {
 	}
 }
 
+func (s *HostSuite) TestExecCrashingJob(t *c.C) {
+	cluster := s.clusterClient(t)
+
+	for _, attach := range []bool{true, false} {
+		t.Logf("attach = %v", attach)
+		cmd := exec.CommandUsingCluster(cluster, exec.DockerImage(imageURIs["test-apps"]), "sh", "-c", "exit 1")
+		if attach {
+			cmd.Stdout = ioutil.Discard
+			cmd.Stderr = ioutil.Discard
+		}
+		t.Assert(cmd.Run(), c.DeepEquals, exec.ExitError(1))
+	}
+}
+
 /*
 	Make an 'ish' application on the given host, returning it when
 	it has registered readiness with discoverd.


### PR DESCRIPTION
Instead of only looking up the containerinit client when we need it, always look it up, and only error when we need it. This allows us to get retrieve the exit status in cases where stdin is provided and the job is not in TTY mode.

Closes #810
Closes #626