### PR TITLE
logging: send container stdout/stderr to logaggregator service

### DIFF
--- a/host/logmux/logmux.go
+++ b/host/logmux/logmux.go
@@ -1,0 +1,144 @@
+package logmux
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/technoweenie/grohl"
+
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+	"github.com/flynn/flynn/pkg/syslog/rfc6587"
+)
+
+// LogMux collects log lines from multiple readers and forwards them to a log
+// aggregator service registered in discoverd. Log lines are buffered in memory
+// and are dropped in LIFO order.
+type LogMux struct {
+	logc chan *rfc5424.Message
+
+	sc *serviceConn
+
+	producerwg *sync.WaitGroup
+
+	shutdowno sync.Once
+	shutdownc chan struct{}
+
+	doneo sync.Once
+	donec chan struct{}
+}
+
+// New returns an instance of LogMux ready to follow io.Reader producers. The
+// log messages are buffered internally until Connect is called.
+func New(bufferSize int) *LogMux {
+	return &LogMux{
+		logc:       make(chan *rfc5424.Message, bufferSize),
+		producerwg: &sync.WaitGroup{},
+		shutdownc:  make(chan struct{}),
+		donec:      make(chan struct{}),
+	}
+}
+
+// Connect opens a connection to the named log aggregation service in discoverd
+// and creates a goroutine that drains the log message buffer to the connection.
+func (m *LogMux) Connect(discd *discoverd.Client, name string) error {
+	conn, err := connect(discd, name, m.donec)
+	if err != nil {
+		return err
+	}
+	m.sc = conn
+
+	go m.drainTo(conn)
+	return nil
+}
+
+func (m *LogMux) drainTo(w io.Writer) {
+	defer close(m.donec)
+
+	g := grohl.NewContext(grohl.Data{"at": "logmux_drain"})
+
+	for {
+		msg, ok := <-m.logc
+		if !ok {
+			return // shutdown
+		}
+
+		_, err := w.Write(rfc6587.Bytes(msg))
+		if err != nil {
+			g.Log(grohl.Data{"status": "error", "err": err.Error()})
+
+			// write logs to local logger when the writer fails
+			g.Log(grohl.Data{"msg": msg.String()})
+			for msg := range m.logc {
+				g.Log(grohl.Data{"msg": msg.String()})
+			}
+
+			return // shutdown
+		}
+	}
+}
+
+// Close blocks until all producers have finished, then terminates the drainer,
+// and blocks until the backlog in logc has been processed.
+func (m *LogMux) Close() {
+	m.producerwg.Wait()
+
+	m.doneo.Do(func() { close(m.logc) })
+
+	select {
+	case <-m.donec:
+	case <-time.NewTimer(3 * time.Second).C:
+		// logs did not drain to logaggregator in 3 seconds, drain them to the local logger
+		close(m.sc.closec)
+		<-m.donec
+	}
+}
+
+type Config struct {
+	AppID, HostID, JobID, JobType string
+}
+
+// Follow forwards log lines from the reader into the syslog client. Follow
+// runs until the reader is closed or an error occurs. If an error occurs, the
+// reader may still be open.
+func (m *LogMux) Follow(r io.Reader, fd int, config Config) {
+	m.producerwg.Add(1)
+
+	hdr := &rfc5424.Header{
+		Hostname: []byte(config.HostID),
+		AppName:  []byte(config.AppID),
+		ProcID:   []byte(config.JobType + "." + config.JobID),
+		MsgID:    []byte(fmt.Sprintf("ID%d", fd)),
+	}
+
+	go m.follow(r, hdr)
+}
+
+func (m *LogMux) follow(r io.Reader, hdr *rfc5424.Header) {
+	defer m.producerwg.Done()
+
+	g := grohl.NewContext(grohl.Data{"at": "logmux_follow"})
+	bufr := bufio.NewReader(r)
+
+	for {
+		line, _, err := bufr.ReadLine()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			g.Log(grohl.Data{"status": "error", "err": err.Error()})
+			return
+		}
+
+		msg := rfc5424.NewMessage(hdr, line)
+
+		select {
+		case m.logc <- msg:
+		default:
+			// throw away msg if logc buffer is full
+		}
+	}
+}

