### PR TITLE
Run HA clusters

### DIFF
--- a/appliance/postgresql/discoverd.go
+++ b/appliance/postgresql/discoverd.go
@@ -31,9 +31,11 @@ func (d *Discoverd) SetState(state *state.DiscoverdState) error {
 	if err != nil {
 		return err
 	}
-	if err := d.service.SetMeta(&discoverd.ServiceMeta{Index: state.Index, Data: data}); err != nil {
+	meta := &discoverd.ServiceMeta{Index: state.Index, Data: data}
+	if err := d.service.SetMeta(meta); err != nil {
 		return err
 	}
+	state.Index = meta.Index
 	if state.State.Primary != nil {
 		if err := d.service.SetLeader(state.State.Primary.ID); err != nil {
 			d.log.Error("error setting discoverd leader", "id", state.State.Primary.ID, "err", err)

--- a/appliance/postgresql/start.sh
+++ b/appliance/postgresql/start.sh
@@ -3,10 +3,11 @@
 case $1 in
   postgres)
     chown -R postgres:postgres /data
+    chmod 0700 /data
     shift
     exec sudo \
       -u postgres \
-	  -E -H \
+      -E -H \
       /bin/flynn-postgres $*
     ;;
   api)

--- a/bootstrap/add_app_action.go
+++ b/bootstrap/add_app_action.go
@@ -91,8 +91,3 @@ func (a *AddAppAction) Run(s *State) error {
 
 	return nil
 }
-
-func (a *AddAppAction) Cleanup(s *State) error {
-	// TODO
-	return nil
-}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -96,6 +97,10 @@ func Run(manifest []byte, ch chan<- *StepInfo, minHosts int) (err error) {
 			ch <- &StepInfo{StepAction: a, State: "error", Error: err.Error(), Err: err, Timestamp: time.Now().UTC()}
 		}
 	}()
+
+	if minHosts == 2 {
+		return errors.New("the minimum number of hosts for a multi-node cluster is 3, min-hosts=2 is invalid")
+	}
 
 	// Make sure we are connected to discoverd first
 	discoverdAttempts.Run(func() error {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 type State struct {
 	StepData  map[string]interface{}
 	Providers map[string]*ct.Provider
+	Singleton bool
 
 	clusterc    *cluster.Client
 	controllerc *controller.Client
@@ -108,6 +110,10 @@ func Run(manifest []byte, ch chan<- *StepInfo, minHosts int) (err error) {
 	state := &State{
 		StepData:  make(map[string]interface{}),
 		Providers: make(map[string]*ct.Provider),
+		Singleton: minHosts == 1,
+	}
+	if s := os.Getenv("SINGLETON"); s != "" {
+		state.Singleton = s == "true"
 	}
 
 	a = StepAction{ID: "online-hosts", Action: "check"}

--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -107,6 +107,11 @@ func (a *DeployAppAction) Run(s *State) error {
 		ReleaseID: a.Release.ID,
 		Processes: a.Processes,
 	}
+	for name, count := range formation.Processes {
+		if s.Singleton && count > 1 {
+			formation.Processes[name] = 1
+		}
+	}
 	if err := client.PutFormation(formation); err != nil {
 		return err
 	}

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -24,7 +24,7 @@
           "data": true,
           "cmd": ["postgres"],
           "env": {
-            "SINGLETON": "true"
+            "SINGLETON": "{{ .Singleton }}"
           }
         },
         "web": {
@@ -38,8 +38,8 @@
       "uri": "$image_repository?name=flynn/postgresql&id=$image_id[postgresql]"
     },
     "processes": {
-      "postgres": 1,
-      "web": 1
+      "postgres": 3,
+      "web": 2
     }
   },
   {
@@ -134,8 +134,8 @@
     "app_step": "controller-inception",
     "processes": {
       "scheduler": 1,
-      "deployer": 1,
-      "web": 1
+      "deployer": 2,
+      "web": 2
     }
   },
   {
@@ -165,7 +165,7 @@
       }
     },
     "processes": {
-      "web": 1
+      "web": 2
     },
     "resources": [{"name":"postgres", "url":"http://pg-api.discoverd/databases"}]
   },
@@ -230,7 +230,7 @@
       }
     },
     "processes": {
-      "app": 1
+      "app": 2
     }
   },
   {
@@ -326,7 +326,7 @@
       }
     },
     "processes": {
-      "web": 1
+      "web": 2
     }
   },
   {

--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -109,6 +109,10 @@ func (a *RunAppAction) Run(s *State) error {
 		return err
 	}
 	for typ, count := range a.Processes {
+		if s.Singleton && count > 1 {
+			a.Processes[typ] = 1
+			count = 1
+		}
 		hosts, err := cc.ListHosts()
 		if err != nil {
 			return err

--- a/bootstrap/scale_app_action.go
+++ b/bootstrap/scale_app_action.go
@@ -27,5 +27,11 @@ func (a *ScaleAppAction) Run(s *State) error {
 	a.Formation.AppID = data.App.ID
 	a.Formation.ReleaseID = data.Release.ID
 
+	for name, count := range a.Formation.Processes {
+		if s.Singleton && count > 1 {
+			a.Formation.Processes[name] = 1
+		}
+	}
+
 	return client.PutFormation(a.Formation)
 }

--- a/docs/content/installation.html.md
+++ b/docs/content/installation.html.md
@@ -173,12 +173,13 @@ demo.localflynn.com.    A      192.168.84.44
 records, you can use [xip.io](http://xip.io) which provides wildcard DNS for
 any IP address.*
 
-Set `CLUSTER_DOMAIN` to the main domain name and start the bootstrap process:
+Set `CLUSTER_DOMAIN` to the main domain name and start the bootstrap process,
+specifying the number of hosts that are expected to be present.
 
 ```
 $ sudo \
     CLUSTER_DOMAIN=demo.localflynn.com \
-    flynn-host bootstrap /etc/flynn/bootstrap-manifest.json
+    flynn-host bootstrap --min-hosts=3 /etc/flynn/bootstrap-manifest.json
 ```
 
 *Note: You only need to run this on a single node in the cluster. It will

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -350,8 +350,8 @@ loop:
 		}
 	}
 	expected := map[string]map[string]int{release.ID: {
-		"web":       1,
-		"deployer":  1,
+		"web":       2,
+		"deployer":  2,
 		"scheduler": testCluster.Size(),
 	}}
 	t.Assert(actual, c.DeepEquals, expected)

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -154,7 +154,7 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 			jobs = append(jobs, job)
 		}
 	}
