### PR TITLE
dashboard: Improve CA certificate installation flow

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/views/install-cert.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/install-cert.js.jsx
@@ -11,6 +11,12 @@ Dashboard.Views.InstallCert = React.createClass({
 				<section>
 					<header>
 						<h1>Install CA certificate to continue</h1>
+						<p>
+							This CA certificate allows you to access the dashboard securely.
+							The certificate was generated as part of the installation process, and the private key has already been discarded.
+							The only certificates it has signed are for the cluster domain, and no more certificates can be signed by it.
+							You <em>should not</em> continue if you are on an untrusted connection.
+						</p>
 					</header>
 
 					{this.props.browserName === "firefox" ? (

--- a/pkg/certgen/certgen.go
+++ b/pkg/certgen/certgen.go
@@ -56,7 +56,7 @@ func Generate(p Params) (*Certificate, error) {
 		IsCA: p.IsCA,
 	}
 	if p.IsCA {
-		template.Subject.OrganizationalUnit = []string{"CA"}
+		template.Subject.OrganizationalUnit = []string{"Flynn Ephemeral CA"}
 		template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
 	} else {
 		template.Subject.CommonName = p.Hosts[0]


### PR DESCRIPTION
Make it clearer what is happening and point out that the CA certificate is ephemeral.