### PR TITLE
test: Don't pull the scratch Docker image

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -393,8 +393,6 @@ git config user.name "CI"
 git merge origin/master
 {{ end }}
 
-docker pull scratch
-
 make
 
 if [[ -f test/scripts/debug-info.sh ]]; then


### PR DESCRIPTION
The scratch image can no longer be pulled (see https://github.com/docker/docker/issues/10737).

This was originally added as building many images at once in CI was failing with a claim that the scratch image did not exist. Given it is no longer an image which gets downloaded, there is no need to pull it.