### PR TITLE
split volume manager into separate package

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flynn/flynn/host/ports"
 	"github.com/flynn/flynn/host/sampi"
 	"github.com/flynn/flynn/host/types"
-	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/host/volume/manager"
 	zfsVolume "github.com/flynn/flynn/host/volume/zfs"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -173,7 +173,7 @@ func runDaemon(args *docopt.Args) {
 	}
 
 	// create volume manager
-	vman := volume.NewManager(volProv)
+	vman := volumemanager.New(volProv)
 
 	switch backendName {
 	case "libvirt-lxc":

--- a/host/http.go
+++ b/host/http.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/host/types"
-	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/host/volume/api"
+	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sse"
 )
@@ -100,7 +100,7 @@ func (h *jobAPI) RegisterRoutes(r *httprouter.Router) error {
 	return nil
 }
 
-func serveHTTP(host *Host, attach *attachHandler, vman *volume.Manager) (*httprouter.Router, error) {
+func serveHTTP(host *Host, attach *attachHandler, vman *volumemanager.Manager) (*httprouter.Router, error) {
 	l, err := net.Listen("tcp", ":1113")
 	if err != nil {
 		return nil, err

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -28,7 +28,7 @@ import (
 	lt "github.com/flynn/flynn/host/libvirt"
 	"github.com/flynn/flynn/host/logbuf"
 	"github.com/flynn/flynn/host/types"
-	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/pinkerton"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -41,7 +41,7 @@ const (
 	bridgeName     = "flynnbr0"
 )
 
-func NewLibvirtLXCBackend(state *State, vman *volume.Manager, volPath, logPath, initPath string) (Backend, error) {
+func NewLibvirtLXCBackend(state *State, vman *volumemanager.Manager, volPath, logPath, initPath string) (Backend, error) {
 	libvirtc, err := libvirt.NewVirConnection("lxc:///")
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ type LibvirtLXCBackend struct {
 	VolPath   string
 	libvirt   libvirt.VirConnection
 	state     *State
-	vman      *volume.Manager
+	vman      *volumemanager.Manager
 	pinkerton *pinkerton.Context
 
 	ifaceMTU   int

--- a/host/manifest.go
+++ b/host/manifest.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/technoweenie/grohl"
 	"github.com/flynn/flynn/host/ports"
 	"github.com/flynn/flynn/host/types"
-	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/random"
 )
@@ -79,7 +79,7 @@ type manifestRunner struct {
 	bindAddr     string
 	backend      Backend
 	state        *State
-	vman         *volume.Manager
+	vman         *volumemanager.Manager
 	ports        map[string]*ports.Allocator
 }
 

--- a/host/volume/api/http.go
+++ b/host/volume/api/http.go
@@ -7,16 +7,17 @@ import (
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/host/volume/zfs"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/random"
 )
 
 type HTTPAPI struct {
-	vman *volume.Manager
+	vman *volumemanager.Manager
 }
 
-func NewHTTPAPI(vman *volume.Manager) *HTTPAPI {
+func NewHTTPAPI(vman *volumemanager.Manager) *HTTPAPI {
 	return &HTTPAPI{vman: vman}
 }
 

--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 /*
@@ -27,3 +28,6 @@ type ProviderSpec struct {
 	// see the ProviderConfig struct in implementation packages for known values.
 	Config json.RawMessage `json:"metadata,omitempty"`
 }
+
+var NoSuchProvider = errors.New("no such provider")
+var ProviderAlreadyExists = errors.New("that provider id already exists")


### PR DESCRIPTION
Upcoming changes were running aground on import cycles: the manager needs to refer into the provider implementation packages as it gains responsibility for initializing them during restores from prior state; and the providers of course need to refer to the volume basic types.

The new import graph is host|api -> manager -> {providers} -> volume.