### PR TITLE
scheduler: Make all schedulers watch events

### DIFF
--- a/controller/schema.go
+++ b/controller/schema.go
@@ -125,6 +125,7 @@ $$ LANGUAGE plpgsql`,
     created_at timestamptz NOT NULL DEFAULT now(),
     FOREIGN KEY (job_id, host_id) REFERENCES job_cache (job_id, host_id)
 )`,
+		`CREATE UNIQUE INDEX ON job_events (job_id, host_id, app_id, state)`,
 		`CREATE FUNCTION notify_job_event() RETURNS TRIGGER AS $$
     BEGIN
     PERFORM pg_notify('job_events:' || NEW.app_id, NEW.event_id || '');


### PR DESCRIPTION
This is so that the down event of the scheduler leader is forwarded to the controller by the non-leaders (previously they would miss the event as only the leader watched for events).

This also ensures that deploying a scheduler will wait for the new scheduler to be watching host events before killing old schedulers.