### PR TITLE
appliance/postgresql: Implement postgres daemon manager

### DIFF
--- a/appliance/postgresql2/postgres.go
+++ b/appliance/postgresql2/postgres.go
@@ -1,0 +1,778 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"text/template"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/appliance/postgresql2/xlog"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/shutdown"
+)
+
+type Config struct {
+	ID          string
+	Singleton   bool
+	Port        string
+	BinDir      string
+	DataDir     string
+	Password    string
+	OpTimeout   time.Duration
+	ReplTimeout time.Duration
+	Logger      log15.Logger
+}
+
+type Postgres struct {
+	db *pgx.ConnPool
+
+	events chan state.PostgresEvent
+
+	config        *state.PgConfig
+	running       bool
+	configApplied bool
+
+	// config options
+	id          string
+	log         log15.Logger
+	singleton   bool
+	port        string
+	binDir      string
+	dataDir     string
+	password    string
+	opTimeout   time.Duration
+	replTimeout time.Duration
+
+	// daemon is the postgres daemon command when running
+	daemon *exec.Cmd
+	// expectExit is bool, true if the daemon is supposed to exit
+	expectExit atomic.Value
+	// daemonExit is closed when the daemon exits
+	daemonExit chan struct{}
+
+	// cancelSyncWait cancels the goroutine that is waiting for the sync to
+	// catch up, if running
+	cancelSyncWait func()
+
+	// mtx ensures that only one operation happens at a time
+	mtx sync.Mutex
+}
+
+const checkInterval = 100 * time.Millisecond
+
+func NewPostgres(c Config) state.Postgres {
+	p := &Postgres{
+		id:             c.ID,
+		log:            c.Logger,
+		singleton:      c.Singleton,
+		port:           c.Port,
+		binDir:         c.BinDir,
+		dataDir:        c.DataDir,
+		password:       c.Password,
+		opTimeout:      c.OpTimeout,
+		replTimeout:    c.ReplTimeout,
+		events:         make(chan state.PostgresEvent, 1),
+		cancelSyncWait: func() {},
+	}
+	if p.log == nil {
+		p.log = log15.Root().New("app", "postgres", "id", p.id)
+	}
+	if p.port == "" {
+		p.port = "5432"
+	}
+	if p.binDir == "" {
+		p.binDir = "/usr/lib/postgresql/9.3/bin/"
+	}
+	if p.dataDir == "" {
+		p.dataDir = "/data"
+	}
+	if p.password == "" {
+		p.password = "password"
+	}
+	if p.opTimeout == 0 {
+		p.opTimeout = 5 * time.Minute
+	}
+	if p.replTimeout == 0 {
+		p.replTimeout = 1 * time.Minute
+	}
+	p.events <- state.PostgresEvent{}
+	return p
+}
+
+func (p *Postgres) Reconfigure(config *state.PgConfig) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	switch config.Role {
+	case state.RolePrimary:
+		if !p.singleton && config.Downstream == nil {
+			return errors.New("missing downstream peer")
+		}
+	case state.RoleSync, state.RoleAsync:
+		if config.Upstream == nil {
+			return fmt.Errorf("missing upstream peer")
+		}
+	case state.RoleNone:
+	default:
+		return fmt.Errorf("unknown role %v", config.Role)
+	}
+
+	if !p.running {
+		p.config = config
+		p.configApplied = false
+		return nil
+	}
+
+	return p.reconfigure(config)
+}
+
+func (p *Postgres) Start() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.running {
+		return errors.New("postgres is already running")
+	}
+	if p.config == nil {
+		return errors.New("postgres is unconfigured")
+	}
+	if p.config.Role == state.RoleNone {
+		return errors.New("start attempted with role 'none'")
+	}
+
+	return p.reconfigure(nil)
+}
+
+func (p *Postgres) Stop() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if !p.running {
+		return errors.New("postgres is already stopped")
+	}
+	return p.stop()
+}
+
+func (p *Postgres) XLogPosition() (res xlog.Position, err error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if !p.running {
+		return "", errors.New("postgres is not running")
+	}
+
+	query := "SELECT pg_last_xlog_replay_location()"
+	if p.config.Role == state.RolePrimary {
+		query = "SELECT pg_current_xlog_location()"
+	}
+	return res, p.db.QueryRow(query).Scan(&res)
+}
+
+func (p *Postgres) Ready() <-chan state.PostgresEvent {
+	return p.events
+}
+
+func (p *Postgres) reconfigure(config *state.PgConfig) (err error) {
+	defer func() {
+		if err == nil {
+			p.config = config
+			p.configApplied = true
+		}
+	}()
+
+	if config != nil && config.Role == state.RoleNone {
+		return nil
+	}
+
+	// If we've already applied the same postgres config, we don't need to do anything
+	if p.configApplied && config != nil && p.config != nil && config.Equal(p.config) {
+		return nil
+	}
+
+	// If we're already running and it's just a change from async to sync with the same node, we don't need to restart
+	if p.configApplied && p.running && p.config != nil && config != nil &&
+		p.config.Role == state.RoleAsync && config.Role == state.RoleSync && config.Upstream.ID == p.config.Upstream.ID {
+		return nil
+	}
+
+	// Make sure that we don't keep waiting for a sync to come up while reconfiguring
+	p.cancelSyncWait()
+
+	// If we're already running and this is only a sync change, we just need to update the config.
+	if p.running && p.config != nil && config != nil && p.config.Role == state.RolePrimary && config.Role == state.RolePrimary {
+		return p.updateSync(config.Downstream)
+	}
+
+	if config == nil {
+		config = p.config
+	}
+
+	if config.Role == state.RolePrimary {
+		return p.assumePrimary(config.Downstream)
+	}
+
+	return p.assumeStandby(config.Upstream)
+}
+
+func (p *Postgres) assumePrimary(downstream *discoverd.Instance) (err error) {
+	log := p.log.New("fn", "assumePrimary")
+	if downstream != nil {
+		log = log.New("downstream", downstream.Addr)
+	}
+
+	if p.running && p.config.Role == state.RoleSync {
+		log.Info("promoting to primary")
+
+		if err := ioutil.WriteFile(p.triggerPath(), nil, 0655); err != nil {
+			log.Error("error creating trigger file", "path", p.triggerPath(), "err", err)
+			return err
+		}
+
+		p.waitForSync(downstream)
+
+		return nil
+	}
+
+	log.Info("starting as primary")
+
+	if p.running {
+		panic(fmt.Sprintf("unexpected state running role=%s", p.config.Role))
+	}
+
+	if err := p.initDB(); err != nil {
+		return err
+	}
+
+	if err := os.Remove(p.recoveryConfPath()); err != nil && !os.IsNotExist(err) {
+		log.Error("error removing recovery.conf", "path", p.recoveryConfPath(), "err", err)
+		return err
+	}
+
+	if err := p.writeConfig(configData{ReadOnly: downstream != nil}); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+
+	if err := p.start(); err != nil {
+		return err
+	}
+
+	var tx *pgx.Tx
+	defer func() {
+		if err != nil {
+			if tx != nil {
+				tx.Rollback()
+			}
+			p.db.Close()
+			if err := p.stop(); err != nil {
+				log.Debug("ignoring error stopping postgres", "err", err)
+			}
+		}
+	}()
+
+	tx, err = p.db.Begin()
+	if err != nil {
+		log.Error("error acquiring connection", "err", err)
+		return err
+	}
+	if _, err := tx.Exec("SET TRANSACTION READ WRITE"); err != nil {
+		log.Error("error setting transaction read-write", "err", err)
+		return err
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`CREATE USER flynn WITH SUPERUSER CREATEDB CREATEROLE REPLICATION PASSWORD '%s'`, p.password)); err != nil {
+		if e, ok := err.(pgx.PgError); !ok || e.Code != "42710" { // role already exists
+			log.Error("error creating superuser", "err", err)
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Error("error committing transaction", "err", err)
+		return err
+	}
+
+	if downstream != nil {
+		p.waitForSync(downstream)
+	}
+
+	return nil
+}
+
+func (p *Postgres) assumeStandby(upstream *discoverd.Instance) error {
+	log := p.log.New("fn", "assumeStandby", "upstream", upstream.Addr)
+	log.Info("starting up as standby")
+
+	// TODO(titanous): investigate using a DNS name, proxy, or iptables rule for
+	// the upstream. (perhaps DNS plus some postgres magic like terminating
+	// a backend would work). Postgres appears to support remastering without
+	// restarting:
+	// http://www.databasesoup.com/2014/05/remastering-without-restarting.html
+
+	if p.running {
+		// if we are running, we can just restart with a new recovery.conf, postgres
+		// supports streaming remastering.
+		if err := p.stop(); err != nil {
+			return err
+		}
+	} else {
+		log.Info("pulling basebackup")
+		// TODO(titanous): make this pluggable
+		err := p.runCmd(exec.Command(
+			p.binPath("pg_basebackup"),
+			"--pgdata", p.dataDir,
+			"--dbname", fmt.Sprintf(
+				"host=%s port=%s user=flynn password=%s application_name=%s",
+				upstream.Host(), upstream.Port(), p.password, upstream.ID,
+			),
+			"--xlog-method=stream",
+			"--progress",
+			"--verbose",
+		))
+		if err != nil {
+			log.Error("error pulling basebackup", "err", err)
+			return err
+		}
+	}
+
+	if err := p.writeConfig(configData{ReadOnly: true}); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+	if err := p.writeRecoveryConf(upstream); err != nil {
+		log.Error("error writing recovery.conf", "path", p.recoveryConfPath(), "err", err)
+		return err
+	}
+
+	return p.start()
+}
+
+func (p *Postgres) updateSync(downstream *discoverd.Instance) error {
+	log := p.log.New("fn", "updateSync", "downstream", downstream.Addr)
+	log.Info("changing sync")
+
+	config := configData{
+		ReadOnly: true,
+		Sync:     downstream.ID,
+	}
+
+	if err := p.writeConfig(config); err != nil {
+		log.Error("error writing postgres.conf", "path", p.configPath(), "err", err)
+		return err
+	}
+
+	if err := p.sighup(); err != nil {
+		p.log.Error("error reloading daemon configuration", "err", err)
+		return err
+	}
+
+	p.waitForSync(downstream)
+
+	return nil
+}
+
+func (p *Postgres) start() error {
+	log := p.log.New("fn", "start", "data_dir", p.dataDir, "bin_dir", p.binDir)
+	log.Info("starting postgres")
+
+	// clear stale pid if it exists
+	os.Remove(filepath.Join(p.dataDir, "postmaster.pid"))
+
+	p.expectExit.Store(false)
+	p.daemonExit = make(chan struct{})
+
+	cmd := exec.Command(p.binPath("postgres"), "-D", p.dataDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Error("failed to start postgres", "err", err)
+		return err
+	}
+	p.daemon = cmd
+	p.running = true
+
+	go func() {
+		err := cmd.Wait()
+		if !p.expectExit.Load().(bool) {
+			p.log.Error("postgres unexpectedly exit", "err", err)
+			shutdown.ExitWithCode(1)
+		}
+		close(p.daemonExit)
+	}()
+
+	log.Debug("waiting for postgres to start")
+	startTime := time.Now().UTC()
+	var err error
+	for {
+		if time.Now().Sub(startTime) > p.opTimeout {
+			log.Error("timed out waiting for postgres to start", "err", err)
+			if err := p.stop(); err != nil {
+				log.Error("error stopping postgres", "err", err)
+			}
+			return err
+		}
+
+		port, _ := strconv.Atoi(p.port)
+		c := pgx.ConnPoolConfig{
+			ConnConfig: pgx.ConnConfig{
+				Host: "127.0.0.1",
+				User: "postgres",
+				Port: uint16(port),
+			},
+		}
+		p.db, err = pgx.NewConnPool(c)
+		if err == nil {
+			_, err = p.db.Exec("SELECT 1")
+			if err == nil {
+				log.Info("postgres started")
+				return nil
+			}
+		}
+
+		log.Debug("ignoring error connecting to postgres", "err", err)
+		time.Sleep(checkInterval)
+	}
+}
+
+func (p *Postgres) stop() error {
+	log := p.log.New("fn", "stop")
+	log.Info("stopping postgres")
+
+	p.cancelSyncWait()
+	p.db.Close()
+	p.expectExit.Store(true)
+
+	tryExit := func(sig os.Signal) bool {
+		log.Debug("signalling daemon", "sig", sig)
+		if err := p.daemon.Process.Signal(sig); err != nil {
+			log.Error("error signalling daemon", "sig", sig, "err", err)
+		}
+		select {
+		case <-time.After(p.opTimeout):
+			return false
+		case <-p.daemonExit:
+			p.running = false
+			return true
+		}
+	}
+
+	// Wait for all clients to terminate before shutting down cleanly
+	if tryExit(syscall.SIGTERM) {
+		return nil
+	}
+
+	// Forcefully disconnect all clients and shut down cleanly
+	if tryExit(syscall.SIGINT) {
+		return nil
+	}
+
+	// Quit immediately, will result in recovery at next start
+	if tryExit(syscall.SIGQUIT) {
+		return nil
+	}
+
+	// If all else fails, forcibly kill the process
+	if tryExit(syscall.SIGKILL) {
+		return nil
+	}
+
+	return errors.New("unable to kill postgres")
+}
+
+func (p *Postgres) sighup() error {
+	p.log.Debug("reloading daemon configuration", "fn", "sighup")
+	return p.daemon.Process.Signal(syscall.SIGHUP)
+}
+
+func (p *Postgres) waitForSync(inst *discoverd.Instance) {
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	var cancelOnce sync.Once
+	p.cancelSyncWait = func() {
+		cancelOnce.Do(func() {
+			close(stopCh)
+			<-doneCh
+		})
+	}
+	go func() {
+		defer close(doneCh)
+
+		startTime := time.Now().UTC()
+		lastFlushed := xlog.Zero
+		log := p.log.New(
+			"fn", "waitForSync",
+			"sync_name", inst.ID,
+			"start_time", log15.Lazy{func() time.Time { return startTime }},
+			"last_flushed", log15.Lazy{func() xlog.Position { return lastFlushed }},
+		)
+
+		shouldStop := func() bool {
+			select {
+			case <-stopCh:
+				log.Debug("canceled, stopping")
+				return true
+			default:
+				return false
+			}
+		}
+
+		sleep := func() bool {
+			select {
+			case <-stopCh:
+				log.Debug("canceled, stopping")
+				return false
+			case <-time.After(checkInterval):
+				return true
+			}
+		}
+
+		log.Info("waiting for sync replication to catch up")
+
+		for {
+			if shouldStop() {
+				return
+			}
+
+			sent, flushed, err := p.checkReplStatus(inst.ID)
+			if err != nil {
+				// If we can't query the replication state, we just keep trying.
+				// We do not count this as part of the replication timeout.
+				// Generally this means the standby hasn't started or is unable
+				// to start. This means that the standby will eventually time
+				// itself out and we will exit the loop since a new event will
+				// be emitted when the standby leaves the cluster.
+				startTime = time.Now().UTC()
+				if !sleep() {
+					return
+				}
+				continue
+			}
+			elapsedTime := time.Now().Sub(startTime)
+			log := log.New("sent", sent, "flushed", flushed, "elapsed", elapsedTime)
+
+			if cmp, err := xlog.Compare(lastFlushed, flushed); err != nil {
+				log.Error("error parsing log locations", "err", err)
+				return
+			} else if lastFlushed == xlog.Zero || cmp == -1 {
+				log.Debug("flushed row incremented, resetting startTime")
+				startTime = time.Now().UTC()
+				lastFlushed = flushed
+			} else if cmp == 1 {
+				// Fail fast if the remote flushed location is greater than our
+				// current location. This means that we (the primary) is behind
+				// the sync and will never catch up.
+				log.Error("error checking replication status", "err", "sync xlog position is greater than the primary position")
+				return
+			}
+
+			if sent == flushed {
+				log.Info("sync caught up")
+				break
+			} else if elapsedTime > p.replTimeout {
+				log.Error("error checking replication status", "err", "sync unable to make forward progress")
+				return
+			} else {
+				log.Debug("continuing replication check")
+				if !sleep() {
+					return
+				}
+				continue
+			}
+		}
+
+		// sync caught up, enable write transactions
+		if err := p.writeConfig(configData{Sync: inst.ID}); err != nil {
+			log.Error("error writing postgres.conf", "err", err)
+			return
+		}
+
+		if err := p.sighup(); err != nil {
+			log.Error("error calling sighup")
+			return
+		}
+	}()
+}
+
+var ErrNoReplicationStatus = errors.New("no replication status")
+
+func (p *Postgres) checkReplStatus(name string) (sent, flushed xlog.Position, err error) {
+	log := p.log.New("fn", "checkReplStatus", "name", name)
+	log.Debug("checking replication status")
+
+	var s, f pgx.NullString
+	err = p.db.QueryRow(`
+SELECT sent_location, flush_location
+FROM pg_stat_replication
+WHERE application_name = $1`, name).Scan(&s, &f)
+	if err != nil && err != pgx.ErrNoRows {
+		log.Error("error checking replication status", "err", err)
+		return
+	}
+	sent, flushed = xlog.Position(s.String), xlog.Position(f.String)
+	if err == pgx.ErrNoRows || sent == "" || flushed == "" {
+		err = ErrNoReplicationStatus
+		log.Debug("no replication status")
+		return
+	}
+	log.Debug("got replication status", "sent_location", sent, "flush_location", flushed)
+	return
+}
+
+// initDB initializes the postgres data directory for a new dDB. This can fail
+// if the db has already been initialized, which is not a fatal error.
+//
+// This method should only be called by the primary of a shard. Standbys will
+// not need to initialize, as they will restore from an already running primary.
+func (p *Postgres) initDB() error {
+	log := p.log.New("fn", "initDB", "dir", p.dataDir)
+	log.Debug("starting initDB")
+
+	// ignore errors, since the db could be already initialized
+	// TODO(titanous): check errors when this is not the case
+	_ = p.runCmd(exec.Command(
+		p.binPath("initdb"),
+		"--pgdata", p.dataDir,
+		"--username=postgres",
+		"--encoding=UTF-8",
+		"--locale=en_US.UTF-8",
+	))
+
+	return p.writeHBAConf()
+}
+func (p *Postgres) runCmd(cmd *exec.Cmd) error {
+	p.log.Debug("running command", "fn", "runCmd", "cmd", cmd.Args)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (p *Postgres) writeConfig(d configData) error {
+	d.ID = p.id
+	d.Port = p.port
+	f, err := os.Create(p.configPath())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return configTemplate.Execute(f, d)
+}
+
+func (p *Postgres) writeRecoveryConf(upstream *discoverd.Instance) error {
+	data := recoveryData{
+		TriggerFile: p.triggerPath(),
+		PrimaryInfo: fmt.Sprintf(
+			"host=%s port=%s user=flynn password=%s application_name=%s",
+			upstream.Host(), upstream.Port(), p.password, p.id,
+		),
+	}
+
+	f, err := os.Create(p.recoveryConfPath())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return recoveryConfTemplate.Execute(f, data)
+}
+
+func (p *Postgres) writeHBAConf() error {
+	return ioutil.WriteFile(p.hbaConfPath(), hbaConf, 0644)
+}
+
+func (p *Postgres) configPath() string {
+	return p.dataPath("postgresql.conf")
+}
+
+func (p *Postgres) recoveryConfPath() string {
+	return p.dataPath("recovery.conf")
+}
+
+func (p *Postgres) hbaConfPath() string {
+	return p.dataPath("pg_hba.conf")
+}
+
+func (p *Postgres) triggerPath() string {
+	return p.dataPath("promote.trigger")
+}
+
+func (p *Postgres) binPath(file string) string {
+	return filepath.Join(p.binDir, file)
+}
+
+func (p *Postgres) dataPath(file string) string {
+	return filepath.Join(p.dataDir, file)
+}
+
+type configData struct {
+	ID       string
+	Port     string
+	Sync     string
+	ReadOnly bool
+
+	DisableFullPageWrites bool
+}
+
+var configTemplate = template.Must(template.New("postgresql.conf").Parse(`
+unix_socket_directories = ''
+listen_addresses = '0.0.0.0'
+port = {{.Port}}
+ssl = off
+ssl_renegotiation_limit = 0 # fix for https://github.com/flynn/flynn/issues/101
+max_connections = 100
+shared_buffers = 32MB
+wal_level = hot_standby
+fsync = on
+{{if .DisableFullPageWrites}}
+full_page_writes = off # Not necessary on ZFS, see http://www.postgresql.org/docs/current/static/wal-reliability.html
+{{end}}
+max_wal_senders = 15
+wal_keep_segments = 1000
+synchronous_commit = remote_write
+synchronous_standby_names = '{{.Sync}}'
+{{if .ReadOnly}}
+default_transaction_read_only = on
+{{end}}
+hot_standby = on
+max_standby_archive_delay = 30s
+max_standby_streaming_delay = 30s
+wal_receiver_status_interval = 10s
+hot_standby_feedback = on
+log_destination = 'stderr'
+logging_collector = false
+log_line_prefix = '{{.ID}} %m '
+log_timezone = 'UTC'
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+client_encoding = 'UTF8'
+default_text_search_config = 'pg_catalog.english'
+`[1:]))
+
+type recoveryData struct {
+	PrimaryInfo string
+	TriggerFile string
+}
+
+var recoveryConfTemplate = template.Must(template.New("recovery.conf").Parse(`
+standby_mode = on
+primary_conninfo = '{{.PrimaryInfo}}'
+trigger_file = '{{.TriggerFile}}'
+recovery_target_timeline = 'latest'
+`[1:]))
+
+var hbaConf = []byte(`
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+host    all             postgres        127.0.0.1/32            trust
+host    all             all             127.0.0.1/32            md5
+host    all             all             all                     md5
+host    replication     flynn           all                     md5
+`[1:])

--- a/appliance/postgresql2/postgres_test.go
+++ b/appliance/postgresql2/postgres_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/flynn/flynn/appliance/postgresql2/state"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/attempt"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type PostgresSuite struct{}
+
+var _ = Suite(&PostgresSuite{})
+
+func (PostgresSuite) TestSingletonPrimary(c *C) {
+	cfg := Config{
+		ID:        "node1",
+		Singleton: true,
+		DataDir:   c.MkDir(),
+		Port:      "54320",
+		OpTimeout: 30 * time.Second,
+	}
+
+	pg := NewPostgres(cfg)
+	err := pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	c.Assert(err, IsNil)
+
+	err = pg.Start()
+	c.Assert(err, IsNil)
+	defer pg.Stop()
+
+	conn := connect(c, 0, "postgres")
+	_, err = conn.Exec("CREATE DATABASE test")
+	conn.Close()
+	c.Assert(err, IsNil)
+
+	err = pg.Stop()
+	c.Assert(err, IsNil)
+
+	// ensure that we can start a new instance from the same directory
+	pg = NewPostgres(cfg)
+	err = pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	c.Assert(err, IsNil)
+	c.Assert(pg.Start(), IsNil)
+	defer pg.Stop()
+
+	conn = connect(c, 0, "test")
+	_, err = conn.Exec("CREATE DATABASE foo")
+	conn.Close()
+	c.Assert(err, IsNil)
+
+	err = pg.Stop()
+	c.Assert(err, IsNil)
+}
+
+func instance(n int) *discoverd.Instance {
+	return &discoverd.Instance{
+		ID:   fmt.Sprintf("node%d", n),
+		Addr: fmt.Sprintf("127.0.0.1:5432%d", n),
+	}
+}
+
+func newPostgres(c *C, n int) state.Postgres {
+	return NewPostgres(Config{
+		ID:        fmt.Sprintf("node%d", n),
+		DataDir:   c.MkDir(),
+		Port:      fmt.Sprintf("5432%d", n),
+		OpTimeout: 30 * time.Second,
+	})
+}
+
+func connect(c *C, n int, db string) *pgx.Conn {
+	conn, err := pgx.Connect(pgx.ConnConfig{
+		Host:     "127.0.0.1",
+		Port:     54320 + uint16(n),
+		User:     "flynn",
+		Password: "password",
+		Database: db,
+	})
+	c.Assert(err, IsNil)
+	return conn
+}
+
+func pgConfig(role state.Role, n int) *state.PgConfig {
+	var inst *discoverd.Instance
+	if n > 0 {
+		inst = instance(n)
+	}
+	if role == state.RolePrimary {
+		return &state.PgConfig{Role: role, Downstream: inst}
+	}
+	return &state.PgConfig{Role: role, Upstream: inst}
+}
+
+var queryAttempts = attempt.Strategy{
+	Min:   5,
+	Total: 30 * time.Second,
+	Delay: 200 * time.Millisecond,
+}
+
+func assertDownstream(c *C, conn *pgx.Conn, n int) {
+	var res string
+	err := conn.QueryRow("SELECT client_addr FROM pg_stat_replication WHERE application_name = $1", fmt.Sprintf("node%d", n)).Scan(&res)
+	c.Assert(err, IsNil)
+}
+
+func assertRecovery(c *C, conn *pgx.Conn) {
+	var recovery bool
+	err := conn.QueryRow("SELECT pg_is_in_recovery()").Scan(&recovery)
+	c.Assert(err, IsNil)
+	c.Assert(recovery, Equals, true)
+}
+
+func waitRow(c *C, conn *pgx.Conn, n int) {
+	var res int64
+	err := queryAttempts.Run(func() error {
+		return conn.QueryRow("SELECT id FROM test WHERE id = $1", n).Scan(&res)
+	})
+	c.Assert(err, IsNil)
+}
+
+func createTable(c *C, conn *pgx.Conn) {
+	_, err := conn.Exec("CREATE TABLE test (id bigint PRIMARY KEY)")
+	c.Assert(err, IsNil)
+	insertRow(c, conn, 1)
+}
+
+func insertRow(c *C, conn *pgx.Conn, n int) {
+	_, err := conn.Exec("INSERT INTO test (id) VALUES ($1)", n)
+	c.Assert(err, IsNil)
+}
+
+func waitReadWrite(c *C, conn *pgx.Conn) {
+	var readOnly string
+	err := queryAttempts.Run(func() error {
+		if err := conn.QueryRow("SHOW default_transaction_read_only").Scan(&readOnly); err != nil {
+			return err
+		}
+		if readOnly == "off" {
+			return nil
+		}
+		return fmt.Errorf("transaction readonly is %q", readOnly)
+	})
+	c.Assert(err, IsNil)
+}
+
+func waitRecovered(c *C, conn *pgx.Conn) {
+	var recovery bool
+	err := queryAttempts.Run(func() error {
+		err := conn.QueryRow("SELECT pg_is_in_recovery()").Scan(&recovery)
+		if err != nil {
+			return err
+		}
+		if recovery {
+			return fmt.Errorf("in recovery")
+		}
+		return nil
+	})
+	c.Assert(err, IsNil)
+}
+
+func (PostgresSuite) TestIntegration(c *C) {
+	// Start a primary
+	node1 := newPostgres(c, 1)
+	err := node1.Reconfigure(pgConfig(state.RolePrimary, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node1.Start(), IsNil)
+	defer node1.Stop()
+
+	// try to write to primary and make sure it's read-only
+	node1Conn := connect(c, 1, "postgres")
+	defer node1Conn.Close()
+	_, err = node1Conn.Exec("CREATE DATABASE foo")
+	c.Assert(err, NotNil)
+	c.Assert(err.(pgx.PgError).Code, Equals, "25006") // can't write while read only
+
+	// Start a sync
+	node2 := newPostgres(c, 2)
+	err = node2.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+	c.Assert(node2.Start(), IsNil)
+	defer node2.Stop()
+
+	// try to query primary until it comes up as read-write
+	waitReadWrite(c, node1Conn)
+
+	// make sure the sync is listed as sync and remote_write is enabled
+	assertDownstream(c, node1Conn, 2)
+	var res string
+	err = node1Conn.QueryRow("SHOW synchronous_standby_names").Scan(&res)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, "node2")
+	err = node1Conn.QueryRow("SHOW synchronous_commit").Scan(&res)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, "remote_write")
+
+	// create a table and a row
+	createTable(c, node1Conn)
+	node1Conn.Close()
+
+	// query the sync and see the database
+	node2Conn := connect(c, 2, "postgres")
+	defer node2Conn.Close()
+	waitRow(c, node2Conn, 1)
+	assertRecovery(c, node2Conn)
+
+	// Start an async
+	node3 := newPostgres(c, 3)
+	err = node3.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node3.Start(), IsNil)
+	defer node3.Stop()
+
+	node3Conn := connect(c, 3, "postgres")
+	defer node3Conn.Close()
+
+	// check that data replicated successfully
+	waitRow(c, node3Conn, 1)
+	assertRecovery(c, node3Conn)
+	assertDownstream(c, node2Conn, 3)
+
+	// Start a second async
+	node4 := newPostgres(c, 4)
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 3))
+	c.Assert(err, IsNil)
+	c.Assert(node4.Start(), IsNil)
+	defer node4.Stop()
+
+	node4Conn := connect(c, 4, "postgres")
+	defer node4Conn.Close()
+
+	// check that data replicated successfully
+	waitRow(c, node4Conn, 1)
+	assertRecovery(c, node4Conn)
+	assertDownstream(c, node3Conn, 4)
+
+	// promote node2 to primary
+	c.Assert(node1.Stop(), IsNil)
+	err = node2.Reconfigure(pgConfig(state.RolePrimary, 3))
+	c.Assert(err, IsNil)
+	err = node3.Reconfigure(pgConfig(state.RoleSync, 2))
+	c.Assert(err, IsNil)
+
+	// wait for recovery and read-write transactions to come up
+	waitRecovered(c, node2Conn)
+	waitReadWrite(c, node2Conn)
+
+	// check replication of each node
+	assertDownstream(c, node2Conn, 3)
+	assertDownstream(c, node3Conn, 4)
+
+	// write to primary and ensure data propagates to followers
+	insertRow(c, node2Conn, 2)
+	node2Conn.Close()
+	waitRow(c, node3Conn, 2)
+	waitRow(c, node4Conn, 2)
+
+	//  promote node3 to primary
+	c.Assert(node2.Stop(), IsNil)
+	err = node3.Reconfigure(pgConfig(state.RolePrimary, 4))
+	c.Assert(err, IsNil)
+	err = node4.Reconfigure(pgConfig(state.RoleSync, -1))
+
+	// check replication
+	waitRecovered(c, node3Conn)
+	waitReadWrite(c, node3Conn)
+	assertDownstream(c, node3Conn, 4)
+	insertRow(c, node3Conn, 3)
+}
+
+func (PostgresSuite) TestRemoveNodes(c *C) {
+	// start a chain of four nodes
+	node1 := newPostgres(c, 1)
+	err := node1.Reconfigure(pgConfig(state.RolePrimary, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node1.Start(), IsNil)
+	defer node1.Stop()
+
+	node2 := newPostgres(c, 2)
+	err = node2.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+	c.Assert(node2.Start(), IsNil)
+	defer node2.Stop()
+
+	node3 := newPostgres(c, 3)
+	err = node3.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	c.Assert(node3.Start(), IsNil)
+	defer node3.Stop()
+
+	node4 := newPostgres(c, 4)
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 3))
+	c.Assert(err, IsNil)
+	c.Assert(node4.Start(), IsNil)
+	defer node4.Stop()
+
+	// wait for cluster to come up
+	node1Conn := connect(c, 1, "postgres")
+	defer node1Conn.Close()
+	node4Conn := connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	waitReadWrite(c, node1Conn)
+	createTable(c, node1Conn)
+	waitRow(c, node4Conn, 1)
+	node4Conn.Close()
+
+	// remove first async
+	c.Assert(node3.Stop(), IsNil)
+	// reconfigure second async
+	err = node4.Reconfigure(pgConfig(state.RoleAsync, 2))
+	c.Assert(err, IsNil)
+	// run query
+	node4Conn = connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	insertRow(c, node1Conn, 2)
+	waitRow(c, node4Conn, 2)
+	node4Conn.Close()
+
+	// remove sync and promote node4 to sync
+	c.Assert(node2.Stop(), IsNil)
+	err = node1.Reconfigure(pgConfig(state.RolePrimary, 4))
+	c.Assert(err, IsNil)
+	err = node4.Reconfigure(pgConfig(state.RoleSync, 1))
+	c.Assert(err, IsNil)
+
+	waitReadWrite(c, node1Conn)
+	insertRow(c, node1Conn, 3)
+	node4Conn = connect(c, 4, "postgres")
+	defer node4Conn.Close()
+	waitRow(c, node4Conn, 3)
+}


### PR DESCRIPTION
This is a concrete implementation of `state.Postgres` that configures/manages a Postgres daemon based on requests from the state machine. The unit tests cover all normal functionality, for expediency of shipping there are error cases that are not currently covered.