### PR TITLE
script: Print usage when too many arguments given

### DIFF
--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -36,6 +36,12 @@ main() {
         ;;
     esac
   done
+  shift $((${OPTIND} - 1))
+
+  if [[ $# -ne 0 ]]; then
+    usage
+    exit 1
+  fi
 
   backend=${backend:-"libvirt-lxc"}
   domain="${domain:="dev.localflynn.com"}"

--- a/script/install-flynn.tmpl
+++ b/script/install-flynn.tmpl
@@ -42,6 +42,12 @@ main() {
         ;;
     esac
   done
+  shift $((${OPTIND} - 1))
+
+  if [[ $# -ne 0 ]]; then
+    usage
+    exit 1
+  fi
 
   repo_url="${repo_url:="https://dl.flynn.io"}"
 

--- a/script/kill-flynn
+++ b/script/kill-flynn
@@ -31,6 +31,12 @@ main() {
         ;;
     esac
   done
+  shift $((${OPTIND} - 1))
+
+  if [[ $# -ne 0 ]]; then
+    usage
+    exit 1
+  fi
 
   backend=${backend:-"libvirt-lxc"}
 

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -60,6 +60,12 @@ main() {
         ;;
     esac
   done
+  shift $((${OPTIND} - 1))
+
+  if [[ $# -ne 0 ]]; then
+    usage
+    exit 1
+  fi
 
   check_aws_keys
   check_github_token

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -33,6 +33,12 @@ main() {
         ;;
     esac
   done
+  shift $((${OPTIND} - 1))
+
+  if [[ $# -ne 0 ]]; then
+    usage
+    exit 1
+  fi
 
   local flynn="${ROOT}/cli/flynn-cli"
 


### PR DESCRIPTION
Missing a flag like `script/run-integration-tests DeployerSuite` is ignored and runs all the tests (it should be `script/run-integration-tests -f DeployerSuite`).