### PR TITLE
gitreceived: Cache repos in blobstore.

### DIFF
--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -1,0 +1,87 @@
+package archiver
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func Tar(dir string, w *tar.Writer) error {
+	if err := filepath.Walk(dir, func(path string, file os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if file.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		fpath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		hdr := &tar.Header{
+			Name:    fpath,
+			Size:    file.Size(),
+			Mode:    int64(file.Mode()),
+			ModTime: file.ModTime(),
+		}
+
+		if err := w.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		if _, err = io.Copy(w, f); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Untar(dir string, r *tar.Reader) error {
+	for {
+		header, err := r.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		filename := filepath.Join(dir, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(filename, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+			if err := os.Chmod(filename, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			// if the files are out of order, the dir might not exist yet
+			if err := os.MkdirAll(filepath.Dir(filename), os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+			writer, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			defer writer.Close()
+			if _, err := io.Copy(writer, r); err != nil {
+				return err
+			}
+		default:
+		}
+	}
+	return nil
+}

--- a/test/test_gitreceive.go
+++ b/test/test_gitreceive.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"time"
+
+	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+type GitreceiveSuite struct {
+	Helper
+}
+
+var _ = c.Suite(&GitreceiveSuite{})
+
+func (s *GitreceiveSuite) SetUpSuite(t *c.C) {
+	t.Assert(flynn(t, "/", "key", "add", s.sshKeys(t).Pub), Succeeds)
+}
+
+func (s *GitreceiveSuite) TestRepoCaching(t *c.C) {
+	r := s.newGitRepo(t, "empty")
+	t.Assert(r.flynn("create"), Succeeds)
+
+	r.git("commit", "-m", "bump", "--allow-empty")
+	r.git("commit", "-m", "bump", "--allow-empty")
+	push := r.git("push", "flynn", "master")
+	t.Assert(push, Succeeds)
+	t.Assert(push, c.Not(OutputContains), "cached")
+
+	// cycle the receiver to clear any cache
+	t.Assert(flynn(t, "/", "-a", "gitreceive", "scale", "app=0"), Succeeds)
+	t.Assert(flynn(t, "/", "-a", "gitreceive", "scale", "app=1"), Succeeds)
+	_, err := s.discoverdClient(t).Instances("gitreceive", 10*time.Second)
+	t.Assert(err, c.IsNil)
+
+	r.git("commit", "-m", "bump", "--allow-empty")
+	push = r.git("push", "flynn", "master", "--progress")
+	t.Assert(push, Succeeds)
+	// should only contain one object
+	t.Assert(push, OutputContains, "Counting objects: 1, done.")
+}


### PR DESCRIPTION
Allows us to consistently cache repos across different gitreceived instances. Fixes #212

Signed-off-by: Blaž Hrastnik <blaz.hrast@gmail.com>