### PR TITLE
pinkerton: Fix fetching image ancestors

### DIFF
--- a/pinkerton/registry/docker.go
+++ b/pinkerton/registry/docker.go
@@ -87,10 +87,20 @@ func (s *dockerSession) GetLayer(id string) (io.ReadCloser, error) {
 	return res.Body, nil
 }
 
-func (s *dockerSession) GetAncestors(id string) ([]string, error) {
+func (s *dockerSession) GetAncestors(id string) ([]*Image, error) {
 	var ids []string
-	_, err := s.get(fmt.Sprintf("/images/%s/ancestry", id), &ids)
-	return ids, err
+	if _, err := s.get(fmt.Sprintf("/images/%s/ancestry", id), &ids); err != nil {
+		return nil, err
+	}
+	images := make([]*Image, len(ids))
+	for i, id := range ids {
+		img := &Image{session: s}
+		if _, err := s.get(fmt.Sprintf("/images/%s/json", id), img); err != nil {
+			return nil, err
+		}
+		images[i] = img
+	}
+	return images, nil
 }
 
 func (s *dockerSession) tags() (map[string]string, error) {

--- a/pinkerton/registry/image.go
+++ b/pinkerton/registry/image.go
@@ -52,14 +52,5 @@ func (i *Image) Ancestors() ([]*Image, error) {
 	if i.ParentID == "" {
 		return nil, ErrNoParent
 	}
-	ids, err := i.session.GetAncestors(i.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]*Image, len(ids))
-	for n, id := range ids {
-		res[n] = &Image{ID: id, session: i.session}
-	}
-	return res, nil
+	return i.session.GetAncestors(i.ID)
 }

--- a/pinkerton/registry/registry.go
+++ b/pinkerton/registry/registry.go
@@ -12,7 +12,7 @@ type Session interface {
 	ImageID() string
 	GetImage() (*Image, error)
 	GetLayer(string) (io.ReadCloser, error)
-	GetAncestors(string) ([]string, error)
+	GetAncestors(string) ([]*Image, error)
 }
 
 func NewRef(s string) (*Ref, error) {

--- a/pinkerton/registry/tuf.go
+++ b/pinkerton/registry/tuf.go
@@ -52,10 +52,20 @@ func (s *tufSession) GetLayer(id string) (io.ReadCloser, error) {
 	return layer, nil
 }
 
-func (s *tufSession) GetAncestors(id string) ([]string, error) {
+func (s *tufSession) GetAncestors(id string) ([]*Image, error) {
 	var ids []string
-	_, err := s.get(fmt.Sprintf("/images/%s/ancestry", id), &ids)
-	return ids, err
+	if _, err := s.get(fmt.Sprintf("/images/%s/ancestry", id), &ids); err != nil {
+		return nil, err
+	}
+	images := make([]*Image, len(ids))
+	for i, id := range ids {
+		img := &Image{session: s}
+		if _, err := s.get(fmt.Sprintf("/images/%s/json", id), img); err != nil {
+			return nil, err
+		}
+		images[i] = img
+	}
+	return images, nil
 }
 
 func (s *tufSession) tags() (map[string]string, error) {


### PR DESCRIPTION
Previously the ancestor layers would not have ParentID set because we did not fetch the layer JSON, so the layer would not get the correct JSON when extracted into the graph driver.

Incremental patch for #617.