### PR TITLE
Volume snapshots

### DIFF
--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -17,6 +17,8 @@ type Provider interface {
 
 	NewVolume() (Volume, error)
 	DestroyVolume(Volume) error
+	CreateSnapshot(Volume) (Volume, error)
+	ForkVolume(Volume) (Volume, error)
 
 	MarshalGlobalState() (json.RawMessage, error)
 	MarshalVolumeState(volumeID string) (json.RawMessage, error)

--- a/host/volume/util.go
+++ b/host/volume/util.go
@@ -1,0 +1,24 @@
+package volume
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func IsMount(path string) (bool, error) {
+	pathStat, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	parentStat, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		return false, err
+	}
+	pathDev := pathStat.Sys().(*syscall.Stat_t).Dev
+	parentDev := parentStat.Sys().(*syscall.Stat_t).Dev
+	return pathDev != parentDev, nil
+}

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -23,7 +23,7 @@ type Volume interface {
 	// Location returns the path to this volume's mount.  To use the volume in a job, bind mount this into the container's filesystem.
 	Location() string
 
-	TakeSnapshot() (Volume, error)
+	IsSnapshot() bool
 }
 
 /*

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -1,14 +1,15 @@
 package zfs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
-	"time"
 
 	zfs "github.com/flynn/flynn/Godeps/_workspace/src/github.com/mistifyio/go-zfs"
 	"github.com/flynn/flynn/host/volume"
@@ -135,7 +136,7 @@ func (b *Provider) NewVolume() (volume.Volume, error) {
 	v := &zfsVolume{
 		info:      &volume.Info{ID: id},
 		provider:  b,
-		basemount: filepath.Join(b.config.WorkingDir, "/mnt/", id),
+		basemount: b.mountPath(id),
 	}
 	var err error
 	v.dataset, err = zfs.CreateFilesystem(path.Join(v.provider.dataset.Name, id), map[string]string{
@@ -148,17 +149,107 @@ func (b *Provider) NewVolume() (volume.Volume, error) {
 	return v, nil
 }
 
-func (b *Provider) DestroyVolume(vol volume.Volume) error {
+func (b *Provider) owns(vol volume.Volume) (*zfsVolume, error) {
 	zvol := b.volumes[vol.Info().ID]
 	if zvol == nil {
-		return fmt.Errorf("volume does not belong to this provider")
+		return nil, fmt.Errorf("volume does not belong to this provider")
 	}
-	if err := zvol.dataset.Destroy(zfs.DestroyRecursive | zfs.DestroyForceUmount); err != nil {
+	if zvol != vol { // these pointers should be canonical
+		panic(fmt.Errorf("volume does not belong to this provider"))
+	}
+	return zvol, nil
+}
+
+func (b Provider) mountPath(id string) string {
+	return filepath.Join(b.config.WorkingDir, "/mnt/", id)
+}
+
+func (b *Provider) DestroyVolume(vol volume.Volume) error {
+	zvol, err := b.owns(vol)
+	if err != nil {
+		return err
+	}
+	if vol.IsSnapshot() {
+		if err := syscall.Unmount(vol.Location(), 0); err != nil {
+			return err
+		}
+		os.Remove(vol.Location())
+	}
+	if err := zvol.dataset.Destroy(zfs.DestroyForceUmount); err != nil {
 		return err
 	}
 	os.Remove(zvol.basemount)
 	delete(b.volumes, vol.Info().ID)
 	return nil
+}
+
+func (b *Provider) CreateSnapshot(vol volume.Volume) (volume.Volume, error) {
+	zvol, err := b.owns(vol)
+	if err != nil {
+		return nil, err
+	}
+	id := random.UUID()
+	snap := &zfsVolume{
+		info:      &volume.Info{ID: id},
+		provider:  zvol.provider,
+		basemount: b.mountPath(id),
+	}
+	snap.dataset, err = zvol.dataset.Snapshot(id, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := b.mountSnapshot(snap); err != nil {
+		return nil, err
+	}
+	b.volumes[id] = snap
+	return snap, nil
+}
+
+func (b *Provider) mountSnapshot(vol *zfsVolume) error {
+	// mount the snapshot (readonly)
+	// 'zfs mount' currently can't perform on snapshots; seealso https://github.com/zfsonlinux/zfs/issues/173
+	alreadyMounted, err := volume.IsMount(vol.basemount)
+	if err != nil {
+		return fmt.Errorf("could not mount snapshot: %s", err)
+	}
+	if alreadyMounted {
+		return nil
+	}
+	if err = os.MkdirAll(vol.basemount, 0644); err != nil {
+		return fmt.Errorf("could not mount snapshot: %s", err)
+	}
+	var buf bytes.Buffer
+	cmd := exec.Command("mount", "-tzfs", vol.dataset.Name, vol.basemount)
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("could not mount snapshot: %s (%s)", err, strings.TrimSpace(buf.String()))
+	}
+	return nil
+}
+
+func (b *Provider) ForkVolume(vol volume.Volume) (volume.Volume, error) {
+	zvol, err := b.owns(vol)
+	if err != nil {
+		return nil, err
+	}
+	if !vol.IsSnapshot() {
+		return nil, fmt.Errorf("can only fork a snapshot")
+	}
+	id := random.UUID()
+	v2 := &zfsVolume{
+		info:      &volume.Info{ID: id},
+		provider:  zvol.provider,
+		basemount: b.mountPath(id),
+	}
+	cloneID := fmt.Sprintf("%s/%s", zvol.provider.dataset.Name, id)
+	v2.dataset, err = zvol.dataset.Clone(cloneID, map[string]string{
+		"mountpoint": v2.basemount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not fork volume: %s", err)
+	}
+	b.volumes[id] = v2
+	return v2, nil
 }
 
 func (v *zfsVolume) Provider() volume.Provider {
@@ -201,6 +292,12 @@ func (b *Provider) RestoreVolumeState(volInfo *volume.Info, data json.RawMessage
 		dataset:   dataset,
 		basemount: record.Basemount,
 	}
+	// zfs should have already remounted filesystems; special remount case for snapshots
+	if v.IsSnapshot() {
+		if err := b.mountSnapshot(v); err != nil {
+			return nil, err
+		}
+	}
 	b.volumes[volInfo.ID] = v
 	return v, nil
 }
@@ -209,40 +306,6 @@ func (v *zfsVolume) Info() *volume.Info {
 	return v.info
 }
 
-func (v1 *zfsVolume) TakeSnapshot() (volume.Volume, error) {
-	id := random.UUID()
-	v2 := &zfsVolume{
-		info:      &volume.Info{ID: id},
-		provider:  v1.provider,
-		basemount: filepath.Join(v1.provider.config.WorkingDir, "/mnt/", id),
-	}
-	var err error
-	v2.dataset, err = cloneFilesystem(path.Join(v2.provider.dataset.Name, v2.info.ID), path.Join(v1.provider.dataset.Name, v1.info.ID), v2.basemount)
-	if err != nil {
-		return nil, err
-	}
-	v2.provider.volumes[id] = v2
-	return v2, nil
-}
-
-func cloneFilesystem(newDatasetName string, parentDatasetName string, mountPath string) (*zfs.Dataset, error) {
-	parentDataset, err := zfs.GetDataset(parentDatasetName)
-	if parentDataset == nil {
-		return nil, err
-	}
-	snapshotName := fmt.Sprintf("%d", time.Now().Nanosecond())
-	snapshot, err := parentDataset.Snapshot(snapshotName, false)
-	if err != nil {
-		return nil, err
-	}
-
-	dataset, err := snapshot.Clone(newDatasetName, map[string]string{
-		"mountpoint": mountPath,
-	})
-	if err != nil {
-		snapshot.Destroy(zfs.DestroyDeferDeletion)
-		return nil, err
-	}
-	err = snapshot.Destroy(zfs.DestroyDeferDeletion)
-	return dataset, err
+func (v *zfsVolume) IsSnapshot() bool {
+	return v.dataset.Type == zfs.DatasetSnapshot
 }

--- a/host/volume/zfs/zfs_test.go
+++ b/host/volume/zfs/zfs_test.go
@@ -1,0 +1,61 @@
+package zfs
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"testing"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	gzfs "github.com/flynn/flynn/Godeps/_workspace/src/github.com/mistifyio/go-zfs"
+	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/pkg/random"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+/*
+	Helper for temporary zpools, embeddable in tests.
+*/
+type TempZpool struct {
+	IDstring          string
+	ZpoolVdevFilePath string
+	ZpoolName         string
+	VolProv           volume.Provider
+}
+
+func (s *TempZpool) SetUpTest(c *C) {
+	if s.IDstring == "" {
+		s.IDstring = random.String(12)
+	}
+
+	// Set up a new provider with a zpool that will be destroyed on teardown
+	s.ZpoolVdevFilePath = fmt.Sprintf("/tmp/flynn-test-zpool-%s.vdev", s.IDstring)
+	s.ZpoolName = fmt.Sprintf("flynn-test-zpool-%s", s.IDstring)
+	var err error
+	s.VolProv, err = NewProvider(&ProviderConfig{
+		DatasetName: s.ZpoolName,
+		Make: &MakeDev{
+			BackingFilename: s.ZpoolVdevFilePath,
+			Size:            int64(math.Pow(2, float64(30))),
+		},
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *TempZpool) TearDownTest(c *C) {
+	if s.ZpoolVdevFilePath != "" {
+		os.Remove(s.ZpoolVdevFilePath)
+	}
+	pool, _ := gzfs.GetZpool(s.ZpoolName)
+	if pool != nil {
+		if datasets, err := pool.Datasets(); err == nil {
+			for _, dataset := range datasets {
+				dataset.Destroy(gzfs.DestroyRecursive | gzfs.DestroyForceUmount)
+				os.Remove(dataset.Mountpoint)
+			}
+		}
+		err := pool.Destroy()
+		c.Assert(err, IsNil)
+	}
+}


### PR DESCRIPTION
Added permanent snapshots.  Snapshot mounts are readonly, but otherwise act mostly like other volumes.  Snapshots can be forked again into live filesystems.

Snapshots can now be serialized and transmitted to other matching providers (once connected to the http API, this will make snapshot transfer possible between hosts).  The provider interface supports negotiation for existing data objects so that transmission can use incremental deltas when possible.