### PR TITLE
discoverd service metadata

### DIFF
--- a/discoverd/client/instance.go
+++ b/discoverd/client/instance.go
@@ -37,6 +37,15 @@ func (k EventKind) String() string {
 	return eventKindStrings[EventKindUnknown]
 }
 
+func (k EventKind) Any(kinds ...EventKind) bool {
+	for _, other := range kinds {
+		if k&other != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 var eventKindMarshalJSON = make(map[EventKind][]byte, len(eventKindStrings))
 var eventKindUnmarshalJSON = make(map[string]EventKind, len(eventKindStrings))
 

--- a/discoverd/client/instance.go
+++ b/discoverd/client/instance.go
@@ -17,17 +17,19 @@ const (
 	EventKindDown
 	EventKindLeader
 	EventKindCurrent
+	EventKindServiceMeta
 	EventKindAll     = ^EventKind(0)
 	EventKindUnknown = EventKind(0)
 )
 
 var eventKindStrings = map[EventKind]string{
-	EventKindUp:      "up",
-	EventKindUpdate:  "update",
-	EventKindDown:    "down",
-	EventKindLeader:  "leader",
-	EventKindCurrent: "current",
-	EventKindUnknown: "unknown",
+	EventKindUp:          "up",
+	EventKindUpdate:      "update",
+	EventKindDown:        "down",
+	EventKindLeader:      "leader",
+	EventKindCurrent:     "current",
+	EventKindUnknown:     "unknown",
+	EventKindServiceMeta: "service_meta",
 }
 
 func (k EventKind) String() string {
@@ -73,9 +75,10 @@ func (k *EventKind) UnmarshalJSON(data []byte) error {
 }
 
 type Event struct {
-	Service  string    `json:"service"`
-	Kind     EventKind `json:"kind"`
-	Instance *Instance `json:"instance,omitempty"`
+	Service     string       `json:"service"`
+	Kind        EventKind    `json:"kind"`
+	Instance    *Instance    `json:"instance,omitempty"`
+	ServiceMeta *ServiceMeta `json:"service_meta,omitempty"`
 }
 
 func (e *Event) String() string {

--- a/discoverd/server/backend.go
+++ b/discoverd/server/backend.go
@@ -7,6 +7,7 @@ type Backend interface {
 	RemoveService(service string) error
 	AddInstance(service string, inst *discoverd.Instance) error
 	RemoveInstance(service, id string) error
+	SetServiceMeta(service string, meta *discoverd.ServiceMeta) error
 	StartSync() error
 	Close() error
 }
@@ -17,5 +18,6 @@ type SyncHandler interface {
 	AddInstance(service string, inst *discoverd.Instance)
 	RemoveInstance(service, id string)
 	SetService(service string, data []*discoverd.Instance)
+	SetServiceMeta(service string, meta []byte, index uint64)
 	ListServices() []string
 }

--- a/discoverd/server/state.go
+++ b/discoverd/server/state.go
@@ -351,7 +351,7 @@ func (s *State) Subscribe(service string, sendCurrent bool, kinds discoverd.Even
 	// locked.
 	var current []*discoverd.Instance
 	var currentLeader *discoverd.Instance
-	getCurrent := sendCurrent && kinds&(discoverd.EventKindUp|discoverd.EventKindLeader) != 0
+	getCurrent := sendCurrent && kinds.Any(discoverd.EventKindUp, discoverd.EventKindLeader)
 	if getCurrent {
 		s.mtx.RLock()
 		current = s.getLocked(service)
@@ -380,7 +380,7 @@ func (s *State) Subscribe(service string, sendCurrent bool, kinds discoverd.Even
 	}
 	sub.el = l.PushBack(sub)
 
-	if kinds&discoverd.EventKindUp != 0 {
+	if kinds.Any(discoverd.EventKindUp) {
 		for _, inst := range current {
 			ch <- &discoverd.Event{
 				Service:  service,
@@ -397,7 +397,7 @@ func (s *State) Subscribe(service string, sendCurrent bool, kinds discoverd.Even
 			Instance: currentLeader,
 		}
 	}
-	if sendCurrent && kinds&discoverd.EventKindCurrent != 0 {
+	if sendCurrent && kinds.Any(discoverd.EventKindCurrent) {
 		ch <- &discoverd.Event{
 			Service: service,
 			Kind:    discoverd.EventKindCurrent,

--- a/discoverd/server/state.go
+++ b/discoverd/server/state.go
@@ -54,6 +54,9 @@ type service struct {
 	// instance ID -> instance
 	instances map[string]*discoverd.Instance
 
+	meta      []byte
+	metaIndex uint64
+
 	leaderID string
 	// leaderIndex is >0 when set, zero is unset
 	leaderIndex uint64
@@ -120,6 +123,13 @@ func (s *service) Leader() *discoverd.Instance {
 		return nil
 	}
 	return s.instances[s.leaderID]
+}
+
+func (s *service) Meta() *discoverd.ServiceMeta {
+	if s == nil || s.metaIndex == 0 {
+		return nil
+	}
+	return &discoverd.ServiceMeta{Data: s.meta, Index: s.metaIndex}
 }
 
 func (s *State) AddService(name string) {
@@ -200,6 +210,36 @@ func (s *State) broadcastLeader(serviceName string) {
 			Instance: leader,
 		})
 	}
+}
+
+func (s *State) SetServiceMeta(serviceName string, data []byte, index uint64) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	service, ok := s.services[serviceName]
+	if !ok {
+		service = newService()
+		s.services[serviceName] = service
+	}
+
+	if service.metaIndex == index {
+		return
+	}
+
+	service.meta = data
+	service.metaIndex = index
+
+	s.broadcast(&discoverd.Event{
+		Service:     serviceName,
+		Kind:        discoverd.EventKindServiceMeta,
+		ServiceMeta: &discoverd.ServiceMeta{Data: data, Index: index},
+	})
+}
+
+func (s *State) GetServiceMeta(service string) *discoverd.ServiceMeta {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.services[service].Meta()
 }
 
 func (s *State) SetService(serviceName string, data []*discoverd.Instance) {
@@ -351,11 +391,19 @@ func (s *State) Subscribe(service string, sendCurrent bool, kinds discoverd.Even
 	// locked.
 	var current []*discoverd.Instance
 	var currentLeader *discoverd.Instance
-	getCurrent := sendCurrent && kinds.Any(discoverd.EventKindUp, discoverd.EventKindLeader)
+	var currentMeta *discoverd.ServiceMeta
+	getCurrent := sendCurrent && kinds.Any(discoverd.EventKindUp, discoverd.EventKindLeader, discoverd.EventKindServiceMeta)
 	if getCurrent {
 		s.mtx.RLock()
-		current = s.getLocked(service)
-		currentLeader = s.services[service].Leader()
+		if kinds.Any(discoverd.EventKindUp) {
+			current = s.getLocked(service)
+		}
+		if kinds.Any(discoverd.EventKindLeader) {
+			currentLeader = s.services[service].Leader()
+		}
+		if kinds.Any(discoverd.EventKindServiceMeta) {
+			currentMeta = s.services[service].Meta()
+		}
 	}
 
 	s.subscribersMtx.Lock()
@@ -395,6 +443,13 @@ func (s *State) Subscribe(service string, sendCurrent bool, kinds discoverd.Even
 			Service:  service,
 			Kind:     discoverd.EventKindLeader,
 			Instance: currentLeader,
+		}
+	}
+	if sendCurrent && kinds.Any(discoverd.EventKindServiceMeta) && currentMeta != nil {
+		ch <- &discoverd.Event{
+			Service:     service,
+			Kind:        discoverd.EventKindServiceMeta,
+			ServiceMeta: currentMeta,
 		}
 	}
 	if sendCurrent && kinds.Any(discoverd.EventKindCurrent) {

--- a/discoverd/server/state_test.go
+++ b/discoverd/server/state_test.go
@@ -397,7 +397,7 @@ func (StateSuite) TestSubscribeInitial(c *C) {
 		state := NewState()
 		state.Subscribe("a", true, t.kinds, events)
 
-		if t.kinds&discoverd.EventKindCurrent != 0 {
+		if t.kinds.Any(discoverd.EventKindCurrent) {
 			assertEvent(c, events, "a", discoverd.EventKindCurrent, nil)
 		}
 		assertNoEvent(c, events)
@@ -411,7 +411,7 @@ func (StateSuite) TestSubscribeInitial(c *C) {
 		state.AddInstance("a", two)
 		events = make(chan *discoverd.Event, 4)
 		state.Subscribe("a", true, t.kinds, events)
-		if t.kinds&discoverd.EventKindUp != 0 {
+		if t.kinds.Any(discoverd.EventKindUp) {
 			up := receiveSomeEvents(c, events, 2)
 			assertEventEqual(c, up[one.ID][0], &discoverd.Event{
 				Service:  "a",
@@ -424,10 +424,10 @@ func (StateSuite) TestSubscribeInitial(c *C) {
 				Instance: two,
 			})
 		}
-		if t.kinds&discoverd.EventKindLeader != 0 {
+		if t.kinds.Any(discoverd.EventKindLeader) {
 			assertEvent(c, events, "a", discoverd.EventKindLeader, one)
 		}
-		if t.kinds&discoverd.EventKindCurrent != 0 {
+		if t.kinds.Any(discoverd.EventKindCurrent) {
 			assertEvent(c, events, "a", discoverd.EventKindCurrent, nil)
 		}
 		assertNoEvent(c, events)

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -18,21 +18,23 @@ import (
 type ErrorCode string
 
 const (
-	NotFoundError       ErrorCode = "not_found"
-	ObjectNotFoundError ErrorCode = "object_not_found"
-	ObjectExistsError   ErrorCode = "object_exists"
-	SyntaxError         ErrorCode = "syntax_error"
-	ValidationError     ErrorCode = "validation_error"
-	UnknownError        ErrorCode = "unknown_error"
+	NotFoundError           ErrorCode = "not_found"
+	ObjectNotFoundError     ErrorCode = "object_not_found"
+	ObjectExistsError       ErrorCode = "object_exists"
+	SyntaxError             ErrorCode = "syntax_error"
+	ValidationError         ErrorCode = "validation_error"
+	PreconditionFailedError ErrorCode = "precondition_failed"
+	UnknownError            ErrorCode = "unknown_error"
 )
 
 var errorResponseCodes = map[ErrorCode]int{
-	NotFoundError:       404,
-	ObjectNotFoundError: 404,
-	ObjectExistsError:   409,
-	SyntaxError:         400,
-	ValidationError:     400,
-	UnknownError:        500,
+	NotFoundError:           404,
+	ObjectNotFoundError:     404,
+	ObjectExistsError:       409,
+	PreconditionFailedError: 412,
+	SyntaxError:             400,
+	ValidationError:         400,
+	UnknownError:            500,
 }
 
 type JSONError struct {


### PR DESCRIPTION
Service metadata provides events, read access, and consistent CAS writes for metadata associated with a service. This metadata may be used to store service-level information such as credentials, configuration, and state machine fields.

The first usecase for service metadata is the state machine for the new PostgreSQL appliance.
