### PR TITLE
deployer: Support resuming deployments

### DIFF
--- a/controller/deployer/main.go
+++ b/controller/deployer/main.go
@@ -104,12 +104,6 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 		return err
 	}
 
-	log.Info("validating deployment strategy")
-	strategyFunc, err := strategy.Get(deployment.Strategy)
-	if err != nil {
-		log.Error("unknown deployment strategy")
-		return err
-	}
 	events := make(chan ct.DeploymentEvent)
 	defer close(events)
 	go func() {
@@ -135,7 +129,7 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 		}
 	}()
 	log.Info("performing deployment")
-	if err := strategyFunc(logger, c.client, deployment, events); err != nil {
+	if err := strategy.Perform(deployment, c.client, events, logger); err != nil {
 		log.Error("error performing deployment", "err", err)
 		return err
 	}

--- a/controller/deployer/strategies/all-at-once.go
+++ b/controller/deployer/strategies/all-at-once.go
@@ -1,84 +1,70 @@
 package strategy
 
-import (
-	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
-	"github.com/flynn/flynn/controller/client"
-	ct "github.com/flynn/flynn/controller/types"
-)
+import ct "github.com/flynn/flynn/controller/types"
 
-func allAtOnce(l log15.Logger, client *controller.Client, d *ct.Deployment, events chan<- ct.DeploymentEvent) error {
-	log := l.New("fn", "allAtOnce", "deployment_id", d.ID, "app_id", d.AppID)
+func allAtOnce(d *Deploy) error {
+	log := d.logger.New("fn", "allAtOnce", "deployment_id", d.ID, "app_id", d.AppID)
 	log.Info("starting all-at-once deployment")
 
-	log.Info("getting job event stream")
-	jobStream := make(chan *ct.JobEvent)
-	stream, err := client.StreamJobEvents(d.AppID, 0, jobStream)
-	if err != nil {
-		log.Error("error getting job event stream", "err", err)
-		return err
-	}
-	defer stream.Close()
-
-	olog := log.New("release_id", d.OldReleaseID)
-	olog.Info("getting old formation")
-	f, err := client.GetFormation(d.AppID, d.OldReleaseID)
-	if err != nil {
-		olog.Error("error getting old formation", "err", err)
-		return err
-	}
-
-	nlog := log.New("release_id", d.NewReleaseID)
-	nlog.Info("creating new formation", "processes", f.Processes)
-	if err := client.PutFormation(&ct.Formation{
-		AppID:     d.AppID,
-		ReleaseID: d.NewReleaseID,
-		Processes: f.Processes,
-	}); err != nil {
-		nlog.Error("error creating new formation", "err", err)
-		return err
-	}
-
 	expected := make(jobEvents)
-	for typ, n := range f.Processes {
-		for i := 0; i < n; i++ {
-			events <- ct.DeploymentEvent{
+	for typ, n := range d.Processes {
+		existing := d.newReleaseState[typ]
+		for i := existing; i < n; i++ {
+			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.NewReleaseID,
 				JobState:  "starting",
 				JobType:   typ,
 			}
 		}
-		expected[typ] = map[string]int{"up": n}
+		expected[typ] = map[string]int{"up": n - existing}
 	}
-	nlog.Info("waiting for job events", "expected", expected)
-	if err := waitForJobEvents(jobStream, events, d.NewReleaseID, expected, nlog); err != nil {
-		nlog.Error("error waiting for job events", "err", err)
-		return err
-	}
+	if expected.count() > 0 {
+		nlog := log.New("release_id", d.NewReleaseID)
+		nlog.Info("creating new formation", "processes", d.Processes)
+		if err := d.client.PutFormation(&ct.Formation{
+			AppID:     d.AppID,
+			ReleaseID: d.NewReleaseID,
+			Processes: d.Processes,
+		}); err != nil {
+			nlog.Error("error creating new formation", "err", err)
+			return err
+		}
 
-	olog.Info("scaling old formation to zero")
-	if err := client.PutFormation(&ct.Formation{
-		AppID:     d.AppID,
-		ReleaseID: d.OldReleaseID,
-	}); err != nil {
-		log.Error("error scaling old formation to zero", "err", err)
-		return err
+		nlog.Info("waiting for job events", "expected", expected)
+		if err := d.waitForJobEvents(d.NewReleaseID, expected, nlog); err != nil {
+			nlog.Error("error waiting for job events", "err", err)
+			return err
+		}
 	}
 
 	expected = make(jobEvents)
-	for typ, n := range f.Processes {
-		for i := 0; i < n; i++ {
-			events <- ct.DeploymentEvent{
+	for typ := range d.Processes {
+		existing := d.oldReleaseState[typ]
+		for i := 0; i < existing; i++ {
+			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.OldReleaseID,
 				JobState:  "stopping",
 				JobType:   typ,
 			}
 		}
-		expected[typ] = map[string]int{"down": n}
+		expected[typ] = map[string]int{"down": existing}
 	}
-	olog.Info("waiting for job events", "expected", expected)
-	if err := waitForJobEvents(jobStream, events, d.OldReleaseID, expected, olog); err != nil {
-		olog.Error("error waiting for job events", "err", err)
-		return err
+	if expected.count() > 0 {
+		olog := log.New("release_id", d.OldReleaseID)
+		olog.Info("scaling old formation to zero")
+		if err := d.client.PutFormation(&ct.Formation{
+			AppID:     d.AppID,
+			ReleaseID: d.OldReleaseID,
+		}); err != nil {
+			log.Error("error scaling old formation to zero", "err", err)
+			return err
+		}
+
+		olog.Info("waiting for job events", "expected", expected)
+		if err := d.waitForJobEvents(d.OldReleaseID, expected, olog); err != nil {
+			olog.Error("error waiting for job events", "err", err)
+			return err
+		}
 	}
 	log.Info("finished all-at-once deployment")
 	return nil

--- a/controller/deployer/strategies/main.go
+++ b/controller/deployer/strategies/main.go
@@ -7,20 +7,132 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/attempt"
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/stream"
 )
 
-type PerformFunc func(log15.Logger, *controller.Client, *ct.Deployment, chan<- ct.DeploymentEvent) error
+type UnknownStrategyError struct {
+	Name string
+}
+
+func (e UnknownStrategyError) Error() string {
+	return fmt.Sprintf(`deployer: unknown strategy "%s"`, e.Name)
+}
+
+type PerformFunc func(d *Deploy) error
 
 var performFuncs = map[string]PerformFunc{
 	"all-at-once": allAtOnce,
 	"one-by-one":  oneByOne,
 }
 
-func Get(strategy string) (PerformFunc, error) {
-	if f, ok := performFuncs[strategy]; ok {
-		return f, nil
+func Perform(d *ct.Deployment, client *controller.Client, deployEvents chan<- ct.DeploymentEvent, logger log15.Logger) error {
+	log := logger.New("fn", "Perform", "deplyment_id", d.ID, "app_id", d.AppID)
+
+	log.Info("validating deployment strategy")
+	performFunc, ok := performFuncs[d.Strategy]
+	if !ok {
+		err := UnknownStrategyError{d.Strategy}
+		log.Error("error validating deployment strategy", "err", err)
+		return err
 	}
-	return nil, fmt.Errorf("Unknown strategy '%s'!", strategy)
+
+	deploy := &Deploy{
+		Deployment:      d,
+		client:          client,
+		deployEvents:    deployEvents,
+		logger:          logger,
+		newReleaseState: make(map[string]int, len(d.Processes)),
+		oldReleaseState: make(map[string]int, len(d.Processes)),
+		knownJobs:       make(map[string]struct{}),
+	}
+
+	log.Info("connecting job event stream")
+	if err := deploy.connectEventStream(); err != nil {
+		log.Error("error connecting job event stream", "err", err)
+		return err
+	}
+	defer deploy.closeEventStream()
+
+	log.Info("determining deployment state")
+	c, err := cluster.NewClient()
+	if err != nil {
+		log.Error("error determining deployment state", "err", err)
+		return err
+	}
+	hosts, err := c.ListHosts()
+	if err != nil {
+		log.Error("error determining deployment state", "err", err)
+		return err
+	}
+	for _, host := range hosts {
+		for _, job := range host.Jobs {
+			appID := job.Metadata["flynn-controller.app"]
+			releaseID := job.Metadata["flynn-controller.release"]
+			if appID != d.AppID || releaseID != d.OldReleaseID && releaseID != d.NewReleaseID {
+				continue
+			}
+
+			// track known jobs so we can drop any events received between
+			// connecting the job stream and getting the list of jobs
+			deploy.knownJobs[job.ID] = struct{}{}
+
+			typ := job.Metadata["flynn-controller.type"]
+			switch releaseID {
+			case d.OldReleaseID:
+				deploy.oldReleaseState[typ]++
+			case d.NewReleaseID:
+				deploy.newReleaseState[typ]++
+			}
+		}
+	}
+	log.Info(
+		"determined deployment state",
+		"original", deploy.Processes,
+		"old_release", deploy.oldReleaseState,
+		"new_release", deploy.newReleaseState,
+	)
+	return performFunc(deploy)
+}
+
+type Deploy struct {
+	*ct.Deployment
+	client          *controller.Client
+	deployEvents    chan<- ct.DeploymentEvent
+	logger          log15.Logger
+	events          chan *ct.JobEvent
+	stream          stream.Stream
+	lastID          int64
+	newReleaseState map[string]int
+	oldReleaseState map[string]int
+	knownJobs       map[string]struct{}
+}
+
+func (d *Deploy) closeEventStream() error {
+	if d.stream != nil {
+		return d.stream.Close()
+	}
+	return nil
+}
+
+var connectAttempts = attempt.Strategy{
+	Total: 10 * time.Second,
+	Delay: 500 * time.Millisecond,
+}
+
+func (d *Deploy) connectEventStream() error {
+	events := make(chan *ct.JobEvent)
+	var stream stream.Stream
+	if err := connectAttempts.Run(func() (err error) {
+		stream, err = d.client.StreamJobEvents(d.AppID, d.lastID, events)
+		return
+	}); err != nil {
+		return err
+	}
+	d.events = events
+	d.stream = stream
+	return nil
 }
 
 // TODO: share with tests
@@ -41,52 +153,65 @@ func jobEventsEqual(expected, actual jobEvents) bool {
 
 type jobEvents map[string]map[string]int
 
-func waitForJobEvents(events chan *ct.JobEvent, deployEvents chan<- ct.DeploymentEvent, releaseID string, expected jobEvents, log log15.Logger) error {
-	actual := make(jobEvents)
-outer:
-	for {
-	inner:
-		select {
-		case event, ok := <-events:
-			if !ok {
-				// if this happens, it means defer cleanup is in progress
+func (j jobEvents) count() int {
+	var n int
+	for _, procs := range j {
+		for _, i := range procs {
+			n += i
+		}
+	}
+	return n
+}
 
-				// TODO: this could also happen if the stream connection
-				// dropped. handle that case
-				break outer
+func (d *Deploy) waitForJobEvents(releaseID string, expected jobEvents, log log15.Logger) error {
+	actual := make(jobEvents)
+
+	for {
+		select {
+		case event, ok := <-d.events:
+			if !ok {
+				// the stream could close when deploying the controller, so try to reconnect
+				log.Warn("reconnecting job event stream", "lastID", d.lastID)
+				if err := d.connectEventStream(); err != nil {
+					log.Error("error reconnecting job event stream", "err", err)
+					return err
+				}
+				continue
 			}
 			if event.Job.ReleaseID != releaseID {
 				continue
 			}
-			log.Info("got job event", "job_id", event.JobID, "type", event.Type, "state", event.State)
+			d.lastID = event.ID
+			if _, ok := d.knownJobs[event.Job.ID]; ok {
+				continue
+			}
+			log.Info("got job event", "type", event.Type, "state", event.State)
 			if _, ok := actual[event.Type]; !ok {
 				actual[event.Type] = make(map[string]int)
 			}
 			switch event.State {
 			case "up":
 				actual[event.Type]["up"] += 1
-				deployEvents <- ct.DeploymentEvent{
+				d.deployEvents <- ct.DeploymentEvent{
 					ReleaseID: releaseID,
 					JobState:  "up",
 					JobType:   event.Type,
 				}
 			case "down":
 				actual[event.Type]["down"] += 1
-				deployEvents <- ct.DeploymentEvent{
+				d.deployEvents <- ct.DeploymentEvent{
 					ReleaseID: releaseID,
 					JobState:  "down",
 					JobType:   event.Type,
 				}
 			case "crashed":
 				actual[event.Type]["crashed"] += 1
-				deployEvents <- ct.DeploymentEvent{
+				d.deployEvents <- ct.DeploymentEvent{
 					ReleaseID: releaseID,
 					JobState:  "crashed",
 					JobType:   event.Type,
 				}
 				return fmt.Errorf("job crashed!")
-			default:
-				break inner
 			}
 			if jobEventsEqual(expected, actual) {
 				return nil

--- a/controller/deployer/strategies/one-by-one.go
+++ b/controller/deployer/strategies/one-by-one.go
@@ -1,77 +1,54 @@
 package strategy
 
-import (
-	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
-	"github.com/flynn/flynn/controller/client"
-	ct "github.com/flynn/flynn/controller/types"
-)
+import ct "github.com/flynn/flynn/controller/types"
 
-func oneByOne(l log15.Logger, client *controller.Client, d *ct.Deployment, events chan<- ct.DeploymentEvent) error {
-	log := l.New("fn", "oneByOne", "deployment_id", d.ID, "app_id", d.AppID)
+func oneByOne(d *Deploy) error {
+	log := d.logger.New("fn", "oneByOne", "deployment_id", d.ID, "app_id", d.AppID)
 	log.Info("starting one-by-one deployment")
 
-	log.Info("getting job event stream")
-	jobStream := make(chan *ct.JobEvent)
-	stream, err := client.StreamJobEvents(d.AppID, 0, jobStream)
-	if err != nil {
-		log.Error("error getting job event stream", "err", err)
-		return err
-	}
-	defer stream.Close()
-
 	olog := log.New("release_id", d.OldReleaseID)
-	olog.Info("getting old formation")
-	f, err := client.GetFormation(d.AppID, d.OldReleaseID)
-	if err != nil {
-		olog.Error("error getting old formation", "err", err)
-		return err
-	}
-
-	oldProcesses := f.Processes
-	newProcesses := make(map[string]int, len(oldProcesses))
-
 	nlog := log.New("release_id", d.NewReleaseID)
-	for typ, num := range f.Processes {
-		for i := 0; i < num; i++ {
+	for typ, num := range d.Processes {
+		for i := d.newReleaseState[typ]; i < num; i++ {
 			nlog.Info("scaling new formation up by one", "type", typ)
-			newProcesses[typ]++
-			if err := client.PutFormation(&ct.Formation{
+			d.newReleaseState[typ]++
+			if err := d.client.PutFormation(&ct.Formation{
 				AppID:     d.AppID,
 				ReleaseID: d.NewReleaseID,
-				Processes: newProcesses,
+				Processes: d.newReleaseState,
 			}); err != nil {
 				nlog.Error("error scaling new formation up by one", "type", typ, "err", err)
 				return err
 			}
-			events <- ct.DeploymentEvent{
+			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.NewReleaseID,
 				JobState:  "starting",
 				JobType:   typ,
 			}
 
 			nlog.Info("waiting for job up event", "type", typ)
-			if err := waitForJobEvents(jobStream, events, d.NewReleaseID, jobEvents{typ: {"up": 1}}, nlog); err != nil {
+			if err := d.waitForJobEvents(d.NewReleaseID, jobEvents{typ: {"up": 1}}, nlog); err != nil {
 				nlog.Error("error waiting for job up event", "err", err)
 				return err
 			}
 
 			olog.Info("scaling old formation down by one", "type", typ)
-			oldProcesses[typ]--
-			if err := client.PutFormation(&ct.Formation{
+			d.oldReleaseState[typ]--
+			if err := d.client.PutFormation(&ct.Formation{
 				AppID:     d.AppID,
 				ReleaseID: d.OldReleaseID,
-				Processes: oldProcesses,
+				Processes: d.oldReleaseState,
 			}); err != nil {
 				olog.Error("error scaling old formation down by one", "type", typ, "err", err)
 				return err
 			}
-			events <- ct.DeploymentEvent{
+			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.OldReleaseID,
 				JobState:  "stopping",
 				JobType:   typ,
 			}
 			olog.Info("waiting for job down event", "type", typ)
-			if err := waitForJobEvents(jobStream, events, d.OldReleaseID, jobEvents{typ: {"down": 1}}, olog); err != nil {
+			if err := d.waitForJobEvents(d.OldReleaseID, jobEvents{typ: {"down": 1}}, olog); err != nil {
 				olog.Error("error waiting for job down event", "err", err)
 				return err
 			}

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -125,6 +125,7 @@ $$ LANGUAGE plpgsql`,
     created_at timestamptz NOT NULL DEFAULT now(),
     FOREIGN KEY (job_id, host_id) REFERENCES job_cache (job_id, host_id)
 )`,
+		`CREATE UNIQUE INDEX ON job_events (job_id, host_id, app_id, state)`,
 		`CREATE FUNCTION notify_job_event() RETURNS TRIGGER AS $$
     BEGIN
     PERFORM pg_notify('job_events:' || NEW.app_id, NEW.event_id || '');

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -144,7 +144,8 @@ $$ LANGUAGE plpgsql`,
     old_release_id uuid REFERENCES releases (release_id),
     new_release_id uuid NOT NULL REFERENCES releases (release_id),
     strategy deployment_strategy NOT NULL,
-	created_at timestamptz NOT NULL DEFAULT now(),
+    processes hstore,
+    created_at timestamptz NOT NULL DEFAULT now(),
     finished_at timestamptz)`,
 
 		`CREATE UNIQUE INDEX isolate_deploys ON deployments (app_id)

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -103,13 +103,14 @@ type NewJob struct {
 }
 
 type Deployment struct {
-	ID           string     `json:"id,omitempty"`
-	AppID        string     `json:"app,omitempty"`
-	OldReleaseID string     `json:"old_release,omitempty"`
-	NewReleaseID string     `json:"new_release,omitempty"`
-	Strategy     string     `json:"strategy,omitempty"`
-	CreatedAt    *time.Time `json:"created_at,omitempty"`
-	FinishedAt   *time.Time `json:"finished_at,omitempty"`
+	ID           string         `json:"id,omitempty"`
+	AppID        string         `json:"app,omitempty"`
+	OldReleaseID string         `json:"old_release,omitempty"`
+	NewReleaseID string         `json:"new_release,omitempty"`
+	Strategy     string         `json:"strategy,omitempty"`
+	Processes    map[string]int `json:"processes,omitempty"`
+	CreatedAt    *time.Time     `json:"created_at,omitempty"`
+	FinishedAt   *time.Time     `json:"finished_at,omitempty"`
 }
 
 type DeployID struct {

--- a/website/schema/controller/deployment.json
+++ b/website/schema/controller/deployment.json
@@ -25,6 +25,13 @@
     "strategy": {
       "$ref": "/schema/controller/common#/definitions/strategy"
     },
+    "processes": {
+      "description": "count of processes to run for each process type",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"
     },


### PR DESCRIPTION
The main changes here are determining what job events to wait for based on currently running jobs, and ensuring the deployer reconnects to the controller when waiting for job events.

Apologies for the big diff, but I did not commit along the way and splitting things out would take time.

Closes #799.