### PR TITLE
router: context, cancelation of requests when clients go away

### DIFF
--- a/pkg/ctxhelper/ctxhelper.go
+++ b/pkg/ctxhelper/ctxhelper.go
@@ -1,6 +1,8 @@
 package ctxhelper
 
 import (
+	"time"
+
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
@@ -10,43 +12,68 @@ type ctxKey int
 
 const (
 	ctxKeyComponent ctxKey = iota
-	ctxKeyReqID
-	ctxKeyParams
 	ctxKeyLogger
+	ctxKeyParams
+	ctxKeyReqID
+	ctxKeyStartTime
 )
 
+// NewContextComponentName creates a new context that carries the provided
+// componentName value.
 func NewContextComponentName(ctx context.Context, componentName string) context.Context {
 	return context.WithValue(ctx, ctxKeyComponent, componentName)
 }
 
+// ComponentNameFromContext extracts a component name from a context.
 func ComponentNameFromContext(ctx context.Context) (componentName string, ok bool) {
 	componentName, ok = ctx.Value(ctxKeyComponent).(string)
 	return
 }
 
+// NewContextLogger creates a new context that carries the provided logger
+// value.
 func NewContextLogger(ctx context.Context, logger log.Logger) context.Context {
 	return context.WithValue(ctx, ctxKeyLogger, logger)
 }
 
+// LoggerFromContext extracts a logger from a context.
 func LoggerFromContext(ctx context.Context) (logger log.Logger, ok bool) {
 	logger, ok = ctx.Value(ctxKeyLogger).(log.Logger)
 	return
 }
 
+// NewContextParams creates a new context that carries the provided params
+// value.
 func NewContextParams(ctx context.Context, params httprouter.Params) context.Context {
 	return context.WithValue(ctx, ctxKeyParams, params)
 }
 
+// ParamsFromContext extracts params from a context.
 func ParamsFromContext(ctx context.Context) (params httprouter.Params, ok bool) {
 	params, ok = ctx.Value(ctxKeyParams).(httprouter.Params)
 	return
 }
 
+// NewContextRequestID creates a new context that carries the provided request
+// ID value.
 func NewContextRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, ctxKeyReqID, id)
 }
 
+// RequestIDFromContext extracts a request ID from a context.
 func RequestIDFromContext(ctx context.Context) (id string, ok bool) {
 	id, ok = ctx.Value(ctxKeyReqID).(string)
+	return
+}
+
+// NewContextStartTime creates a new context that carries the provided start
+// time.
+func NewContextStartTime(ctx context.Context, start time.Time) context.Context {
+	return context.WithValue(ctx, ctxKeyStartTime, start)
+}
+
+// StartTimeFromContext extracts a start time from a context.
+func StartTimeFromContext(ctx context.Context) (start time.Time, ok bool) {
+	start, ok = ctx.Value(ctxKeyStartTime).(time.Time)
 	return
 }

--- a/router/http.go
+++ b/router/http.go
@@ -344,7 +344,7 @@ func (s *httpService) ServeHTTP(ctx context.Context, w http.ResponseWriter, req 
 	req.Header.Set("X-Request-Start", strconv.FormatInt(start.UnixNano()/int64(time.Millisecond), 10))
 	req.Header.Set("X-Request-Id", random.UUID())
 
-	s.rp.ServeHTTP(w, req)
+	s.rp.ServeHTTP(ctx, w, req)
 }
 
 func mustPortFromAddr(addr string) string {

--- a/router/http.go
+++ b/router/http.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/tlsconfig"
 	"github.com/flynn/flynn/router/proxy"
@@ -308,13 +310,15 @@ func fail(w http.ResponseWriter, code int) {
 }
 
 func (s *HTTPListener) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
+	ctx = ctxhelper.NewContextStartTime(ctx, time.Now())
 	r := s.findRouteForHost(req.Host)
 	if r == nil {
 		fail(w, 404)
 		return
 	}
 
-	r.service.ServeHTTP(w, req)
+	r.service.ServeHTTP(ctx, w, req)
 }
 
 // A domain served by a listener, associated TLS certs,
@@ -335,8 +339,9 @@ type httpService struct {
 	rp *proxy.ReverseProxy
 }
 
-func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+func (s *httpService) ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	start, _ := ctxhelper.StartTimeFromContext(ctx)
+	req.Header.Set("X-Request-Start", strconv.FormatInt(start.UnixNano()/int64(time.Millisecond), 10))
 	req.Header.Set("X-Request-Id", random.UUID())
 
 	s.rp.ServeHTTP(w, req)

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -869,6 +869,75 @@ func (s *S) runTestErrorAfterConnOnlyHitsOneBackend(c *C, upgrade bool) {
 	c.Assert(string(data), Equals, "Service Unavailable\n")
 }
 
