### PR TITLE
discoverd: Implement manual leader election

### DIFF
--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -27,7 +27,7 @@ type Heartbeater interface {
 }
 
 func (c *Client) maybeAddService(service string) error {
-	if err := c.AddService(service); err != nil {
+	if err := c.AddService(service, nil); err != nil {
 		if je, ok := err.(hh.JSONError); !ok || je.Code != hh.ObjectExistsError {
 			return err
 		}

--- a/discoverd/server/backend.go
+++ b/discoverd/server/backend.go
@@ -3,21 +3,23 @@ package server
 import "github.com/flynn/flynn/discoverd/client"
 
 type Backend interface {
-	AddService(service string) error
+	AddService(service string, config *discoverd.ServiceConfig) error
 	RemoveService(service string) error
 	AddInstance(service string, inst *discoverd.Instance) error
 	RemoveInstance(service, id string) error
 	SetServiceMeta(service string, meta *discoverd.ServiceMeta) error
+	SetLeader(service, id string) error
 	StartSync() error
 	Close() error
 }
 
 type SyncHandler interface {
-	AddService(service string)
+	AddService(service string, config *discoverd.ServiceConfig)
 	RemoveService(service string)
 	AddInstance(service string, inst *discoverd.Instance)
 	RemoveInstance(service, id string)
-	SetService(service string, data []*discoverd.Instance)
+	SetService(service string, config *discoverd.ServiceConfig, data []*discoverd.Instance)
 	SetServiceMeta(service string, meta []byte, index uint64)
+	SetLeader(service, id string)
 	ListServices() []string
 }

--- a/discoverd/server/dns_test.go
+++ b/discoverd/server/dns_test.go
@@ -23,7 +23,7 @@ var _ = Suite(&DNSSuite{})
 func (s *DNSSuite) SetUpTest(c *C) {
 	s.state = NewState()
 	s.srv = s.newServer(c, []string{"8.8.8.8", "8.8.4.4"})
-	s.state.AddService("a")
+	s.state.AddService("a", DefaultServiceConfig)
 }
 
 func (s *DNSSuite) newServer(c *C, recursors []string) *DNSServer {
@@ -388,9 +388,9 @@ func (s *DNSSuite) TestServiceLookup(c *C) {
 	for _, t := range tests {
 		if len(t.data) == 0 {
 			// nil deletes the service, so use an empty slice
-			s.state.SetService("a", []*discoverd.Instance{})
+			s.state.SetService("a", DefaultServiceConfig, []*discoverd.Instance{})
 		} else {
-			s.state.SetService("a", t.data)
+			s.state.SetService("a", DefaultServiceConfig, t.data)
 		}
 		client := &dns.Client{Net: t.net}
 		for q, addrs := range t.qs {

--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -419,7 +419,7 @@ func monitor(port host.Port, container *ContainerInit, env map[string]string) (d
 
 	if config.Create {
 		// TODO: maybe reuse maybeAddService() from the client
-		if err := client.AddService(config.Name); err != nil {
+		if err := client.AddService(config.Name, nil); err != nil {
 			if je, ok := err.(hh.JSONError); !ok || je.Code != hh.ObjectExistsError {
 				return nil, fmt.Errorf("something went wrong with discoverd: %s", err)
 			}


### PR DESCRIPTION
This patch adds support for creating services with a configuration that selects a leader election type. It also adds a manual leader election type that can be used instead of the default oldest instance election.

Manual leader election is useful if an external state machine is responsible for choosing the leader, but the discoverd API (DNS and HTTP) should be kept in sync. The first use case for this is the postgres appliance state machine (#986) which takes into account more than the instance age when doing leader election.