### PR TITLE
Flynn host cli volume-destroy command

### DIFF
--- a/host/cli/destroy-volumes.go
+++ b/host/cli/destroy-volumes.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/host/volume/manager"
+	"github.com/flynn/flynn/pkg/shutdown"
+)
+
+func init() {
+	Register("destroy-volumes", runVolumeDestroy, `
+usage: flynn-host destroy-volumes [options]
+
+options:
+  --volpath=PATH     directory to create volumes in [default: /var/lib/flynn/volumes]
+  --include-data     actually destroy data in backends *this is dangerous* [default: false]
+
+Destroys all data volumes on this host.  This is a dangerous operation: data
+may be permanently discarded.
+
+If the '--include-data' flag is given, the volume database will be loaded, and
+all data in the referenced systems will be removed (i.e., with a zfs backend,
+the datasets will be destroyed).
+
+If '--include-data' is not specified (or the volume database cannot be loaded),
+it will simply be removed.  In this case, data will remain behind in the backend
+storage engines (and eventually require manual cleanup), but the flynn-host
+daemon's next launch will still be like a fresh launch.
+
+Major features of backends will not be adjusted (i.e., zfs datasets will be
+destroyed, but zpools will not be touched).`)
+}
+
+func runVolumeDestroy(args *docopt.Args) error {
+	if os.Getuid() != 0 {
+		fmt.Println("this command requires root!\ntry again with `sudo flynn-host destroy-volumes`.")
+		shutdown.ExitWithCode(1)
+	}
+
+	volPath := args.String["--volpath"]
+	includeData := args.Bool["--include-data"]
+
+	volumeDBPath := filepath.Join(volPath, "volumes.bolt")
+
+	// if there is no state db, nothing to do
+	if _, err := os.Stat(volumeDBPath); err != nil && os.IsNotExist(err) {
+		fmt.Printf("no volume state db exists at %q; already clean.\n", volumeDBPath)
+		shutdown.Exit()
+	}
+
+	// open state db.  we're maybe using it; and regardless want to flock before removing it
+	vman, vmanErr := loadVolumeState(volumeDBPath)
+
+	// if '--include-data' specified and vman loaded, destroy volumes
+	allVolumesDestroyed := true
+	if vmanErr != nil {
+		fmt.Printf("%s\n", vmanErr)
+	} else if includeData == false {
+		fmt.Println("'--include-data' not specified; leaving backend data storage intact.")
+	} else {
+		if err := destroyVolumes(vman); err != nil {
+			fmt.Printf("%s\n", err)
+			allVolumesDestroyed = false
+		}
+	}
+
+	// remove db file
+	if err := os.Remove(volumeDBPath); err != nil {
+		fmt.Printf("could not remove volume state db file %q: %s.\n", volumeDBPath, err)
+		shutdown.ExitWithCode(5)
+	}
+	fmt.Printf("state db file %q removed.\n", volumeDBPath)
+
+	// exit code depends on if all volumes were destroyed successfully or not
+	if includeData && !allVolumesDestroyed {
+		shutdown.ExitWithCode(6)
+	}
+	shutdown.Exit()
+	return nil
+}
+
+func loadVolumeState(volumeDBPath string) (*volumemanager.Manager, error) {
+	// attempt to restore manager from state db
+	// no need to defer closing the db; we're about to unlink it and the fd can drop on exit
+	fmt.Println("opening volume state db...")
+	vman, err := volumemanager.New(
+		volumeDBPath,
+		func() (volume.Provider, error) {
+			return nil, nil
+		},
+	)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "timeout") { //bolt.ErrTimeout
+			fmt.Println("volume state db is locked by another process; aborting.")
+			shutdown.ExitWithCode(4)
+		}
+		return nil, fmt.Errorf("warning: the previous volume database could not be loaded; any data in backends may need manual removal\n  (error was: %s)", err)
+	}
+	fmt.Println("volume state db opened.")
+	return vman, nil
+}
+
+func destroyVolumes(vman *volumemanager.Manager) error {
+	someVolumesNotDestroyed := false
+	for volID := range vman.Volumes() {
+		fmt.Printf("removing volume id=%q... ", volID)
+		if err := vman.DestroyVolume(volID); err == nil {
+			fmt.Println("success")
+		} else {
+			fmt.Printf("error: %s\n", err)
+			someVolumesNotDestroyed = true
+		}
+	}
+
+	if someVolumesNotDestroyed {
+		return fmt.Errorf("some volumes were not destroyed successfully")
+	}
+	return nil
+}

--- a/host/host.go
+++ b/host/host.go
@@ -74,6 +74,7 @@ Commands:
   log                        Get the logs of a job
   ps                         List jobs
   stop                       Stop running jobs
+  destroy-volumes            Destroys the local volume database
   upload-debug-info          Upload debug information to an anonymous gist
 
 See 'flynn-host help <command>' for more information on a specific command.

--- a/host/host.go
+++ b/host/host.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -46,7 +47,8 @@ options:
   --state=PATH           path to state file [default: /var/lib/flynn/host-state.bolt]
   --id=ID                host id
   --force                kill all containers booted by flynn-host before starting
-  --volpath=PATH         directory to create volumes in [default: /var/lib/flynn/host-volumes]
+  --legacy-volpath=PATH  directory to create legacy volumes in [default: /var/lib/flynn/host-volumes]
+  --volpath=PATH         directory to create volumes in [default: /var/lib/flynn/volumes]
   --backend=BACKEND      runner backend [default: libvirt-lxc]
   --meta=<KEY=VAL>...    key=value pair to add as metadata
   --bind=IP              bind containers to IP
