### PR TITLE
appliance/etcd: Bump etcd to v2.0.3

### DIFF
--- a/appliance/etcd/build.sh
+++ b/appliance/etcd/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-version=2.0.0
+version=2.0.3
 tmpdir=$(mktemp --directory)
 pkg="etcd-v${version}-linux-amd64"
 


### PR DESCRIPTION
https://github.com/coreos/etcd/compare/v2.0.0...v2.0.3