### PR TITLE
host: Don't respawn in upstart.conf

### DIFF
--- a/host/upstart.conf
+++ b/host/upstart.conf
@@ -1,7 +1,7 @@
 description "Flynn layer 0"
 
 #start on (started libvirt-bin and started networking)
-respawn
-respawn limit 1000 60
+#respawn
+#respawn limit 1000 60
 
 exec /usr/local/bin/flynn-host daemon --manifest /etc/flynn/host-manifest.json --state /tmp/flynn-host-state.bolt


### PR DESCRIPTION
It is currently unlikely that respawning flynn-host will fix anything, it usually results in the daemon continuously flapping and filling up the logs.