### PR TITLE
dashboard: Fix log output in Chrome/Safari

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/stores/job-output.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/job-output.js
@@ -111,7 +111,6 @@ var JobOutput = Dashboard.Stores.JobOutput = Dashboard.Store.createClass({
 					eventSource.close();
 					return;
 			}
-			evnt.data.stream = evnt.name;
 			this.setState({
 				output: this.state.output.concat([evnt])
 			});


### PR DESCRIPTION
Remove unused assignment which causes an error in Chrome/Safari

refs 985209b6041bf0076a6294f5e5f09c3c54b35e7c

closes #1030