### PR TITLE
test: Use Basic Auth with cluster API

### DIFF
--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/flynn/flynn/host/types"
@@ -22,11 +23,17 @@ type Client struct {
 var ErrNotFound = errors.New("testcluster: resource not found")
 
 func NewClient(endpoint string) (*Client, error) {
+	authKey := os.Getenv("TEST_RUNNER_AUTH_KEY")
+	if authKey == "" {
+		return nil, errors.New("missing TEST_RUNNER_AUTH_KEY environment variable")
+	}
+
 	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: "ci.flynn.io"}}}
 	client := &Client{
 		Client: &httpclient.Client{
 			ErrNotFound: ErrNotFound,
 			URL:         endpoint,
+			Key:         authKey,
 			HTTP:        httpClient,
 		},
 	}

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -329,10 +329,18 @@ func (c *Cluster) setup() error {
 }
 
 func (c *Cluster) Run(command string, s *Streams) error {
+	return c.run(command, s, nil)
+}
+
+func (c *Cluster) RunWithEnv(command string, s *Streams, env map[string]string) error {
+	return c.run(command, s, env)
+}
+
+func (c *Cluster) run(command string, s *Streams, env map[string]string) error {
 	if len(c.Instances) == 0 {
 		return errors.New("no booted servers in cluster")
 	}
-	return c.Instances[0].Run(command, s)
+	return c.Instances[0].RunWithEnv(command, s, env)
 }
 
 func (c *Cluster) CLIConfig() (*config.Config, error) {

--- a/test/cluster/instance.go
+++ b/test/cluster/instance.go
@@ -263,6 +263,14 @@ var sshAttempts = attempt.Strategy{
 }
 
 func (i *Instance) Run(command string, s *Streams) error {
+	return i.run(command, s, nil)
+}
+
+func (i *Instance) RunWithEnv(command string, s *Streams, env map[string]string) error {
+	return i.run(command, s, env)
+}
+
+func (i *Instance) run(command string, s *Streams, env map[string]string) error {
 	if s == nil {
 		s = &Streams{}
 	}
@@ -281,6 +289,9 @@ func (i *Instance) Run(command string, s *Streams) error {
 	sess.Stdin = s.Stdin
 	sess.Stdout = s.Stdout
 	sess.Stderr = s.Stderr
+	for k, v := range env {
+		sess.Setenv(k, v)
+	}
 	if err := sess.Run(command); err != nil {
 		return fmt.Errorf("failed to run command on %s: %s", i.IP, err)
 	}

--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -151,6 +151,9 @@ trap "rm -rf ${GOPATH}" EXIT
 go get github.com/flynn/go-tuf/cmd/tuf
 mv "${GOPATH}/bin/tuf" /usr/bin/tuf
 
+# allow the test runner to set TEST_RUNNER_AUTH_KEY
+echo AcceptEnv TEST_RUNNER_AUTH_KEY >> /etc/ssh/sshd_config
+
 # cleanup
 apt-get autoremove -y
 apt-get clean


### PR DESCRIPTION
Putting the auth key in the URL gets leaked in the test logs because the run script is executed with trace on.