### PR TITLE
pkg/sse: Fix writer.Error

### DIFF
--- a/pkg/sse/sse.go
+++ b/pkg/sse/sse.go
@@ -41,8 +41,8 @@ func (w *writer) Write(p []byte) (int, error) {
 
 func (w *writer) Error(err error) (int, error) {
 	w.mtx.Lock()
-	defer w.mtx.Unlock()
 	_, e := w.w.Write([]byte("event: error\n"))
+	w.mtx.Unlock()
 	if e != nil {
 		return 0, e
 	}


### PR DESCRIPTION
`writer.Write` also tries to lock the mutex, so `writer.Error` was previously causing a deadlock.