### PR TITLE
[WIP] router: log HTTP requests

### DIFF
--- a/router/proxy/log.go
+++ b/router/proxy/log.go
@@ -1,0 +1,19 @@
+package proxy
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// countingReadCloser is wrapper of io.ReadCloser that keeps track of the number
+// of bytes read from it.
+type countingReadCloser struct {
+	io.ReadCloser
+	count uint64
+}
+
+func (r *countingReadCloser) Read(b []byte) (int, error) {
+	count, err := r.ReadCloser.Read(b)
+	atomic.AddUint64(&r.count, uint64(count))
+	return count, err
+}

--- a/router/reqlog/reqlog.go
+++ b/router/reqlog/reqlog.go
@@ -1,0 +1,102 @@
+package reqlog
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+)
+
+type Log struct {
+	ID         string
+	Method     string
+	Path       string
+	Host       string
+	RemoteAddr string
+	Backend    string
+	Start      time.Time
+	Finish     time.Time
+	StatusCode int
+	BodyBytes  uint64
+
+	// heroku-isms:
+
+	Level string
+	Code  string
+}
+
+func (rl *Log) WriteTo(logger log15.Logger) {
+	logger.Info("request",
+		"method", rl.Method,
+		"path", rl.Path,
+		"host", rl.Host,
+		"fwd", rl.RemoteAddr,
+		"backend", rl.Backend,
+		"service", durationMS(rl.Start, rl.Finish),
+		"status", rl.StatusCode,
+		"bytes.body", rl.BodyBytes,
+		"request_id", rl.ID,
+	)
+}
+
+type ctxKey int
+
+const (
+	ctxKeyLog ctxKey = iota
+)
+
+// NewContext creates a new context that carries the provided request log.
+func NewContext(ctx context.Context, log Log) context.Context {
+	return context.WithValue(ctx, ctxKeyLog, &log)
+}
+
+// StartTimeFromContext extracts a start time from a context.
+func FromContext(ctx context.Context) (log *Log, ok bool) {
+	log, ok = ctx.Value(ctxKeyLog).(*Log)
+	return
+}
+
+// TODO: maybe add a FromRequest function
+
+type ResponseWriterPlus interface {
+	http.CloseNotifier
+	http.Flusher
+	http.Hijacker
+	http.ResponseWriter
+}
+
+// ResponseTracker is wrapper of http.ResponseWriter that keeps track of its HTTP
+// status code and body size.
+type ResponseTracker struct {
+	ResponseWriterPlus
+
+	StatusCode int
+	// TODO(bgentry): for now, this only counts the bytes in the body. There's no
+	// easy way to count the bytes in the response headers, unfortunately:
+	// https://groups.google.com/forum/#!topic/golang-nuts/zq_i3Hf7Nbs
+	Size uint64
+}
+
+func (rt *ResponseTracker) Write(b []byte) (int, error) {
+	if rt.StatusCode == 0 {
+		// The status will be StatusOK if WriteHeader has not been called yet
+		rt.StatusCode = http.StatusOK
+	}
+	size, err := rt.ResponseWriterPlus.Write(b)
+	atomic.AddUint64(&rt.Size, uint64(size))
+	return size, err
+}
+
+func (rt *ResponseTracker) WriteHeader(s int) {
+	rt.ResponseWriterPlus.WriteHeader(s)
+	rt.StatusCode = s
+}
+
+func durationMS(start, finish time.Time) int {
+	if finish.IsZero() || start.IsZero() {
+		return 0
+	}
+	return int(finish.Sub(start) / time.Millisecond)
+}


### PR DESCRIPTION
This is an attempt to add structured logging to the router for HTTP requests. This fixes #168 for HTTP requests. No idea if/how this should work for the TCP listener, but that could also be done as a separate PR if it's important.

It turned out to be a bit more complicated than expected because of the fact that different bits of knowledge about a request / response pair are generated at many different places throughout the code base. To overcome that, I stuck a `Log` struct in the context at the beginning of the request pipeline. Anywhere in the code where we need to add something to that struct, we can fetch it out of the context and change a value on it.

Some items, in particular the `StatusCode` and `BodyBytes` (count of bytes in the response body) were easiest to log at the top level using a wrapped `ResponseWriter`. Others, like the time the response is received, are measured deeper in the pipeline as soon as we receive headers from the backend.

Here's a sample of the resulting logs:

```
INFO[02-16|18:50:00] request                                  app=router method=GET path=/body host=example.com fwd=127.0.0.1 backend= service=1 status=200 bytes.body=1 request_id=3a9fc75fbc8b4f76859c88c77a6682b9
INFO[02-16|18:50:00] request                                  app=router method=GET path=/header host=example.com fwd=127.0.0.1 backend= service=0 status=200 bytes.body=0 request_id=946f5e5a83434982beae7d512ce219a2
```

The format was designed to mimc the [Heroku router log format](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format). It's not a complete match, mainly because of the log15 prefixes for log level, timestamp, and message. Another key difference is that instead of recording `bytes` to represent the entire size of the response, we record `bytes.body` to record only the size of the body. It turns out it's not really feasible to record the total number of bytes for the entire response (save for hijacked conns), so hopefully this is good enough for now.

Please do let me know how you want the format to end up looking.

There are some pieces of data that we're not yet recording. One is the backend that the request was served by. Should I be logging the `ip:port` of the backend for that?

Another piece of data is the size of the request. Heroku's logs don't include this, but many will consider it valuable. We could easily wrap the request body in a `countingReadCloser`, similar to the `serveUpgrade()` path, if we wanted that data.

One result of this change is that the test logs become very noisy. Would you prefer that logs be disabled in test mode? Maybe there's already a convention for this elsewhere in Flynn?

Finally, there are no logs yet for things like failed connections to backends. Also, all 503s will look the same at this point. We could add a `code` field similar to Heroku's logs if you wanted to give more detail about why 503s are happening.

There are a few TODOs that I've intentionally left in this PR because I wasn't sure how to address them. Please give feedback on those items so I can finish it up.