### PR TITLE
dashboard: Use new route JSON structure

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/views/app-routes.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/app-routes.js.jsx
@@ -42,10 +42,10 @@ Dashboard.Views.AppRoutes = React.createClass({
 				<ul>
 					{this.state.routes.map(function (route) {
 						return (
-							<li key={route.id || route.config.domain}>
-								<ExternalLink href={"http://"+ route.config.domain}>{route.config.domain}</ExternalLink>
+							<li key={route.id || route.domain}>
+								<ExternalLink href={"http://"+ route.domain}>{route.domain}</ExternalLink>
 								{route.id ? (
-									<RouteLink path={getAppPath("/routes/:route/delete", {route: route.id, domain: route.config.domain})}>
+									<RouteLink path={getAppPath("/routes/:route/delete", {route: route.id, domain: route.domain})}>
 										<i className="icn-trash" />
 									</RouteLink>
 								) : null}


### PR DESCRIPTION
Properties previously found in `config` are now in the root object

refs 4ebafaa3078786fb6561b5ca61a541ca57e0442f

refs #1030