### PR TITLE
Replace App.Protected with app metadata

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -105,6 +105,7 @@
     "from_step": "controller",
     "app": {
       "name": "controller",
+      "meta": {"flynn-system-app": "true"},
       "strategy": "one-by-one"
     }
   },
@@ -114,7 +115,7 @@
     "from_step": "postgres",
     "app": {
       "name": "postgres",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     }
   },
   {
@@ -140,7 +141,7 @@
     "action": "deploy-app",
     "app": {
       "name": "blobstore",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     },
     "artifact": {
       "type": "docker",
@@ -163,7 +164,7 @@
     "action": "deploy-app",
     "app": {
       "name": "router",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     },
     "artifact": {
       "type": "docker",
@@ -192,7 +193,7 @@
     "action": "deploy-app",
     "app": {
       "name": "gitreceive",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     },
     "artifact": {
       "type": "docker",
@@ -262,7 +263,7 @@
     "action": "deploy-app",
     "app": {
       "name": "taffy",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     },
     "artifact": {
       "type": "docker",
@@ -281,7 +282,7 @@
     "action": "deploy-app",
     "app": {
       "name": "dashboard",
-      "protected": true
+      "meta": {"flynn-system-app": "true"}
     },
     "artifact": {
       "type": "docker",

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -101,7 +101,7 @@ func (c *Client) CreateApp(app *ct.App) error {
 	return c.Post("/apps", app, app)
 }
 
-// UpdateApp updates the protected flag, meta and update strategy using app.ID.
+// UpdateApp updates the meta and strategy using app.ID.
 func (c *Client) UpdateApp(app *ct.App) error {
 	if app.ID == "" {
 		return errors.New("controller: missing id")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -175,27 +175,6 @@ func (s *S) TestRecreateApp(c *C) {
 	c.Assert(app.Name, Equals, "recreate-app")
 }
 
-func (s *S) TestProtectedApp(c *C) {
-	app := s.createTestApp(c, &ct.App{Name: "protected-app", Protected: true})
-	release := s.createTestRelease(c, &ct.Release{
-		Processes: map[string]ct.ProcessType{"web": {}, "worker": {}},
-	})
-
-	f := &ct.Formation{AppID: app.ID, ReleaseID: release.ID}
-	for _, t := range []struct {
-		procs map[string]int
-		check Checker
-	}{
-		{nil, NotNil},
-		{map[string]int{"web": 1}, NotNil},
-		{map[string]int{"worker": 1, "web": 0}, NotNil},
-		{map[string]int{"worker": 1, "web": 1}, IsNil},
-	} {
-		f.Processes = t.procs
-		c.Assert(s.c.PutFormation(f), t.check)
-	}
-}
-
 func (s *S) createTestArtifact(c *C, in *ct.Artifact) *ct.Artifact {
 	if in.Type == "" {
 		in.Type = "docker"

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -97,13 +97,12 @@ func (s *S) createTestApp(c *C, in *ct.App) *ct.App {
 
 func (s *S) TestCreateApp(c *C) {
 	for _, id := range []string{"", random.UUID()} {
-		app := s.createTestApp(c, &ct.App{ID: id, Protected: true, Meta: map[string]string{"foo": "bar"}})
+		app := s.createTestApp(c, &ct.App{ID: id, Meta: map[string]string{"foo": "bar"}})
 		c.Assert(app.Name, Not(Equals), "")
 		c.Assert(app.ID, Not(Equals), "")
 		if id != "" {
 			c.Assert(app.ID, Equals, id)
 		}
-		c.Assert(app.Protected, Equals, true)
 		c.Assert(app.Meta["foo"], Equals, "bar")
 
 		gotApp, err := s.c.GetApp(app.ID)
@@ -119,29 +118,33 @@ func (s *S) TestCreateApp(c *C) {
 	}
 }
 
+func (s *S) TestSystemApp(c *C) {
+	app := s.createTestApp(c, &ct.App{Meta: map[string]string{"flynn-system-app": "true"}})
+	c.Assert(app.System(), Equals, true)
+
+	app.Meta["flynn-system-app"] = "false"
+	c.Assert(s.c.UpdateApp(app), IsNil)
+	c.Assert(app.System(), Equals, false)
+
+	delete(app.Meta, "flynn-system-app")
+	c.Assert(s.c.UpdateApp(app), IsNil)
+	c.Assert(app.System(), Equals, false)
+}
+
 func (s *S) TestUpdateApp(c *C) {
 	meta := map[string]string{"foo": "bar"}
 	app := s.createTestApp(c, &ct.App{Name: "update-app", Meta: meta})
-	c.Assert(app.Protected, Equals, false)
 	c.Assert(app.Meta, DeepEquals, meta)
 
-	gotApp := &ct.App{ID: app.ID}
-	gotApp.Protected = true
-	c.Assert(s.c.UpdateApp(gotApp), IsNil)
-	c.Assert(gotApp.Protected, Equals, true)
-	c.Assert(gotApp.Meta, DeepEquals, meta)
-
+	app = &ct.App{ID: app.ID}
 	meta = map[string]string{"foo": "baz", "bar": "foo"}
-	gotApp.Meta = meta
-	gotApp.Protected = false
-	c.Assert(s.c.UpdateApp(gotApp), IsNil)
-	c.Assert(gotApp.Protected, Equals, false)
-	c.Assert(gotApp.Meta, DeepEquals, meta)
+	app.Meta = meta
+	c.Assert(s.c.UpdateApp(app), IsNil)
+	c.Assert(app.Meta, DeepEquals, meta)
 
-	gotApp, err := s.c.GetApp(app.ID)
+	app, err := s.c.GetApp(app.ID)
 	c.Assert(err, IsNil)
-	c.Assert(gotApp.Protected, Equals, false)
-	c.Assert(gotApp.Meta, DeepEquals, meta)
+	c.Assert(app.Meta, DeepEquals, meta)
 }
 
 func (s *S) TestDeleteApp(c *C) {

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -275,14 +275,6 @@ func (c *controllerAPI) PutFormation(ctx context.Context, w http.ResponseWriter,
 
 	formation.AppID = app.ID
 	formation.ReleaseID = release.ID
-	if app.Protected {
-		for typ := range release.Processes {
-			if formation.Processes[typ] == 0 {
-				respondWithError(w, ct.ValidationError{Message: "unable to scale to zero, app is protected"})
-				return
-			}
-		}
-	}
 
 	if err = schema.Validate(formation); err != nil {
 		respondWithError(w, err)

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -34,7 +34,6 @@ func migrateDB(db *sql.DB) error {
     app_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     name text NOT NULL,
     release_id uuid REFERENCES releases (release_id),
-    protected bool NOT NULL DEFAULT false,
 	meta hstore,
 	strategy deployment_strategy NOT NULL DEFAULT 'all-at-once',
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -20,11 +20,15 @@ type ExpandedFormation struct {
 type App struct {
 	ID        string            `json:"id,omitempty"`
 	Name      string            `json:"name,omitempty"`
-	Protected bool              `json:"protected"`
 	Meta      map[string]string `json:"meta,omitempty"`
 	Strategy  string            `json:"strategy,omitempty"`
 	CreatedAt *time.Time        `json:"created_at,omitempty"`
 	UpdatedAt *time.Time        `json:"updated_at,omitempty"`
+}
+
+func (a *App) System() bool {
+	v, ok := a.Meta["flynn-system-app"]
+	return ok && v == "true"
 }
 
 type Release struct {

--- a/dashboard/app/lib/javascripts/dashboard/routers/apps.js
+++ b/dashboard/app/lib/javascripts/dashboard/routers/apps.js
@@ -87,7 +87,7 @@ Dashboard.routers.Apps = Marbles.Router.createClass({
 
 	__getAppsProps: function (params) {
 		var appProps = this.__getAppProps(params);
-		var showProtected = params[0].protected === "true";
+		var showSystemApps = params[0].system === "true";
 		var defaultRouteDomain = Dashboard.config.default_route_domain;
 		var getAppPath = function (appId) {
 			var __params = Marbles.Utils.extend({}, params[0]);
@@ -95,14 +95,14 @@ Dashboard.routers.Apps = Marbles.Router.createClass({
 			return this.__getAppPath(appId, __params, "");
 		}.bind(this);
 		return {
-			showProtected: showProtected,
+			showSystemApps: showSystemApps,
 			defaultRouteDomain: defaultRouteDomain,
 			appProps: appProps,
 			appsListProps: {
 				selectedAppId: appProps.appId,
 				getAppPath: getAppPath,
 				defaultRouteDomain: defaultRouteDomain,
-				showProtected: showProtected,
+				showSystemApps: showSystemApps,
 			},
 			appsListHeaderProps: {
 				githubAuthed: !!Dashboard.githubClient

--- a/dashboard/app/lib/javascripts/dashboard/stores/app.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/app.js
@@ -482,4 +482,8 @@ App.handleEvent = function (event) {
 };
 Dashboard.Dispatcher.register(App.handleEvent);
 
+App.isSystemApp = function (app) {
+	return app.meta && app.meta["flynn-system-app"] === "true";
+};
+
 })();

--- a/dashboard/app/lib/javascripts/dashboard/stores/apps.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/apps.js
@@ -40,12 +40,7 @@ var Apps = Dashboard.Stores.Apps = Dashboard.Store.createClass({
 		return this.__getClient().getApps().then(function (args) {
 			var res = args[0];
 			this.setState({
-				apps: res.map(function (app) {
-					if (app.name === "controller") {
-						app.protected = true; // bug
-					}
-					return app;
-				}),
+				apps: res,
 			});
 		}.bind(this));
 	},

--- a/dashboard/app/lib/javascripts/dashboard/views/app.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/app.js.jsx
@@ -8,6 +8,7 @@
 "use strict";
 
 var AppStore = Dashboard.Stores.App;
+var isSystemApp = AppStore.isSystemApp;
 
 Dashboard.Views.App = React.createClass({
 	displayName: "Views.App",
@@ -103,8 +104,8 @@ Dashboard.Views.App = React.createClass({
 	},
 
 	__getClusterPathParams: function () {
-		if (this.state.app && this.state.app.protected) {
-			return [{ protected: "true" }];
+		if (this.state.app && isSystemApp(this.state.app)) {
+			return [{ system: "true" }];
 		}
 		return null;
 	}

--- a/dashboard/app/lib/javascripts/dashboard/views/apps-list.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/apps-list.js.jsx
@@ -1,11 +1,13 @@
 //= require ./route-link
 //= require ./external-link
+//= require ../stores/app
 
 (function () {
 
 "use strict";
 
 var RouteLink = Dashboard.Views.RouteLink;
+var isSystemApp = Dashboard.Stores.App.isSystemApp;
 
 Dashboard.Views.AppsList = React.createClass({
 	displayName: "Views.AppsList",
@@ -51,9 +53,9 @@ Dashboard.Views.AppsList = React.createClass({
 	__getState: function (props) {
 		var state = {};
 
-		var showProtected = props.showProtected;
+		var showSystemApps = props.showSystemApps;
 		state.apps = props.apps.filter(function (app) {
-			return !app.protected || showProtected;
+			return !isSystemApp(app) || showSystemApps;
 		});
 
 		return state;


### PR DESCRIPTION
This changes the concept of a "protected" app to a "system" app, and lifts the restriction that such apps cannot be scaled to zero (so that they can be deployed).

@jvatic this requires a change to the dashboard, could you push a change to this PR?