### PR TITLE
cli: Output flag parse errors plainly.

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -106,7 +106,8 @@ See 'flynn help <command>' for more information on a specific command.
 	}
 
 	if err := runCommand(cmd, cmdArgs); err != nil {
-		shutdown.Fatal(err)
+		log.Println(err)
+		shutdown.ExitWithCode(1)
 		return
 	}
 }


### PR DESCRIPTION
`shutdown.Fatal`'s behavior is to format output as a log line, which isn't relevant here.  Replace it with a plain log statement and explicit exit code.

Fixes #938.