### PR TITLE
gather test utils together

### DIFF
--- a/blobstore/blobstore_test.go
+++ b/blobstore/blobstore_test.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/shutdown"
-	"github.com/flynn/flynn/pkg/testutils"
+	"github.com/flynn/flynn/pkg/testutils/postgres"
 )
 
 func TestOSFilesystem(t *testing.T) {
@@ -26,7 +26,7 @@ func TestOSFilesystem(t *testing.T) {
 }
 
 func TestPostgresFilesystem(t *testing.T) {
-	if err := testutils.SetupPostgres("blobstoretest"); err != nil {
+	if err := pgtestutils.SetupPostgres("blobstoretest"); err != nil {
 		t.Fatal(err)
 	}
 	db, err := sql.Open("postgres", "")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -18,7 +18,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
-	"github.com/flynn/flynn/pkg/testutils"
+	"github.com/flynn/flynn/pkg/testutils/postgres"
 )
 
 func init() {
@@ -41,7 +41,7 @@ var authKey = "test"
 
 func (s *S) SetUpSuite(c *C) {
 	dbname := "controllertest"
-	if err := testutils.SetupPostgres(dbname); err != nil {
+	if err := pgtestutils.SetupPostgres(dbname); err != nil {
 		c.Fatal(err)
 	}
 

--- a/host/volume/zfs/zfs_basics_test.go
+++ b/host/volume/zfs/zfs_basics_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	zfs "github.com/flynn/flynn/Godeps/_workspace/src/github.com/mistifyio/go-zfs"
+	"github.com/flynn/flynn/pkg/testutils"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -23,7 +24,7 @@ var _ = Suite(&ZfsSnapshotTests{})
 func (ZfsSnapshotTests) SetUpSuite(c *C) {
 	// Skip all tests in this suite if not running as root.
 	// Many zfs operations require root priviledges.
-	skipIfNotRoot(c)
+	testutils.SkipIfNotRoot(c)
 }
 
 func (s *ZfsSnapshotTests) SetUpTest(c *C) {
@@ -61,22 +62,22 @@ func (ZfsSnapshotTests) TestSnapshotShouldCarryFiles(c *C) {
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{})
 
 	f, err := os.Create(filepath.Join(v.(*zfsVolume).basemount, "alpha"))
 	c.Assert(err, IsNil)
 	f.Close()
 
 	// sanity check, can we so much as even write a file:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 
 	v2, err := v.TakeSnapshot()
 	c.Assert(err, IsNil)
 
 	// taking a snapshot shouldn't change the source dir:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 	// the newly mounted snapshot in the new location should have the same content:
-	c.Assert(v2.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v2.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 }
 
 func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToSource(c *C) {
@@ -87,14 +88,14 @@ func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToSource(c *C) {
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{})
 
 	f, err := os.Create(filepath.Join(v.(*zfsVolume).basemount, "alpha"))
 	c.Assert(err, IsNil)
 	f.Close()
 
 	// sanity check, can we so much as even write a file:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 
 	v2, err := v.TakeSnapshot()
 	c.Assert(err, IsNil)
@@ -105,9 +106,9 @@ func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToSource(c *C) {
 	f.Close()
 
 	// the source dir should contain our changes:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha", "beta"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha", "beta"})
 	// the snapshot should be unaffected:
-	c.Assert(v2.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v2.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 }
 
 func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToFork(c *C) {
@@ -118,14 +119,14 @@ func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToFork(c *C) {
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{})
 
 	f, err := os.Create(filepath.Join(v.(*zfsVolume).basemount, "alpha"))
 	c.Assert(err, IsNil)
 	f.Close()
 
 	// sanity check, can we so much as even write a file:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 
 	v2, err := v.TakeSnapshot()
 	c.Assert(err, IsNil)
@@ -136,7 +137,7 @@ func (ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToFork(c *C) {
 	f.Close()
 
 	// the source dir should be unaffected:
-	c.Assert(v.(*zfsVolume).basemount, DirContains, []string{"alpha"})
+	c.Assert(v.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha"})
 	// the snapshot should contain our changes:
-	c.Assert(v2.(*zfsVolume).basemount, DirContains, []string{"alpha", "beta"})
+	c.Assert(v2.(*zfsVolume).basemount, testutils.DirContains, []string{"alpha", "beta"})
 }

--- a/host/volume/zfs/zpool_test.go
+++ b/host/volume/zfs/zpool_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	gzfs "github.com/flynn/flynn/Godeps/_workspace/src/github.com/mistifyio/go-zfs"
 	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/testutils"
 )
 
 // note: whimsical/unique dataset names per test are chosen to help debug
@@ -24,7 +25,7 @@ var _ = Suite(&ZpoolTests{})
 func (ZpoolTests) SetUpSuite(c *C) {
 	// Skip all tests in this suite if not running as root.
 	// Many zfs operations require root priviledges.
-	skipIfNotRoot(c)
+	testutils.SkipIfNotRoot(c)
 }
 
 var one_gig = int64(math.Pow(2, float64(30)))

--- a/pkg/testutils/checkers.go
+++ b/pkg/testutils/checkers.go
@@ -1,4 +1,4 @@
-package zfs
+package testutils
 
 import (
 	"os"
@@ -7,12 +7,6 @@ import (
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 )
-
-func skipIfNotRoot(t *C) {
-	if os.Getuid() != 0 {
-		t.Skip("cannot perform operations requiring root")
-	}
-}
 
 type dirContainsChecker struct {
 	*CheckerInfo

--- a/pkg/testutils/postgres/utils.go
+++ b/pkg/testutils/postgres/utils.go
@@ -1,4 +1,4 @@
-package testutils
+package pgtestutils
 
 import (
 	"fmt"

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -1,0 +1,18 @@
+package testutils
+
+import (
+	"os"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+/*
+	Skips a test if the UID isn't 0.
+
+	Use in a suite's `SetUpSuite` method for great effect.
+*/
+func SkipIfNotRoot(t *C) {
+	if os.Getuid() != 0 {
+		t.Skip("cannot perform operations requiring root")
+	}
+}


### PR DESCRIPTION
Gather test utils.

Shuffle some postgres stuff; the general package needn't carry pg references.

(This is triggered by more import cycle avoidance for volume persistence work.)