### PR TITLE
slugbuilder: Fix buildpack ordering (to explicit ordering set in buildpacks.txt)

### DIFF
--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -1,6 +1,7 @@
 FROM flynn/cedarish
 
 ADD ./builder/ /tmp/builder
-RUN xargs -L 1 /tmp/builder/install-buildpack /tmp/buildpacks < /tmp/builder/buildpacks.txt
+# Explicitly number the buildpacks directory based on the order of buildpacks.txt
+RUN nl -nrz /tmp/builder/buildpacks.txt | awk '{print $2 "\t" $1}' | xargs -L 1 /tmp/builder/install-buildpack /tmp/buildpacks
 ENTRYPOINT ["/tmp/builder/build.sh"]
 CMD []

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -92,13 +92,14 @@ export CURL_TIMEOUT=600
 
 ## Buildpack detection
 
+# Ordering here is in line number order from buildpacks.txt
 buildpacks=(${buildpack_root}/*)
 selected_buildpack=
 
 if [[ -n "${BUILDPACK_URL}" ]]; then
   echo_title "Fetching custom buildpack"
 
-  buildpack="${buildpack_root}/custom"
+  buildpack="${buildpack_root}/custom*"
   rm -rf "${buildpack}"
   /tmp/builder/install-buildpack \
     "${buildpack_root}" \
@@ -106,7 +107,8 @@ if [[ -n "${BUILDPACK_URL}" ]]; then
     custom \
     "${env_dir}" \
     &> /dev/null
-  selected_buildpack="${buildpack}"
+  buildpacks=($buildpack)
+  selected_buildpack=${buildpack[0]}
   buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_root}")
 else
   for buildpack in "${buildpacks[@]}"; do

--- a/slugbuilder/builder/install-buildpack
+++ b/slugbuilder/builder/install-buildpack
@@ -3,7 +3,7 @@ set -eo pipefail
 
 buildpacks_dir="$1"
 buildpack_url="$2"
-buildpack_name="$3"
+buildpack_order="$3"
 env_dir="$4"
 
 export_env_dir() {
@@ -22,11 +22,8 @@ export_env_dir() {
 #Only import proxy related environment variables to support 'git clone'
 export_env_dir "${env_dir}" '(HTTP_PROXY|HTTPS_PROXY|NO_PROXY)$'
 
-
-if [[ "${buildpack_name}" == "" ]]; then
-  buildpack_name="$(basename "${buildpack_url}")"
-  buildpack_name="${buildpack_name%.*}"
-fi
+buildpack_name="$(basename "${buildpack_url}")"
+buildpack_name="${buildpack_order}_${buildpack_name%.*}"
 
 mkdir -p "${buildpacks_dir}"
 pushd "${buildpacks_dir}" > /dev/null


### PR DESCRIPTION
Signed-off-by: Nathaniel Eliot <nathaniel.eliot@bazaarvoice.com>