### PR TITLE
pinkerton: Move LayerPullInfo into package

### DIFF
--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -2,11 +2,13 @@ package testutils
 
 import (
 	"errors"
+	"io"
 	"sync"
 	"time"
 
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/stream"
 )
@@ -94,6 +96,10 @@ func (c *FakeHostClient) SendEvent(event, id string) {
 	for _, ch := range c.listeners {
 		ch <- e
 	}
+}
+
+func (c *FakeHostClient) PullImages(repository, driver, root string, tufDB io.Reader, ch chan<- *layer.PullInfo) (stream.Stream, error) {
+	return nil, nil
 }
 
 type attachFunc func(req *host.AttachReq, wait bool) (cluster.AttachClient, error)

--- a/host/cli/update.go
+++ b/host/cli/update.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
-	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/cluster"
 )
 
@@ -67,7 +67,7 @@ func runUpdate(args *docopt.Args) error {
 				hostErrs <- err
 				return
 			}
-			ch := make(chan *pinkerton.LayerPullInfo)
+			ch := make(chan *layer.PullInfo)
 			stream, err := host.PullImages(
 				args.String["--repository"],
 				args.String["--driver"],

--- a/host/http.go
+++ b/host/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/host/volume/api"
 	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sse"
 )
@@ -109,7 +110,7 @@ func (h *jobAPI) PullImages(w http.ResponseWriter, r *http.Request, ps httproute
 	w.(http.Flusher).Flush()
 
 	ws := sse.NewWriter(w)
-	info := make(chan pinkerton.LayerPullInfo)
+	info := make(chan layer.PullInfo)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/iptables"
@@ -966,9 +967,9 @@ func (l *LibvirtLXCBackend) MarshalJobState(jobID string) ([]byte, error) {
 	return nil, nil
 }
 
-func (l *LibvirtLXCBackend) pinkertonPull(url string) ([]pinkerton.LayerPullInfo, error) {
-	var layers []pinkerton.LayerPullInfo
-	info := make(chan pinkerton.LayerPullInfo)
+func (l *LibvirtLXCBackend) pinkertonPull(url string) ([]layer.PullInfo, error) {
+	var layers []layer.PullInfo
+	info := make(chan layer.PullInfo)
 	done := make(chan struct{})
 	go func() {
 		for l := range info {

--- a/pinkerton/layer/layer.go
+++ b/pinkerton/layer/layer.go
@@ -1,0 +1,14 @@
+package layer
+
+type PullInfo struct {
+	Repo   string `json:"repo"`
+	ID     string `json:"id"`
+	Status Status `json:"status"`
+}
+
+type Status string
+
+const (
+	StatusExists     Status = "exists"
+	StatusDownloaded Status = "downloaded"
+)

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
-	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/httpclient"
 	"github.com/flynn/flynn/pkg/stream"
 )
@@ -39,7 +39,7 @@ type Host interface {
 	CreateVolume(providerId string) (*volume.Info, error)
 
 	// PullImages pulls images from a TUF repository using the local TUF file in tufDB
-	PullImages(repository, driver, root string, tufDB io.Reader, ch chan<- *pinkerton.LayerPullInfo) (stream.Stream, error)
+	PullImages(repository, driver, root string, tufDB io.Reader, ch chan<- *layer.PullInfo) (stream.Stream, error)
 }
 
 type hostClient struct {
@@ -97,7 +97,7 @@ func (c *hostClient) CreateVolume(providerId string) (*volume.Info, error) {
 	return &res, err
 }
 
-func (c *hostClient) PullImages(repository, driver, root string, tufDB io.Reader, ch chan<- *pinkerton.LayerPullInfo) (stream.Stream, error) {
+func (c *hostClient) PullImages(repository, driver, root string, tufDB io.Reader, ch chan<- *layer.PullInfo) (stream.Stream, error) {
 	header := http.Header{"Content-Type": {"application/octet-stream"}}
 	path := fmt.Sprintf("/host/pull-images?repository=%s&driver=%s&root=%s", repository, driver, root)
 	return c.c.StreamWithHeader("POST", path, header, tufDB, ch)


### PR DESCRIPTION
This is so that components don't need to import pinkerton, which introduces a dependency on libdevmapper.