### PR TITLE
host: Allocate IP addresses on job restore.

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -323,6 +323,17 @@ func (l *LibvirtLXCBackend) ConfigureNetworking(strategy NetworkStrategy, job st
 		return nil, err
 	}
 
+	// Allocate IPs for running jobs
+	for i, container := range l.containers {
+		if !container.job.Config.HostNetwork {
+			var err error
+			l.containers[i].IP, err = ipallocator.RequestIP(l.bridgeNet, container.IP)
+			if err != nil {
+				grohl.Log(grohl.Data{"fn": "ConfigureNetworking", "at": "request_ip", "status": "error", "err": err})
+			}
+		}
+	}
+
 	return &NetworkInfo{BridgeAddr: l.bridgeAddr.String(), Nameservers: dnsConf.Servers}, nil
 }
 


### PR DESCRIPTION
Allocate IP addresses on job restore. Setup networking on restarts.

IPs from running containers should be marked as used. Log any errors in doing so. Additionally, ConfigureNetworking needs to be ran regardless of whether flannel was already running or not.

Note that for this functionality to work correctly, --force should not be set on flynn-host, as that will run Cleanup() before starting it, destroying all of the old containers.

Closes #60.