### PR TITLE
router: detect early termination of downstream TCP connections

### DIFF
--- a/router/proxy/close_notify.go
+++ b/router/proxy/close_notify.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"io"
+	"net"
+)
+
+type closeNotifyConn struct {
+	net.Conn
+
+	r io.Reader
+
+	cnc chan bool
+}
+
+// CloseNotifyConn returns a net.Conn that implements http.CloseNotifier.
+// Used to detect connections closed early on the client side.
+func CloseNotifyConn(conn net.Conn) net.Conn {
+	pr, pw := io.Pipe()
+
+	c := &closeNotifyConn{
+		Conn: conn,
+		r:    pr,
+		cnc:  make(chan bool),
+	}
+
+	go func() {
+		_, err := io.Copy(pw, conn)
+		if err == nil {
+			err = io.EOF
+		}
+		pw.CloseWithError(err)
+		close(c.cnc)
+	}()
+
+	return c
+}
+
+// CloseNotify returns a channel that receives a single value when the client
+// connection has gone away.
+func (c *closeNotifyConn) CloseNotify() <-chan bool {
+	return c.cnc
+}
+
+func (c *closeNotifyConn) Read(p []byte) (n int, err error) {
+	return c.r.Read(p)
+}

--- a/router/proxy/reverseproxy_test.go
+++ b/router/proxy/reverseproxy_test.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+func TestServeConnClientGone(t *testing.T) {
+	control, conn := net.Pipe()
+	cnConn := CloseNotifyConn(conn)
+
+	clientGone := false
+	dialer = dialerFunc(func(_, _ string) (net.Conn, error) {
+		if clientGone {
+			err := errors.New("dial after client gone")
+			t.Error(err)
+			return nil, err
+		}
+
+		if err := control.Close(); err != nil {
+			t.Fatal(err)
+		}
+		<-cnConn.(http.CloseNotifier).CloseNotify()
+
+		clientGone = true
+		return nil, &dialErr{}
+	})
+
+	fn := func() []string { return []string{"127.0.0.1:0", "127.0.0.1:0"} }
+	prox := NewReverseProxy(fn, nil, false)
+
+	prox.ServeConn(context.Background(), cnConn)
+}
+
+type dialerFunc func(string, string) (net.Conn, error)
+
+func (f dialerFunc) Dial(network, addr string) (net.Conn, error) {
+	return f(network, addr)
+}

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/router/proxy"
 	"github.com/flynn/flynn/router/types"
 )
@@ -279,5 +280,5 @@ type tcpService struct {
 }
 
 func (s *tcpService) ServeConn(conn net.Conn) {
-	s.rp.ServeConn(conn)
+	s.rp.ServeConn(context.Background(), proxy.CloseNotifyConn(conn))
 }


### PR DESCRIPTION
Wrap downstream TCP connections in a net.Conn that implements CloseNotify so that early termination can be detected before dialing a backend.

I'm not sure how to write a test for this, any ideas?