### PR TITLE
util/packer: Disable cron before starting work

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -5,6 +5,8 @@ set -xeo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 main() {
+  stop_cron
+
   if virtualbox_build; then
     # run early to speed up subsequent steps
     fix_dns_resolution
@@ -40,6 +42,11 @@ main() {
     net_cleanup
     compress
   fi
+}
+
+stop_cron() {
+  # cron can run apt/dpkg commands that will disrupt our tasks
+  service cron stop
 }
 
 virtualbox_build() {

--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -4,6 +4,9 @@ set -xeo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+# cron can run apt/dpkg commands that will disrupt our tasks
+service cron stop
+
 apt-get update
 
 if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then


### PR DESCRIPTION
The default daily crontab has a bunch of apt/dpkg commands and runs at ~06:00 which can coincide with releases and one-off builds. This will cause lock errors, as only one command at a time can manipulate the dpkg/apt databases.

This should resolve the intermittent errors during releases like this:

    Could not get lock /var/lib/apt/lists/lock - open (11: Resource temporarily unavailable)