--- a/host/logmux/logmux_test.go
+++ b/host/logmux/logmux_test.go
@@ -1,0 +1,203 @@
+package logmux
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/discoverd/testutil"
+	"github.com/flynn/flynn/discoverd/testutil/etcdrunner"
+	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+	"github.com/flynn/flynn/pkg/syslog/rfc6587"
+)
+
+// Hook gocheck up to the "go test" runner
+func TestLogMux(t *testing.T) { TestingT(t) }
+
+type S struct {
+	discd   *discoverd.Client
+	cleanup func()
+}
+
+var _ = Suite(&S{})
+
+func (s *S) SetUpSuite(c *C) {
+	etcdAddr, killEtcd := etcdrunner.RunEtcdServer(c)
+	discd, killDiscoverd := testutil.BootDiscoverd(c, "", etcdAddr)
+
+	s.discd = discd
+	s.cleanup = func() {
+		killDiscoverd()
+		killEtcd()
+	}
+}
+
+func (s *S) TearDownSuite(c *C) {
+	s.cleanup()
+}
+
+func (s *S) TestLogMux(c *C) {
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, IsNil)
+	defer l.Close()
+
+	addr := l.Addr().String()
+	hb, err := s.discd.AddServiceAndRegister("logaggregator", addr)
+	c.Assert(err, IsNil)
+	defer hb.Close()
+
+	mu := sync.Mutex{}
+	srvDone := make(chan struct{})
+	msgCount := 0
+	handler := func(msg *rfc5424.Message) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		msgCount++
+		if msgCount == 10000 {
+			close(srvDone)
+		}
+	}
+
+	go runServer(l, handler)
+
+	lm := New(10000)
+	err = lm.Connect(s.discd, "logaggregator")
+	c.Assert(err, IsNil)
+
+	config := Config{
+		AppID:   "test",
+		HostID:  "1234",
+		JobType: "worker",
+		JobID:   "567",
+	}
+
+	for i := 0; i < 100; i++ {
+		pr, pw := io.Pipe()
+		lm.Follow(pr, i, config)
+
+		go func() {
+			defer pw.Close()
+			for j := 0; j < 100; j++ {
+				fmt.Fprintf(pw, "test log entry %d\n", j)
+			}
+		}()
+	}
+
+	lm.Close()
+	<-srvDone
+}
+
+func (s *S) TestLIFOBuffer(c *C) {
+	n := 100
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, IsNil)
+	defer l.Close()
+
+	mu := sync.Mutex{}
+	srvDone := make(chan struct{})
+	msgCount := 0
+	handler := func(msg *rfc5424.Message) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !bytes.Equal(msg.Msg, []byte("retained")) {
+			close(srvDone)
+			c.Assert(msg.Msg, DeepEquals, []byte("retained"))
+		}
+
+		msgCount++
+		if msgCount == n {
+			close(srvDone)
+		}
+	}
+
+	go runServer(l, handler)
+
+	lm := New(n)
+	addr := l.Addr().String()
+	hb := discoverdRegister(c, s.discd, "logaggregator", addr)
+	defer hb.Close()
+
+	config := Config{
+		AppID:   "test",
+		HostID:  "1234",
+		JobType: "worker",
+		JobID:   "567",
+	}
+
+	pr, pw := io.Pipe()
+	lm.Follow(pr, 1, config)
+
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(pw, "retained\n")
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(pw, "dropped\n")
+	}
+	pw.Close()
+
+	err = lm.Connect(s.discd, "logaggregator")
+	c.Assert(err, IsNil)
+	<-srvDone
+}
+
+func runServer(l net.Listener, h func(*rfc5424.Message)) {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+
+		go func() {
+			s := bufio.NewScanner(conn)
+			s.Split(rfc6587.Split)
+
+			for s.Scan() {
+				msg, err := rfc5424.Parse(s.Bytes())
+				if err != nil {
+					conn.Close()
+					return
+				}
+
+				h(msg)
+			}
+			conn.Close()
+		}()
+	}
+}
+
+func discoverdRegister(c *C, dc *discoverd.Client, name, addr string) discoverd.Heartbeater {
+	events := make(chan *discoverd.Event)
+	done := make(chan struct{})
+
+	srv := dc.Service(name)
+	srv.Watch(events)
+
+	go func() {
+		defer close(done)
+		for event := range events {
+			if event.Kind == discoverd.EventKindUp && event.Instance.Addr == addr {
+				return
+			}
+		}
+	}()
+
+	hb, err := dc.AddServiceAndRegister(name, addr)
+	c.Assert(err, IsNil)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		c.Fatal("timed out waiting for discoverd registration")
+	}
+
+	return hb
+}

