### PR TITLE
deployer: Only rollback if jobs fail to start

### DIFF
--- a/controller/deployer/strategies/main.go
+++ b/controller/deployer/strategies/main.go
@@ -70,21 +70,20 @@ outer:
 					JobState:  "up",
 					JobType:   event.Type,
 				}
-			case "down":
+			case "down", "crashed":
 				actual[event.Type]["down"] += 1
 				deployEvents <- ct.DeploymentEvent{
 					ReleaseID: releaseID,
 					JobState:  "down",
 					JobType:   event.Type,
 				}
-			case "crashed":
-				actual[event.Type]["crashed"] += 1
+			case "failed":
 				deployEvents <- ct.DeploymentEvent{
 					ReleaseID: releaseID,
-					JobState:  "crashed",
+					JobState:  "failed",
 					JobType:   event.Type,
 				}
-				return fmt.Errorf("job crashed!")
+				return fmt.Errorf("deployer: %s job failed to start", event.Type)
 			default:
 				break inner
 			}

--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -315,8 +315,10 @@ func jobState(event *host.Event) string {
 		return "up"
 	case host.StatusDone:
 		return "down"
-	case host.StatusCrashed, host.StatusFailed:
+	case host.StatusCrashed:
 		return "crashed"
+	case host.StatusFailed:
+		return "failed"
 	default:
 		return ""
 	}

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -102,7 +102,7 @@ $$ LANGUAGE plpgsql`,
 )`,
 		`CREATE INDEX ON app_resources (resource_id)`,
 
-		`CREATE TYPE job_state AS ENUM ('starting', 'up', 'down', 'crashed')`,
+		`CREATE TYPE job_state AS ENUM ('starting', 'up', 'down', 'crashed', 'failed')`,
 		`CREATE TABLE job_cache (
     job_id text NOT NULL,
     host_id text NOT NULL,

--- a/website/schema/controller/job.json
+++ b/website/schema/controller/job.json
@@ -28,7 +28,7 @@
     },
     "state": {
       "type": "string",
-      "enum": ["starting", "up", "down", "crashed"]
+      "enum": ["starting", "up", "down", "crashed", "failed"]
     },
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"


### PR DESCRIPTION
A crashed job means the job exited non-zero, but was running at some point, so the only case when a deployment will receive a crashed event is when scaling down an old formation, in which case it doesn't matter that the job crashed as we want it to be down anyway.