### PR TITLE
deployer: Only send failed event after rolling back

### DIFF
--- a/controller/deployer/main.go
+++ b/controller/deployer/main.go
@@ -127,11 +127,11 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 		// rollback failed deploy
 		if e != nil {
 			log.Warn("rolling back deployment due to error", "err", e)
+			e = c.rollback(log, deployment, f)
 			events <- ct.DeploymentEvent{
 				ReleaseID: deployment.NewReleaseID,
 				Status:    "failed",
 			}
-			e = c.rollback(log, deployment, f)
 		}
 	}()
 	log.Info("performing deployment")


### PR DESCRIPTION
This fixes a race where consumers of the events assume the deployment rollback has completed when receiving a failed event (for example `DeployerSuite.TestRollback`).

Fixes #1012.