--- a/host/logmux/service_conn.go
+++ b/host/logmux/service_conn.go
@@ -1,0 +1,183 @@
+package logmux
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/technoweenie/grohl"
+
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+// serviceConn dials and watches a connection to a discoverd service. Writes
+// are blocked when the service is down and during a leader change.
+type serviceConn struct {
+	net.Conn
+	cond *sync.Cond
+
+	closed bool
+
+	donec  chan struct{}
+	closec chan struct{}
+	errc   chan error
+}
+
+func connect(discd *discoverd.Client, name string, donec chan struct{}) (*serviceConn, error) {
+	srv := discd.Service(name)
+	eventc := make(chan *discoverd.Event)
+
+	stream, err := srv.Watch(eventc)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := &serviceConn{
+		cond:   &sync.Cond{L: &sync.Mutex{}},
+		donec:  donec,
+		closec: make(chan struct{}),
+		errc:   make(chan error),
+	}
+
+	if err := sc.connect(srv); err != nil {
+		grohl.Log(grohl.Data{"service": name, "status": "connect-error", "err": err.Error()})
+	}
+
+	go sc.watch(srv, eventc, stream)
+	return sc, nil
+}
+
+// Write writes data to the connection.
+// Write blocks while the service is unavailable. Errors from the internal
+// connection are returned.
+func (c *serviceConn) Write(p []byte) (int, error) {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+
+	for {
+		if c.Conn != nil {
+			n, err := c.Conn.Write(p)
+			if err == nil {
+				return n, nil
+			}
+			if c.closed {
+				return 0, errors.New("connection closed")
+			}
+
+			c.errc <- err
+		}
+
+		c.cond.Wait()
+	}
+}
+
+func (c *serviceConn) watch(srv discoverd.Service, eventc <-chan *discoverd.Event, stream stream.Stream) {
+	g := grohl.NewContext(grohl.Data{"at": "logmux_service_watch"})
+
+	var (
+		resetc                  = make(chan time.Time)
+		reconc <-chan time.Time = resetc
+	)
+	defer close(resetc)
+
+	for {
+		select {
+		case event, ok := <-eventc:
+			if !ok {
+				c.hangup()
+				return
+			}
+			g.Log(grohl.Data{"status": "event", "event": event.Kind.String()})
+
+			switch event.Kind {
+			case discoverd.EventKindLeader:
+				reconc = resetc
+
+				if err := c.reset(); err != nil {
+					g.Log(grohl.Data{"status": "error", "err": err.Error()})
+				}
+
+				if err := c.connect(srv); err != nil {
+					g.Log(grohl.Data{"status": "error", "err": err.Error()})
+					reconc = time.After(100 * time.Millisecond)
+				}
+			default:
+			}
+		case err := <-c.errc:
+			g.Log(grohl.Data{"status": "write-error", "err": err.Error()})
+			reconc = resetc
+
+			if err := c.reset(); err != nil {
+				g.Log(grohl.Data{"status": "error", "err": err.Error()})
+			}
+
+			if err := c.connect(srv); err != nil {
+				g.Log(grohl.Data{"status": "error", "err": err.Error()})
+				reconc = time.After(100 * time.Millisecond)
+			}
+		case <-reconc:
+			if err := c.connect(srv); err != nil {
+				g.Log(grohl.Data{"status": "reconnect-error", "err": err.Error()})
+				reconc = time.After(100 * time.Millisecond)
+			}
+		case <-c.donec:
+			if err := stream.Close(); err != nil {
+				g.Log(grohl.Data{"status": "error", "err": err.Error()})
+			}
+			if err := c.reset(); err != nil {
+				g.Log(grohl.Data{"status": "error", "err": err.Error()})
+			}
+
+			return
+		case <-c.closec:
+			if err := stream.Close(); err != nil {
+				g.Log(grohl.Data{"status": "error", "err": err.Error()})
+			}
+
+			c.hangup()
+			return
+		}
+	}
+}
+
+func (c *serviceConn) connect(srv discoverd.Service) error {
+	ldr, err := srv.Leader()
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.Dial("tcp", ldr.Addr)
+	if err != nil {
+		return err
+	}
+
+	c.cond.L.Lock()
+	c.Conn = conn
+	c.cond.L.Unlock()
+	c.cond.Broadcast()
+
+	return nil
+}
+
+func (c *serviceConn) reset() error {
+	c.cond.L.Lock()
+	conn := c.Conn
+	c.Conn = nil
+	c.cond.L.Unlock()
+
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
+}
+
+func (c *serviceConn) hangup() {
+	c.reset()
+
+	c.cond.L.Lock()
+	c.closed = true
+	c.cond.L.Unlock()
+	c.cond.Broadcast()
+}

