### PR TITLE
logging: Add a log aggregator component

### DIFF
--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/flynn/flynn/pkg/shutdown"
+)
+
+func main() {
+	defer shutdown.Exit()
+
+	listenPort := os.Getenv("PORT")
+	if listenPort == "" {
+		listenPort = "5000"
+	}
+
+	listenAddr := flag.String("listenaddr", ":"+listenPort, "syslog input listen address")
+
+	a := NewAggregator(*listenAddr)
+	if err := a.Start(); err != nil {
+		shutdown.Fatal(err)
+	}
+	shutdown.BeforeExit(a.Shutdown)
+	defer shutdown.Exit()
+}
+
+// Aggregator is a log aggregation server that collects syslog messages.
+type Aggregator struct {
+	// Addr is the address (host:port) to listen on for incoming syslog messages.
+	Addr string
+
+	listener     net.Listener
+	logc         chan []byte
+	numConsumers int
+	consumerwg   sync.WaitGroup
+	producerwg   sync.WaitGroup
+
+	once     sync.Once // protects the following:
+	shutdown chan struct{}
+}
+
+// NewAggregator creates a new unstarted Aggregator that will listen on addr.
+func NewAggregator(addr string) *Aggregator {
+	return &Aggregator{
+		Addr:         "127.0.0.1:0",
+		logc:         make(chan []byte),
+		numConsumers: 10,
+		shutdown:     make(chan struct{}),
+	}
+}
+
+// Start starts the Aggregator on Addr.
+func (a *Aggregator) Start() error {
+	var err error
+	a.listener, err = net.Listen("tcp", a.Addr)
+	if err != nil {
+		return err
+	}
+	a.Addr = a.listener.Addr().String()
+
+	for i := 0; i < a.numConsumers; i++ {
+		a.consumerwg.Add(1)
+		go func() {
+			defer a.consumerwg.Done()
+			a.consumeLogs()
+		}()
+	}
+
+	a.producerwg.Add(1)
+	go func() {
+		defer a.producerwg.Done()
+		a.accept()
+	}()
+	return nil
+}
+
+// Shutdown shuts down the Aggregator gracefully by closing its listener,
+// and waiting for already-received logs to be processed.
+func (a *Aggregator) Shutdown() {
+	a.once.Do(func() {
+		close(a.shutdown)
+		a.listener.Close()
+		a.producerwg.Wait()
+		close(a.logc)
+		a.consumerwg.Wait()
+	})
+}
+
+func (a *Aggregator) accept() {
+	defer a.listener.Close()
+
+	for {
+		select {
+		case <-a.shutdown:
+			return
+		default:
+		}
+		conn, err := a.listener.Accept()
+		if err != nil {
+			continue
+		}
+
+		a.producerwg.Add(1)
+		go func() {
+			defer a.producerwg.Done()
+			a.readLogsFromConn(conn)
+		}()
+	}
+}
+
+// testing hook:
+var afterMessage func()
+
+func (a *Aggregator) consumeLogs() {
+	for line := range a.logc {
+		// TODO: forward message to follower aggregator
+		// TODO: parse the message, send it to the right bucket
+		fmt.Printf("message received: %q\n", string(line))
+		if afterMessage != nil {
+			afterMessage()
+		}
+	}
+}
+
+func (a *Aggregator) readLogsFromConn(conn net.Conn) {
+	defer conn.Close()
+
+	connDone := make(chan struct{})
+	defer close(connDone)
+
+	go func() {
+		select {
+		case <-connDone:
+		case <-a.shutdown:
+			conn.Close()
+		}
+	}()
+
+	s := bufio.NewScanner(conn)
+	s.Split(rfc6587Split)
+	for s.Scan() {
+		msg := s.Bytes()
+		// slice in msg could get modified on next Scan(), need to copy it
+		msgCopy := make([]byte, len(msg))
+		copy(msgCopy, msg)
+		a.logc <- msgCopy
+	}
+}
+
+func rfc6587Split(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	i := bytes.IndexByte(data, ' ')
+	switch {
+	case i == 0:
+		return 0, nil, errors.New("expected MSG-LEN, got space")
+	case i > 5:
+		return 0, nil, errors.New("MSG-LEN was longer than 5 characters")
+	case i > 0:
+		msgLen := data[0:i]
+		length, err := strconv.Atoi(string(msgLen))
+		if err != nil {
+			return 0, nil, err
+		}
+		if length > 10000 {
+			return 0, nil, fmt.Errorf("maximum MSG-LEN is 10000, got %d", length)
+		}
+		end := length + i + 1
+		if len(data) >= end {
+			// Return frame without msg length
+			return end, data[i+1 : end], nil
+		}
+	}
+	// Request more data.
+	return 0, nil, nil
+}

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/flynn/flynn/logaggregator/rfc5424"
+	"github.com/flynn/flynn/logaggregator/ring"
 	"github.com/flynn/flynn/pkg/shutdown"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
