### PR TITLE
postgres appliance state machine

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -376,6 +376,14 @@
 			"Rev": "c46bdbf4af2e43e5f163092037ec27e9e9aee1f3"
 		},
 		{
+			"ImportPath": "github.com/kylelemons/godebug/diff",
+			"Rev": "808ac284003ce2b08ef590da08f95379e8a06936"
+		},
+		{
+			"ImportPath": "github.com/kylelemons/godebug/pretty",
+			"Rev": "808ac284003ce2b08ef590da08f95379e8a06936"
+		},
+		{
 			"ImportPath": "github.com/martini-contrib/binding",
 			"Rev": "f77b87950a1910e11b2de09446f8b331eedc18ac"
 		},

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/diff/diff.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/diff/diff.go
@@ -1,0 +1,133 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diff implements a linewise diff algorithm.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Chunk represents a piece of the diff.  A chunk will not have both added and
+// deleted lines.  Equal lines are always after any added or deleted lines.
+// A Chunk may or may not have any lines in it, especially for the first or last
+// chunk in a computation.
+type Chunk struct {
+	Added   []string
+	Deleted []string
+	Equal   []string
+}
+
+// Diff returns a string containing a line-by-line unified diff of the linewise
+// changes required to make A into B.  Each line is prefixed with '+', '-', or
+// ' ' to indicate if it should be added, removed, or is correct respectively.
+func Diff(A, B string) string {
+	aLines := strings.Split(A, "\n")
+	bLines := strings.Split(B, "\n")
+
+	chunks := DiffChunks(aLines, bLines)
+
+	buf := new(bytes.Buffer)
+	for _, c := range chunks {
+		for _, line := range c.Added {
+			fmt.Fprintf(buf, "+%s\n", line)
+		}
+		for _, line := range c.Deleted {
+			fmt.Fprintf(buf, "-%s\n", line)
+		}
+		for _, line := range c.Equal {
+			fmt.Fprintf(buf, " %s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// DiffChunks uses an O(D(N+M)) shortest-edit-script algorithm
+// to compute the edits required from A to B and returns the
+// edit chunks.
+func DiffChunks(A, B []string) []Chunk {
+	// algorithm: http://www.xmailserver.org/diff2.pdf
+
+	N, M := len(A), len(B)
+	MAX := N + M
+	V := make([]int, 2*MAX+1)
+	Vs := make([][]int, 0, 8)
+
+	var D int
+dLoop:
+	for D = 0; D <= MAX; D++ {
+		for k := -D; k <= D; k += 2 {
+			var x int
+			if k == -D || (k != D && V[MAX+k-1] < V[MAX+k+1]) {
+				x = V[MAX+k+1]
+			} else {
+				x = V[MAX+k-1] + 1
+			}
+			y := x - k
+			for x < N && y < M && A[x] == B[y] {
+				x++
+				y++
+			}
+			V[MAX+k] = x
+			if x >= N && y >= M {
+				Vs = append(Vs, append(make([]int, 0, len(V)), V...))
+				break dLoop
+			}
+		}
+		Vs = append(Vs, append(make([]int, 0, len(V)), V...))
+	}
+	if D == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, D+1)
+
+	x, y := N, M
+	for d := D; d > 0; d-- {
+		V := Vs[d]
+		k := x - y
+		insert := k == -d || (k != d && V[MAX+k-1] < V[MAX+k+1])
+
+		x1 := V[MAX+k]
+		var x0, xM, kk int
+		if insert {
+			kk = k + 1
+			x0 = V[MAX+kk]
+			xM = x0
+		} else {
+			kk = k - 1
+			x0 = V[MAX+kk]
+			xM = x0 + 1
+		}
+		y0 := x0 - kk
+
+		var c Chunk
+		if insert {
+			c.Added = B[y0:][:1]
+		} else {
+			c.Deleted = A[x0:][:1]
+		}
+		if xM < x1 {
+			c.Equal = A[xM:][:x1-xM]
+		}
+
+		x, y = x0, y0
+		chunks[d] = c
+	}
+	if x > 0 {
+		chunks[0].Equal = A[:x]
+	}
+	return chunks
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/diff/diff_test.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/diff/diff_test.go
@@ -1,0 +1,120 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDiff(t *testing.T) {
+	tests := []struct {
+		desc   string
+		A, B   []string
+		chunks []Chunk
+	}{
+		{
+			desc: "constitution",
+			A: []string{
+				"We the People of the United States, in Order to form a more perfect Union,",
+				"establish Justice, insure domestic Tranquility, provide for the common defence,",
+				"and secure the Blessings of Liberty to ourselves",
+				"and our Posterity, do ordain and establish this Constitution for the United",
+				"States of America.",
+			},
+			B: []string{
+				"We the People of the United States, in Order to form a more perfect Union,",
+				"establish Justice, insure domestic Tranquility, provide for the common defence,",
+				"promote the general Welfare, and secure the Blessings of Liberty to ourselves",
+				"and our Posterity, do ordain and establish this Constitution for the United",
+				"States of America.",
+			},
+			chunks: []Chunk{
+				0: {
+					Equal: []string{
+						"We the People of the United States, in Order to form a more perfect Union,",
+						"establish Justice, insure domestic Tranquility, provide for the common defence,",
+					},
+				},
+				1: {
+					Deleted: []string{
+						"and secure the Blessings of Liberty to ourselves",
+					},
+				},
+				2: {
+					Added: []string{
+						"promote the general Welfare, and secure the Blessings of Liberty to ourselves",
+					},
+					Equal: []string{
+						"and our Posterity, do ordain and establish this Constitution for the United",
+						"States of America.",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got := DiffChunks(test.A, test.B)
+		if got, want := len(got), len(test.chunks); got != want {
+			t.Errorf("%s: edit distance = %v, want %v", test.desc, got-1, want-1)
+			continue
+		}
+		for i := range got {
+			got, want := got[i], test.chunks[i]
+			if got, want := got.Added, want.Added; !reflect.DeepEqual(got, want) {
+				t.Errorf("%s[%d]: Added = %v, want %v", test.desc, i, got, want)
+			}
+			if got, want := got.Deleted, want.Deleted; !reflect.DeepEqual(got, want) {
+				t.Errorf("%s[%d]: Deleted = %v, want %v", test.desc, i, got, want)
+			}
+			if got, want := got.Equal, want.Equal; !reflect.DeepEqual(got, want) {
+				t.Errorf("%s[%d]: Equal = %v, want %v", test.desc, i, got, want)
+			}
+		}
+	}
+}
+
+func ExampleDiff() {
+	constitution := strings.TrimSpace(`
+We the People of the United States, in Order to form a more perfect Union,
+establish Justice, insure domestic Tranquility, provide for the common defence,
+promote the general Welfare, and secure the Blessings of Liberty to ourselves
+and our Posterity, do ordain and establish this Constitution for the United
+States of America.
+`)
+
+	got := strings.TrimSpace(`
+:wq
+We the People of the United States, in Order to form a more perfect Union,
+establish Justice, insure domestic Tranquility, provide for the common defence,
+and secure the Blessings of Liberty to ourselves
+and our Posterity, do ordain and establish this Constitution for the United
+States of America.
+`)
+
+	fmt.Println(Diff(got, constitution))
+
+	// Output:
+	// -:wq
+	//  We the People of the United States, in Order to form a more perfect Union,
+	//  establish Justice, insure domestic Tranquility, provide for the common defence,
+	// -and secure the Blessings of Liberty to ourselves
+	// +promote the general Welfare, and secure the Blessings of Liberty to ourselves
+	//  and our Posterity, do ordain and establish this Constitution for the United
+	//  States of America.
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/.gitignore
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/.gitignore
@@ -1,0 +1,5 @@
+*.test
+*.bench
+*.golden
+*.txt
+*.prof

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/doc.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pretty pretty-prints Go structures.
+//
+// This package uses reflection to examine a Go value and can
+// print out in a nice, aligned fashion.  It supports three
+// modes (normal, compact, and extended) for advanced use.
+//
+// See the Reflect and Print examples for what the output looks like.
+package pretty
+
+// TODO:
+//   - Catch cycles

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/examples_test.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/examples_test.go
@@ -1,0 +1,158 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty_test
+
+import (
+	"fmt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty"
+)
+
+func ExampleConfig_Sprint() {
+	type Pair [2]int
+	type Map struct {
+		Name      string
+		Players   map[string]Pair
+		Obstacles map[Pair]string
+	}
+
+	m := Map{
+		Name: "Rock Creek",
+		Players: map[string]Pair{
+			"player1": {1, 3},
+			"player2": {0, -1},
+		},
+		Obstacles: map[Pair]string{
+			Pair{0, 0}: "rock",
+			Pair{2, 1}: "pond",
+			Pair{1, 1}: "stream",
+			Pair{0, 1}: "stream",
+		},
+	}
+
+	// Specific output formats
+	compact := &pretty.Config{
+		Compact: true,
+	}
+	diffable := &pretty.Config{
+		Diffable: true,
+	}
+
+	// Print out a summary
+	fmt.Printf("Players: %s\n", compact.Sprint(m.Players))
+
+	// Print diffable output
+	fmt.Printf("Map State:\n%s", diffable.Sprint(m))
+
+	// Output:
+	// Players: {player1:[1,3],player2:[0,-1]}
+	// Map State:
+	// {
+	//  Name:      "Rock Creek",
+	//  Players:   {
+	//              player1: [
+	//                        1,
+	//                        3,
+	//                       ],
+	//              player2: [
+	//                        0,
+	//                        -1,
+	//                       ],
+	//             },
+	//  Obstacles: {
+	//              [0,0]: "rock",
+	//              [0,1]: "stream",
+	//              [1,1]: "stream",
+	//              [2,1]: "pond",
+	//             },
+	// }
+}
+
+func ExamplePrint() {
+	type ShipManifest struct {
+		Name     string
+		Crew     map[string]string
+		Androids int
+		Stolen   bool
+	}
+
+	manifest := &ShipManifest{
+		Name: "Spaceship Heart of Gold",
+		Crew: map[string]string{
+			"Zaphod Beeblebrox": "Galactic President",
+			"Trillian":          "Human",
+			"Ford Prefect":      "A Hoopy Frood",
+			"Arthur Dent":       "Along for the Ride",
+		},
+		Androids: 1,
+		Stolen:   true,
+	}
+
+	pretty.Print(manifest)
+
+	// Output:
+	// {Name:     "Spaceship Heart of Gold",
+	//  Crew:     {Arthur Dent:       "Along for the Ride",
+	//             Ford Prefect:      "A Hoopy Frood",
+	//             Trillian:          "Human",
+	//             Zaphod Beeblebrox: "Galactic President"},
+	//  Androids: 1,
+	//  Stolen:   true}
+}
+
+func ExampleCompare() {
+	type ShipManifest struct {
+		Name     string
+		Crew     map[string]string
+		Androids int
+		Stolen   bool
+	}
+
+	reported := &ShipManifest{
+		Name: "Spaceship Heart of Gold",
+		Crew: map[string]string{
+			"Zaphod Beeblebrox": "Galactic President",
+			"Trillian":          "Human",
+			"Ford Prefect":      "A Hoopy Frood",
+			"Arthur Dent":       "Along for the Ride",
+		},
+		Androids: 1,
+		Stolen:   true,
+	}
+
+	expected := &ShipManifest{
+		Name: "Spaceship Heart of Gold",
+		Crew: map[string]string{
+			"Rowan Artosok": "Captain",
+		},
+		Androids: 1,
+		Stolen:   false,
+	}
+
+	fmt.Println(pretty.Compare(reported, expected))
+	// Output:
+	//  {
+	//   Name:     "Spaceship Heart of Gold",
+	//   Crew:     {
+	// -            Arthur Dent:       "Along for the Ride",
+	// -            Ford Prefect:      "A Hoopy Frood",
+	// -            Trillian:          "Human",
+	// -            Zaphod Beeblebrox: "Galactic President",
+	// +            Rowan Artosok: "Captain",
+	//             },
+	//   Androids: 1,
+	// - Stolen:   true,
+	// + Stolen:   false,
+	//  }
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/public.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/public.go
@@ -1,0 +1,101 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kylelemons/godebug/diff"
+)
+
+// A Config represents optional configuration parameters for formatting.
+//
+// Some options, notably ShortList, dramatically increase the overhead
+// of pretty-printing a value.
+type Config struct {
+	// Verbosity options
+	Compact  bool // One-line output. Overrides Diffable.
+	Diffable bool // Adds extra newlines for more easily diffable output.
+
+	// Field and value options
+	IncludeUnexported bool // Include unexported fields in output
+	PrintStringers    bool // Call String on a fmt.Stringer
+
+	// Output transforms
+	ShortList int // Maximum character length for short lists if nonzero.
+}
+
+var DefaultConfig = &Config{}
+
+func (cfg *Config) fprint(buf *bytes.Buffer, vals ...interface{}) {
+	for i, val := range vals {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		cfg.val2node(reflect.ValueOf(val)).WriteTo(buf, "", cfg)
+	}
+}
+
+// Print writes the default representation of the given values to standard output.
+func Print(vals ...interface{}) {
+	DefaultConfig.Print(vals...)
+}
+
+// Print writes the configured presentation of the given values to standard output.
+func (cfg *Config) Print(vals ...interface{}) {
+	fmt.Println(cfg.Sprint(vals...))
+}
+
+// Sprint returns a string representation of the given value according to the default config.
+func Sprint(vals ...interface{}) string {
+	return DefaultConfig.Sprint(vals...)
+}
+
+// Sprint returns a string representation of the given value according to cfg.
+func (cfg *Config) Sprint(vals ...interface{}) string {
+	buf := new(bytes.Buffer)
+	cfg.fprint(buf, vals...)
+	return buf.String()
+}
+
+// Fprint writes the representation of the given value to the writer according to the default config.
+func Fprint(w io.Writer, vals ...interface{}) (n int64, err error) {
+	return DefaultConfig.Fprint(w, vals...)
+}
+
+// Fprint writes the representation of the given value to the writer according to the cfg.
+func (cfg *Config) Fprint(w io.Writer, vals ...interface{}) (n int64, err error) {
+	buf := new(bytes.Buffer)
+	cfg.fprint(buf, vals...)
+	return buf.WriteTo(w)
+}
+
+// Compare returns a string containing a line-by-line unified diff of the
+// values in got and want.  Compare includes unexported fields.
+//
+// Each line in the output is prefixed with '+', '-', or ' ' to indicate if it
+// should be added to, removed from, or is correct for the "got" value with
+// respect to the "want" value.
+func Compare(got, want interface{}) string {
+	diffOpt := &Config{
+		Diffable:          true,
+		IncludeUnexported: true,
+	}
+
+	return diff.Diff(diffOpt.Sprint(got), diffOpt.Sprint(want))
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/public_test.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/public_test.go
@@ -1,0 +1,72 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"testing"
+)
+
+func TestDiff(t *testing.T) {
+	type example struct {
+		Name    string
+		Age     int
+		Friends []string
+	}
+
+	tests := []struct {
+		desc      string
+		got, want interface{}
+		diff      string
+	}{
+		{
+			desc: "basic struct",
+			got: example{
+				Name: "Zaphd",
+				Age:  42,
+				Friends: []string{
+					"Ford Prefect",
+					"Trillian",
+					"Marvin",
+				},
+			},
+			want: example{
+				Name: "Zaphod",
+				Age:  42,
+				Friends: []string{
+					"Ford Prefect",
+					"Trillian",
+				},
+			},
+			diff: ` {
+- Name:    "Zaphd",
++ Name:    "Zaphod",
+  Age:     42,
+  Friends: [
+            "Ford Prefect",
+            "Trillian",
+-           "Marvin",
+           ],
+ }`,
+		},
+	}
+
+	for _, test := range tests {
+		if got, want := Compare(test.got, test.want), test.diff; got != want {
+			t.Errorf("%s:", test.desc)
+			t.Errorf("  got:  %q", got)
+			t.Errorf("  want: %q", want)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/reflect.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/reflect.go
@@ -1,0 +1,92 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func (c *Config) val2node(val reflect.Value) node {
+	// TODO(kevlar): pointer tracking?
+
+	if c.PrintStringers && val.CanInterface() {
+		stringer, ok := val.Interface().(fmt.Stringer)
+		if ok {
+			return stringVal(stringer.String())
+		}
+	}
+
+	switch kind := val.Kind(); kind {
+	case reflect.Ptr, reflect.Interface:
+		if val.IsNil() {
+			return rawVal("nil")
+		}
+		return c.val2node(val.Elem())
+	case reflect.String:
+		return stringVal(val.String())
+	case reflect.Slice, reflect.Array:
+		n := list{}
+		length := val.Len()
+		for i := 0; i < length; i++ {
+			n = append(n, c.val2node(val.Index(i)))
+		}
+		return n
+	case reflect.Map:
+		n := keyvals{}
+		keys := val.MapKeys()
+		for _, key := range keys {
+			// TODO(kevlar): Support arbitrary type keys?
+			n = append(n, keyval{compactString(c.val2node(key)), c.val2node(val.MapIndex(key))})
+		}
+		sort.Sort(n)
+		return n
+	case reflect.Struct:
+		n := keyvals{}
+		typ := val.Type()
+		fields := typ.NumField()
+		for i := 0; i < fields; i++ {
+			sf := typ.Field(i)
+			if !c.IncludeUnexported && sf.PkgPath != "" {
+				continue
+			}
+			n = append(n, keyval{sf.Name, c.val2node(val.Field(i))})
+		}
+		return n
+	case reflect.Bool:
+		if val.Bool() {
+			return rawVal("true")
+		}
+		return rawVal("false")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rawVal(fmt.Sprintf("%d", val.Int()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return rawVal(fmt.Sprintf("%d", val.Uint()))
+	case reflect.Uintptr:
+		return rawVal(fmt.Sprintf("0x%X", val.Uint()))
+	case reflect.Float32, reflect.Float64:
+		return rawVal(fmt.Sprintf("%v", val.Float()))
+	case reflect.Complex64, reflect.Complex128:
+		return rawVal(fmt.Sprintf("%v", val.Complex()))
+	}
+
+	// Fall back to the default %#v if we can
+	if val.CanInterface() {
+		return rawVal(fmt.Sprintf("%#v", val.Interface()))
+	}
+
+	return rawVal(val.String())
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/reflect_test.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/reflect_test.go
@@ -1,0 +1,143 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestVal2nodeDefault(t *testing.T) {
+	tests := []struct {
+		desc string
+		raw  interface{}
+		want node
+	}{
+		{
+			"nil",
+			(*int)(nil),
+			rawVal("nil"),
+		},
+		{
+			"string",
+			"zaphod",
+			stringVal("zaphod"),
+		},
+		{
+			"slice",
+			[]string{"a", "b"},
+			list{stringVal("a"), stringVal("b")},
+		},
+		{
+			"map",
+			map[string]string{
+				"zaphod": "beeblebrox",
+				"ford":   "prefect",
+			},
+			keyvals{
+				{"ford", stringVal("prefect")},
+				{"zaphod", stringVal("beeblebrox")},
+			},
+		},
+		{
+			"map of [2]int",
+			map[[2]int]string{
+				[2]int{-1, 2}: "school",
+				[2]int{0, 0}:  "origin",
+				[2]int{1, 3}:  "home",
+			},
+			keyvals{
+				{"[-1,2]", stringVal("school")},
+				{"[0,0]", stringVal("origin")},
+				{"[1,3]", stringVal("home")},
+			},
+		},
+		{
+			"struct",
+			struct{ Zaphod, Ford string }{"beeblebrox", "prefect"},
+			keyvals{
+				{"Zaphod", stringVal("beeblebrox")},
+				{"Ford", stringVal("prefect")},
+			},
+		},
+		{
+			"int",
+			3,
+			rawVal("3"),
+		},
+	}
+
+	for _, test := range tests {
+		if got, want := DefaultConfig.val2node(reflect.ValueOf(test.raw)), test.want; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
+		}
+	}
+}
+
+func TestVal2node(t *testing.T) {
+	tests := []struct {
+		desc string
+		raw  interface{}
+		cfg  *Config
+		want node
+	}{
+		{
+			"struct default",
+			struct{ Zaphod, Ford, foo string }{"beeblebrox", "prefect", "BAD"},
+			DefaultConfig,
+			keyvals{
+				{"Zaphod", stringVal("beeblebrox")},
+				{"Ford", stringVal("prefect")},
+			},
+		},
+		{
+			"struct w/ IncludeUnexported",
+			struct{ Zaphod, Ford, foo string }{"beeblebrox", "prefect", "GOOD"},
+			&Config{
+				IncludeUnexported: true,
+			},
+			keyvals{
+				{"Zaphod", stringVal("beeblebrox")},
+				{"Ford", stringVal("prefect")},
+				{"foo", stringVal("GOOD")},
+			},
+		},
+		{
+			"time default",
+			struct{ Date time.Time }{time.Unix(1234567890, 0).UTC()},
+			DefaultConfig,
+			keyvals{
+				{"Date", keyvals{}}, // empty struct, it has unexported fields
+			},
+		},
+		{
+			"time w/ PrintStringers",
+			struct{ Date time.Time }{time.Unix(1234567890, 0).UTC()},
+			&Config{
+				PrintStringers: true,
+			},
+			keyvals{
+				{"Date", stringVal("2009-02-13 23:31:30 +0000 UTC")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if got, want := test.cfg.val2node(reflect.ValueOf(test.raw)), test.want; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/structure.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/structure.go
@@ -1,0 +1,128 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+type node interface {
+	WriteTo(w *bytes.Buffer, indent string, cfg *Config)
+}
+
+func compactString(n node) string {
+	switch k := n.(type) {
+	case stringVal:
+		return string(k)
+	case rawVal:
+		return string(k)
+	}
+
+	buf := new(bytes.Buffer)
+	n.WriteTo(buf, "", &Config{Compact: true})
+	return buf.String()
+}
+
+type stringVal string
+
+func (str stringVal) WriteTo(w *bytes.Buffer, indent string, cfg *Config) {
+	w.WriteString(strconv.Quote(string(str)))
+}
+
+type rawVal string
+
+func (r rawVal) WriteTo(w *bytes.Buffer, indent string, cfg *Config) {
+	w.WriteString(string(r))
+}
+
+type keyval struct {
+	key string
+	val node
+}
+
+type keyvals []keyval
+
+func (l keyvals) Len() int           { return len(l) }
+func (l keyvals) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l keyvals) Less(i, j int) bool { return l[i].key < l[j].key }
+
+func (l keyvals) WriteTo(w *bytes.Buffer, indent string, cfg *Config) {
+	keyWidth := 0
+
+	for _, kv := range l {
+		if kw := len(kv.key); kw > keyWidth {
+			keyWidth = kw
+		}
+	}
+	padding := strings.Repeat(" ", keyWidth+1)
+
+	inner := indent + "  " + padding
+	w.WriteByte('{')
+	for i, kv := range l {
+		if cfg.Compact {
+			w.WriteString(kv.key)
+			w.WriteByte(':')
+		} else {
+			if i > 0 || cfg.Diffable {
+				w.WriteString("\n ")
+				w.WriteString(indent)
+			}
+			w.WriteString(kv.key)
+			w.WriteByte(':')
+			w.WriteString(padding[len(kv.key):])
+		}
+		kv.val.WriteTo(w, inner, cfg)
+		if i+1 < len(l) || cfg.Diffable {
+			w.WriteByte(',')
+		}
+	}
+	if !cfg.Compact && cfg.Diffable && len(l) > 0 {
+		w.WriteString("\n")
+		w.WriteString(indent)
+	}
+	w.WriteByte('}')
+}
+
+type list []node
+
+func (l list) WriteTo(w *bytes.Buffer, indent string, cfg *Config) {
+	if max := cfg.ShortList; max > 0 {
+		short := compactString(l)
+		if len(short) <= max {
+			w.WriteString(short)
+			return
+		}
+	}
+
+	inner := indent + " "
+	w.WriteByte('[')
+	for i, v := range l {
+		if !cfg.Compact && (i > 0 || cfg.Diffable) {
+			w.WriteByte('\n')
+			w.WriteString(inner)
+		}
+		v.WriteTo(w, inner, cfg)
+		if i+1 < len(l) || cfg.Diffable {
+			w.WriteByte(',')
+		}
+	}
+	if !cfg.Compact && cfg.Diffable && len(l) > 0 {
+		w.WriteByte('\n')
+		w.WriteString(indent)
+	}
+	w.WriteByte(']')
+}

--- a/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/structure_test.go
+++ b/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty/structure_test.go
@@ -1,0 +1,262 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pretty
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteTo(t *testing.T) {
+	tests := []struct {
+		desc     string
+		node     node
+		normal   string
+		extended string
+	}{
+		{
+			desc:     "string",
+			node:     stringVal("zaphod"),
+			normal:   `"zaphod"`,
+			extended: `"zaphod"`,
+		},
+		{
+			desc:     "raw",
+			node:     rawVal("42"),
+			normal:   `42`,
+			extended: `42`,
+		},
+		{
+			desc: "keyvals",
+			node: keyvals{
+				{"name", stringVal("zaphod")},
+				{"age", rawVal("42")},
+			},
+			normal: `{name: "zaphod",
+ age:  42}`,
+			extended: `{
+ name: "zaphod",
+ age:  42,
+}`,
+		},
+		{
+			desc: "list",
+			node: list{
+				stringVal("zaphod"),
+				rawVal("42"),
+			},
+			normal: `["zaphod",
+ 42]`,
+			extended: `[
+ "zaphod",
+ 42,
+]`,
+		},
+		{
+			desc: "nested",
+			node: list{
+				stringVal("first"),
+				list{rawVal("1"), rawVal("2"), rawVal("3")},
+				keyvals{
+					{"trillian", keyvals{
+						{"race", stringVal("human")},
+						{"age", rawVal("36")},
+					}},
+					{"zaphod", keyvals{
+						{"occupation", stringVal("president of the galaxy")},
+						{"features", stringVal("two heads")},
+					}},
+				},
+				keyvals{},
+			},
+			normal: `["first",
+ [1,
+  2,
+  3],
+ {trillian: {race: "human",
+             age:  36},
+  zaphod:   {occupation: "president of the galaxy",
+             features:   "two heads"}},
+ {}]`,
+			extended: `[
+ "first",
+ [
+  1,
+  2,
+  3,
+ ],
+ {
+  trillian: {
+             race: "human",
+             age:  36,
+            },
+  zaphod:   {
+             occupation: "president of the galaxy",
+             features:   "two heads",
+            },
+ },
+ {},
+]`,
+		},
+	}
+
+	for _, test := range tests {
+		buf := new(bytes.Buffer)
+		test.node.WriteTo(buf, "", &Config{})
+		if got, want := buf.String(), test.normal; got != want {
+			t.Errorf("%s: normal rendendered incorrectly\ngot:\n%s\nwant:\n%s", test.desc, got, want)
+		}
+		buf.Reset()
+		test.node.WriteTo(buf, "", &Config{Diffable: true})
+		if got, want := buf.String(), test.extended; got != want {
+			t.Errorf("%s: extended rendendered incorrectly\ngot:\n%s\nwant:\n%s", test.desc, got, want)
+		}
+	}
+}
+
+func TestCompactString(t *testing.T) {
+	tests := []struct {
+		node
+		compact string
+	}{
+		{
+			stringVal("abc"),
+			"abc",
+		},
+		{
+			rawVal("2"),
+			"2",
+		},
+		{
+			list{
+				rawVal("2"),
+				rawVal("3"),
+			},
+			"[2,3]",
+		},
+		{
+			keyvals{
+				{"name", stringVal("zaphod")},
+				{"age", rawVal("42")},
+			},
+			`{name:"zaphod",age:42}`,
+		},
+		{
+			list{
+				list{
+					rawVal("0"),
+					rawVal("1"),
+					rawVal("2"),
+					rawVal("3"),
+				},
+				list{
+					rawVal("1"),
+					rawVal("2"),
+					rawVal("3"),
+					rawVal("0"),
+				},
+				list{
+					rawVal("2"),
+					rawVal("3"),
+					rawVal("0"),
+					rawVal("1"),
+				},
+			},
+			`[[0,1,2,3],[1,2,3,0],[2,3,0,1]]`,
+		},
+	}
+
+	for _, test := range tests {
+		if got, want := compactString(test.node), test.compact; got != want {
+			t.Errorf("%#v: compact = %q, want %q", test.node, got, want)
+		}
+	}
+}
+
+func TestShortList(t *testing.T) {
+	cfg := &Config{
+		ShortList: 16,
+	}
+
+	tests := []struct {
+		node
+		want string
+	}{
+		{
+			list{
+				list{
+					rawVal("0"),
+					rawVal("1"),
+					rawVal("2"),
+					rawVal("3"),
+				},
+				list{
+					rawVal("1"),
+					rawVal("2"),
+					rawVal("3"),
+					rawVal("0"),
+				},
+				list{
+					rawVal("2"),
+					rawVal("3"),
+					rawVal("0"),
+					rawVal("1"),
+				},
+			},
+			`[[0,1,2,3],
+ [1,2,3,0],
+ [2,3,0,1]]`,
+		},
+	}
+
+	for _, test := range tests {
+		buf := new(bytes.Buffer)
+		test.node.WriteTo(buf, "", cfg)
+		if got, want := buf.String(), test.want; got != want {
+			t.Errorf("%#v: got:\n%s\nwant:\n%s", test.node, got, want)
+		}
+	}
+}
+
+var benchNode = keyvals{
+	{"list", list{
+		rawVal("0"),
+		rawVal("1"),
+		rawVal("2"),
+		rawVal("3"),
+	}},
+	{"keyvals", keyvals{
+		{"a", stringVal("b")},
+		{"c", stringVal("e")},
+		{"d", stringVal("f")},
+	}},
+}
+
+func benchOpts(b *testing.B, cfg *Config) {
+	buf := new(bytes.Buffer)
+	benchNode.WriteTo(buf, "", cfg)
+	b.SetBytes(int64(buf.Len()))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		benchNode.WriteTo(buf, "", cfg)
+	}
+}
+
+func BenchmarkWriteDefault(b *testing.B)   { benchOpts(b, DefaultConfig) }
+func BenchmarkWriteShortList(b *testing.B) { benchOpts(b, &Config{ShortList: 16}) }
+func BenchmarkWriteCompact(b *testing.B)   { benchOpts(b, &Config{Compact: true}) }
+func BenchmarkWriteDiffable(b *testing.B)  { benchOpts(b, &Config{Diffable: true}) }

--- a/appliance/postgresql2/.gitignore
+++ b/appliance/postgresql2/.gitignore
@@ -1,0 +1,1 @@
+cmd/simcli/simcli

--- a/appliance/postgresql2/cmd/simcli/main.go
+++ b/appliance/postgresql2/cmd/simcli/main.go
@@ -1,0 +1,29 @@
+// Don't build to avoid vendoring uniline
+// +build ignore
+
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/flynn/flynn/appliance/postgresql2/simulator"
+	"github.com/tiborvass/uniline"
+)
+
+func main() {
+	sim := simulator.New(false, os.Stdout, os.Stdout)
+	scanner := uniline.DefaultScanner()
+	for scanner.Scan("> ") {
+		line := scanner.Text()
+		if len(line) == 0 {
+			continue
+		}
+
+		sim.RunCommand(strings.TrimSpace(line))
+		scanner.AddToHistory(line)
+	}
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+}

--- a/appliance/postgresql2/postgres.go
+++ b/appliance/postgresql2/postgres.go
@@ -1,0 +1,778 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"text/template"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/appliance/postgresql2/xlog"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/shutdown"
+)
+
+type Config struct {
+	ID          string
+	Singleton   bool
+	Port        string
+	BinDir      string
+	DataDir     string
+	Password    string
+	OpTimeout   time.Duration
+	ReplTimeout time.Duration
+	Logger      log15.Logger
+}
+
+type Postgres struct {
+	db *pgx.ConnPool
+
+	events chan state.PostgresEvent
+
+	config        *state.PgConfig
+	running       bool
+	configApplied bool
+
+	// config options
+	id          string
+	log         log15.Logger
+	singleton   bool
+	port        string
+	binDir      string
+	dataDir     string
+	password    string
+	opTimeout   time.Duration
+	replTimeout time.Duration
+
+	// daemon is the postgres daemon command when running
+	daemon *exec.Cmd
+	// expectExit is bool, true if the daemon is supposed to exit
+	expectExit atomic.Value
+	// daemonExit is closed when the daemon exits
+	daemonExit chan struct{}
+
+	// cancelSyncWait cancels the goroutine that is waiting for the sync to
+	// catch up, if running
+	cancelSyncWait func()
+
+	// mtx ensures that only one operation happens at a time
+	mtx sync.Mutex
+}
+
+const checkInterval = 100 * time.Millisecond
+
+func NewPostgres(c Config) state.Postgres {
+	p := &Postgres{
+		id:             c.ID,
+		log:            c.Logger,
+		singleton:      c.Singleton,
+		port:           c.Port,
+		binDir:         c.BinDir,
+		dataDir:        c.DataDir,
+		password:       c.Password,
+		opTimeout:      c.OpTimeout,
+		replTimeout:    c.ReplTimeout,
+		events:         make(chan state.PostgresEvent, 1),
+		cancelSyncWait: func() {},
+	}
+	if p.log == nil {
+		p.log = log15.Root().New("app", "postgres", "id", p.id)
+	}
+	if p.port == "" {
+		p.port = "5432"
+	}
+	if p.binDir == "" {
+		p.binDir = "/usr/lib/postgresql/9.3/bin/"
+	}
+	if p.dataDir == "" {
+		p.dataDir = "/data"
+	}
+	if p.password == "" {
+		p.password = "password"
+	}
+	if p.opTimeout == 0 {
+		p.opTimeout = 5 * time.Minute
+	}
+	if p.replTimeout == 0 {
+		p.replTimeout = 1 * time.Minute
+	}
+	p.events <- state.PostgresEvent{}
+	return p
+}
+
+func (p *Postgres) Reconfigure(config *state.PgConfig) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	switch config.Role {
+	case state.RolePrimary:
+		if !p.singleton && config.Downstream == nil {
+			return errors.New("missing downstream peer")
+		}
+	case state.RoleSync, state.RoleAsync:
+		if config.Upstream == nil {
+			return fmt.Errorf("missing upstream peer")
+		}
+	case state.RoleNone:
+	default:
+		return fmt.Errorf("unknown role %v", config.Role)
+	}
+
+	if !p.running {
+		p.config = config
+		p.configApplied = false
+		return nil
+	}
+
+	return p.reconfigure(config)
+}
+
+func (p *Postgres) Start() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.running {
+		return errors.New("postgres is already running")
+	}
+	if p.config == nil {
+		return errors.New("postgres is unconfigured")
+	}
+	if p.config.Role == state.RoleNone {
+		return errors.New("start attempted with role 'none'")
+	}
+
+	return p.reconfigure(nil)
+}
+
+func (p *Postgres) Stop() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if !p.running {
+		return errors.New("postgres is already stopped")
+	}
+	return p.stop()
+}
+
+func (p *Postgres) XLogPosition() (res xlog.Position, err error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if !p.running {
+		return "", errors.New("postgres is not running")
+	}
+
+	query := "SELECT pg_last_xlog_replay_location()"
+	if p.config.Role == state.RolePrimary {
+		query = "SELECT pg_current_xlog_location()"
+	}
+	return res, p.db.QueryRow(query).Scan(&res)
+}
+
+func (p *Postgres) Ready() <-chan state.PostgresEvent {
+	return p.events
+}
+
+func (p *Postgres) reconfigure(config *state.PgConfig) (err error) {
+	defer func() {
+		if err == nil {
+			p.config = config
+			p.configApplied = true
+		}
+	}()
+
+	if config != nil && config.Role == state.RoleNone {
+		return nil
+	}
+
+	// If we've already applied the same postgres config, we don't need to do anything
+	if p.configApplied && config != nil && p.config != nil && config.Equal(p.config) {
+		return nil
+	}
+
+	// If we're already running and it's just a change from async to sync with the same node, we don't need to restart
+	if p.configApplied && p.running && p.config != nil && config != nil &&
+		p.config.Role == state.RoleAsync && config.Role == state.RoleSync && config.Upstream.ID == p.config.Upstream.ID {
+		return nil
+	}
+
+	// Make sure that we don't keep waiting for a sync to come up while reconfiguring
+	p.cancelSyncWait()
+
+	// If we're already running and this is only a sync change, we just need to update the config.
+	if p.running && p.config != nil && config != nil && p.config.Role == state.RolePrimary && config.Role == state.RolePrimary {
+		return p.updateSync(config.Downstream)
+	}
+
+	if config == nil {
+		config = p.config
+	}
+
+	if config.Role == state.RolePrimary {
+		return p.assumePrimary(config.Downstream)
+	}
+
+	return p.assumeStandby(config.Upstream)
+}
+
+func (p *Postgres) assumePrimary(downstream *discoverd.Instance) (err error) {
+	log := p.log.New("fn", "assumePrimary")
+	if downstream != nil {
+		log = log.New("downstream", downstream.Addr)
+	}
+
+	if p.running && p.config.Role == state.RoleSync {
+		log.Info("promoting to primary")
+
+		if err := ioutil.WriteFile(p.triggerPath(), nil, 0655); err != nil {
+			log.Error("error creating trigger file", "path", p.triggerPath(), "err", err)
+			return err
+		}
+
+		p.waitForSync(downstream)
+
+		return nil
+	}
+
+	log.Info("starting as primary")
+
+	if p.running {
+		panic(fmt.Sprintf("unexpected state running role=%s", p.config.Role))
+	}
+
+	if err := p.initDB(); err != nil {
+		return err
+	}
+
+	if err := os.Remove(p.recoveryConfPath()); err != nil && !os.IsNotExist(err) {
+		log.Error("error removing recovery.conf", "path", p.recoveryConfPath(), "err", err)
+		return err
+	}
+
+	if err := p.writeConfig(configData{ReadOnly: downstream != nil}); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+
+	if err := p.start(); err != nil {
+		return err
+	}
+
+	var tx *pgx.Tx
+	defer func() {
+		if err != nil {
+			if tx != nil {
+				tx.Rollback()
+			}
+			p.db.Close()
+			if err := p.stop(); err != nil {
+				log.Debug("ignoring error stopping postgres", "err", err)
+			}
+		}
+	}()
+
+	tx, err = p.db.Begin()
+	if err != nil {
+		log.Error("error acquiring connection", "err", err)
+		return err
+	}
+	if _, err := tx.Exec("SET TRANSACTION READ WRITE"); err != nil {
+		log.Error("error setting transaction read-write", "err", err)
+		return err
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`CREATE USER flynn WITH SUPERUSER CREATEDB CREATEROLE REPLICATION PASSWORD '%s'`, p.password)); err != nil {
+		if e, ok := err.(pgx.PgError); !ok || e.Code != "42710" { // role already exists
+			log.Error("error creating superuser", "err", err)
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Error("error committing transaction", "err", err)
+		return err
+	}
+
+	if downstream != nil {
+		p.waitForSync(downstream)
+	}
+
+	return nil
+}
+
+func (p *Postgres) assumeStandby(upstream *discoverd.Instance) error {
+	log := p.log.New("fn", "assumeStandby", "upstream", upstream.Addr)
+	log.Info("starting up as standby")
+
+	// TODO(titanous): investigate using a DNS name, proxy, or iptables rule for
+	// the upstream. (perhaps DNS plus some postgres magic like terminating
+	// a backend would work). Postgres appears to support remastering without
+	// restarting:
+	// http://www.databasesoup.com/2014/05/remastering-without-restarting.html
+
+	if p.running {
+		// if we are running, we can just restart with a new recovery.conf, postgres
+		// supports streaming remastering.
+		if err := p.stop(); err != nil {
+			return err
+		}
+	} else {
+		log.Info("pulling basebackup")
+		// TODO(titanous): make this pluggable
+		err := p.runCmd(exec.Command(
+			p.binPath("pg_basebackup"),
+			"--pgdata", p.dataDir,
+			"--dbname", fmt.Sprintf(
+				"host=%s port=%s user=flynn password=%s application_name=%s",
+				upstream.Host(), upstream.Port(), p.password, upstream.ID,
+			),
+			"--xlog-method=stream",
+			"--progress",
+			"--verbose",
+		))
+		if err != nil {
+			log.Error("error pulling basebackup", "err", err)
+			return err
+		}
+	}
+
+	if err := p.writeConfig(configData{ReadOnly: true}); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+	if err := p.writeRecoveryConf(upstream); err != nil {
+		log.Error("error writing recovery.conf", "path", p.recoveryConfPath(), "err", err)
+		return err
+	}
+
+	return p.start()
+}
+
+func (p *Postgres) updateSync(downstream *discoverd.Instance) error {
+	log := p.log.New("fn", "updateSync", "downstream", downstream.Addr)
+	log.Info("changing sync")
+
+	config := configData{
+		ReadOnly: true,
+		Sync:     downstream.ID,
+	}
+
+	if err := p.writeConfig(config); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+
+	if err := p.sighup(); err != nil {
+		p.log.Error("error reloading daemon configuration", "err", err)
+		return err
+	}
+
+	p.waitForSync(downstream)
+
+	return nil
+}
+
+func (p *Postgres) start() error {
+	log := p.log.New("fn", "start", "data_dir", p.dataDir, "bin_dir", p.binDir)
+	log.Info("starting postgres")
+
+	// clear stale pid if it exists
+	os.Remove(filepath.Join(p.dataDir, "postmaster.pid"))
+
+	p.expectExit.Store(false)
+	p.daemonExit = make(chan struct{})
+
+	cmd := exec.Command(p.binPath("postgres"), "-D", p.dataDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Error("failed to start postgres", "err", err)
+		return err
+	}
+	p.daemon = cmd
+	p.running = true
+
+	go func() {
+		err := cmd.Wait()
+		if !p.expectExit.Load().(bool) {
+			p.log.Error("postgres unexpectedly exit", "err", err)
+			shutdown.ExitWithCode(1)
+		}
+		close(p.daemonExit)
+	}()
+
+	log.Debug("waiting for postgres to start")
+	startTime := time.Now().UTC()
+	var err error
+	for {
+		if time.Now().Sub(startTime) > p.opTimeout {
+			log.Error("timed out waiting for postgres to start", "err", err)
+			if err := p.stop(); err != nil {
+				log.Error("error stopping postgres", "err", err)
+			}
+			return err
+		}
+
+		port, _ := strconv.Atoi(p.port)
+		c := pgx.ConnPoolConfig{
+			ConnConfig: pgx.ConnConfig{
+				Host: "127.0.0.1",
+				User: "postgres",
+				Port: uint16(port),
+			},
+		}
+		p.db, err = pgx.NewConnPool(c)
+		if err == nil {
+			_, err = p.db.Exec("SELECT 1")
+			if err == nil {
+				log.Info("postgres started")
+				return nil
+			}
+		}
+
+		log.Debug("ignoring error connecting to postgres", "err", err)
+		time.Sleep(checkInterval)
+	}
+}
+
+func (p *Postgres) stop() error {
+	log := p.log.New("fn", "stop")
+	log.Info("stopping postgres")
+
+	p.cancelSyncWait()
+	p.db.Close()
+	p.expectExit.Store(true)
+
+	tryExit := func(sig os.Signal) bool {
+		log.Debug("signalling daemon", "sig", sig)
+		if err := p.daemon.Process.Signal(sig); err != nil {
+			log.Error("error signalling daemon", "sig", sig, "err", err)
+		}
+		select {
+		case <-time.After(p.opTimeout):
+			return false
+		case <-p.daemonExit:
+			p.running = false
+			return true
+		}
+	}
+
+	// Wait for all clients to terminate before shutting down cleanly
+	if tryExit(syscall.SIGTERM) {
+		return nil
+	}
+
+	// Forcefully disconnect all clients and shut down cleanly
+	if tryExit(syscall.SIGINT) {
+		return nil
+	}
+
+	// Quit immediately, will result in recovery at next start
+	if tryExit(syscall.SIGQUIT) {
+		return nil
+	}
+
+	// If all else fails, forcibly kill the process
+	if tryExit(syscall.SIGKILL) {
+		return nil
+	}
+
+	return errors.New("unable to kill postgres")
+}
+
+func (p *Postgres) sighup() error {
+	p.log.Debug("reloading daemon configuration", "fn", "sighup")
+	return p.daemon.Process.Signal(syscall.SIGHUP)
+}
+
+func (p *Postgres) waitForSync(inst *discoverd.Instance) {
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	var cancelOnce sync.Once
+	p.cancelSyncWait = func() {
+		cancelOnce.Do(func() {
+			close(stopCh)
+			<-doneCh
+		})
+	}
+	go func() {
+		defer close(doneCh)
+
+		startTime := time.Now().UTC()
+		lastFlushed := xlog.Zero
+		log := p.log.New(
+			"fn", "waitForSync",
+			"sync_name", inst.ID,
+			"start_time", log15.Lazy{func() time.Time { return startTime }},
+			"last_flushed", log15.Lazy{func() xlog.Position { return lastFlushed }},
+		)
+
+		shouldStop := func() bool {
+			select {
+			case <-stopCh:
+				log.Debug("canceled, stopping")
+				return true
+			default:
+				return false
+			}
+		}
+
+		sleep := func() bool {
+			select {
+			case <-stopCh:
+				log.Debug("canceled, stopping")
+				return false
+			case <-time.After(checkInterval):
+				return true
+			}
+		}
+
+		log.Info("waiting for sync replication to catch up")
+
+		for {
+			if shouldStop() {
+				return
+			}
+
+			sent, flushed, err := p.checkReplStatus(inst.ID)
+			if err != nil {
+				// If we can't query the replication state, we just keep trying.
+				// We do not count this as part of the replication timeout.
+				// Generally this means the standby hasn't started or is unable
+				// to start. This means that the standby will eventually time
+				// itself out and we will exit the loop since a new event will
+				// be emitted when the standby leaves the cluster.
+				startTime = time.Now().UTC()
+				if !sleep() {
+					return
+				}
+				continue
+			}
+			elapsedTime := time.Now().Sub(startTime)
+			log := log.New("sent", sent, "flushed", flushed, "elapsed", elapsedTime)
+
+			if cmp, err := xlog.Compare(lastFlushed, flushed); err != nil {
+				log.Error("error parsing log locations", "err", err)
+				return
+			} else if lastFlushed == xlog.Zero || cmp == -1 {
+				log.Debug("flushed row incremented, resetting startTime")
+				startTime = time.Now().UTC()
+				lastFlushed = flushed
+			} else if cmp == 1 {
+				// Fail fast if the remote flushed location is greater than our
+				// current location. This means that we (the primary) is behind
+				// the sync and will never catch up.
+				log.Error("error checking replication status", "err", "sync xlog position is greater than the primary position")
+				return
+			}
+
+			if sent == flushed {
+				log.Info("sync caught up")
+				break
+			} else if elapsedTime > p.replTimeout {
+				log.Error("error checking replication status", "err", "sync unable to make forward progress")
+				return
+			} else {
+				log.Debug("continuing replication check")
+				if !sleep() {
+					return
+				}
+				continue
+			}
+		}
+
+		// sync caught up, enable write transactions
+		if err := p.writeConfig(configData{Sync: inst.ID}); err != nil {
+			log.Error("error writing postgres.conf", "err", err)
+			return
+		}
+
+		if err := p.sighup(); err != nil {
+			log.Error("error calling sighup")
+			return
+		}
+	}()
+}
+
+var ErrNoReplicationStatus = errors.New("no replication status")
+
+func (p *Postgres) checkReplStatus(name string) (sent, flushed xlog.Position, err error) {
+	log := p.log.New("fn", "checkReplStatus", "name", name)
+	log.Debug("checking replication status")
+
+	var s, f pgx.NullString
+	err = p.db.QueryRow(`
+SELECT sent_location, flush_location
+FROM pg_stat_replication
+WHERE application_name = $1`, name).Scan(&s, &f)
+	if err != nil && err != pgx.ErrNoRows {
+		log.Error("error checking replication status", "err", err)
+		return
+	}
+	sent, flushed = xlog.Position(s.String), xlog.Position(f.String)
+	if err == pgx.ErrNoRows || sent == "" || flushed == "" {
+		err = ErrNoReplicationStatus
+		log.Debug("no replication status")
+		return
+	}
+	log.Debug("got replication status", "sent_location", sent, "flush_location", flushed)
+	return
+}
+
+// initDB initializes the postgres data directory for a new dDB. This can fail
+// if the db has already been initialized, which is not a fatal error.
+//
+// This method should only be called by the primary of a shard. Standbys will
+// not need to initialize, as they will restore from an already running primary.
+func (p *Postgres) initDB() error {
+	log := p.log.New("fn", "initDB", "dir", p.dataDir)
+	log.Debug("starting initDB")
+
+	// ignore errors, since the db could be already initialized
+	// TODO(titanous): check errors when this is not the case
+	_ = p.runCmd(exec.Command(
+		p.binPath("initdb"),
+		"--pgdata", p.dataDir,
+		"--username=postgres",
+		"--encoding=UTF-8",
+		"--locale=en_US.UTF-8",
+	))
+
+	return p.writeHBAConf()
+}
+func (p *Postgres) runCmd(cmd *exec.Cmd) error {
+	p.log.Debug("running command", "fn", "runCmd", "cmd", cmd.Args)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (p *Postgres) writeConfig(d configData) error {
+	d.ID = p.id
+	d.Port = p.port
+	f, err := os.Create(p.configPath())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return configTemplate.Execute(f, d)
+}
+
+func (p *Postgres) writeRecoveryConf(upstream *discoverd.Instance) error {
+	data := recoveryData{
+		TriggerFile: p.triggerPath(),
+		PrimaryInfo: fmt.Sprintf(
+			"host=%s port=%s user=flynn password=%s application_name=%s",
+			upstream.Host(), upstream.Port(), p.password, p.id,
+		),
+	}
+
+	f, err := os.Create(p.recoveryConfPath())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return recoveryConfTemplate.Execute(f, data)
+}
+
+func (p *Postgres) writeHBAConf() error {
+	return ioutil.WriteFile(p.hbaConfPath(), hbaConf, 0644)
+}
+
+func (p *Postgres) configPath() string {
+	return p.dataPath("postgresql.conf")
+}
+
+func (p *Postgres) recoveryConfPath() string {
+	return p.dataPath("recovery.conf")
+}
+
+func (p *Postgres) hbaConfPath() string {
+	return p.dataPath("pg_hba.conf")
+}
+
+func (p *Postgres) triggerPath() string {
+	return p.dataPath("promote.trigger")
+}
+
+func (p *Postgres) binPath(file string) string {
+	return filepath.Join(p.binDir, file)
+}
+
+func (p *Postgres) dataPath(file string) string {
+	return filepath.Join(p.dataDir, file)
+}
+
+type configData struct {
+	ID       string
+	Port     string
+	Sync     string
+	ReadOnly bool
+
+	DisableFullPageWrites bool
+}
+
+var configTemplate = template.Must(template.New("postgresql.conf").Parse(`
+unix_socket_directories = ''
+listen_addresses = '0.0.0.0'
+port = {{.Port}}
+ssl = off
+ssl_renegotiation_limit = 0 # fix for https://github.com/flynn/flynn/issues/101
+max_connections = 100
+shared_buffers = 32MB
+wal_level = hot_standby
+fsync = on
+{{if .DisableFullPageWrites}}
+full_page_writes = off # Not necessary on ZFS, see http://www.postgresql.org/docs/current/static/wal-reliability.html
+{{end}}
+max_wal_senders = 15
+wal_keep_segments = 1000
+synchronous_commit = remote_write
+synchronous_standby_names = '{{.Sync}}'
+{{if .ReadOnly}}
+default_transaction_read_only = on
+{{end}}
+hot_standby = on
+max_standby_archive_delay = 30s
+max_standby_streaming_delay = 30s
+wal_receiver_status_interval = 10s
+hot_standby_feedback = on
+log_destination = 'stderr'
+logging_collector = false
+log_line_prefix = '{{.ID}} %m '
+log_timezone = 'UTC'
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+client_encoding = 'UTF8'
+default_text_search_config = 'pg_catalog.english'
+`[1:]))
+
+type recoveryData struct {
+	PrimaryInfo string
+	TriggerFile string
+}
+
+var recoveryConfTemplate = template.Must(template.New("recovery.conf").Parse(`
+standby_mode = on
+primary_conninfo = '{{.PrimaryInfo}}'
+trigger_file = '{{.TriggerFile}}'
+recovery_target_timeline = 'latest'
+`[1:]))
+
+var hbaConf = []byte(`
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+host    all             postgres        127.0.0.1/32            trust
+host    all             all             127.0.0.1/32            md5
+host    all             all             all                     md5
+host    replication     flynn           all                     md5
+`[1:])

--- a/appliance/postgresql2/postgres_test.go
+++ b/appliance/postgresql2/postgres_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/attempt"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type PostgresSuite struct{}
+
+var _ = Suite(&PostgresSuite{})
+
+func (PostgresSuite) TestSingletonPrimary(c *C) {
+	cfg := Config{
+		ID:        "node1",
+		Singleton: true,
+		DataDir:   c.MkDir(),
+		Port:      "54320",
+		OpTimeout: 30 * time.Second,
+	}
+
+	pg := NewPostgres(cfg)
+	err := pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	c.Assert(err, IsNil)
+
+	err = pg.Start()
+	c.Assert(err, IsNil)
+	defer pg.Stop()
+
+	conn := connect(c, 0, "postgres")
+	_, err = conn.Exec("CREATE DATABASE test")
+	conn.Close()
+	c.Assert(err, IsNil)
+
+	err = pg.Stop()
+	c.Assert(err, IsNil)
+
+	// ensure that we can start a new instance from the same directory
+	pg = NewPostgres(cfg)
+	err = pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	c.Assert(err, IsNil)
+	c.Assert(pg.Start(), IsNil)
+	defer pg.Stop()
+
+	conn = connect(c, 0, "test")
+	_, err = conn.Exec("CREATE DATABASE foo")
+	conn.Close()
+	c.Assert(err, IsNil)
+
+	err = pg.Stop()
+	c.Assert(err, IsNil)
+}
+
+func instance(n int) *discoverd.Instance {
+	return &discoverd.Instance{
+		ID:   fmt.Sprintf("node%d", n),
+		Addr: fmt.Sprintf("127.0.0.1:5432%d", n),
+	}
+}
+
+func newPostgres(c *C, n int) state.Postgres {
+	return NewPostgres(Config{
+		ID:        fmt.Sprintf("node%d", n),
+		DataDir:   c.MkDir(),
+		Port:      fmt.Sprintf("5432%d", n),
+		OpTimeout: 30 * time.Second,
+	})
+}
+
+func connect(c *C, n int, db string) *pgx.Conn {
+	conn, err := pgx.Connect(pgx.ConnConfig{
+		Host:     "127.0.0.1",
+		Port:     54320 + uint16(n),
+		User:     "flynn",
+		Password: "password",
+		Database: db,
+	})
+	c.Assert(err, IsNil)
+	return conn
+}
+
+func pgConfig(role state.Role, n int) *state.PgConfig {
+	var inst *discoverd.Instance
+	if n > 0 {
+		inst = instance(n)
+	}
+	if role == state.RolePrimary {
+		return &state.PgConfig{Role: role, Downstream: inst}
+	}
+	return &state.PgConfig{Role: role, Upstream: inst}
+}
+
+var queryAttempts = attempt.Strategy{
+	Min:   5,
+	Total: 30 * time.Second,
+	Delay: 200 * time.Millisecond,
+}
+
+func assertDownstream(c *C, conn *pgx.Conn, n int) {
+	var res string
+	err := conn.QueryRow("SELECT client_addr FROM pg_stat_replication WHERE application_name = $1", fmt.Sprintf("node%d", n)).Scan(&res)
+	c.Assert(err, IsNil)
+}
+
+func assertRecovery(c *C, conn *pgx.Conn) {
+	var recovery bool
+	err := conn.QueryRow("SELECT pg_is_in_recovery()").Scan(&recovery)
+	c.Assert(err, IsNil)
+	c.Assert(recovery, Equals, true)
+}
+
+func waitRow(c *C, conn *pgx.Conn, n int) {
+	var res int64
+	err := queryAttempts.Run(func() error {
+		return conn.QueryRow("SELECT id FROM test WHERE id = $1", n).Scan(&res)
+	})
+	c.Assert(err, IsNil)
+}
+
+func createTable(c *C, conn *pgx.Conn) {
+	_, err := conn.Exec("CREATE TABLE test (id bigint PRIMARY KEY)")
+	c.Assert(err, IsNil)
+	insertRow(c, conn, 1)
+}
+
+func insertRow(c *C, conn *pgx.Conn, n int) {
+	_, err := conn.Exec("INSERT INTO test (id) VALUES ($1)", n)
+	c.Assert(err, IsNil)
+}
+
+func waitReadWrite(c *C, conn *pgx.Conn) {
+	var readOnly string
+	err := queryAttempts.Run(func() error {
+		if err := conn.QueryRow("SHOW default_transaction_read_only").Scan(&readOnly); err != nil {
+			return err
+		}
+		if readOnly == "off" {
+			return nil
+		}
+		return fmt.Errorf("transaction readonly is %q", readOnly)
+	})
+	c.Assert(err, IsNil)
+}
+
+func waitRecovered(c *C, conn *pgx.Conn) {
+	var recovery bool
+	err := queryAttempts.Run(func() error {
+		err := conn.QueryRow("SELECT pg_is_in_recovery()").Scan(&recovery)
+		if err != nil {
+			return err
+		}
+		if recovery {
+			return fmt.Errorf("in recovery")
+		}
+		return nil
+	})
+	c.Assert(err, IsNil)
+}
+
+func (PostgresSuite) TestIntegration(c *C) {
+	// Start a primary
+	node1 := newPostgres(c, 1)
+	err := node1.Reconfigure(pgConfig(state.RolePrimary, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node1.Start(), IsNil)
+	defer node1.Stop()
+
+	// try to write to primary and make sure it's read-only
+	node1Conn := connect(c, 1, "postgres")
+	defer node1Conn.Close()
+	_, err = node1Conn.Exec("CREATE DATABASE foo")
+	c.Assert(err, NotNil)
+	c.Assert(err.(pgx.PgError).Code, Equals, "25006") // can't write while read only
+
+	// Start a sync
+	node2 := newPostgres(c, 2)
+	err = node2.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+	c.Assert(node2.Start(), IsNil)
+	defer node2.Stop()
+
+	// try to query primary until it comes up as read-write
+	waitReadWrite(c, node1Conn)
+
+	// make sure the sync is listed as sync and remote_write is enabled
+	assertDownstream(c, node1Conn, 2)
+	var res string
+	err = node1Conn.QueryRow("SHOW synchronous_standby_names").Scan(&res)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, "node2")
+	err = node1Conn.QueryRow("SHOW synchronous_commit").Scan(&res)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, "remote_write")
+
+	// create a table and a row
+	createTable(c, node1Conn)
+	node1Conn.Close()
+
+	// query the sync and see the database
+	node2Conn := connect(c, 2, "postgres")
+	defer node2Conn.Close()
+	waitRow(c, node2Conn, 1)
+	assertRecovery(c, node2Conn)
+
+	// Start an async
+	node3 := newPostgres(c, 3)
+	err = node3.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node3.Start(), IsNil)
+	defer node3.Stop()
+
+	node3Conn := connect(c, 3, "postgres")
+	defer node3Conn.Close()
+
+	// check that data replicated successfully
+	waitRow(c, node3Conn, 1)
+	assertRecovery(c, node3Conn)
+	assertDownstream(c, node2Conn, 3)
+
+	// Start a second async
+	node4 := newPostgres(c, 4)
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 3))
+	c.Assert(err, IsNil)
+	c.Assert(node4.Start(), IsNil)
+	defer node4.Stop()
+
+	node4Conn := connect(c, 4, "postgres")
+	defer node4Conn.Close()
+
+	// check that data replicated successfully
+	waitRow(c, node4Conn, 1)
+	assertRecovery(c, node4Conn)
+	assertDownstream(c, node3Conn, 4)
+
+	// promote node2 to primary
+	c.Assert(node1.Stop(), IsNil)
+	err = node2.Reconfigure(pgConfig(state.RolePrimary, 3))
+	c.Assert(err, IsNil)
+	err = node3.Reconfigure(pgConfig(state.RoleSync, 2))
+	c.Assert(err, IsNil)
+
+	// wait for recovery and read-write transactions to come up
+	waitRecovered(c, node2Conn)
+	waitReadWrite(c, node2Conn)
+
+	// check replication of each node
+	assertDownstream(c, node2Conn, 3)
+	assertDownstream(c, node3Conn, 4)
+
+	// write to primary and ensure data propagates to followers
+	insertRow(c, node2Conn, 2)
+	node2Conn.Close()
+	waitRow(c, node3Conn, 2)
+	waitRow(c, node4Conn, 2)
+
+	//  promote node3 to primary
+	c.Assert(node2.Stop(), IsNil)
+	err = node3.Reconfigure(pgConfig(state.RolePrimary, 4))
+	c.Assert(err, IsNil)
+	err = node4.Reconfigure(pgConfig(state.RoleSync, -1))
+
+	// check replication
+	waitRecovered(c, node3Conn)
+	waitReadWrite(c, node3Conn)
+	assertDownstream(c, node3Conn, 4)
+	insertRow(c, node3Conn, 3)
+}
+
+func (PostgresSuite) TestRemoveNodes(c *C) {
+	// start a chain of four nodes
+	node1 := newPostgres(c, 1)
+	err := node1.Reconfigure(pgConfig(state.RolePrimary, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node1.Start(), IsNil)
+	defer node1.Stop()
+
+	node2 := newPostgres(c, 2)
+	err = node2.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+	c.Assert(node2.Start(), IsNil)
+	defer node2.Stop()
+
+	node3 := newPostgres(c, 3)
+	err = node3.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node3.Start(), IsNil)
+	defer node3.Stop()
+
+	node4 := newPostgres(c, 4)
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 3))
+	c.Assert(err, IsNil)
+	c.Assert(node4.Start(), IsNil)
+	defer node4.Stop()
+
+	// wait for cluster to come up
+	node1Conn := connect(c, 1, "postgres")
+	defer node1Conn.Close()
+	node4Conn := connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	waitReadWrite(c, node1Conn)
+	createTable(c, node1Conn)
+	waitRow(c, node4Conn, 1)
+	node4Conn.Close()
+
+	// remove first async
+	c.Assert(node3.Stop(), IsNil)
+	// reconfigure second async
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	// run query
+	node4Conn = connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	insertRow(c, node1Conn, 2)
+	waitRow(c, node4Conn, 2)
+	node4Conn.Close()
+
+	// remove sync and promote node4 to sync
+	c.Assert(node2.Stop(), IsNil)
+	err = node1.Reconfigure(pgConfig(state.RolePrimary, 4))
+	c.Assert(err, IsNil)
+	err = node4.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+
+	waitReadWrite(c, node1Conn)
+	insertRow(c, node1Conn, 3)
+	node4Conn = connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	waitRow(c, node4Conn, 3)
+}

--- a/appliance/postgresql2/simulator/simulator.go
+++ b/appliance/postgresql2/simulator/simulator.go
@@ -1,0 +1,804 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//
+// This file is derived from
+// https://github.com/joyent/manatee-state-machine/blob/d441fe941faddb51d6e6237d792dd4d7fae64cc6/lib/sim.js
+// https://github.com/joyent/manatee-state-machine/blob/d441fe941faddb51d6e6237d792dd4d7fae64cc6/lib/sim-zk.js
+// https://github.com/joyent/manatee-state-machine/blob/d441fe941faddb51d6e6237d792dd4d7fae64cc6/lib/sim-pg.js
+//
+// Copyright (c) 2014, Joyent, Inc.
+// Copyright (c) 2015, Prime Directive, Inc.
+//
+
+package simulator
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/appliance/postgresql2/xlog"
+	"github.com/flynn/flynn/discoverd/client"
+)
+
+type commandFunc func([]string)
+type command struct {
+	Name     string
+	Help     string
+	Args     string
+	Func     commandFunc
+	WaitRest bool
+}
+
+const opLag = 1 * time.Millisecond
+
+type Simulator struct {
+	singleton bool
+	nextPeer  int
+
+	allIdents map[string]*discoverd.Instance
+
+	out       io.Writer
+	log       log15.Logger
+	postgres  *postgresSimulator
+	discoverd *discoverdSimulator
+	peer      *simPeer
+	restCh    chan struct{}
+	retryCh   chan struct{}
+	started   bool
+
+	commands       []*command
+	commandsByName map[string]*command
+}
+
+func New(singleton bool, out io.Writer, logOut io.Writer) *Simulator {
+	if logOut == nil {
+		logOut = out
+	}
+	s := &Simulator{
+		singleton: singleton,
+		allIdents: make(map[string]*discoverd.Instance),
+		out:       out,
+		log:       log15.New(),
+		restCh:    make(chan struct{}),
+		retryCh:   make(chan struct{}, 1),
+	}
+	s.discoverd = newDiscoverdSimulator(s.log.New("component", "discoverd"))
+	s.postgres = newPostgresSimulator(s.discoverd, s.log.New("component", "pg"))
+	s.peer = s.createSimPeer()
+	s.initCommands()
+	s.log.SetHandler(log15.StreamHandler(logOut, log15.LogfmtFormat()))
+	return s
+}
+
+func (s *Simulator) initCommands() {
+	s.commands = []*command{
+		{"addpeer", "simulate a new peer joining the discoverd cluster", "[NAME]", s.AddPeer, true},
+		{"bootstrap", "simulate initial setup", "PRIMARY [SYNC]", s.Bootstrap, true},
+		{"catchUp", "simulate peer's postgres catching up to primary", "", s.CatchUp, false},
+		{"depose", "simulate a takeover from the current config", "", s.Depose, true},
+		{"rebuild", "simulate rebuilding a deposed peer", "NAME", s.Rebuild, true},
+		{"echo", "emit the string to stdout", "STR", s.Echo, false},
+		{"freeze", "freeze cluster", "", s.Freeze, true},
+		{"help", "show help output", "", s.Help, false},
+		{"ident", "print the identity of the peer being tested", "", s.Ident, false},
+		{"lspeers", "list simulated peers", "", s.LsPeers, false},
+		{"peer", "dump peer's current state", "", s.Peer, false},
+		{"rmpeer", "simulate a peer being removed from the discoverd cluster", "ID", s.RmPeer, true},
+		{"setClusterState", "simulate a write to the cluster state stored in discoverd", "STATE", s.SetClusterState, true},
+		{"startPeer", "start the peer state machine", "", s.StartPeer, true},
+		{"unfreeze", "unfreeze the cluster", "", s.Unfreeze, true},
+		{"discoverd", "print simulated discoverd state", "", s.Discoverd, false},
+		{"exit", "exit the simulator", "", s.Exit, false},
+	}
+	s.commandsByName = make(map[string]*command, len(s.commands))
+	for _, c := range s.commands {
+		s.commandsByName[strings.ToLower(c.Name)] = c
+	}
+}
+
+func (s *Simulator) newPeerIdent(name string) *discoverd.Instance {
+	s.nextPeer++
+	if name == "" {
+		name = fmt.Sprintf("node%d", s.nextPeer)
+	}
+	inst := &discoverd.Instance{
+		Addr:  fmt.Sprintf("10.0.0.%d:5432", s.nextPeer),
+		Proto: "tcp",
+		Meta:  map[string]string{"name": name},
+	}
+	inst.ID = md5sum(inst.Proto + "-" + inst.Addr)
+	s.allIdents[name] = inst
+	return inst
+}
+
+type simPeer struct {
+	Self      *discoverd.Instance
+	Peer      *state.Peer
+	Discoverd *discoverdSimulatorClient
+	Postgres  *postgresSimulatorClient
+}
+
+func (s *Simulator) createSimPeer() *simPeer {
+	ident := s.newPeerIdent("")
+	dd := s.discoverd.NewClient(ident)
+	pg := s.postgres.NewClient(ident)
+	p := state.NewPeer(ident, s.singleton, dd, pg, s.log.New("component", "peer"))
+	p.SetDebugChannels(s.restCh, s.retryCh)
+
+	return &simPeer{
+		Self:      ident,
+		Discoverd: dd,
+		Postgres:  pg,
+		Peer:      p,
+	}
+}
+
+func (s *Simulator) jsonDump(v interface{}) {
+	data, _ := json.MarshalIndent(v, "", "\t")
+	fmt.Fprintln(s.out, string(data))
+}
+
+func (s *Simulator) Close() error {
+	return s.peer.Peer.Close()
+}
+
+func (s *Simulator) RunCommand(cmdline string) {
+	cmdArgs := strings.SplitN(cmdline, " ", 2)
+	name := cmdArgs[0]
+	var argStr string
+	if len(cmdArgs) > 1 {
+		argStr = cmdArgs[1]
+	}
+
+	cmd, ok := s.commandsByName[strings.ToLower(name)]
+	if !ok {
+		s.log.Error("unknown command", "name", name)
+		return
+	}
+
+	var retryLater bool
+	if strings.HasSuffix(argStr, "retrylater") {
+		retryLater = true
+		argStr = strings.TrimSuffix(argStr, "retrylater")
+	}
+
+	var args []string
+	if len(cmd.Args) > 0 {
+		args = strings.SplitN(strings.TrimSpace(argStr), " ", len(cmd.Args))
+	}
+	cmd.Func(args)
+
+	if s.started && retryLater {
+		select {
+		case <-s.retryCh:
+		case <-time.After(time.Second):
+			panic("timed out waiting for retry signal")
+		}
+	}
+	if s.started && cmd.WaitRest {
+		select {
+		case <-s.restCh:
+		case <-time.After(time.Second):
+			panic("timed out waiting for command to run")
+		}
+	}
+}
+
+func (s *Simulator) StartPeer(args []string) {
+	s.discoverd.PeerJoined(s.peer.Self)
+	go s.peer.Peer.Run()
+	s.peer.Discoverd.startSimulation()
+	s.peer.Postgres.startSimulation()
+	s.started = true
+}
+
+func (s *Simulator) Echo(args []string) {
+	if len(args) > 0 {
+		fmt.Fprintln(s.out, args[0])
+	}
+}
+
+func (s *Simulator) Exit(args []string) {
+	os.Exit(0)
+}
+
+func (s *Simulator) Help(args []string) {
+	w := tabwriter.NewWriter(s.out, 0, 8, 0, '\t', 0)
+	for _, c := range s.commands {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", c.Name, c.Args, c.Help)
+	}
+	w.Flush()
+}
+
+func (s *Simulator) Ident(args []string) {
+	fmt.Fprintln(s.out, s.peer.Self.ID, s.peer.Self.Addr)
+}
+
+type DiscoverdInfo struct {
+	State *state.DiscoverdState `json:"state"`
+	Peers []*discoverd.Instance `json:"peers"`
+}
+
+func (s *Simulator) Discoverd(args []string) {
+	s.jsonDump(DiscoverdInfo{
+		State: s.discoverd.ClusterState(),
+		Peers: s.discoverd.Peers(),
+	})
+}
+
+func (s *Simulator) AddPeer(args []string) {
+	var name string
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	peer := s.allIdents[name]
+	if peer == nil {
+		peer = s.newPeerIdent(name)
+	}
+	s.discoverd.PeerJoined(peer)
+
+	// If the primary is one of the simulated peers, then simulate the behavior
+	// where the primary adds new peers to the async list.
+	cs := s.discoverd.ClusterState()
+	if cs.State != nil && cs.State.Primary.ID != s.peer.Self.ID &&
+		peer.ID != cs.State.Primary.ID &&
+		cs.State.Sync != nil && cs.State.Sync.ID != peer.ID {
+		cs.State.Async = append(cs.State.Async, peer)
+		s.discoverd.SetClusterState(cs)
+	}
+
+	s.jsonDump(s.discoverd.Peers())
+}
+
+func (s *Simulator) RmPeer(args []string) {
+	if len(args) != 1 {
+		s.log.Error("missing peer name")
+		return
+	}
+	name := args[0]
+
+	if name != s.peer.Self.Meta["name"] {
+		s.discoverd.PeerRemoved(name)
+	}
+
+	cs := s.discoverd.ClusterState()
+	if cs.State != nil && cs.State.Primary.ID != s.peer.Self.ID {
+		for i, p := range cs.State.Async {
+			if p.Meta["name"] == name {
+				cs.State.Async = append(cs.State.Async[:i], cs.State.Async[i+1:]...)
+				s.discoverd.SetClusterState(cs)
+				break
+			}
+		}
+		if cs.State.Sync != nil && cs.State.Sync.Meta["name"] == name && len(cs.State.Async) > 0 {
+			cs.State.Generation++
+			cs.State.Sync = cs.State.Async[0]
+			cs.State.Async = cs.State.Async[1:]
+			s.discoverd.SetClusterState(cs)
+		}
+	}
+
+	s.jsonDump(s.discoverd.Peers())
+}
+
+func (s *Simulator) Bootstrap(args []string) {
+	cs := s.discoverd.ClusterState()
+	if cs.State != nil {
+		s.log.Error("cluster is already set up")
+		return
+	}
+
+	peers := s.discoverd.Peers()
+	if len(peers) < 2 {
+		s.log.Error("setup requires at least two peers")
+		return
+	}
+
+	var primaryName, syncName string
+	if len(args) > 0 {
+		primaryName = args[0]
+	}
+	if len(args) > 1 {
+		syncName = args[1]
+	}
+
+	cs.State = &state.State{
+		Generation: 1,
+		InitWAL:    xlog.Zero,
+	}
+	if primaryName != "" {
+		for _, p := range peers {
+			switch {
+			case p.Meta["name"] == primaryName:
+				cs.State.Primary = p
+			case syncName != "" && p.Meta["name"] == syncName:
+				cs.State.Sync = p
+			case syncName == "" && cs.State.Sync == nil:
+				cs.State.Sync = p
+			default:
+				cs.State.Async = append(cs.State.Async, p)
+			}
+		}
+		if cs.State.Primary == nil {
+			s.log.Error("requested primary not found", "name", primaryName)
+			return
+		}
+		if cs.State.Sync == nil {
+			s.log.Error("requested sync not found", "name", syncName)
+			return
+		}
+	} else {
+		cs.State.Primary = peers[0]
+		cs.State.Sync = peers[1]
+		cs.State.Async = peers[2:]
+		fmt.Fprintf(s.out, "selected %q as primary", cs.State.Primary.Meta["name"])
+	}
+
+	s.discoverd.SetClusterState(cs)
+	s.jsonDump(cs)
+}
+
+func (s *Simulator) CatchUp(args []string) {
+	s.peer.Postgres.catchUp()
+}
+
+func (s *Simulator) Depose(args []string) {
+	cs := s.discoverd.ClusterState()
+	if cs.State == nil {
+		s.log.Error("cluster is not yet configured (try `bootstrap`)")
+		return
+	}
+	if len(cs.State.Async) == 0 {
+		s.log.Error("cannot depose with no asyncs")
+		return
+	}
+
+	newWAL, err := xlog.Increment(cs.State.InitWAL, 10)
+	if err != nil {
+		panic(err)
+	}
+	cs.State = &state.State{
+		Generation: cs.State.Generation + 1,
+		Deposed:    append(cs.State.Deposed, cs.State.Primary),
+		Primary:    cs.State.Sync,
+		Sync:       cs.State.Async[0],
+		Async:      cs.State.Async[1:],
+		InitWAL:    newWAL,
+	}
+	s.discoverd.SetClusterState(cs)
+	s.jsonDump(cs)
+}
+
+func (s *Simulator) Rebuild(args []string) {
+	if len(args) == 0 {
+		s.log.Error("missing peer name argument")
+		return
+	}
+	name := args[0]
+
+	cs := s.discoverd.ClusterState()
+	if cs.State == nil {
+		s.log.Error("cluster is not yet configured (try `bootstrap`)")
+		return
+	}
+	var peer *discoverd.Instance
+
+	cs.State = cs.State.Clone()
+	newDeposed := make([]*discoverd.Instance, 0, len(cs.State.Deposed))
+	for _, p := range cs.State.Deposed {
+		if p.Meta["name"] == name {
+			peer = p
+			continue
+		}
+		newDeposed = append(newDeposed, p)
+	}
+	cs.State.Deposed = newDeposed
+	if peer == nil {
+		s.log.Error("peer is not deposed", "name", name)
+		return
+	}
+
+	// If we are simulating the current primary, make the newly rebuilt peer an
+	// async now.
+	if cs.State.Primary.ID != s.peer.Self.ID {
+		cs.State.Async = append(cs.State.Async, peer)
+	}
+
+	s.discoverd.SetClusterState(cs)
+	s.jsonDump(cs)
+}
+
+func (s *Simulator) Freeze(args []string) {
+	cs := s.discoverd.ClusterState()
+	cs.State.Freeze = &state.FreezeDetails{
+		FrozenAt: state.TimeNow(),
+		Reason:   "frozen by simulator",
+	}
+	s.discoverd.SetClusterState(cs)
+	s.jsonDump(cs)
+}
+
+func (s *Simulator) Unfreeze(args []string) {
+	cs := s.discoverd.ClusterState()
+	cs.State.Freeze = nil
+	s.discoverd.SetClusterState(cs)
+	s.jsonDump(cs)
+}
+
+func (s *Simulator) LsPeers(args []string) {
+	s.jsonDump(s.discoverd.Peers())
+}
+
+type PeerSimInfo struct {
+	Peer     *state.PeerInfo `json:"peer"`
+	Postgres *PostgresInfo   `json:"postgres"`
+}
+
+func (s *Simulator) Peer(args []string) {
+	s.jsonDump(PeerSimInfo{
+		Peer:     s.peer.Peer.Info(),
+		Postgres: s.peer.Postgres.Info(),
+	})
+}
+
+func (s *Simulator) SetClusterState(args []string) {
+	if len(args) == 0 {
+		s.log.Error("missing state")
+		return
+	}
+	cs := s.discoverd.ClusterState()
+	if err := json.Unmarshal([]byte(args[0]), &cs.State); err != nil {
+		s.log.Error("error decoding state", "err", err)
+		return
+	}
+	s.discoverd.SetClusterState(cs)
+}
+
+func md5sum(data string) string {
+	digest := md5.Sum([]byte(data))
+	return hex.EncodeToString(digest[:])
+}
+
+type discoverdSimulator struct {
+	sync.Mutex
+	log     log15.Logger
+	state   *state.DiscoverdState
+	peers   []*discoverd.Instance
+	clients []*discoverdSimulatorClient
+}
+
+func newDiscoverdSimulator(log log15.Logger) *discoverdSimulator {
+	return &discoverdSimulator{
+		log:   log,
+		state: &state.DiscoverdState{},
+	}
+}
+
+func (d *discoverdSimulator) NewClient(inst *discoverd.Instance) *discoverdSimulatorClient {
+	c := &discoverdSimulatorClient{
+		d:      d,
+		inst:   inst,
+		events: make(chan *state.DiscoverdEvent),
+	}
+	d.clients = append(d.clients, c)
+	return c
+}
+
+func (d *discoverdSimulator) PeerJoined(inst *discoverd.Instance) {
+	d.Lock()
+	defer d.Unlock()
+
+	for _, p := range d.peers {
+		if p.ID == inst.ID {
+			d.log.Error("peer already exists", "addr", inst.Addr)
+			return
+		}
+	}
+
+	inst.Index = 1
+	if len(d.peers) > 0 {
+		inst.Index = d.peers[len(d.peers)-1].Index + 1
+	}
+	inst = inst.Clone()
+	d.peers = append(d.peers, inst)
+	for _, c := range d.clients {
+		go c.notifyPeersChanged()
+	}
+}
+
+func (d *discoverdSimulator) PeerRemoved(name string) {
+	d.Lock()
+	defer d.Unlock()
+
+	removed := false
+	for i, p := range d.peers {
+		if p.Meta["name"] == name {
+			d.peers = append(d.peers[:i], d.peers[i+1:]...)
+			removed = true
+			break
+		}
+	}
+	if !removed {
+		d.log.Error("peer not present", "name", name)
+		return
+	}
+	for _, c := range d.clients {
+		go c.notifyPeersChanged()
+	}
+}
+
+func (d *discoverdSimulator) SetClusterState(s *state.DiscoverdState) {
+	d.Lock()
+	defer d.Unlock()
+
+	if d.state.Index != s.Index {
+		panic(fmt.Sprintf("incorrect state index, have %d, want %d", s.Index, d.state.Index))
+	}
+	d.state.Index++
+	d.state.State = s.State.Clone()
+	s.Index = d.state.Index
+	for _, c := range d.clients {
+		go c.notifyStateChanged()
+	}
+}
+
+func (d *discoverdSimulator) ClusterState() *state.DiscoverdState {
+	d.Lock()
+	defer d.Unlock()
+
+	return &state.DiscoverdState{
+		Index: d.state.Index,
+		State: d.state.State.Clone(),
+	}
+}
+
+func (d *discoverdSimulator) Peers() []*discoverd.Instance {
+	d.Lock()
+	defer d.Unlock()
+
+	res := make([]*discoverd.Instance, len(d.peers))
+	copy(res, d.peers)
+	return res
+}
+
+type discoverdSimulatorClient struct {
+	sync.RWMutex
+	d      *discoverdSimulator
+	inst   *discoverd.Instance
+	events chan *state.DiscoverdEvent
+	init   bool
+}
+
+func (d *discoverdSimulatorClient) SetState(s *state.DiscoverdState) error {
+	time.Sleep(opLag)
+	d.d.SetClusterState(s)
+	return nil
+}
+
+func (d *discoverdSimulatorClient) Events() <-chan *state.DiscoverdEvent {
+	return d.events
+}
+
+func (d *discoverdSimulatorClient) notifyPeersChanged() {
+	d.RLock()
+	defer d.RUnlock()
+
+	if !d.init {
+		return
+	}
+	d.events <- &state.DiscoverdEvent{
+		Kind:  state.DiscoverdEventPeers,
+		Peers: d.d.Peers(),
+	}
+}
+
+func (d *discoverdSimulatorClient) notifyStateChanged() {
+	d.RLock()
+	defer d.RUnlock()
+
+	if !d.init {
+		return
+	}
+	d.events <- &state.DiscoverdEvent{
+		Kind:  state.DiscoverdEventState,
+		State: d.d.ClusterState(),
+	}
+}
+
+func (d *discoverdSimulatorClient) startSimulation() {
+	d.events <- &state.DiscoverdEvent{
+		Kind:  state.DiscoverdEventInit,
+		State: d.d.ClusterState(),
+		Peers: d.d.Peers(),
+	}
+
+	d.Lock()
+	d.init = true
+	d.Unlock()
+}
+
+type postgresSimulator struct {
+	log log15.Logger
+	ds  *discoverdSimulator
+}
+
+func newPostgresSimulator(ds *discoverdSimulator, log log15.Logger) *postgresSimulator {
+	return &postgresSimulator{ds: ds, log: log}
+}
+
+func (p *postgresSimulator) NewClient(inst *discoverd.Instance) *postgresSimulatorClient {
+	c := &postgresSimulatorClient{
+		p:      p,
+		inst:   inst,
+		events: make(chan state.PostgresEvent),
+	}
+	c.XLog = xlog.Zero
+	return c
+}
+
+type postgresSimulatorClient struct {
+	p      *postgresSimulator
+	inst   *discoverd.Instance
+	events chan state.PostgresEvent
+
+	PostgresInfo
+}
+
+type PostgresInfo struct {
+	Config      *state.PgConfig `json:"config"`
+	Online      bool            `json:"online"`
+	XLog        xlog.Position   `json:"xlog"`
+	XLogWaiting xlog.Position   `json:"xlog_waiting,omitempty"`
+}
+
+func (p *postgresSimulatorClient) Info() *PostgresInfo {
+	return &p.PostgresInfo
+}
+
+func (p *postgresSimulatorClient) startSimulation() {
+	p.events <- state.PostgresEvent{}
+}
+
+func (p *postgresSimulatorClient) XLogPosition() (xlog.Position, error) {
+	time.Sleep(opLag)
+	if !p.Online {
+		return "", fmt.Errorf("postgres is offline")
+	}
+	return p.XLog, nil
+}
+
+func (p *postgresSimulatorClient) Reconfigure(conf *state.PgConfig) error {
+	s := p.p.ds.ClusterState()
+	if s.State == nil && conf.Role != state.RoleNone {
+		panic("attempted to configure postgres with no cluster state")
+	}
+
+	p.XLogWaiting = ""
+	p.p.log.Info("reconfiguring postgres")
+	time.Sleep(opLag)
+	p.Config = conf
+	p.updateXlog(s)
+
+	return nil
+}
+
+func (p *postgresSimulatorClient) Start() error {
+	if p.Config == nil {
+		panic("cannot call Start before configured")
+	}
+	if p.Online {
+		panic("cannot call Start while running")
+	}
+	if p.XLogWaiting != "" {
+		panic(fmt.Sprintf("unexpected xlog_waiting %q", p.XLogWaiting))
+	}
+
+	p.p.log.Info("starting postgres")
+	time.Sleep(opLag)
+	p.Online = true
+	p.updateXlog(p.p.ds.ClusterState())
+
+	return nil
+}
+
+func (p *postgresSimulatorClient) Stop() error {
+	if !p.Online {
+		panic("cannot call Stop while stopped")
+	}
+
+	p.p.log.Info("stopping postgres")
+	time.Sleep(opLag)
+	p.Online = false
+
+	return nil
+}
+
+func (p *postgresSimulatorClient) Ready() <-chan state.PostgresEvent {
+	return p.events
+}
+
+// Given the current state, figure out our current role and update our xlog
+// position accordingly. This is used when we assume a new role or when postgres
+// comes online in order to simulate client writes to the primary, synchronous
+// replication (and catch-up) on the sync, and asynchronous replication on the
+// other peers.
+func (p *postgresSimulatorClient) updateXlog(ds *state.DiscoverdState) {
+	if ds.State == nil || !p.Online || p.Config == nil {
+		return
+	}
+	s := ds.State
+
+	var role state.Role
+	switch {
+	case s.Primary.ID == p.inst.ID:
+		role = state.RolePrimary
+	case s.Sync.ID == p.inst.ID:
+		role = state.RoleSync
+	case p.Config.Role == state.RoleAsync:
+		role = state.RoleAsync
+	default:
+		role = state.RoleNone
+	}
+
+	// If the peer we're testing is an async or unassigned, we don't modify the
+	// transaction log position at all. We act as though these are getting
+	// arbitrarily far behind (since that should be fine).
+	if role == state.RoleAsync || role == state.RoleNone {
+		return
+	}
+
+	// If the peer we're testing is a primary, we act as though the sync
+	// instantly connected and caught up, and we start taking writes immediately
+	// and bump the transaction log position.
+	if role == state.RolePrimary {
+		if cmp, err := xlog.Compare(s.InitWAL, p.XLog); err != nil {
+			panic(err)
+		} else if cmp > 0 {
+			panic("primary is behind the generation's initial xlog")
+		}
+		var err error
+		p.XLog, err = xlog.Increment(p.XLog, 10)
+		if err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	// The most complicated case is the sync, for which we need to schedule the
+	// wal position to catch up to the primary's.
+	if role != state.RoleSync {
+		panic("unexpected role")
+	}
+	if cmp, err := xlog.Compare(s.InitWAL, p.XLog); err != nil {
+		panic(err)
+	} else if cmp < 0 {
+		panic("sync is ahead of primary")
+	}
+	p.XLogWaiting = s.InitWAL
+}
+
+func (p *postgresSimulatorClient) catchUp() {
+	if p.XLogWaiting == "" {
+		p.p.log.Error("catchUp when not sync or not currently waiting")
+	}
+	var err error
+	p.XLog, err = xlog.Increment(p.XLogWaiting, 10)
+	if err != nil {
+		panic(err)
+	}
+	p.XLogWaiting = ""
+}

--- a/appliance/postgresql2/state/state.go
+++ b/appliance/postgresql2/state/state.go
@@ -1,0 +1,1027 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//
+// This file is derived from
+// https://github.com/joyent/manatee-state-machine/blob/d441fe941faddb51d6e6237d792dd4d7fae64cc6/lib/manatee-peer.js
+//
+// Copyright (c) 2014, Joyent, Inc.
+// Copyright (c) 2015, Prime Directive, Inc.
+//
+
+package state
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/appliance/postgresql2/xlog"
+	"github.com/flynn/flynn/discoverd/client"
+)
+
+type State struct {
+	Generation int                   `json:"generation"`
+	Freeze     *FreezeDetails        `json:"freeze,omitempty"`
+	Singleton  bool                  `json:"singleton,omitempty"`
+	InitWAL    xlog.Position         `json:"init_wal"`
+	Primary    *discoverd.Instance   `json:"primary"`
+	Sync       *discoverd.Instance   `json:"sync"`
+	Async      []*discoverd.Instance `json:"async"`
+	Deposed    []*discoverd.Instance `json:"deposed,omitempty"`
+}
+
+func (s *State) Clone() *State {
+	if s == nil {
+		return nil
+	}
+	res := *s
+	if s.Freeze != nil {
+		f := *s.Freeze
+		res.Freeze = &f
+	}
+	if s.Async != nil {
+		res.Async = make([]*discoverd.Instance, len(s.Async))
+		copy(res.Async, s.Async)
+	}
+	if s.Deposed != nil {
+		res.Deposed = make([]*discoverd.Instance, len(s.Deposed))
+		copy(res.Deposed, s.Deposed)
+	}
+	return &res
+}
+
+type FreezeDetails struct {
+	FrozenAt time.Time `json:"frozen_at"`
+	Reason   string    `json:"reason"`
+}
+
+var TimeNow = func() time.Time {
+	return time.Now().UTC()
+}
+
+func NewFreezeDetails(reason string) *FreezeDetails {
+	return &FreezeDetails{
+		FrozenAt: TimeNow(),
+		Reason:   reason,
+	}
+}
+
+type Role int
+
+const (
+	RoleUnknown Role = iota
+	RolePrimary
+	RoleSync
+	RoleAsync
+	RoleUnassigned
+	RoleDeposed
+	RoleNone
+)
+
+var roleStrings = map[Role]string{
+	RoleUnknown:    "unknown",
+	RolePrimary:    "primary",
+	RoleSync:       "sync",
+	RoleAsync:      "async",
+	RoleUnassigned: "unassigned",
+	RoleDeposed:    "deposed",
+	RoleNone:       "none",
+}
+
+var roleJSON = make(map[string]Role, len(roleStrings))
+
+func init() {
+	for k, v := range roleStrings {
+		roleJSON[`"`+v+`"`] = k
+	}
+}
+
+func (r Role) String() string {
+	return roleStrings[r]
+}
+
+func (r Role) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, roleStrings[r])), nil
+}
+
+func (r *Role) UnmarshalJSON(b []byte) error {
+	*r = roleJSON[string(b)]
+	return nil
+}
+
+type PgConfig struct {
+	Role       Role                `json:"role"`
+	Upstream   *discoverd.Instance `json:"upstream"`
+	Downstream *discoverd.Instance `json:"downstream"`
+}
+
+func (x *PgConfig) Equal(y *PgConfig) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+
+	peersEqual := func(a, b *discoverd.Instance) bool {
+		if a == nil || b == nil {
+			return a == b
+		}
+		return a.ID == b.ID
+
+	}
+
+	return x.Role == y.Role && peersEqual(x.Upstream, y.Upstream) && peersEqual(x.Downstream, y.Downstream)
+}
+
+type Postgres interface {
+	XLogPosition() (xlog.Position, error)
+	Reconfigure(*PgConfig) error
+	Start() error
+	Stop() error
+
+	// Ready returns a channel that returns a single event when the interface
+	// is ready.
+	Ready() <-chan PostgresEvent
+}
+
+type Discoverd interface {
+	SetState(*DiscoverdState) error
+	Events() <-chan *DiscoverdEvent
+}
+
+type PostgresEvent struct {
+	Online bool
+	Setup  bool
+}
+
+type DiscoverdEventKind int
+
+const (
+	DiscoverdEventInit DiscoverdEventKind = iota
+	DiscoverdEventState
+	DiscoverdEventPeers
+)
+
+type DiscoverdState struct {
+	Index uint64 `json:"index"`
+	State *State `json:"state"`
+}
+
+type DiscoverdEvent struct {
+	Kind  DiscoverdEventKind
+	Peers []*discoverd.Instance
+	State *DiscoverdState
+}
+
+type Peer struct {
+	// Configuration
+	self      *discoverd.Instance
+	singleton bool
+
+	// External Interfaces
+	log       log15.Logger
+	discoverd Discoverd
+	postgres  Postgres
+
+	// Dynamic state
+	role          Role   // current role
+	generation    int    // last generation updated processed
+	updatingState *State // new state object
+
+	clusterStateIndex uint64                // last received cluster state index
+	clusterState      *State                // last received cluster state
+	clusterPeers      []*discoverd.Instance // last received list of peers
+
+	pgOnline       *bool     // nil for unknown
+	pgSetup        bool      // whether db existed at start
+	pgRetryCount   int       // consecutive failed retries
+	pgApplied      *PgConfig // last configuration applied
+	pgRetryPending *time.Time
+	pgUpstream     *discoverd.Instance // upstream replication target
+
+	evalStateCh chan struct{}
+	applyConfCh chan struct{}
+	restCh      chan struct{}
+	workDoneCh  chan struct{}
+	retryCh     chan struct{}
+	stopCh      chan struct{}
+}
+
+func NewPeer(self *discoverd.Instance, singleton bool, d Discoverd, pg Postgres, log log15.Logger) *Peer {
+	return &Peer{
+		self:        self,
+		singleton:   singleton,
+		postgres:    pg,
+		discoverd:   d,
+		log:         log,
+		evalStateCh: make(chan struct{}, 1),
+		applyConfCh: make(chan struct{}, 1),
+		stopCh:      make(chan struct{}),
+	}
+}
+
+func (p *Peer) SetDebugChannels(restCh, retryCh chan struct{}) {
+	p.restCh = restCh
+	p.retryCh = retryCh
+}
+
+func (p *Peer) Run() {
+	discoverdCh := p.discoverd.Events()
+	postgresCh := p.postgres.Ready()
+	for {
+		select {
+		// try to run any pending configuration first
+		case <-p.applyConfCh:
+			p.pgApplyConfig()
+			continue
+		case <-p.stopCh:
+			return
+		default:
+		}
+		select {
+		case e := <-discoverdCh:
+			p.handleDiscoverdEvent(e)
+			continue
+		case e := <-postgresCh:
+			p.handlePgInit(e)
+			continue
+		case <-p.evalStateCh:
+			p.evalClusterState()
+			continue
+		case <-p.applyConfCh:
+			p.pgApplyConfig()
+			continue
+		case <-p.stopCh:
+			return
+		default:
+			// There were no receivable channels, fallthrough to the select that
+			// includes the work done channel
+		}
+		select {
+		case e := <-discoverdCh:
+			p.handleDiscoverdEvent(e)
+		case e := <-postgresCh:
+			p.handlePgInit(e)
+		case <-p.evalStateCh:
+			p.evalClusterState()
+		case <-p.applyConfCh:
+			p.pgApplyConfig()
+		case <-p.workDoneCh:
+			// There is no work to do, we are now at rest
+			p.rest()
+		case <-p.stopCh:
+			return
+		}
+	}
+}
+
+func (p *Peer) Close() error {
+	close(p.stopCh)
+	return nil
+}
+
+type PeerInfo struct {
+	ID             string                `json:"id"`
+	Role           Role                  `json:"role"`
+	PgRetryPending *time.Time            `json:"pg_retry_pending,omitempty"`
+	Updating       bool                  `json:"updating,omitempty"`
+	State          *State                `json:"state"`
+	Peers          []*discoverd.Instance `json:"peers"`
+}
+
+func (p *Peer) Info() *PeerInfo {
+	return &PeerInfo{
+		ID:             p.self.ID,
+		Role:           p.role,
+		PgRetryPending: p.pgRetryPending,
+		State:          p.clusterState,
+		Peers:          p.clusterPeers,
+	}
+}
+
+func (p *Peer) handlePgInit(e PostgresEvent) {
+	p.log.Info("postgres init", "online", e.Online, "setup", e.Setup)
+	if p.pgOnline != nil {
+		panic("received postgres init event after already initialized")
+	}
+
+	p.pgOnline = &e.Online
+	p.pgSetup = e.Setup
+
+	if p.clusterPeers != nil {
+		p.evalClusterState()
+	}
+}
+
+func (p *Peer) handleDiscoverdEvent(e *DiscoverdEvent) {
+	switch e.Kind {
+	case DiscoverdEventInit:
+		p.handleDiscoverdInit(e)
+	case DiscoverdEventState:
+		p.handleDiscoverdState(e)
+	case DiscoverdEventPeers:
+		p.handleDiscoverdPeers(e)
+	}
+}
+
+func (p *Peer) handleDiscoverdInit(e *DiscoverdEvent) {
+	p.log.Info("discoverd init", "peers", len(e.Peers), "state", e.State.State != nil)
+	if p.clusterState != nil {
+		panic("received discoverd init after already initialized")
+	}
+	p.clusterPeers = e.Peers
+	p.decodeState(e)
+	if p.pgOnline != nil {
+		p.evalClusterState()
+	}
+}
+
+func (p *Peer) handleDiscoverdPeers(e *DiscoverdEvent) {
+	p.log.Info("discoverd peers", "peers", len(e.Peers))
+	if p.clusterPeers == nil {
+		panic("received discoverd peers before init")
+	}
+	p.clusterPeers = e.Peers
+	p.evalClusterState()
+}
+
+func (p *Peer) handleDiscoverdState(e *DiscoverdEvent) {
+	log := p.log.New("fn", "handleDiscoverdState", "index", e.State.Index)
+	log.Info("got discoverd state", "state", e.State.State != nil)
+	if p.clusterPeers == nil {
+		panic("received discoverd state before init")
+	}
+	if p.decodeState(e) {
+		p.evalClusterState()
+	} else {
+		log.Info("already have this state")
+	}
+}
+
+func (p *Peer) decodeState(e *DiscoverdEvent) bool {
+	if e.State.Index > p.clusterStateIndex {
+		p.clusterStateIndex = e.State.Index
+		p.clusterState = e.State.State
+		return true
+	}
+	return false
+}
+
+// evalLater triggers a cluster state evaluation after delay has elapsed
+func (p *Peer) evalLater(delay time.Duration) {
+	if p.retryCh != nil {
+		p.retryCh <- struct{}{}
+		return
+	}
+	time.AfterFunc(delay, p.triggerEval)
+}
+
+func (p *Peer) applyConfigLater(delay time.Duration) {
+	if p.retryCh != nil {
+		p.retryCh <- struct{}{}
+		return
+	}
+	time.AfterFunc(delay, p.triggerApplyConfig)
+}
+
+func (p *Peer) triggerEval() {
+	select {
+	case p.evalStateCh <- struct{}{}:
+	default:
+		// if we can't send to the channel, there is already a pending state
+		// evaluation, as it is buffered
+	}
+}
+
+func (p *Peer) triggerApplyConfig() {
+	select {
+	case p.applyConfCh <- struct{}{}:
+	default:
+		// if we can't send to the channel, there is already a pending
+		// configuration, as it is buffered
+	}
+}
+
+func (p *Peer) moving() {
+	if !p.atRest() {
+		return
+	}
+	p.log.Debug("moving")
+
+	// Set up a channel that the select in the run loop can use to detect
+	// when there is no more work to do.
+	p.workDoneCh = make(chan struct{}, 1)
+	p.workDoneCh <- struct{}{}
+}
+
+func (p *Peer) rest() {
+	p.log.Debug("at rest", "fn", "rest")
+	p.workDoneCh = nil
+	if p.restCh != nil {
+		p.restCh <- struct{}{}
+	}
+}
+
+func (p *Peer) atRest() bool {
+	return p.workDoneCh == nil
+}
+
+// Examine the current cluster state and determine if new actions need to be
+// taken. For example, if we're the primary, and there's no sync present, then
+// we need to declare a new generation.
+func (p *Peer) evalClusterState() {
+	p.moving()
+	log := p.log.New("fn", "evalClusterState")
+	log.Info("starting state evaluation")
+
+	// If there's no cluster state, check whether we should set up the cluster.
+	// If not, wait for something else to happen.
+	if p.clusterState == nil {
+		log.Debug("no cluster state")
+
+		if !p.pgSetup &&
+			p.clusterPeers[0].ID == p.self.ID &&
+			(p.singleton || len(p.clusterPeers) > 1) {
+			p.startInitialSetup()
+		} else if p.role != RoleUnassigned {
+			p.assumeUnassigned()
+		}
+
+		return
+	}
+
+	// Bail out if we're configured for singleton mode but the cluster is not.
+	if p.singleton && !p.clusterState.Singleton {
+		panic("configured for singleton mode but cluster found in normal mode")
+	}
+
+	// If the generation has changed, then go back to square one (unless we
+	// think we're the primary but no longer are, in which case it's game over).
+	// This may cause us to update our role and then trigger another call to
+	// evalClusterState() to deal with any other changes required. We update
+	// p.generation so that we know that we've handled the generation change
+	// already.
+	if p.generation != p.clusterState.Generation {
+		p.generation = p.clusterState.Generation
+
+		if p.role == RolePrimary {
+			if p.clusterState.Primary.ID != p.self.ID {
+				p.assumeDeposed()
+			}
+		} else {
+			p.evalInitClusterState()
+		}
+
+		return
+	}
+
+	// Unassigned peers and async peers only need to watch their position in the
+	// async peer list and reconfigure themselves as needed
+	if p.role == RoleUnassigned {
+		if i := p.whichAsync(); i != -1 {
+			p.assumeAsync(i)
+		}
+		return
+	}
+
+	if p.role == RoleAsync {
+		if whichAsync := p.whichAsync(); whichAsync == -1 {
+			p.assumeUnassigned()
+		} else {
+			upstream := p.upstream(whichAsync)
+			if upstream.ID != p.pgUpstream.ID {
+				p.assumeAsync(whichAsync)
+			}
+		}
+		return
+	}
+
+	// The synchronous peer needs to check the takeover condition, which is that
+	// the primary has disappeared and the sync's WAL has caught up enough to
+	// takeover as primary.
+	if p.role == RoleSync {
+		if !p.peerIsPresent(p.clusterState.Primary) {
+			p.startTakeover("primary gone", p.clusterState.InitWAL)
+		}
+		return
+	}
+
+	if p.role != RolePrimary {
+		panic(fmt.Sprintf("unexpected role %v", p.role))
+	}
+
+	if p.clusterState.Freeze != nil {
+		log.Info("cluster frozen, not making any changes")
+		return
+	}
+
+	if !p.singleton && p.clusterState.Singleton {
+		log.Info("configured for normal mode but found cluster in singleton mode, transitioning cluster to normal mode")
+		if p.clusterState.Primary.ID != p.self.ID {
+			panic(fmt.Sprintf("unexpected cluster state, we should be the primary, but %s is", p.clusterState.Primary.ID))
+		}
+		p.startTransitionToNormalMode()
+		return
+	}
+
+	// The primary peer needs to check not just for liveness of the synchronous
+	// peer, but also for other new or removed peers. We only do this in normal
+	// mode, not one-node-write mode.
+	if p.singleton {
+		return
+	}
+
+	// TODO: It would be nice to process the async peers showing up and
+	// disappearing as part of the same cluster state change update as our
+	// takeover attempt. As long as we're not, though, we must handle the case
+	// that we go to start a takeover, but we cannot proceed because there are
+	// no asyncs. In that case, we want to go ahead and process the asyncs, then
+	// consider a takeover the next time around. If we update this to handle
+	// both operations at once, we can get rid of the goofy boolean returned by
+	// startTakeover.
+	if !p.peerIsPresent(p.clusterState.Sync) &&
+		p.startTakeover("sync gone", p.clusterState.InitWAL) {
+		return
+	}
+
+	presentPeers := make(map[string]struct{}, len(p.clusterPeers))
+	presentPeers[p.clusterState.Primary.ID] = struct{}{}
+	presentPeers[p.clusterState.Sync.ID] = struct{}{}
+
+	newAsync := make([]*discoverd.Instance, 0, len(p.clusterPeers))
+	changes := false
+
+	for _, a := range p.clusterState.Async {
+		if p.peerIsPresent(a) {
+			presentPeers[a.ID] = struct{}{}
+			newAsync = append(newAsync, a)
+		} else {
+			log.Debug("peer missing", "async.id", a.ID, "async.addr", a.Addr)
+			changes = true
+		}
+	}
+
+	// Deposed peers should not be assigned as asyncs
+	for _, d := range p.clusterState.Deposed {
+		presentPeers[d.ID] = struct{}{}
+	}
+
+	for _, peer := range p.clusterPeers {
+		if _, ok := presentPeers[peer.ID]; ok {
+			continue
+		}
+		log.Debug("new peer", "async.id", peer.ID, "async.addr", peer.Addr)
+		newAsync = append(newAsync, peer)
+		changes = true
+	}
+
+	if !changes {
+		return
+	}
+
+	p.startUpdateAsyncs(newAsync)
+}
+
+func (p *Peer) startInitialSetup() {
+	if p.updatingState != nil {
+		panic("already have updating state")
+	}
+
+	p.updatingState = &State{
+		Generation: 1,
+		Primary:    p.self,
+		InitWAL:    xlog.Zero,
+	}
+	if p.singleton {
+		p.updatingState.Singleton = true
+		p.updatingState.Freeze = NewFreezeDetails("cluster started in singleton mode")
+	} else {
+		p.updatingState.Sync = p.clusterPeers[1]
+		p.updatingState.Async = p.clusterPeers[2:]
+	}
+	log := p.log.New("fn", "startInitialSetup")
+	log.Info("creating initial cluster state", "generation", 1)
+
+	if err := p.putClusterState(); err != nil {
+		log.Error("failed to create cluster state", "err", err)
+		p.evalLater(1 * time.Second)
+		return
+	} else {
+		p.clusterState = p.updatingState
+	}
+	p.updatingState = nil
+
+	p.triggerEval()
+}
+
+func (p *Peer) assumeUnassigned() {
+	p.log.Info("assuming unassigned role", "role", "unassigned", "fn", "assumeUnassigned")
+	p.role = RoleUnassigned
+	p.pgUpstream = nil
+	p.triggerApplyConfig()
+}
+
+func (p *Peer) assumeDeposed() {
+	p.log.Info("assuming deposed role", "role", "deposed", "fn", "assumeDeposed")
+	p.role = RoleDeposed
+	p.pgUpstream = nil
+	p.triggerApplyConfig()
+}
+
+func (p *Peer) assumePrimary() {
+	p.log.Info("assuming primary role", "role", "primary", "fn", "assumePrimary")
+	p.role = RolePrimary
+	p.pgUpstream = nil
+
+	// It simplifies things to say that evalClusterState() only deals with one
+	// change at a time. Now that we've handled the change to become primary,
+	// check for other changes.
+	//
+	// For example, we may have just read the initial state that identifies us
+	// as the primary, and we may also discover that the synchronous peer is
+	// not present. The first call to evalClusterState() will get us here, and
+	// we call it again to check for the presence of the synchronous peer.
+	//
+	// We invoke pgApplyConfig() after evalClusterState(), though it may well
+	// turn out that evalClusterState() kicked off an operation that will
+	// change the desired postgres configuration. In that case, we'll end up
+	// calling pgApplyConfig() again.
+	p.evalClusterState()
+	p.triggerApplyConfig()
+}
+
+func (p *Peer) assumeSync() {
+	if p.singleton {
+		panic("assumeSync as singleton")
+	}
+	p.log.Info("assuming sync role", "role", "sync", "fn", "assumeSync")
+
+	p.role = RoleSync
+	p.pgUpstream = p.clusterState.Primary
+	// See assumePrimary()
+	p.evalClusterState()
+	p.triggerApplyConfig()
+}
+
+func (p *Peer) assumeAsync(i int) {
+	if p.singleton {
+		panic("assumeAsync as singleton")
+	}
+	p.log.Info("assuming async role", "role", "async", "fn", "assumeAsync")
+
+	p.role = RoleAsync
+	p.pgUpstream = p.upstream(i)
+
+	// See assumePrimary(). We don't need to check the cluster state here
+	// because there's never more than one thing to do when becoming the async
+	// peer.
+	p.triggerApplyConfig()
+}
+
+func (p *Peer) evalInitClusterState() {
+	if p.clusterState.Primary.ID == p.self.ID {
+		p.assumePrimary()
+		return
+	}
+	if p.clusterState.Singleton {
+		p.assumeUnassigned()
+		return
+	}
+	if p.clusterState.Sync.ID == p.self.ID {
+		p.assumeSync()
+		return
+	}
+
+	for _, d := range p.clusterState.Deposed {
+		if p.self.ID == d.ID {
+			p.assumeDeposed()
+			return
+		}
+	}
+
+	// If we're an async, figure out which one we are.
+	if i := p.whichAsync(); i != -1 {
+		p.assumeAsync(i)
+		return
+	}
+
+	p.assumeUnassigned()
+}
+
+func (p *Peer) startTakeover(reason string, minWAL xlog.Position) bool {
+	log := p.log.New("fn", "startTakeover", "reason", reason, "min_wal", minWAL)
+
+	// Select the first present async peer to be the next sync
+	var newSync *discoverd.Instance
+	for _, a := range p.clusterState.Async {
+		if p.peerIsPresent(a) {
+			newSync = a
+			break
+		}
+	}
+	if newSync == nil {
+		log.Warn("would takeover but no async peers present")
+		return false
+	}
+
+	log.Debug("preparing for new generation")
+	newAsync := make([]*discoverd.Instance, 0, len(p.clusterState.Async))
+	for _, a := range p.clusterState.Async {
+		if a.ID != newSync.ID && p.peerIsPresent(a) {
+			newAsync = append(newAsync, a)
+		}
+	}
+
+	newDeposed := append(make([]*discoverd.Instance, 0, len(p.clusterState.Deposed)+1), p.clusterState.Deposed...)
+	if p.clusterState.Primary.ID != p.self.ID {
+		newDeposed = append(newDeposed, p.clusterState.Primary)
+	}
+
+	p.startTakeoverWithPeer(reason, minWAL, &State{
+		Sync:    newSync,
+		Async:   newAsync,
+		Deposed: newDeposed,
+	})
+	return true
+}
+
+var (
+	ErrClusterFrozen   = errors.New("cluster is frozen")
+	ErrPostgresOffline = errors.New("postgres is offline")
+	ErrPeerNotCaughtUp = errors.New("peer is not caught up")
+)
+
+func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newState *State) (err error) {
+	log := p.log.New("fn", "startTakeoverWithPeer", "reason", reason, "min_wal", minWAL)
+	log.Info("starting takeover")
+
+	if p.updatingState != nil {
+		panic("startTakeoverWithPeer with non-nil updatingState")
+	}
+	newState.Generation = p.clusterState.Generation + 1
+	newState.Primary = p.self
+	p.updatingState = newState
+
+	if p.updatingState.Primary.ID != p.clusterState.Primary.ID && len(p.updatingState.Deposed) == 0 {
+		panic("startTakeoverWithPeer without deposing old primary")
+	}
+
+	defer func() {
+		if err == nil {
+			return
+		}
+		p.updatingState = nil
+
+		switch err {
+		case ErrPostgresOffline:
+			// If postgres is offline, it's because we haven't started yet, so
+			// trigger another state evaluation after we start it.
+			log.Error("failed to declare new generation, trying later", "err", err)
+			p.triggerEval()
+		case ErrClusterFrozen:
+			log.Error("failed to declare new generation", "err", err)
+		default:
+			// In the event of an error, back off a bit and check state again in
+			// a second. There are several transient failure modes that will resolve
+			// themselves (e.g. postgres synchronous replication not yet caught up).
+			log.Error("failed to declare new generation, backing off", "err", err)
+			p.evalLater(1 * time.Second)
+		}
+	}()
+
+	if p.clusterState.Freeze != nil {
+		return ErrClusterFrozen
+	}
+
+	// In order to declare a new generation, we'll need to fetch our current
+	// transaction log position, which requires that postres be online. In most
+	// cases, it will be, since we only declare a new generation as a primary or
+	// a caught-up sync. During initial startup, however, we may find out
+	// simultaneously that we're the primary or sync AND that the other is gone,
+	// so we may attempt to declare a new generation before we've started
+	// postgres. In this case, this step will fail, but we'll just skip the
+	// takeover attempt until postgres is running.
+	if !*p.pgOnline {
+		return ErrPostgresOffline
+	}
+	wal, err := p.postgres.XLogPosition()
+	if err != nil {
+		return err
+	}
+	if x, err := xlog.Compare(wal, minWAL); err != nil || x < 0 {
+		if err == nil {
+			log.Warn("would attempt takeover but not caught up with primary yet", "found_wal", wal)
+			err = ErrPeerNotCaughtUp
+		}
+		return err
+	}
+	p.updatingState.InitWAL = wal
+	log.Info("declaring new generation")
+
+	if err := p.putClusterState(); err != nil {
+		return err
+	}
+
+	p.clusterState = p.updatingState
+	p.updatingState = nil
+	p.generation = p.clusterState.Generation
+	log.Info("declared new generation", "generation", p.clusterState.Generation)
+
+	// assumePrimary() calls evalClusterState() to catch any
+	// changes we missed while we were updating.
+	p.assumePrimary()
+
+	return nil
+}
+
+// As the primary, converts the current cluster to normal mode from singleton
+// mode.
+func (p *Peer) startTransitionToNormalMode() {
+	log := p.log.New("fn", "startTransitionToNormalMode")
+	if p.clusterState.Primary.ID != p.self.ID || p.role != RolePrimary {
+		panic("startTransitionToNormalMode called when not primary")
+	}
+
+	// In the normal takeover case, we'd pick an async. In this case, we take
+	// any other peer because we know none of them has anything replicated.
+	var newSync *discoverd.Instance
+	for _, peer := range p.clusterPeers {
+		if peer.ID != p.self.ID {
+			newSync = peer
+		}
+	}
+	if newSync == nil {
+		log.Warn("would takeover but no peers present")
+		return
+	}
+	newAsync := make([]*discoverd.Instance, 0, len(p.clusterPeers))
+	for _, a := range p.clusterPeers {
+		if a.ID != p.self.ID && a.ID != newSync.ID {
+			newAsync = append(newAsync, a)
+		}
+	}
+
+	log.Debug("transitioning to normal mode")
+	p.startTakeoverWithPeer("transitioning to normal mode", xlog.Zero, &State{
+		Sync:  newSync,
+		Async: newAsync,
+	})
+}
+
+func (p *Peer) startUpdateAsyncs(newAsync []*discoverd.Instance) {
+	if p.updatingState != nil {
+		panic("startUpdateAsyncs with existing update state")
+	}
+	log := p.log.New("fn", "startUpdateAsyncs")
+
+	p.updatingState = &State{
+		Generation: p.clusterState.Generation,
+		Primary:    p.clusterState.Primary,
+		Sync:       p.clusterState.Sync,
+		Async:      newAsync,
+		Deposed:    p.clusterState.Deposed,
+		InitWAL:    p.clusterState.InitWAL,
+	}
+	log.Info("updating list of asyncs")
+	if err := p.putClusterState(); err != nil {
+		log.Error("failed to update cluster state", "err", err)
+	} else {
+		p.clusterState = p.updatingState
+	}
+	p.updatingState = nil
+
+	p.triggerEval()
+}
+
+// Reconfigure postgres based on the current configuration. During
+// reconfiguration, new requests to reconfigure will be ignored, and incoming
+// cluster state changes will be recorded but otherwise ignored. When
+// reconfiguration completes, if the desired configuration has changed, we'll
+// take another lap to apply the updated configuration.
+func (p *Peer) pgApplyConfig() (err error) {
+	p.moving()
+	log := p.log.New("fn", "pgApplyConfig")
+
+	if p.pgOnline == nil {
+		panic("pgApplyConfig with postgres in unknown state")
+	}
+
+	config := p.pgConfig()
+	if p.pgApplied != nil && p.pgApplied.Equal(config) {
+		log.Info("skipping config apply, no changes")
+		return nil
+	}
+
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		// This is a very unexpected error, and it's very unclear how to deal
+		// with it. If we're the primary or sync, we might be tempted to
+		// abdicate our position. But without understanding the failure mode,
+		// there's no reason to believe any other peer is in a better position
+		// to deal with this, and we don't want to flap unnecessarily. So just
+		// log an error and try again shortly.
+		log.Error("error applying pg config", "err", err)
+		t := TimeNow()
+		p.pgRetryPending = &t
+		p.applyConfigLater(1 * time.Second)
+	}()
+
+	log.Info("reconfiguring postgres")
+	if err := p.postgres.Reconfigure(config); err != nil {
+		return err
+	}
+
+	if config.Role != RoleNone {
+		if *p.pgOnline {
+			log.Debug("skipping start, already online")
+		} else {
+			log.Debug("starting postgres")
+			if err := p.postgres.Start(); err != nil {
+				return err
+			}
+		}
+	} else {
+		if *p.pgOnline {
+			log.Debug("stopping postgres")
+			if err := p.postgres.Stop(); err != nil {
+				return err
+			}
+		} else {
+			log.Debug("skipping stop, already offline")
+		}
+	}
+
+	log.Info("applied pg config")
+	p.pgRetryPending = nil
+	p.pgApplied = config
+	online := config.Role != RoleNone
+	p.pgOnline = &online
+
+	// Try applying the configuration again in case anything's
+	// changed. If not, this will be a no-op.
+	p.triggerApplyConfig()
+	return nil
+}
+
+func (p *Peer) pgConfig() *PgConfig {
+	switch p.role {
+	case RolePrimary:
+		return &PgConfig{Role: p.role, Downstream: p.clusterState.Sync}
+	case RoleSync, RoleAsync:
+		return &PgConfig{Role: p.role, Upstream: p.pgUpstream}
+	case RoleUnassigned, RoleDeposed:
+		return &PgConfig{Role: RoleNone}
+	default:
+		panic(fmt.Sprintf("unexpected role %v", p.role))
+	}
+}
+
+// Determine our index in the async peer list. -1 means not present.
+func (p *Peer) whichAsync() int {
+	for i, a := range p.clusterState.Async {
+		if p.self.ID == a.ID {
+			return i
+		}
+	}
+	return -1
+}
+
+// Return the upstream peer for a given one of the async peers
+func (p *Peer) upstream(whichAsync int) *discoverd.Instance {
+	if whichAsync == 0 {
+		return p.clusterState.Sync
+	}
+	return p.clusterState.Async[whichAsync-1]
+}
+
+// Returns true if the given other peer appears to be present in the most
+// recently received list of present peers.
+func (p *Peer) peerIsPresent(other *discoverd.Instance) bool {
+	// We should never even be asking whether we're present. If we need to do
+	// this at some point in the future, we need to consider we should always
+	// consider ourselves present or whether we should check the list.
+	if other.ID == p.self.ID {
+		panic("peerIsPresent with self")
+	}
+	for _, p := range p.clusterPeers {
+		if p.ID == other.ID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *Peer) putClusterState() error {
+	s := &DiscoverdState{State: p.updatingState, Index: p.clusterStateIndex}
+	if err := p.discoverd.SetState(s); err != nil {
+		return err
+	}
+	p.clusterStateIndex = s.Index
+	return nil
+}

--- a/appliance/postgresql2/state/state_test.go
+++ b/appliance/postgresql2/state/state_test.go
@@ -1,0 +1,2137 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//
+// This file is derived from the files in this tree:
+// https://github.com/joyent/manatee-state-machine/tree/d441fe941faddb51d6e6237d792dd4d7fae64cc6/test
+//
+// Copyright (c) 2014, Joyent, Inc.
+// Copyright (c) 2015, Prime Directive, Inc.
+//
+
+package state_test
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty"
+	"github.com/flynn/flynn/appliance/postgresql2/simulator"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/appliance/postgresql2/xlog"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/iotool"
+)
+
+type step struct {
+	Cmd   string
+	Check interface{}
+	JSON  interface{}
+}
+
+var fakeTime = time.Now().UTC()
+
+func init() {
+	state.TimeNow = func() time.Time { return fakeTime }
+}
+
+func runSteps(t *testing.T, singleton bool, steps []step) {
+	logOut := &bytes.Buffer{}
+	logOut.WriteByte('\n')
+	logW := &iotool.SafeWriter{W: logOut}
+	defer func() {
+		logW.SetWriter(nil) // disable writes to avoid races
+		t.Log(logOut)
+	}()
+
+	dataOut := &bytes.Buffer{}
+	sim := simulator.New(singleton, dataOut, logW)
+	defer sim.Close()
+
+	for _, step := range steps {
+		if step.JSON != nil {
+			jsonData, _ := json.Marshal(step.JSON)
+			step.Cmd = fmt.Sprintf("%s %s", step.Cmd, string(jsonData))
+		}
+
+		fmt.Fprintf(logW, "== %s\n", step.Cmd)
+		sim.RunCommand(step.Cmd)
+		if step.Check != nil {
+			actual := reflect.New(reflect.Indirect(reflect.ValueOf(step.Check)).Type()).Interface()
+			if err := json.Unmarshal(dataOut.Bytes(), actual); err != nil {
+				t.Fatal("json decode error", err)
+			}
+			if diff := pretty.Compare(step.Check, actual); diff != "" {
+				t.Fatalf("check failed:\n%s", diff)
+			}
+		}
+		dataOut.Reset()
+	}
+}
+
+func node(n int, index uint64) *discoverd.Instance {
+	inst := &discoverd.Instance{
+		Addr:  fmt.Sprintf("10.0.0.%d:5432", n),
+		Proto: "tcp",
+		Meta:  map[string]string{"name": fmt.Sprintf("node%d", n)},
+		Index: index,
+	}
+	inst.ID = md5sum(inst.Proto + "-" + inst.Addr)
+	return inst
+}
+
+func md5sum(data string) string {
+	digest := md5.Sum([]byte(data))
+	return hex.EncodeToString(digest[:])
+}
+
+var node1ID = node(1, 1).ID
+
+var pgOffline = &simulator.PostgresInfo{
+	Online: false,
+	Config: &state.PgConfig{Role: state.RoleNone},
+	XLog:   xlog.Zero,
+}
+
+// tests the basic flow of unassigned -> async -> sync -> primary
+func TestBasic(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		Sync:       node(3, 2),
+		Async:      []*discoverd.Instance{node(1, 3)},
+		InitWAL:    xlog.Zero,
+	}
+	peers := []*discoverd.Instance{node(2, 1), node(3, 2), node(1, 3)}
+
+	gen2_0 := &state.State{
+		Generation: 2,
+		InitWAL:    "0/0000000A",
+		Primary:    node(3, 2),
+		Sync:       node(1, 3),
+		Deposed:    []*discoverd.Instance{node(2, 1)},
+	}
+	gen2_1 := &state.State{
+		Generation: 2,
+		InitWAL:    "0/0000000A",
+		Primary:    node(3, 2),
+		Sync:       node(1, 3),
+		Async:      []*discoverd.Instance{node(2, 1)},
+		Deposed:    []*discoverd.Instance{},
+	}
+
+	pgSync := &simulator.PostgresInfo{
+		Config: &state.PgConfig{
+			Role:     state.RoleSync,
+			Upstream: node(3, 2),
+		},
+		Online:      true,
+		XLog:        xlog.Zero,
+		XLogWaiting: "0/0000000A",
+	}
+	pgPrimary := &simulator.PostgresInfo{
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(2, 1),
+		},
+		Online: true,
+		XLog:   "0/0000001E",
+	}
+	pgPrimary2 := &simulator.PostgresInfo{
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(3, 4),
+		},
+		Online: true,
+		XLog:   "0/00000028",
+	}
+
+	runSteps(t, false, []step{
+		// validate initial state
+		{Cmd: "echo test: validating initial state"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{Index: 0},
+				Peers: []*discoverd.Instance{},
+			},
+		},
+
+		// validate addpeer
+		{Cmd: "echo test: addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{Index: 0},
+				Peers: peers,
+			},
+		},
+
+		// validate bootstrap
+		{Cmd: "echo test: bootstrap"},
+		{Cmd: "bootstrap node2 node3"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{Index: 1, State: gen1},
+				Peers: peers,
+			},
+		},
+
+		// validate initial peer state
+		{Cmd: "echo test: initial peer state"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer:     &state.PeerInfo{ID: node1ID},
+				Postgres: &simulator.PostgresInfo{XLog: xlog.Zero},
+			},
+		},
+
+		// bring up the peer as an async
+		{Cmd: "echo test: start up as async"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleAsync,
+					Peers: peers,
+					State: gen1,
+				},
+				Postgres: &simulator.PostgresInfo{
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(3, 2),
+					},
+					Online: true,
+					XLog:   xlog.Zero,
+				},
+			},
+		},
+
+		// depose the primary and make sure that our peer comes up as the sync
+		{Cmd: "echo test: depose"},
+		{Cmd: "depose"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: peers,
+					State: gen2_0,
+				},
+				Postgres: pgSync,
+			},
+		},
+
+		// rebuild the deposed sync and ensure it shows up in the state
+		{Cmd: "echo test: rebuild"},
+		{Cmd: "rebuild node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: peers,
+					State: gen2_1,
+				},
+				Postgres: pgSync,
+			},
+		},
+
+		// At this point if the primary fails, our peer should not take over
+		// because it has not caught up.
+		{Cmd: "echo test: no catch up and remove primary"},
+		{Cmd: "rmpeer node3 retrylater"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 3)},
+					State: gen2_1,
+				},
+				Postgres: pgSync,
+			},
+		},
+		{Cmd: "addpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 3), node(3, 4)},
+					State: gen2_1,
+				},
+				Postgres: pgSync,
+			},
+		},
+
+		// Now if we issue a catchUp and do the same thing, our peer should
+		// become the primary.
+		{Cmd: "echo test: catch up and remove primary"},
+		{Cmd: "catchup"},
+		{Cmd: "rmpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 3)},
+					State: &state.State{
+						Generation: 3,
+						InitWAL:    "0/00000014",
+						Primary:    node(1, 3),
+						Sync:       node(2, 1),
+						Deposed:    []*discoverd.Instance{node(3, 2)},
+					},
+				},
+				Postgres: pgPrimary,
+			},
+		},
+		{Cmd: "rebuild node3"},
+		{Cmd: "addpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 3), node(3, 4)},
+					State: &state.State{
+						Generation: 3,
+						InitWAL:    "0/00000014",
+						Primary:    node(1, 3),
+						Sync:       node(2, 1),
+						Async:      []*discoverd.Instance{node(3, 4)},
+					},
+				},
+				Postgres: pgPrimary,
+			},
+		},
+
+		// Now have the sync fail. Our peer should promote the async.
+		{Cmd: "echo test: sync fail"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 3), node(3, 4)},
+					State: &state.State{
+						Generation: 4,
+						InitWAL:    "0/0000001E",
+						Primary:    node(1, 3),
+						Sync:       node(3, 4),
+					},
+				},
+				Postgres: pgPrimary2,
+			},
+		},
+		{Cmd: "addpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 3), node(3, 4), node(2, 5)},
+					State: &state.State{
+						Generation: 4,
+						InitWAL:    "0/0000001E",
+						Primary:    node(1, 3),
+						Sync:       node(3, 4),
+						Async:      []*discoverd.Instance{node(2, 5)},
+					},
+				},
+				Postgres: pgPrimary2,
+			},
+		},
+
+		// Test adding a new async peer
+		{Cmd: "echo test: add async"},
+		{Cmd: "addpeer node4"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 3), node(3, 4), node(2, 5), node(4, 6)},
+					State: &state.State{
+						Generation: 4,
+						InitWAL:    "0/0000001E",
+						Primary:    node(1, 3),
+						Sync:       node(3, 4),
+						Async:      []*discoverd.Instance{node(2, 5), node(4, 6)},
+					},
+				},
+				Postgres: pgPrimary2,
+			},
+		},
+
+		// Test out removing an async peer
+		{Cmd: "echo test: remove async"},
+		{Cmd: "rmpeer node4"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 3), node(3, 4), node(2, 5)},
+					State: &state.State{
+						Generation: 4,
+						InitWAL:    "0/0000001E",
+						Primary:    node(1, 3),
+						Sync:       node(3, 4),
+						Async:      []*discoverd.Instance{node(2, 5)},
+					},
+				},
+				Postgres: pgPrimary2,
+			},
+		},
+
+		// Finally, have someone depose our peer
+		{Cmd: "echo test: primary deposed"},
+		{Cmd: "depose"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleDeposed,
+					Peers: []*discoverd.Instance{node(1, 3), node(3, 4), node(2, 5)},
+					State: &state.State{
+						Generation: 5,
+						InitWAL:    "0/00000028",
+						Primary:    node(3, 4),
+						Sync:       node(2, 5),
+						Deposed:    []*discoverd.Instance{node(1, 3)},
+					},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: false,
+					Config: &state.PgConfig{Role: state.RoleNone},
+					XLog:   "0/00000028",
+				},
+			},
+		},
+	})
+}
+
+// tests cluster setup when no peers are initially present.
+func TestClusterSetupDelay(t *testing.T) {
+	runSteps(t, false, []step{
+		// Test that when the peer comes up with no other peers, we wait on
+		// cluster setup
+		{Cmd: "echo test: start up with no peers"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					Peers: []*discoverd.Instance{node(1, 1)},
+				},
+				Postgres: pgOffline,
+			},
+		},
+
+		// When we add a peer, we create a cluster
+		{Cmd: "addpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2)},
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						InitWAL:    xlog.Zero,
+					},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(2, 2),
+					},
+					XLog: "0/0000000A",
+				},
+			},
+		},
+	})
+}
+
+// Test cluster setup when another peer is already present
+func TestClusterSetupImmediate(t *testing.T) {
+	runSteps(t, false, []step{
+		// Test that when the peer comes up with other peers present and we're
+		// the first peer, we initiate the cluster setup.
+		{Cmd: "echo test: start up with other peers"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2)},
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						InitWAL:    xlog.Zero,
+					},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(2, 2),
+					},
+					XLog: "0/0000000A",
+				},
+			},
+		},
+	})
+}
+
+// Test cluster setup in singleton mode
+func TestClusterSetupSingleton(t *testing.T) {
+	runSteps(t, true, []step{
+		{Cmd: "echo: test: start up in singleton mode"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 1)},
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						InitWAL:    xlog.Zero,
+						Singleton:  true,
+						Freeze: &state.FreezeDetails{
+							Reason:   "cluster started in singleton mode",
+							FrozenAt: fakeTime,
+						},
+					},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{Role: state.RolePrimary},
+					XLog:   "0/0000000A",
+				},
+			},
+		},
+	})
+}
+
+// Test cluster setup from the perspective of the second peer
+func TestSetupPassive(t *testing.T) {
+	runSteps(t, false, []step{
+		// Test that when the peer comes up with other peers present but we're
+		// not first, we wait on cluster setup.
+		{Cmd: "echo test: start up with other peers"},
+		{Cmd: "addpeer"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2)},
+				},
+				Postgres: pgOffline,
+			},
+		},
+
+		// Now simulate the other peer setting up the cluster
+		{Cmd: "bootstrap"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2)},
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(1, 2),
+						InitWAL:    xlog.Zero,
+					},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleSync,
+						Upstream: node(2, 1),
+					},
+					XLog:        xlog.Zero,
+					XLogWaiting: xlog.Zero,
+				},
+			},
+		},
+	})
+}
+
+// Test several cases where we shouldn't takeover
+func TestNoFlap(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		Sync:       node(1, 2),
+		InitWAL:    xlog.Zero,
+	}
+	gen1pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:     state.RoleSync,
+			Upstream: node(2, 1),
+		},
+		XLog:        xlog.Zero,
+		XLogWaiting: xlog.Zero,
+	}
+
+	gen2_0 := &state.State{
+		Generation: 2,
+		Primary:    node(1, 2),
+		Sync:       node(3, 3),
+		Deposed:    []*discoverd.Instance{node(2, 1)},
+		InitWAL:    xlog.Zero,
+	}
+	gen2_1 := &state.State{
+		Generation: 2,
+		Primary:    node(1, 2),
+		Sync:       node(3, 3),
+		InitWAL:    xlog.Zero,
+	}
+	gen2pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(3, 3),
+		},
+		XLog: "0/0000000A",
+	}
+
+	runSteps(t, false, []step{
+		// Bring up our peer as a sync and make sure it doesn't take over when
+		// there are no asyncs available.
+		{Cmd: "echo test: no takeover without asyncs (as sync)"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "bootstrap node2 node1"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2)},
+					State: gen1,
+				},
+				Postgres: gen1pg,
+			},
+		},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					Peers: []*discoverd.Instance{node(1, 2)},
+					State: gen1,
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Now allow the peer to takeover by adding a new async
+		{Cmd: "addpeer"}, // this also adds to the async list in the state
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 2), node(3, 3)},
+					State: gen2_0,
+				},
+				Postgres: gen2pg,
+			},
+		},
+		{Cmd: "rebuild node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 2), node(3, 3)},
+					State: gen2_1,
+				},
+				Postgres: gen2pg,
+			},
+		},
+
+		// Make sure we don't declare a new generation when the sync fails
+		// because there is no async.
+		{Cmd: "rmpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 2)},
+					State: gen2_1,
+				},
+				Postgres: gen2pg,
+			},
+		},
+	})
+}
+
+// Test operation in singleton mode
+func TestSingleton(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(1, 1),
+		InitWAL:    xlog.Zero,
+		Freeze:     state.NewFreezeDetails("singleton"),
+		Singleton:  true,
+	}
+	gen1pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{Role: state.RolePrimary},
+		XLog:   "0/0000000A",
+	}
+
+	info := &simulator.PeerSimInfo{
+		Peer: &state.PeerInfo{
+			ID:    node1ID,
+			Role:  state.RolePrimary,
+			Peers: []*discoverd.Instance{node(1, 1)},
+			State: gen1,
+		},
+		Postgres: gen1pg,
+	}
+
+	runSteps(t, true, []step{
+		// Test starting up in singleton mode
+		{Cmd: "echo test: start up as primary in singleton mode"},
+		{Cmd: "setClusterState", JSON: gen1},
+		{Cmd: "startPeer"},
+		{Cmd: "peer", Check: info},
+
+		// Test not doing anything when another peer shows up
+		{Cmd: "echo test: do nothing with new peers"},
+		{Cmd: "addpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2)},
+					State: gen1,
+				},
+				Postgres: gen1pg,
+			},
+		},
+		{Cmd: "rmpeer node2"},
+		{Cmd: "peer", Check: info},
+	})
+}
+
+// Test what happens when we show up as the second node in singleton mode
+func TestSingletonSecond(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		InitWAL:    xlog.Zero,
+		Freeze:     state.NewFreezeDetails("singleton"),
+		Singleton:  true,
+	}
+
+	runSteps(t, true, []step{
+		// Test that we don't do anything if we start up in singleton mode when
+		// another peer is the primary
+		{Cmd: "echo test: start in singleton mode"},
+		{Cmd: "addpeer"},
+		{Cmd: "setclusterstate", JSON: gen1},
+		{Cmd: "startpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					State: gen1,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2)},
+				},
+				Postgres: pgOffline,
+			},
+		},
+
+		// Check that we don't do anything even if the primary fails
+		{Cmd: "echo test: do nothing even if primary fails"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					State: gen1,
+					Peers: []*discoverd.Instance{node(1, 2)},
+				},
+				Postgres: pgOffline,
+			},
+		},
+	})
+}
+
+// Test upgrading from singleton to normal mode
+func TestSingletonUpgradeToNormal(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(1, 1),
+		InitWAL:    xlog.Zero,
+		Freeze:     state.NewFreezeDetails("singleton"),
+		Singleton:  true,
+	}
+
+	runSteps(t, false, []step{
+		// Start in singleton mode
+		{Cmd: "echo test: start up as primary in singleton mode"},
+		{Cmd: "setclusterstate", JSON: gen1},
+		{Cmd: "startpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1,
+					Peers: []*discoverd.Instance{node(1, 1)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{Role: state.RolePrimary},
+					XLog:   "0/0000000A",
+				},
+			},
+		},
+
+		// Unfreeze the cluster and make sure we do nothing
+		{Cmd: "echo test: unfreeze"},
+		{Cmd: "unfreeze"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						InitWAL:    xlog.Zero,
+						Singleton:  true,
+					},
+					Peers: []*discoverd.Instance{node(1, 1)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{Role: state.RolePrimary},
+					XLog:   "0/0000000A",
+				},
+			},
+		},
+
+		// Add another peer and see that we transition to normal mode
+		{Cmd: "echo test: transition to normal mode"},
+		{Cmd: "addpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(2, 2),
+					},
+					XLog: "0/00000014",
+				},
+			},
+		},
+
+		// Add another peer, fail the sync, and make sure we reconfigure
+		// appropriately.
+		{Cmd: "echo test: reconfiguration in normal mode"},
+		{Cmd: "addpeer"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 3),
+					},
+					XLog: "0/0000001E",
+				},
+			},
+		},
+		{Cmd: "addpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      []*discoverd.Instance{node(2, 4)},
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(2, 4)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 3),
+					},
+					XLog: "0/0000001E",
+				},
+			},
+		},
+	})
+}
+
+// Test starting as a deposed peer
+func TestStartDeposed(t *testing.T) {
+	gen2 := &state.State{
+		Generation: 2,
+		Primary:    node(2, 2),
+		Sync:       node(3, 3),
+		Deposed:    []*discoverd.Instance{node(1, 1)},
+		InitWAL:    "0/0000000A",
+	}
+	peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)}
+
+	runSteps(t, false, []step{
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap"},
+		{Cmd: "depose"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{Index: 2, State: gen2},
+				Peers: peers,
+			},
+		},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleDeposed,
+					State: gen2,
+					Peers: peers,
+				},
+				Postgres: pgOffline,
+			},
+		},
+	})
+}
+
+// Test starting as the primary peer
+func TestStartPrimary(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(1, 1),
+		Sync:       node(2, 2),
+		Async:      []*discoverd.Instance{node(3, 3)},
+		InitWAL:    xlog.Zero,
+	}
+	gen1peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)}
+	gen3pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(3, 3),
+		},
+		XLog: "0/00000014",
+	}
+
+	runSteps(t, false, []step{
+		// Start as the primary
+		{Cmd: "echo test: start as primary"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{
+					Index: 1,
+					State: gen1,
+				},
+				Peers: gen1peers,
+			},
+		},
+		{Cmd: "startpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1,
+					Peers: gen1peers,
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(2, 2),
+					},
+					XLog: "0/0000000A",
+				},
+			},
+		},
+
+		// Now have the sync fail. Our peer should promote the async.
+		{Cmd: "echo test: sync fail"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: gen3pg,
+			},
+		},
+		{Cmd: "addpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      []*discoverd.Instance{node(2, 4)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(2, 4)},
+				},
+				Postgres: gen3pg,
+			},
+		},
+	})
+}
+
+// Test starting the primary when the sync is not up but the async is. This
+// simulates a cluster reboot where the sync comes up last.
+func TestStartPrimaryAsync(t *testing.T) {
+	runSteps(t, false, []step{
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap node1 node2"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{
+					Index: 1,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						Async:      []*discoverd.Instance{node(3, 3)},
+						InitWAL:    xlog.Zero,
+					},
+				},
+				Peers: []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)},
+			},
+		},
+		{Cmd: "rmpeer node2"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 3),
+					},
+					XLog: "0/00000014",
+				},
+			},
+		},
+	})
+}
+
+// Test starting as a sync peer
+func TestStartSync(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(3, 3),
+		Sync:       node(1, 1),
+		Async:      []*discoverd.Instance{node(2, 2)},
+		InitWAL:    xlog.Zero,
+	}
+	gen1peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)}
+
+	gen2pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(2, 2),
+		},
+		XLog: "0/00000014",
+	}
+	gen3pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(3, 3),
+		},
+		XLog: "0/0000001E",
+	}
+
+	runSteps(t, false, []step{
+		// Validate bootstrap
+		{Cmd: "echo test: bootstrap"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap node3"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{Index: 1, State: gen1},
+				Peers: gen1peers,
+			},
+		},
+
+		// Bring up the peer as the sync
+		{Cmd: "startpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					State: gen1,
+					Peers: gen1peers,
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleSync,
+						Upstream: node(3, 3),
+					},
+					XLog:        xlog.Zero,
+					XLogWaiting: xlog.Zero,
+				},
+			},
+		},
+
+		// Catch up, kill the primary, and our peer should become primary
+		{Cmd: "echo test: catch up and remove primary"},
+		{Cmd: "catchUp"},
+		{Cmd: "rmpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						Deposed:    []*discoverd.Instance{node(3, 3)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2)},
+				},
+				Postgres: gen2pg,
+			},
+		},
+		{Cmd: "rebuild node3"},
+		{Cmd: "addpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						Async:      []*discoverd.Instance{node(3, 3)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)},
+				},
+				Postgres: gen2pg,
+			},
+		},
+
+		// Now have the sync fail. Our peer should promote the async.
+		{Cmd: "echo test: sync fail"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: gen3pg,
+			},
+		},
+		{Cmd: "addpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      []*discoverd.Instance{node(2, 4)},
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(2, 4)},
+				},
+				Postgres: gen3pg,
+			},
+		},
+	})
+}
+
+// Test starting as the sync when the primary is not up but the async is. This
+// simulates a cluster reboot where the primary comes up last.
+func TestStartSyncAsync(t *testing.T) {
+	runSteps(t, false, []step{
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "bootstrap node2 node1"},
+		{
+			Cmd: "discoverd",
+			Check: &simulator.DiscoverdInfo{
+				State: &state.DiscoverdState{
+					Index: 1,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(1, 3),
+						Async:      []*discoverd.Instance{node(3, 2)},
+						InitWAL:    xlog.Zero,
+					},
+				},
+				Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(1, 3)},
+			},
+		},
+		{Cmd: "rmpeer node2"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 3),
+						Sync:       node(3, 2),
+						Deposed:    []*discoverd.Instance{node(2, 1)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(3, 2), node(1, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 2),
+					},
+					XLog: "0/0000000A",
+				},
+			},
+		},
+	})
+}
+
+// Test starting as the sync with no other peers present
+func TestStartSyncAlone(t *testing.T) {
+	runSteps(t, false, []step{
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "bootstrap node2 node1"},
+		{Cmd: "rmpeer node2"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleSync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(1, 2),
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(1, 2)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleSync,
+						Upstream: node(2, 1),
+					},
+					XLog:        xlog.Zero,
+					XLogWaiting: xlog.Zero,
+				},
+			},
+		},
+	})
+}
+
+// Test starting with an existing state as the only peer, unassigned
+func TestStartUnassigned(t *testing.T) {
+	peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3), node(4, 4)}
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		Sync:       node(3, 2),
+		InitWAL:    xlog.Zero,
+	}
+	gen1_1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		Sync:       node(3, 3),
+		Async:      peers[:1],
+		InitWAL:    xlog.Zero,
+	}
+
+	runSteps(t, false, []step{
+		// Start with an existing state and the nodes referenced all gone
+		{Cmd: "echo test: start unassigned"},
+		{Cmd: "setClusterState", JSON: gen1},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					State: gen1,
+					Peers: peers[:1],
+				},
+				Postgres: pgOffline,
+			},
+		},
+
+		// Start the nodes in the state, and simulate adding as an async
+		{Cmd: "echo test: start and add async"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleUnassigned,
+					State: gen1,
+					Peers: peers[:3],
+				},
+				Postgres: pgOffline,
+			},
+		},
+		{Cmd: "setClusterState", JSON: gen1_1},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleAsync,
+					State: gen1_1,
+					Peers: peers[:3],
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(3, 3),
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+
+		// Add another async, and depose the primary and secondary so we end up
+		// with node1 as primary and node4 as sync.
+		{Cmd: "echo test: depose node2/node3"},
+		{Cmd: "addpeer"},
+		{Cmd: "depose"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleSync,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(3, 3),
+						Sync:       node(1, 1),
+						Deposed:    []*discoverd.Instance{node(2, 1)},
+						Async:      []*discoverd.Instance{node(4, 4)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: peers,
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleSync,
+						Upstream: node(3, 3),
+					},
+					XLog:        xlog.Zero,
+					XLogWaiting: "0/0000000A",
+				},
+			},
+		},
+		{Cmd: "catchUp"},
+		{Cmd: "rmpeer node2"},
+		{Cmd: "rmpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(4, 4),
+						Deposed:    []*discoverd.Instance{node(2, 1), node(3, 3)},
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(4, 4)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(4, 4),
+					},
+					XLog: "0/0000001E",
+				},
+			},
+		},
+	})
+}
+
+// Test promotion with multiple asyncs when the sync fails
+func TestMultiAsync(t *testing.T) {
+	peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3), node(4, 4)}
+
+	runSteps(t, false, []step{
+		// start with two asyncs
+		{Cmd: "echo test: start"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(1, 1),
+						Sync:       node(2, 2),
+						Async:      peers[2:],
+						InitWAL:    xlog.Zero,
+					},
+					Peers: peers,
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(2, 2),
+					},
+					XLog: "0/0000000A",
+				},
+			},
+		},
+
+		// Removing the sync should result in a new generation
+		{Cmd: "echo test: remove sync"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      peers[3:],
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(4, 4)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 3),
+					},
+					XLog: "0/00000014",
+				},
+			},
+		},
+
+		// Removing the sync again should result in yet another generation
+		{Cmd: "echo test: remove sync again"},
+		{Cmd: "rmpeer node3"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 3,
+						Primary:    node(1, 1),
+						Sync:       node(4, 4),
+						InitWAL:    "0/00000014",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(4, 4)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(4, 4),
+					},
+					XLog: "0/0000001E",
+				},
+			},
+		},
+	})
+}
+
+// Test that no generation changes happen while the cluster is frozen and we are
+// the primary.
+func TestFreezePrimary(t *testing.T) {
+	peers := []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)}
+
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(1, 1),
+		Sync:       node(2, 2),
+		Async:      peers[2:],
+		InitWAL:    xlog.Zero,
+	}
+	gen1frozen := &state.State{
+		Generation: 1,
+		Primary:    node(1, 1),
+		Sync:       node(2, 2),
+		Async:      peers[2:],
+		InitWAL:    xlog.Zero,
+		Freeze: &state.FreezeDetails{
+			FrozenAt: fakeTime,
+			Reason:   "frozen by simulator",
+		},
+	}
+	gen1pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(2, 2),
+		},
+		XLog: "0/0000000A",
+	}
+	gen2pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:       state.RolePrimary,
+			Downstream: node(3, 3),
+		},
+		XLog: "0/00000014",
+	}
+
+	runSteps(t, false, []step{
+		// start a three node cluster and freeze it
+		{Cmd: "echo test: start cluster"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1,
+					Peers: peers,
+				},
+				Postgres: gen1pg,
+			},
+		},
+		{Cmd: "freeze"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1frozen,
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3)},
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Add another async and ensure the state does not change
+		{Cmd: "echo test: add async"},
+		{Cmd: "addpeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1frozen,
+					Peers: []*discoverd.Instance{node(1, 1), node(2, 2), node(3, 3), node(4, 4)},
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Remove the sync and make sure nothing happens
+		{Cmd: "echo test: remove sync"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RolePrimary,
+					State: gen1frozen,
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(4, 4)},
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Unfreeze and ensure the expected changes are applied
+		{Cmd: "echo test: unfreeze with missing sync"},
+		{Cmd: "unfreeze"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      []*discoverd.Instance{node(4, 4)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3), node(4, 4)},
+				},
+				Postgres: gen2pg,
+			},
+		},
+
+		// Freeze and remove an async
+		{Cmd: "echo test: freeze and remove async"},
+		{Cmd: "freeze"},
+		{Cmd: "rmpeer node4"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						Async:      []*discoverd.Instance{node(4, 4)},
+						InitWAL:    "0/0000000A",
+						Freeze: &state.FreezeDetails{
+							FrozenAt: fakeTime,
+							Reason:   "frozen by simulator",
+						},
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: gen2pg,
+			},
+		},
+
+		// Freeze and ensure the async is removed from the state
+		{Cmd: "echo test: unfreeze with missing async"},
+		{Cmd: "unfreeze"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 1),
+						Sync:       node(3, 3),
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 1), node(3, 3)},
+				},
+				Postgres: gen2pg,
+			},
+		},
+	})
+}
+
+// Test that no generation changes happen while the cluster is frozen and we are
+// the sync.
+func TestFreezeSync(t *testing.T) {
+	gen1 := &state.State{
+		Generation: 1,
+		Primary:    node(2, 1),
+		Sync:       node(1, 2),
+		Async:      []*discoverd.Instance{node(3, 3)},
+		InitWAL:    xlog.Zero,
+		Freeze: &state.FreezeDetails{
+			FrozenAt: fakeTime,
+			Reason:   "frozen by simulator",
+		},
+	}
+	gen1pg := &simulator.PostgresInfo{
+		Online: true,
+		Config: &state.PgConfig{
+			Role:     state.RoleSync,
+			Upstream: node(2, 1),
+		},
+		XLog: "0/0000000A",
+	}
+
+	runSteps(t, false, []step{
+		// start cluster frozen as sync
+		{Cmd: "echo test: start cluster"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap node2 node1"},
+		{Cmd: "freeze"},
+		{Cmd: "startPeer"},
+		{Cmd: "catchUp"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					State: gen1,
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2), node(3, 3)},
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Remove the primary, creating a takeover condition but do nothing due
+		// to freeze
+		{Cmd: "echo test: remove primary"},
+		{Cmd: "rmpeer node2"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:    node1ID,
+					Role:  state.RoleSync,
+					State: gen1,
+					Peers: []*discoverd.Instance{node(1, 2), node(3, 3)},
+				},
+				Postgres: gen1pg,
+			},
+		},
+
+		// Unfreeze the cluster and make sure that we takeover
+		{Cmd: "echo test: unfreeze"},
+		{Cmd: "unfreeze"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RolePrimary,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(1, 2),
+						Sync:       node(3, 3),
+						Deposed:    []*discoverd.Instance{node(2, 1)},
+						InitWAL:    "0/0000000A",
+					},
+					Peers: []*discoverd.Instance{node(1, 2), node(3, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:       state.RolePrimary,
+						Downstream: node(3, 3),
+					},
+					XLog: "0/00000014",
+				},
+			},
+		},
+	})
+}
+
+// Test changing our upstream as an async
+func TestAsyncChangeUpstream(t *testing.T) {
+	runSteps(t, false, []step{
+		// start cluster as async with async upstream
+		{Cmd: "echo test: start cluster"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "bootstrap node2 node3"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleAsync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(3, 2),
+						Async:      []*discoverd.Instance{node(4, 3), node(5, 4), node(1, 5)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(4, 3), node(5, 4), node(1, 5)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(5, 4),
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+
+		// remove our upstream async
+		{Cmd: "echo test: remove upstream async"},
+		{Cmd: "rmpeer node5"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleAsync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(3, 2),
+						Async:      []*discoverd.Instance{node(4, 3), node(1, 5)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(4, 3), node(1, 5)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(4, 3),
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+
+		// remove our upstream async, making our new upstream the sync
+		{Cmd: "echo test: remove upstream again"},
+		{Cmd: "rmpeer node4"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleAsync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(3, 2),
+						Async:      []*discoverd.Instance{node(1, 5)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(1, 5)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(3, 2),
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+	})
+
+}
+
+// Test being removed as async
+func TestRemovedAsync(t *testing.T) {
+	runSteps(t, false, []step{
+		// start cluster as async
+		{Cmd: "echo test: start cluster"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "bootstrap node2 node3"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleAsync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(3, 2),
+						Async:      []*discoverd.Instance{node(1, 3)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(1, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleAsync,
+						Upstream: node(3, 2),
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+
+		// remove from cluster state
+		{Cmd: "echo test: remove from cluster state"},
+		{Cmd: "rmpeer node1"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleUnassigned,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(3, 2),
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(3, 2), node(1, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: false,
+					Config: &state.PgConfig{
+						Role: state.RoleNone,
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+	})
+}
+
+// Test being removed as sync
+func TestRemovedSync(t *testing.T) {
+	runSteps(t, false, []step{
+		// start cluster as sync
+		{Cmd: "echo test: start cluster"},
+		{Cmd: "addpeer"},
+		{Cmd: "addpeer node1"},
+		{Cmd: "addpeer"},
+		{Cmd: "bootstrap node2 node1"},
+		{Cmd: "startPeer"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleSync,
+					State: &state.State{
+						Generation: 1,
+						Primary:    node(2, 1),
+						Sync:       node(1, 2),
+						Async:      []*discoverd.Instance{node(3, 3)},
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2), node(3, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: true,
+					Config: &state.PgConfig{
+						Role:     state.RoleSync,
+						Upstream: node(2, 1),
+					},
+					XLog:        xlog.Zero,
+					XLogWaiting: xlog.Zero,
+				},
+			},
+		},
+
+		// remove from cluster state
+		{Cmd: "echo test: remove from cluster state"},
+		{Cmd: "rmpeer node1"},
+		{
+			Cmd: "peer",
+			Check: &simulator.PeerSimInfo{
+				Peer: &state.PeerInfo{
+					ID:   node1ID,
+					Role: state.RoleUnassigned,
+					State: &state.State{
+						Generation: 2,
+						Primary:    node(2, 1),
+						Sync:       node(3, 3),
+						InitWAL:    xlog.Zero,
+					},
+					Peers: []*discoverd.Instance{node(2, 1), node(1, 2), node(3, 3)},
+				},
+				Postgres: &simulator.PostgresInfo{
+					Online: false,
+					Config: &state.PgConfig{
+						Role: state.RoleNone,
+					},
+					XLog: xlog.Zero,
+				},
+			},
+		},
+	})
+}

--- a/appliance/postgresql2/xlog/xlog.go
+++ b/appliance/postgresql2/xlog/xlog.go
@@ -1,0 +1,104 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This file is derived from:
+// https://github.com/joyent/manatee-state-machine/blob/d441fe941faddb51d6e6237d792dd4d7fae64cc6/lib/xlog.js
+//
+// Copyright (c) 2014, Joyent, Inc.
+// Copyright (c) 2015, Prime Directive, Inc.
+//
+
+/*
+
+Package xlog provides constants and functions for working with PostgreSQL xlog positions.
+
+The package makes a number of assumptions about the format of xlog positions.
+It's not totally clear that this is a committed Postgres interface, but it seems
+to be true.
+
+We assume that postgres xlog positions are represented as strings of the form:
+
+    filepart/offset		e.g., "0/17BB660"
+
+where both "filepart" and "offset" are hexadecimal numbers. xlog position F1/O1
+is at least as new as F2/O2 if (F1 > F2) or (F1 == F2 and O1 >= O2). We try to
+avoid assuming that they're zero-padded (i.e., that a simple string comparison
+might do the right thing). We also don't make any assumptions about the size of
+each file, which means we can't compute the actual difference between two
+positions.
+
+*/
+package xlog
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Position string
+
+const Zero Position = "0/00000000"
+
+// Increment increments an xlog position by the given number.
+func Increment(xlog Position, increment int) (Position, error) {
+	parts, err := parse(xlog)
+	if err != nil {
+		return "", err
+	}
+	return makePosition(parts[0], parts[1]+increment), nil
+}
+
+// Compare compares two xlog positions returning -1 if xlog1 < xlog2, 0 if xlog1
+// == xlog2, and 1 if xlog1 > xlog2.
+func Compare(xlog1, xlog2 Position) (int, error) {
+	p1, err := parse(xlog1)
+	if err != nil {
+		return 0, err
+	}
+	p2, err := parse(xlog2)
+	if err != nil {
+		return 0, err
+	}
+
+	if p1[0] == p2[0] && p1[1] == p2[1] {
+		return 0, nil
+	}
+	if p1[0] > p2[0] || p1[0] == p2[0] && p1[1] > p2[1] {
+		return 1, nil
+	}
+	return -1, nil
+}
+
+// parse takes an xlog position emitted by postgres and returns an array of two
+// integers representing the filepart and offset components of the xlog
+// position. This is an internal representation that should not be exposed
+// outside of this package.
+func parse(xlog Position) (res [2]int, err error) {
+	parts := strings.SplitN(string(xlog), "/", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("malformed xlog position %q", xlog)
+		return
+	}
+
+	res[0], err = parseHex(parts[0])
+	if err != nil {
+		return
+	}
+	res[1], err = parseHex(parts[1])
+
+	return
+}
+
+// MakePosition constructs an xlog position string from a numeric file part and
+// offset.
+func makePosition(filepart int, offset int) Position {
+	return Position(fmt.Sprintf("%X/%08X", filepart, offset))
+}
+
+func parseHex(s string) (int, error) {
+	res, err := strconv.ParseInt(s, 16, 64)
+	return int(res), err
+}

--- a/pkg/iotool/safewriter.go
+++ b/pkg/iotool/safewriter.go
@@ -1,6 +1,7 @@
 package iotool
 
 import (
+	"errors"
 	"io"
 	"sync"
 )
@@ -14,5 +15,14 @@ type SafeWriter struct {
 func (s *SafeWriter) Write(p []byte) (int, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+	if s.W == nil {
+		return 0, errors.New("writes disabled")
+	}
 	return s.W.Write(p)
+}
+
+func (s *SafeWriter) SetWriter(w io.Writer) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.W = w
 }


### PR DESCRIPTION
First, I'd like to apologize for the size of this. You're not reading the diff wrong, there are indeed over 4k lines of new code here. Most of that is the tests and the simulator supporting the tests, the state machine itself weighs in at 1k lines. I couldn't come up with an incremental way to deliver this, as it is a direct translation that doesn't make much sense in a partial state.

---

This adds a Go translation of the [manatee-state-machine project](https://github.com/joyent/manatee-state-machine/tree/d441fe941faddb51d6e6237d792dd4d7fae64cc6) from Joyent. It is translated verbatim with the following minor differences:

- A few extra tests were added for completeness
- Changes were made to translate from the Node.js async model to a more
  straightforward single-threaded model that uses channels for coordination.
- The term 'one-node-write-mode' (abbreviated as ONWM) was replaced
  with 'singleton' as they are used interchangeably upstream.
- Assertions were translated into panics wrapped in if statements.
- Discoverd is used instead of Zookeeper.

The state machine provides a fault-tolerant system for running Postgres clusters that automatically fail over with minimal downtime and no possibility for data loss or split brain during failovers. The README linked above has a good overview and some diagrams. I expect we'll change this a bit to fit containers better, but this is a really good starting point.

A simulator is used for testing and is also available in an interactive REPL for experimenting with various scenarios.

Test coverage is at 87.9% with only assertions, a few error paths, and very rare cases not covered. 