--- a/host/logmux/service_conn_test.go
+++ b/host/logmux/service_conn_test.go
@@ -1,0 +1,107 @@
+package logmux
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+	"github.com/flynn/flynn/pkg/syslog/rfc6587"
+)
+
+func (s *S) TestServiceConnBlockWrite(c *C) {
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, IsNil)
+
+	msgc := make(chan *rfc5424.Message)
+	handler := func(msg *rfc5424.Message) {
+		msgc <- msg
+	}
+
+	go runServer(l, handler)
+
+	donec := make(chan struct{})
+	defer close(donec)
+
+	sc, err := connect(s.discd, "test-syslog", donec)
+	c.Assert(err, IsNil)
+
+	want := rfc5424.NewMessage(&rfc5424.Header{}, []byte("test message"))
+	go sc.Write(rfc6587.Bytes(want))
+
+	addr := l.Addr().String()
+	_, err = s.discd.AddServiceAndRegister("test-syslog", addr)
+	c.Assert(err, IsNil)
+
+	c.Assert(<-msgc, DeepEquals, want)
+}
+
+func (s *S) TestDurableWrite(c *C) {
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, IsNil)
+
+	msgc := make(chan *rfc5424.Message)
+	handler := func(msg *rfc5424.Message) {
+		msgc <- msg
+	}
+
+	go runServer(l, handler)
+
+	donec := make(chan struct{})
+	defer close(donec)
+
+	sc, err := connect(s.discd, "test-broken", donec)
+	c.Assert(err, IsNil)
+
+	addr := l.Addr().String()
+	_, err = s.discd.AddServiceAndRegister("test-broken", addr)
+	c.Assert(err, IsNil)
+
+	hdr := &rfc5424.Header{}
+	for i := 0; i < 10; i++ {
+		want := rfc5424.NewMessage(hdr, []byte(fmt.Sprintf("line %d", i+1)))
+
+		_, err = sc.Write(rfc6587.Bytes(want))
+		c.Assert(err, IsNil)
+
+		if i%2 == 0 {
+			// break the underlying connection before the next Write
+			c.Assert(sc.Conn.Close(), IsNil)
+		}
+
+		got := <-msgc
+		c.Assert(want, DeepEquals, got)
+	}
+}
+
+func (s *S) TestReconnect(c *C) {
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, IsNil)
+	err = l.Close()
+	c.Assert(err, IsNil)
+
+	msgc := make(chan *rfc5424.Message)
+	handler := func(msg *rfc5424.Message) {
+		msgc <- msg
+	}
+
+	addr := l.Addr().String()
+	_, err = s.discd.AddServiceAndRegister("test-reconnect", addr)
+	c.Assert(err, IsNil)
+
+	donec := make(chan struct{})
+	defer close(donec)
+
+	sc, err := connect(s.discd, "test-reconnect", donec)
+	c.Assert(err, IsNil)
+
+	l, err = net.Listen("tcp", addr)
+	c.Assert(err, IsNil)
+	go runServer(l, handler)
+
+	want := rfc5424.NewMessage(&rfc5424.Header{Version: 1}, []byte("test message"))
+	_, err = sc.Write(rfc6587.Bytes(want))
+	c.Assert(err, IsNil)
+
+	c.Assert(<-msgc, DeepEquals, want)
+}

--- a/pkg/syslog/rfc5424/message.go
+++ b/pkg/syslog/rfc5424/message.go
@@ -19,12 +19,22 @@ type Message struct {
 	Msg            []byte
 }
 
+// NewMessage builds a new message from a copy of the header and message.
 func NewMessage(hdr *Header, msg []byte) *Message {
-	if hdr.Timestamp.IsZero() {
-		hdr.Timestamp = time.Now().UTC()
+	h := *hdr
+
+	if h.Timestamp.IsZero() {
+		h.Timestamp = time.Now().UTC()
 	}
 
-	return &Message{Header: *hdr, Msg: msg}
+	if h.Version == 0 {
+		h.Version = 1
+	}
+
+	m := make([]byte, len(msg))
+	copy(m, msg)
+
+	return &Message{Header: h, Msg: m}
 }
 
 var msgSep = []byte{' '}


### PR DESCRIPTION
Send container output on STDOUT, STDERR, and containerinit to the logaggregator service over TCP as rfc5424 encoded syslog messages.

### TODO
- [x] replace `panic`s in `LogMux` methods.
- [x] figure out a better way to test this stuff.
- [x] bootstrap process for the `logaggregator` service.
- [x] make `Follow` compatible with `Close`.