### PR TITLE
Modify ZFS installation instructions to keep them consistent

### DIFF
--- a/website/source/docs/installation.html.md
+++ b/website/source/docs/installation.html.md
@@ -86,7 +86,7 @@ Flynn uses ZFS for persistent data volumes.  To install ZFS, run these commands:
 $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
 $ echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main | sudo tee /etc/apt/sources.list.d/zfs.list
 $ sudo apt-get update
-$ sudo apt-get install -y ubuntu-zfs
+$ sudo apt-get install ubuntu-zfs
 ```
 
 ### Installation

--- a/website/source/docs/installation.html.md
+++ b/website/source/docs/installation.html.md
@@ -83,9 +83,10 @@ $ sudo apt-get install linux-image-extra-$(uname -r)
 Flynn uses ZFS for persistent data volumes.  To install ZFS, run these commands:
 
 ```
-apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
-echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
-apt-get install -y ubuntu-zfs
+$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
+$ echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main | sudo tee /etc/apt/sources.list.d/zfs.list
+$ sudo apt-get update
+$ sudo apt-get install -y ubuntu-zfs
 ```
 
 ### Installation


### PR DESCRIPTION
Hello,

I've made 2 changes:
- Use `sudo` in the commands and make their presentation consistent with other commands (which assume the running user is unprivileged)
- Remove the 'assume yes'  from `apt-get install` flag for consistency

I'm happy to spit/remove one of the changes if necessary.

Thanks,
Jay