### PR TITLE
Expose containerinit logs

### DIFF
--- a/host/attach.go
+++ b/host/attach.go
@@ -89,6 +89,9 @@ func (h *attachHandler) attach(req *host.AttachReq, conn io.ReadWriteCloser) {
 	if req.Flags&host.AttachFlagStderr != 0 {
 		opts.Stderr = newFrameWriter(2, w, writeMtx)
 	}
+	if req.Flags&host.AttachFlagInitLog != 0 {
+		opts.InitLog = newFrameWriter(3, w, writeMtx)
+	}
 
 	go func() {
 		defer func() {

--- a/host/backend.go
+++ b/host/backend.go
@@ -15,9 +15,10 @@ type AttachRequest struct {
 
 	Attached chan struct{}
 
-	Stdout io.WriteCloser
-	Stderr io.WriteCloser
-	Stdin  io.Reader
+	Stdout  io.WriteCloser
+	Stderr  io.WriteCloser
+	InitLog io.WriteCloser
+	Stdin   io.Reader
 }
 
 type Backend interface {

--- a/host/cli/upload-debug-info.go
+++ b/host/cli/upload-debug-info.go
@@ -110,7 +110,7 @@ func captureJobs(gist *Gist) error {
 		var content bytes.Buffer
 		printJobDesc(&job, &content)
 		fmt.Fprint(&content, "\n\n***** ***** ***** ***** ***** ***** ***** ***** ***** *****\n\n")
-		getLog(job.HostID, job.Job.ID, client, false, &content, &content)
+		getLog(job.HostID, job.Job.ID, client, false, true, &content, &content)
 
 		gist.AddFile(name, content.String())
 	}

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -659,9 +659,9 @@ func (c *libvirtContainer) watch(ready chan<- error) error {
 
 	if !c.job.Config.TTY {
 		g.Log(grohl.Data{"at": "get_stdout"})
-		stdout, stderr, err := c.Client.GetStdout()
+		stdout, stderr, initLog, err := c.Client.GetStreams()
 		if err != nil {
-			g.Log(grohl.Data{"at": "get_stdout", "status": "error", "err": err.Error()})
+			g.Log(grohl.Data{"at": "get_streams", "status": "error", "err": err.Error()})
 			return err
 		}
 		log := c.l.openLog(c.job.ID)
@@ -669,6 +669,7 @@ func (c *libvirtContainer) watch(ready chan<- error) error {
 		// TODO: log errors from these
 		go log.Follow(1, stdout)
 		go log.Follow(2, stderr)
+		go log.Follow(3, initLog)
 	}
 
 	g.Log(grohl.Data{"at": "watch_changes"})
@@ -880,6 +881,8 @@ func (l *LibvirtLXCBackend) Attach(req *AttachRequest) (err error) {
 			w = req.Stdout
 		case 2:
 			w = req.Stderr
+		case 3:
+			w = req.InitLog
 		}
 		if w == nil {
 			continue

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -219,6 +219,7 @@ const (
 	AttachFlagStdin
 	AttachFlagLogs
 	AttachFlagStream
+	AttachFlagInitLog
 )
 
 type JobStatus uint8

--- a/pkg/cluster/attach.go
+++ b/pkg/cluster/attach.go
@@ -163,9 +163,9 @@ func (c *attachClient) Receive(stdout, stderr io.Writer) (int, error) {
 					return -1, errors.New("attach: got frame for stdout, but no writer available")
 				}
 				out = &stdout
-			case 2:
+			case 2, 3:
 				if stderr == nil {
-					return -1, errors.New("attach: got frame for stderr, but no writer available")
+					return -1, errors.New("attach: got frame for stderr / initLog, but no writer available")
 				}
 				out = &stderr
 			default:

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -596,6 +596,6 @@ func (c *Cluster) dumpLogs(w io.Writer) {
 			fallback()
 			return
 		}
-		run(c.Instances[0], fmt.Sprintf("flynn-host log %s", id))
+		run(c.Instances[0], fmt.Sprintf("flynn-host log --init %s", id))
 	}
 }


### PR DESCRIPTION
In order to debug #907, it would be useful to know what is happening internally in containerinit, and exposing logs is a start at that.

My first aim was to redirect the console of the containers to a file, but that is not supported ([the console must be a PTY](http://libvirt.org/git/?p=libvirt.git;a=blob;f=src/lxc/lxc_process.c;h=f1b36f1;hb=7212990#l1060)), and the consoles can't be connected after a container has exited to get the log, so instead I have exposed the logs via RPC and used logbuf to pipe them to a file.

Ideally I would like to call something like `flynn-host log --init ID` to see these logs but would like to get feedback on how that can be achieved? A new flag for attach to return the init logs?