### PR TITLE
test: Don't start daemons when building the rootfs

### DIFF
--- a/test/rootfs/build.sh
+++ b/test/rootfs/build.sh
@@ -19,7 +19,9 @@ trap cleanup ERR
 image="http://cdimage.ubuntu.com/ubuntu-core/releases/14.04.1/release/ubuntu-core-14.04.1-core-amd64.tar.gz"
 curl -L ${image} | sudo tar -xzC ${dir}
 
-sudo chroot ${dir} bash < "${src_dir}/setup.sh"
+# use jchroot (https://github.com/vincentbernat/jchroot) which uses a PID
+# namespace so daemons do not outlive the setup and prevent unmounting rootfs.img
+sudo jchroot ${dir} bash < "${src_dir}/setup.sh"
 
 sudo cp ${dir}/boot/vmlinuz-* ${build_dir}/vmlinuz
 


### PR DESCRIPTION
Some daemons were starting in the chroot (e.g. upstart-udev-bridge, docker, rsyslogd) and preventing unmounting the rootfs.img.

The `initctl` + `policy-rc.d` hacks were good enough for most daemons, but for some reason `docker` was managing to circumvent that, so `jchroot` is needed so that `docker` gets killed by the kernel when the PID namespace goes away.

Fixes #1026.