### PR TITLE
discoverd/server: Run a single etcd server for all tests

### DIFF
--- a/discoverd/server/http_test.go
+++ b/discoverd/server/http_test.go
@@ -5,10 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/discoverd/client"
-	"github.com/flynn/flynn/discoverd/testutil/etcdrunner"
 )
 
 var _ = Suite(&HTTPSuite{})
@@ -23,12 +21,9 @@ type HTTPSuite struct {
 
 func (s *HTTPSuite) SetUpTest(c *C) {
 	s.cleanup = nil
-	etcdAddr, etcdCleanup := etcdrunner.RunEtcdServer(c)
-	s.cleanup = append(s.cleanup, etcdCleanup)
-
 	s.state = NewState()
 
-	s.backend = NewEtcdBackend(etcd.NewClient([]string{etcdAddr}), "/test/discoverd", s.state)
+	s.backend = newEtcdBackend(s.state)
 	c.Assert(s.backend.StartSync(), IsNil)
 	s.cleanup = append(s.cleanup, func() { s.backend.Close() })
 

--- a/discoverd/server/state_test.go
+++ b/discoverd/server/state_test.go
@@ -7,16 +7,12 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"testing"
 	"time"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/random"
 )
-
-// Hook gocheck up to the "go test" runner
-func Test(t *testing.T) { TestingT(t) }
 
 type StateSuite struct{}
 


### PR DESCRIPTION
Instead of booting a new server, we can just use a different prefix for each test case.

This shaves ~20s off of the test runtime.