-	t.Assert(jobs, c.HasLen, 1)
+	t.Assert(jobs, c.HasLen, 2)
 	hostID, jobID, _ := cluster.ParseJobID(jobs[0].ID)
 	t.Assert(hostID, c.Not(c.Equals), "")
 	t.Assert(jobID, c.Not(c.Equals), "")
@@ -168,7 +168,7 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 	t.Assert(s.controllerClient(t).PutFormation(&ct.Formation{
 		AppID:     app.ID,
 		ReleaseID: release.ID,
-		Processes: map[string]int{"web": 2, "scheduler": 1},
+		Processes: map[string]int{"web": 3, "scheduler": 1},
 	}), c.IsNil)
 	lastID, _ := waitForJobEvents(t, stream, events, jobEvents{"web": {"up": 1}})
 	stream.Close()
@@ -184,10 +184,10 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 		if err != nil {
 			return err
 		}
-		if len(addrs) != 2 {
-			return fmt.Errorf("expected 2 controller processes, got %d", len(addrs))
+		if len(addrs) != 3 {
+			return fmt.Errorf("expected 3 controller processes, got %d", len(addrs))
 		}
-		addr := addrs[1]
+		addr := addrs[2]
 		debug(t, "new controller address: ", addr)
 		client, err = controller.NewClient("http://"+addr, s.clusterConf(t).Key)
 		if err != nil {
@@ -213,7 +213,7 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 	t.Assert(s.controllerClient(t).PutFormation(&ct.Formation{
 		AppID:     app.ID,
 		ReleaseID: release.ID,
-		Processes: map[string]int{"web": 1, "scheduler": 1},
+		Processes: map[string]int{"web": 2, "scheduler": 1},
 	}), c.IsNil)
 	waitForJobEvents(t, stream, events, jobEvents{"web": {"down": 1}})
 


### PR DESCRIPTION
This changes bootstrap to detect whether it should run in singleton mode by first checking the `SINGLETON` environment variable and if not set, checking if the number of expected nodes is 1.

If singleton mode is not enabled, enough instances of each process are run to make the control plane tolerate the loss of a node without having to start new instances.