@@ -40,6 +41,8 @@ type Aggregator struct {
 	// Addr is the address (host:port) to listen on for incoming syslog messages.
 	Addr string
 
+	bmu          sync.Mutex // protects buffers
+	buffers      map[string]*ring.Buffer
 	listener     net.Listener
 	logc         chan []byte
 	numConsumers int
@@ -54,6 +57,7 @@ type Aggregator struct {
 func NewAggregator(addr string) *Aggregator {
 	return &Aggregator{
 		Addr:         "127.0.0.1:0",
+		buffers:      make(map[string]*ring.Buffer),
 		logc:         make(chan []byte),
 		numConsumers: 10,
 		shutdown:     make(chan struct{}),
@@ -125,19 +129,29 @@ var afterMessage func()
 func (a *Aggregator) consumeLogs() {
 	for line := range a.logc {
 		// TODO: forward message to follower aggregator
-		// TODO: parse the message, send it to the right bucket
-		fmt.Printf("message received: %q\n", string(line))
 		msg, err := rfc5424.Parse(line)
 		if err != nil {
 			log15.Error("rfc5424 parse error", "err", err)
 			continue
 		}
-		fmt.Printf("MSG: %#v\n", msg)
+		a.getBuffer(msg.AppName).Add(msg)
 
 		if afterMessage != nil {
 			afterMessage()
 		}
 	}
+}
+
+func (a *Aggregator) getBuffer(id string) *ring.Buffer {
+	a.bmu.Lock()
+	defer a.bmu.Unlock()
+
+	if buf, ok := a.buffers[id]; ok {
+		return buf
+	}
+	buf := ring.NewBuffer()
+	a.buffers[id] = buf
+	return buf
 }
 
 func (a *Aggregator) readLogsFromConn(conn net.Conn) {

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -101,6 +101,15 @@ func (a *Aggregator) Shutdown() {
 	})
 }
 
+// ReadNLogs reads up to N logs from the log buffer with id. If n is 0, or if
+// there are fewer than n logs buffered, all buffered logs are returned.
+func (a *Aggregator) ReadLastN(id string, n int) []*rfc5424.Message {
+	if n == 0 {
+		return a.getBuffer(id).ReadAll()
+	}
+	return a.getBuffer(id).ReadLastN(n)
+}
+
 func (a *Aggregator) accept() {
 	defer a.listener.Close()
 

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -11,7 +11,10 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/flynn/flynn/logaggregator/rfc5424"
 	"github.com/flynn/flynn/pkg/shutdown"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 )
 
 func main() {
@@ -124,6 +127,13 @@ func (a *Aggregator) consumeLogs() {
 		// TODO: forward message to follower aggregator
 		// TODO: parse the message, send it to the right bucket
 		fmt.Printf("message received: %q\n", string(line))
+		msg, err := rfc5424.Parse(line)
+		if err != nil {
+			log15.Error("rfc5424 parse error", "err", err)
+			continue
+		}
+		fmt.Printf("MSG: %#v\n", msg)
+
 		if afterMessage != nil {
 			afterMessage()
 		}

--- a/logaggregator/main_test.go
+++ b/logaggregator/main_test.go
@@ -79,8 +79,7 @@ func (s *LogAggregatorTestSuite) TestAggregatorBuffersMessages(c *C) {
 		<-messageReceived // wait for messages to be received
 	}
 
-	buf := s.a.getBuffer("app")
-	msgs := buf.ReadAll()
+	msgs := s.a.ReadLastN("app", 0)
 	c.Assert(msgs, HasLen, 2)
 	c.Assert(msgs[0].ProcID, Equals, "web.1")
 	c.Assert(msgs[1].ProcID, Equals, "web.2")

--- a/logaggregator/main_test.go
+++ b/logaggregator/main_test.go
@@ -38,8 +38,8 @@ func (s *LogAggregatorTestSuite) TestAggregatorListensOnAddr(c *C) {
 }
 
 const (
-	sampleLogLine1 = "120 <40>1 2012-11-30T06:45:26+00:00 host app web.3 - - Starting process with command `bundle exec rackup config.ru -p 24405`"
-	sampleLogLine2 = "77 <40>1 2012-11-30T06:45:26+00:00 host app web.3 - - 25 yay this is a message!!!\n"
+	sampleLogLine1 = "120 <40>1 2012-11-30T06:45:26+00:00 host app web.1 - - Starting process with command `bundle exec rackup config.ru -p 24405`"
+	sampleLogLine2 = "77 <40>1 2012-11-30T06:45:26+00:00 host app web.2 - - 25 yay this is a message!!!\n"
 )
 
 func (s *LogAggregatorTestSuite) TestAggregatorShutdown(c *C) {
@@ -57,7 +57,7 @@ func (s *LogAggregatorTestSuite) TestAggregatorShutdown(c *C) {
 	}
 }
 
-func (s *LogAggregatorTestSuite) TestAggregatorReceivesMessages(c *C) {
+func (s *LogAggregatorTestSuite) TestAggregatorBuffersMessages(c *C) {
 	// set up testing hook:
 	messageReceived := make(chan struct{})
 	afterMessage = func() {
@@ -79,6 +79,11 @@ func (s *LogAggregatorTestSuite) TestAggregatorReceivesMessages(c *C) {
 		<-messageReceived // wait for messages to be received
 	}
 
+	buf := s.a.getBuffer("app")
+	msgs := buf.ReadAll()
+	c.Assert(msgs, HasLen, 2)
+	c.Assert(msgs[0].ProcID, Equals, "web.1")
+	c.Assert(msgs[1].ProcID, Equals, "web.2")
 	s.a.Shutdown()
 }
 

--- a/logaggregator/main_test.go
+++ b/logaggregator/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type LogAggregatorTestSuite struct {
+	a *Aggregator
+}
+
+var _ = Suite(&LogAggregatorTestSuite{})
+
+func (s *LogAggregatorTestSuite) SetUpTest(c *C) {
+	s.a = NewAggregator("127.0.0.1:0")
+	err := s.a.Start()
+	c.Assert(err, IsNil)
+}
+
+func (s *LogAggregatorTestSuite) TearDownTest(c *C) {
+	s.a.Shutdown()
+}
+
+func (s *LogAggregatorTestSuite) TestAggregatorListensOnAddr(c *C) {
+	ip, port, err := net.SplitHostPort(s.a.Addr)
+	c.Assert(err, IsNil)
+	c.Assert(ip, Equals, "127.0.0.1")
+	c.Assert(port, Not(Equals), "0")
+
+	conn, err := net.Dial("tcp", s.a.Addr)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+}
+
+const (
+	sampleLogLine1 = "120 <40>1 2012-11-30T06:45:26+00:00 host app web.3 - - Starting process with command `bundle exec rackup config.ru -p 24405`"
+	sampleLogLine2 = "77 <40>1 2012-11-30T06:45:26+00:00 host app web.3 - - 25 yay this is a message!!!\n"
+)
+
+func (s *LogAggregatorTestSuite) TestAggregatorShutdown(c *C) {
+	conn, err := net.Dial("tcp", s.a.Addr)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	conn.Write([]byte(sampleLogLine1))
+	s.a.Shutdown()
+
+	select {
+	case <-s.a.logc:
+	default:
+		c.Errorf("logc was not closed")
+	}
+}
+
+func (s *LogAggregatorTestSuite) TestAggregatorReceivesMessages(c *C) {
+	// set up testing hook:
+	messageReceived := make(chan struct{})
+	afterMessage = func() {
+		messageReceived <- struct{}{}
+	}
+	defer func() { afterMessage = nil }()
+
+	conn, err := net.Dial("tcp", s.a.Addr)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(sampleLogLine1))
+	c.Assert(err, IsNil)
+	_, err = conn.Write([]byte(sampleLogLine2))
+	c.Assert(err, IsNil)
+	conn.Close()
+
+	for i := 0; i < 2; i++ {
+		<-messageReceived // wait for messages to be received
+	}
+
+	s.a.Shutdown()
+}
+
+// TODO(bgentry): tests specifically for rfc6587Split()

--- a/logaggregator/rfc5424/rfc5424.go
+++ b/logaggregator/rfc5424/rfc5424.go
@@ -1,0 +1,172 @@
+package rfc5424
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+	"time"
+)
+
+type Message struct {
+	Facility       int
+	Severity       int
+	Version        int
+	Timestamp      time.Time
+	Hostname       string
+	AppName        string
+	ProcID         string
+	MsgID          string
+	StructuredData string
+	Msg            string
+}
+
+func (m Message) PriVal() int {
+	return m.Facility*8 + m.Severity
+}
+
+func Parse(buf []byte) (*Message, error) {
+	cursor := 0
+	msg := &Message{}
+	if err := parseHeader(buf, &cursor, msg); err != nil {
+		return nil, err
+	}
+
+	if err := parseStructuredData(buf, &cursor, msg); err != nil {
+		return nil, err
+	}
+
+	if cursor < len(buf) {
+		msg.Msg = string(buf[cursor:])
+	}
+
+	return msg, nil
+}
+
+const (
+	priStart = '<'
+	priEnd   = '>'
+)
+
+// HEADER = PRI VERSION SP TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID
+func parseHeader(buf []byte, cursor *int, msg *Message) error {
+	var err error
+	if err = parsePriority(buf, cursor, msg); err != nil {
+		return err
+	}
+
+	if err = parseVersion(buf, cursor, msg); err != nil {
+		return err
+	}
+
+	if err = parseTimestamp(buf, cursor, msg); err != nil {
+		return err
+	}
+
+	if msg.Hostname, err = parseNextStringField(buf, cursor); err != nil {
+		return err
+	}
+
+	if msg.AppName, err = parseNextStringField(buf, cursor); err != nil {
+		return err
+	}
+
+	if msg.ProcID, err = parseNextStringField(buf, cursor); err != nil {
+		return err
+	}
+
+	if msg.MsgID, err = parseNextStringField(buf, cursor); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parsePriority(buf []byte, cursor *int, msg *Message) error {
+	if len(buf) < *cursor+3 {
+		return errors.New("invalid priority")
+	}
+	if buf[*cursor] != priStart {
+		return errors.New("invalid priority")
+	}
+	*cursor++
+	i := indexByteAfter(buf, priEnd, *cursor)
+	if i < 1 || i > 4 {
+		return errors.New("invalid priority")
+	}
+	prival, err := strconv.Atoi(string(buf[*cursor:i]))
+	if err != nil {
+		return err
+	}
+	if prival < 0 || prival > 191 {
+		return errors.New("invalid priority")
+	}
+	msg.Facility = prival / 8
+	msg.Severity = prival % 8
+	*cursor = i + 1
+
+	return nil
+}
+
+func parseVersion(buf []byte, cursor *int, msg *Message) error {
+	if len(buf) < *cursor+1 {
+		return errors.New("message ended before version was received")
+	}
+	if buf[*cursor] != '1' || buf[*cursor+1] != ' ' {
+		return errors.New("unexpected syslog version")
+	}
+	msg.Version = 1
+	*cursor += 2
+	return nil
+}
+
+func parseTimestamp(buf []byte, cursor *int, msg *Message) error {
+	var err error
+	nextSpace := indexByteAfter(buf, ' ', *cursor)
+	if nextSpace < *cursor {
+		return errors.New("missing space")
+	}
+	if nextSpace == *cursor {
+		return errors.New("missing timestamp")
+	}
+	msg.Timestamp, err = time.Parse(time.RFC3339Nano, string(buf[*cursor:nextSpace]))
+	if err != nil {
+		return err
+	}
+	*cursor = nextSpace + 1
+	return nil
+}
+
+func parseNextStringField(buf []byte, cursor *int) (string, error) {
+	if len(buf) < *cursor {
+		return "", errors.New("missing field")
+	}
+	nextSpace := indexByteAfter(buf, ' ', *cursor)
+	if nextSpace < 0 {
+		return "", errors.New("missing space")
+	}
+	if nextSpace == 1 {
+		return "", errors.New("missing value")
+	}
+	res := string(buf[*cursor:nextSpace])
+	*cursor = nextSpace + 1
+	return res, nil
+}
+
+func parseStructuredData(buf []byte, cursor *int, msg *Message) error {
+	if len(buf) < *cursor {
+		return errors.New("missing structured data field")
+	}
+	if buf[*cursor] == '-' {
+		if len(buf) < *cursor+1 || buf[*cursor+1] != ' ' {
+			return errors.New("invalid structured data")
+		}
+		*cursor++
+		msg.StructuredData = "-"
+		return nil
+	}
+	return errors.New("structured data is unsupported")
+}
+
+func indexByteAfter(buf []byte, c byte, after int) int {
+	return bytes.IndexByte(buf[after:], c) + after
+}

--- a/logaggregator/ring/ring.go
+++ b/logaggregator/ring/ring.go
@@ -1,0 +1,92 @@
+package ring
+
+import (
+	"sync"
+
+	"github.com/flynn/flynn/logaggregator/rfc5424"
+)
+
+// Buffer is a ring buffer that holds rfc5424.Messages. The Buffer's entire
+// contents can be read at once. Reading elements out of the buffer does not
+// clear them; messages merely get moved out of the buffer when they are
+// replaced by new messages.
+type Buffer struct {
+	messages []*rfc5424.Message
+	start    int
+	mu       sync.RWMutex
+}
+
+const DefaultBufferCapacity = 10000
+
+// NewBuffer returns an empty allocated Buffer with DefaultBufferCapacity.
+func NewBuffer() *Buffer {
+	return &Buffer{
+		messages: make([]*rfc5424.Message, 0, DefaultBufferCapacity),
+	}
+}
+
+// Add adds an element to the Buffer. If the Buffer is already full, it replaces
+// an existing message.
+func (b *Buffer) Add(m *rfc5424.Message) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.messages) < cap(b.messages) {
+		// buffer not yet full
+		b.messages = append(b.messages, m)
+	} else {
+		// buffer already full, replace the value at start
+		b.messages[b.start] = m
+		b.start++
+
+		if b.start == cap(b.messages) {
+			b.start = 0
+		}
+	}
+}
+
+// Capacity returns the capicity of the Buffer.
+func (b *Buffer) Capacity() int {
+	return cap(b.messages)
+}
+
+// ReadAll returns a copied slice with the contents of the Buffer. It does not
+// modify the underlying buffer in any way. You are free to modify the
+// returned slice without affecting Buffer, though modifying the individual
+// elements in the result will also modify those elements in the Buffer.
+func (b *Buffer) ReadAll() []*rfc5424.Message {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	buf := make([]*rfc5424.Message, len(b.messages))
+	if n := copy(buf, b.messages[b.start:len(b.messages)]); n < len(b.messages) {
+		copy(buf[n:], b.messages[:b.start])
+	}
+	return buf
+}
+
+// ReadLastN will return the most recent n messages from the Buffer, up to the
+// length of the buffer. If n is larger than the Buffer length, a smaller number
+// will be returned. Panics if n < 0.
+func (b *Buffer) ReadLastN(n int) []*rfc5424.Message {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if n > len(b.messages) {
+		n = len(b.messages)
+	}
+
+	buf := make([]*rfc5424.Message, n)
+	copied := 0
+	if n > (b.start) {
+		start := b.start
+		if n < len(b.messages)-start {
+			start = len(b.messages) - n
+		}
+		copied = copy(buf, b.messages[start:])
+	}
+	if n > copied {
+		copy(buf[copied:], b.messages[n-copied:(b.start-copied)])
+	}
+	return buf
+}

--- a/logaggregator/ring/ring_test.go
+++ b/logaggregator/ring/ring_test.go
@@ -1,0 +1,87 @@
+package ring
+
+import (
+	"strconv"
+	"testing"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/logaggregator/rfc5424"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct {
+}
+
+var _ = Suite(&S{})
+
+func (s *S) TestNewBuffer(c *C) {
+	b := NewBuffer()
+	c.Assert(b.messages, HasLen, 0)
+	c.Assert(cap(b.messages), Equals, DefaultBufferCapacity)
+	c.Assert(b.start, Equals, 0)
+}
+
+func (s *S) TestBuffer(c *C) {
+	b := NewBuffer()
+
+	// test the empty buffer
+	res := b.ReadAll()
+	c.Assert(res, HasLen, 0)
+	c.Assert(cap(res), Equals, 0)
+
+	// add a couple of elements
+	msg0 := &rfc5424.Message{Msg: "0"}
+	msg1 := &rfc5424.Message{Msg: "1"}
+	b.Add(msg0)
+	b.Add(msg1)
+
+	res = b.ReadAll()
+	c.Assert(res, HasLen, 2)
+	c.Assert(cap(res), Equals, 2)
+	c.Assert(res[0], Equals, msg0)
+	c.Assert(res[1], Equals, msg1)
+
+	// overfill the buffer by exactly one
+	for i := 2; i < DefaultBufferCapacity+1; i++ {
+		b.Add(&rfc5424.Message{Msg: strconv.Itoa(i)})
+	}
+	res = b.ReadAll()
+	c.Assert(res, HasLen, DefaultBufferCapacity)
+	c.Assert(cap(res), Equals, DefaultBufferCapacity)
+	c.Assert(res[0], Equals, msg1)
+	for i := 1; i < len(res); i++ {
+		c.Assert(res[i].Msg, Equals, strconv.Itoa(i+1))
+	}
+
+	// ensure that modifying an element in res doesn't modify original buffer
+	res[0] = &rfc5424.Message{Msg: "A replacement message"}
+	c.Assert(b.messages[1], Equals, msg1)
+}
+
+func (s *S) TestReadLastN(c *C) {
+	b := NewBuffer()
+
+	// add a couple of elements
+	msg0 := &rfc5424.Message{Msg: "0"}
+	msg1 := &rfc5424.Message{Msg: "1"}
+	b.Add(msg0)
+	b.Add(msg1)
+
+	res := b.ReadLastN(1)
+	c.Assert(res, HasLen, 1)
+	c.Assert(cap(res), Equals, 1)
+	c.Assert(res[0], Equals, msg1)
+
+	// overfill the buffer by exactly one
+	for i := 2; i < DefaultBufferCapacity+1; i++ {
+		b.Add(&rfc5424.Message{Msg: strconv.Itoa(i)})
+	}
+	res = b.ReadLastN(5)
+	c.Assert(res, HasLen, 5)
+	c.Assert(cap(res), Equals, 5)
+	for i := 0; i < 5; i++ {
+		c.Assert(res[i].Msg, Equals, strconv.Itoa(b.Capacity()-5+i))
+	}
+}


### PR DESCRIPTION
This is my first batch of progress on a log aggregator component. This component takes syslog-over-TCP input (RFC 6587 / RFC 5424), parses the messages, and buckets the logs into individual buffers based on the `AppName` field in the syslog header.

Buffers currently have a fixed size of 10,000 log messages. I think I'd like to change this to be configurable and maybe make it work based on the number of bytes in the buffered messages, rather than be based on the count of the messages. It would probably be good if all buffers weren't pre-allocated with a slice of capacity 10,000.

Logs will be sent to this aggregator by the “collectors” running on each instance, a component that @benburkert is working on.

The log aggregator will provide an API that the controller will use to fetch logs out of the buffer. It will also replicate the raw log stream to another aggregator for failover purposes. Eventually it should be able to drain logs for a given channel to syslog or HTTP destinations.

Any comments on the direction of this at this early stage would be appreciated!