+func (s *S) TestUpgradeAfterKeepAlive(c *C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// empty 200
+	}))
+
+	defer srv.Close()
+
+	l := s.newHTTPListener(c)
+	defer l.Close()
+
+	addHTTPRoute(c, l)
+	discoverdRegisterHTTP(c, l, srv.Listener.Addr().String())
+
+	conn, err := net.Dial("tcp", l.listener.Addr().String())
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	req := newReq("http://"+l.Addr, "example.com")
+	err = req.Write(conn)
+	c.Assert(err, IsNil)
+
+	connReader := bufio.NewReader(conn)
+	res, err := http.ReadResponse(connReader, req)
+	c.Assert(err, IsNil)
+	c.Assert(res.StatusCode, Equals, 200)
+
+	data, err := ioutil.ReadAll(res.Body)
+	c.Assert(err, IsNil)
+	res.Body.Close()
+	c.Assert(string(data), Equals, "")
+
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Connection", "upgrade")
+		w.WriteHeader(101)
+		conn, bufrw, err := w.(http.Hijacker).Hijack()
+		c.Assert(err, IsNil)
+		defer conn.Close()
+
+		bufrw.Write([]byte("data after upgrade"))
+	})
+
+	req = newReq("http://"+l.Addr, "example.com")
+	req.Header.Set("Connection", "upgrade")
+	err = req.Write(conn)
+	c.Assert(err, IsNil)
+
+	res, err = http.ReadResponse(connReader, req)
+	c.Assert(err, IsNil)
+
+	data, err = ioutil.ReadAll(res.Body)
+	c.Assert(err, IsNil)
+	res.Body.Close()
+	c.Assert(res.StatusCode, Equals, 101)
+	c.Assert(string(data), Equals, "")
+
+	datac := make(chan []byte)
+	go func() {
+		data, err = ioutil.ReadAll(connReader)
+		c.Assert(err, IsNil)
+		datac <- data
+	}()
+
+	select {
+	case <-datac:
+	case <-time.After(2 * time.Second):
+		c.Fatal("never received from datac")
+	}
+}
+
 func (s *S) TestClientClosesConnectionBeforeResponse(c *C) {
 	gotReq := make(chan struct{})
 	backendDone := make(chan struct{})

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 const (
@@ -71,7 +73,7 @@ func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky bool) *Reve
 }
 
 // ServeHTTP implements http.Handler.
-func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (p *ReverseProxy) ServeHTTP(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
 	transport := p.transport
 	if transport == nil {
 		panic("router: nil transport for proxy")
@@ -84,8 +86,24 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	res, err := transport.RoundTrip(outreq)
+	clientGone := rw.(http.CloseNotifier).CloseNotify()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // tells cancellation goroutine to exit
+
+	go func() {
+		select {
+		case <-clientGone:
+			cancel() // client went away, cancel request
+		case <-ctx.Done():
+		}
+	}()
+
+	res, err := transport.RoundTrip(ctx, outreq)
 	if err != nil {
+		if err == errRequestCanceled {
+			// TODO(bgentry): anything special to log here?
+			return
+		}
 		p.logf("router: proxy error: %v", err)
 		rw.WriteHeader(http.StatusServiceUnavailable)
 		rw.Write(serviceUnavailable)

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -127,6 +127,7 @@ func (p *ReverseProxy) ServeConn(conn net.Conn) {
 		p.logf("router: proxy error: %v", err)
 		return
 	}
+	defer dconn.Close()
 
 	joinConns(conn, dconn)
 }
@@ -158,6 +159,7 @@ func (p *ReverseProxy) serveUpgrade(rw http.ResponseWriter, req *http.Request) {
 		p.logf("router: hijack failed: %v", err)
 		return
 	}
+	defer dconn.Close()
 	joinConns(uconn, &streamConn{bufrw.Reader, dconn})
 }
 

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -115,21 +115,21 @@ func (p *ReverseProxy) ServeHTTP(ctx context.Context, rw http.ResponseWriter, re
 }
 
 // ServeConn takes an inbound conn and proxies it to a backend.
-func (p *ReverseProxy) ServeConn(conn net.Conn) {
+func (p *ReverseProxy) ServeConn(dconn net.Conn) {
 	transport := p.transport
 	if transport == nil {
 		panic("router: nil transport for proxy")
 	}
-	defer conn.Close()
+	defer dconn.Close()
 
-	dconn, err := transport.Connect(conn.RemoteAddr())
+	uconn, err := transport.Connect()
 	if err != nil {
 		p.logf("router: proxy error: %v", err)
 		return
 	}
-	defer dconn.Close()
+	defer uconn.Close()
 
-	joinConns(conn, dconn)
+	joinConns(uconn, dconn)
 }
 
 func (p *ReverseProxy) serveUpgrade(rw http.ResponseWriter, req *http.Request) {

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -64,8 +64,6 @@ func (t *transport) setStickyBackend(res *http.Response, originalStickyBackend s
 	}
 }
 
-// always sets the response.Request.URL.Host to the last backend that was
-// connected to.
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// http.Transport closes the request body on a failed dial, issue #875
 	req.Body = &fakeCloseReadCloser{req.Body}

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -118,7 +118,7 @@ func (t *transport) RoundTrip(ctx context.Context, req *http.Request) (*http.Res
 	return nil, errNoBackends
 }
 
-func (t *transport) Connect(remoteAddr net.Addr) (net.Conn, error) {
+func (t *transport) Connect() (net.Conn, error) {
 	backends := t.getOrderedBackends("")
 	conn, _, err := dialTCP(backends)
 	return conn, err

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -20,8 +20,9 @@ var (
 	errRequestCanceled = errors.New("router: request canceled")
 
 	httpTransport = &http.Transport{
-		Dial:                customDial,
-		TLSHandshakeTimeout: 10 * time.Second, // unused, but safer to leave default in place
+		Dial: customDial,
+		ResponseHeaderTimeout: 120 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second, // unused, but safer to leave default in place
 	}
 
 	dialer = &net.Dialer{


### PR DESCRIPTION
Introduce contexts into the router stack. Use them to carry request metadata (currently just start time) down the stack, and to coordinate cancelation of requests to backends when clients disappear. That behavior currently only applies to the non-upgrade path.

Also, add a 120 second timeout for response headers from backends. There's no test for this yet, and I'm not sure if/how I should add one. Perhaps we could just test that the value is indeed set on the `httpTransport` since we can already trust that to use the setting correctly?