@@ -128,6 +130,7 @@ func runDaemon(args *docopt.Args) {
 	stateFile := args.String["--state"]
 	hostID := args.String["--id"]
 	force := args.Bool["--force"]
+	legacyVolPath := args.String["--legacyvolpath"]
 	volPath := args.String["--volpath"]
 	backendName := args.String["--backend"]
 	flynnInit := args.String["--flynn-init"]
@@ -162,14 +165,15 @@ func runDaemon(args *docopt.Args) {
 
 	// create volume manager
 	vman, err := volumemanager.New(
-		"/var/lib/flynn/volumes/volumes.bolt",
+		filepath.Join(volPath, "volumes.bolt"),
 		func() (volume.Provider, error) {
 			return zfsVolume.NewProvider(&zfsVolume.ProviderConfig{
 				DatasetName: "flynn-default",
 				Make: &zfsVolume.MakeDev{
-					BackingFilename: "/var/lib/flynn/volumes/zfs/vdev/flynn-default-zpool.vdev",
+					BackingFilename: filepath.Join(volPath, "zfs/vdev/flynn-default-zpool.vdev"),
 					Size:            int64(math.Pow(2, float64(30))),
 				},
+				WorkingDir: filepath.Join(volPath, "zfs"),
 			})
 		},
 	)
@@ -179,7 +183,7 @@ func runDaemon(args *docopt.Args) {
 
 	switch backendName {
 	case "libvirt-lxc":
-		backend, err = NewLibvirtLXCBackend(state, vman, volPath, "/tmp/flynn-host-logs", flynnInit)
+		backend, err = NewLibvirtLXCBackend(state, vman, legacyVolPath, "/tmp/flynn-host-logs", flynnInit)
 	default:
 		log.Fatalf("unknown backend %q", backendName)
 	}

--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -16,6 +16,7 @@ type Provider interface {
 	Kind() string
 
 	NewVolume() (Volume, error)
+	DestroyVolume(Volume) error
 
 	MarshalGlobalState() (json.RawMessage, error)
 	MarshalVolumeState(volumeID string) (json.RawMessage, error)

--- a/host/volume/manager/manager.go
+++ b/host/volume/manager/manager.go
@@ -63,8 +63,10 @@ func New(stateFilePath string, defProvFn func() (volume.Provider, error)) (*Mana
 		if err != nil {
 			return nil, fmt.Errorf("could not initialize default provider: %s", err)
 		}
-		if err := m.AddProvider("default", p); err != nil {
-			panic(err)
+		if p != nil {
+			if err := m.AddProvider("default", p); err != nil {
+				panic(err)
+			}
 		}
 	}
 	return m, nil

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -148,6 +148,19 @@ func (b *Provider) NewVolume() (volume.Volume, error) {
 	return v, nil
 }
 
+func (b *Provider) DestroyVolume(vol volume.Volume) error {
+	zvol := b.volumes[vol.Info().ID]
+	if zvol == nil {
+		return fmt.Errorf("volume does not belong to this provider")
+	}
+	if err := zvol.dataset.Destroy(zfs.DestroyRecursive | zfs.DestroyForceUmount); err != nil {
+		return err
+	}
+	os.Remove(zvol.basemount)
+	delete(b.volumes, vol.Info().ID)
+	return nil
+}
+
 func (v *zfsVolume) Provider() volume.Provider {
 	return v.provider
 }

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -44,6 +44,10 @@ type ProviderConfig struct {
 	DatasetName string `json:"dataset"`
 
 	Make *MakeDev `json:"makedev,omitempty"`
+
+	// WorkingDir specifies the working directory zfs will use to expose mounts.
+	// A default will be chosen if left blank.
+	WorkingDir string `json:"working_dir"`
 }
 
 /*
@@ -112,6 +116,9 @@ func NewProvider(config *ProviderConfig) (volume.Provider, error) {
 			return nil, err
 		}
 	}
+	if config.WorkingDir == "" {
+		config.WorkingDir = "/var/lib/flynn/volumes/zfs/"
+	}
 	return &Provider{
 		config:  config,
 		dataset: dataset,
@@ -128,7 +135,7 @@ func (b *Provider) NewVolume() (volume.Volume, error) {
 	v := &zfsVolume{
 		info:      &volume.Info{ID: id},
 		provider:  b,
-		basemount: filepath.Join("/var/lib/flynn/volumes/zfs/mnt/", id),
+		basemount: filepath.Join(b.config.WorkingDir, "/mnt/", id),
 	}
 	var err error
 	v.dataset, err = zfs.CreateFilesystem(path.Join(v.provider.dataset.Name, id), map[string]string{
@@ -194,7 +201,7 @@ func (v1 *zfsVolume) TakeSnapshot() (volume.Volume, error) {
 	v2 := &zfsVolume{
 		info:      &volume.Info{ID: id},
 		provider:  v1.provider,
-		basemount: filepath.Join("/var/lib/flynn/volumes/zfs/", id),
+		basemount: filepath.Join(v1.provider.config.WorkingDir, "/mnt/", id),
 	}
 	var err error
 	v2.dataset, err = cloneFilesystem(path.Join(v2.provider.dataset.Name, v2.info.ID), path.Join(v1.provider.dataset.Name, v1.info.ID), v2.basemount)


### PR DESCRIPTION
Adds a command to `flynn-host` which destroys volumes and their configuration in an attempt to return the host to a clean state for a future run.