### PR TITLE
router: context

### DIFF
--- a/pkg/ctxhelper/ctxhelper.go
+++ b/pkg/ctxhelper/ctxhelper.go
@@ -1,6 +1,8 @@
 package ctxhelper
 
 import (
+	"time"
+
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
@@ -10,43 +12,68 @@ type ctxKey int
 
 const (
 	ctxKeyComponent ctxKey = iota
-	ctxKeyReqID
-	ctxKeyParams
 	ctxKeyLogger
+	ctxKeyParams
+	ctxKeyReqID
+	ctxKeyStartTime
 )
 
+// NewContextComponentName creates a new context that carries the provided
+// componentName value.
 func NewContextComponentName(ctx context.Context, componentName string) context.Context {
 	return context.WithValue(ctx, ctxKeyComponent, componentName)
 }
 
+// ComponentNameFromContext extracts a component name from a context.
 func ComponentNameFromContext(ctx context.Context) (componentName string, ok bool) {
 	componentName, ok = ctx.Value(ctxKeyComponent).(string)
 	return
 }
 
+// NewContextLogger creates a new context that carries the provided logger
+// value.
 func NewContextLogger(ctx context.Context, logger log.Logger) context.Context {
 	return context.WithValue(ctx, ctxKeyLogger, logger)
 }
 
+// LoggerFromContext extracts a logger from a context.
 func LoggerFromContext(ctx context.Context) (logger log.Logger, ok bool) {
 	logger, ok = ctx.Value(ctxKeyLogger).(log.Logger)
 	return
 }
 
+// NewContextParams creates a new context that carries the provided params
+// value.
 func NewContextParams(ctx context.Context, params httprouter.Params) context.Context {
 	return context.WithValue(ctx, ctxKeyParams, params)
 }
 
+// ParamsFromContext extracts params from a context.
 func ParamsFromContext(ctx context.Context) (params httprouter.Params, ok bool) {
 	params, ok = ctx.Value(ctxKeyParams).(httprouter.Params)
 	return
 }
 
+// NewContextRequestID creates a new context that carries the provided request
+// ID value.
 func NewContextRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, ctxKeyReqID, id)
 }
 
+// RequestIDFromContext extracts a request ID from a context.
 func RequestIDFromContext(ctx context.Context) (id string, ok bool) {
 	id, ok = ctx.Value(ctxKeyReqID).(string)
+	return
+}
+
+// NewContextStartTime creates a new context that carries the provided start
+// time.
+func NewContextStartTime(ctx context.Context, start time.Time) context.Context {
+	return context.WithValue(ctx, ctxKeyStartTime, start)
+}
+
+// StartTimeFromContext extracts a start time from a context.
+func StartTimeFromContext(ctx context.Context) (start time.Time, ok bool) {
+	start, ok = ctx.Value(ctxKeyStartTime).(time.Time)
 	return
 }

--- a/router/http.go
+++ b/router/http.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/tlsconfig"
 	"github.com/flynn/flynn/router/proxy"
@@ -308,13 +310,15 @@ func fail(w http.ResponseWriter, code int) {
 }
 
 func (s *HTTPListener) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
+	ctx = ctxhelper.NewContextStartTime(ctx, time.Now())
 	r := s.findRouteForHost(req.Host)
 	if r == nil {
 		fail(w, 404)
 		return
 	}
 
-	r.service.ServeHTTP(w, req)
+	r.service.ServeHTTP(ctx, w, req)
 }
 
 // A domain served by a listener, associated TLS certs,
@@ -335,8 +339,9 @@ type httpService struct {
 	rp *proxy.ReverseProxy
 }
 
-func (s *httpService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	req.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+func (s *httpService) ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	start, _ := ctxhelper.StartTimeFromContext(ctx)
+	req.Header.Set("X-Request-Start", strconv.FormatInt(start.UnixNano()/int64(time.Millisecond), 10))
 	req.Header.Set("X-Request-Id", random.UUID())
 
 	s.rp.ServeHTTP(w, req)

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -97,21 +97,21 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 // ServeConn takes an inbound conn and proxies it to a backend.
-func (p *ReverseProxy) ServeConn(conn net.Conn) {
+func (p *ReverseProxy) ServeConn(dconn net.Conn) {
 	transport := p.transport
 	if transport == nil {
 		panic("router: nil transport for proxy")
 	}
-	defer conn.Close()
+	defer dconn.Close()
 
-	dconn, err := transport.Connect(conn.RemoteAddr())
+	uconn, err := transport.Connect()
 	if err != nil {
 		p.logf("router: proxy error: %v", err)
 		return
 	}
-	defer dconn.Close()
+	defer uconn.Close()
 
-	joinConns(conn, dconn)
+	joinConns(uconn, dconn)
 }
 
 func (p *ReverseProxy) serveUpgrade(rw http.ResponseWriter, req *http.Request) {

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -109,6 +109,7 @@ func (p *ReverseProxy) ServeConn(conn net.Conn) {
 		p.logf("router: proxy error: %v", err)
 		return
 	}
+	defer dconn.Close()
 
 	joinConns(conn, dconn)
 }

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -18,8 +18,9 @@ var (
 	errNoBackends = errors.New("router: no backends available")
 
 	httpTransport = &http.Transport{
-		Dial:                customDial,
-		TLSHandshakeTimeout: 10 * time.Second, // unused, but safer to leave default in place
+		Dial: customDial,
+		ResponseHeaderTimeout: 120 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second, // unused, but safer to leave default in place
 	}
 
 	dialer = &net.Dialer{

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -87,7 +87,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return nil, errNoBackends
 }
 
-func (t *transport) Connect(remoteAddr net.Addr) (net.Conn, error) {
+func (t *transport) Connect() (net.Conn, error) {
 	backends := t.getOrderedBackends("")
 	conn, _, err := dialTCP(backends)
 	return conn, err

--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -64,8 +64,6 @@ func (t *transport) setStickyBackend(res *http.Response, originalStickyBackend s
 	}
 }
 
-// always sets the response.Request.URL.Host to the last backend that was
-// connected to.
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// http.Transport closes the request body on a failed dial, issue #875
 	req.Body = &fakeCloseReadCloser{req.Body}


### PR DESCRIPTION
This includes everything from #926 except for the CloseNotify stuff (which became an issue due to conflicts w/ Hijack).

Introduce contexts into the router stack. Use them to carry request metadata (currently just start time) down the stack.

Also, add a 120 second timeout for response headers from backends. There's no test for this yet, and I'm not sure if/how I should add one. Perhaps we could just test that the value is indeed set on the `httpTransport` since we can already trust that to use the setting correctly?