### PR TITLE
Deployer updates

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -134,14 +134,6 @@
     }
   },
   {
-    "id": "deployer",
-    "action": "run-app",
-    "app_step": "controller-inception",
-    "processes": {
-      "deployer": 1
-    }
-  },
-  {
     "id": "blobstore",
     "action": "deploy-app",
     "app": {

--- a/controller/deployer/main.go
+++ b/controller/deployer/main.go
@@ -113,6 +113,7 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 		return err
 	}
 	events := make(chan ct.DeploymentEvent)
+	defer close(events)
 	go func() {
 		log.Info("watching deployment events")
 		for ev := range events {
@@ -122,7 +123,6 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 				log.Error("error creating deployment event record", "err", err)
 			}
 		}
-		close(events)
 		log.Info("stopped watching deployment events")
 	}()
 	defer func() {

--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -93,6 +93,7 @@ func scanDeployment(s postgres.Scanner) (*ct.Deployment, error) {
 		err = ErrNotFound
 	}
 	d.ID = postgres.CleanUUID(d.ID)
+	d.AppID = postgres.CleanUUID(d.AppID)
 	d.OldReleaseID = postgres.CleanUUID(d.OldReleaseID)
 	d.NewReleaseID = postgres.CleanUUID(d.NewReleaseID)
 	return d, err


### PR DESCRIPTION
The main change here is to make the deployer log more verbosely, as currently it only really logs on error. I also made the log messages more consistent by always using lower case, and starting error messages with the word "error" to make the logs easier to scan down.