### PR TITLE
logging: fix syslog parser

### DIFF
--- a/pkg/syslog/rfc5424/parser.go
+++ b/pkg/syslog/rfc5424/parser.go
@@ -137,6 +137,10 @@ func parseNextField(buf []byte, cursor *int) ([]byte, error) {
 	}
 	res := buf[*cursor:nextSpace]
 	*cursor = nextSpace + 1
+
+	if bytes.Equal(res, nilValue) {
+		return nil, nil
+	}
 	return res, nil
 }
 
@@ -145,11 +149,13 @@ func parseStructuredData(buf []byte, cursor *int, msg *Message) error {
 		return &ParseError{*cursor, "missing structured data field"}
 	}
 	if buf[*cursor] == '-' {
-		if len(buf) < *cursor+1 || buf[*cursor+1] != ' ' {
+		if len(buf) > *cursor+1 && buf[*cursor+1] != ' ' {
 			return &ParseError{*cursor, "invalid structured data"}
 		}
+		if len(buf) > *cursor+2 {
+			*cursor++
+		}
 		*cursor++
-		msg.StructuredData = nilValue
 		return nil
 	}
 	return &ParseError{*cursor, "structured data is unsupported"}

--- a/pkg/syslog/rfc5424/parser_test.go
+++ b/pkg/syslog/rfc5424/parser_test.go
@@ -1,0 +1,57 @@
+package rfc5424
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+func (s *S) TestParse(c *C) {
+	ts := time.Now().UTC()
+	tss := ts.Format(time.RFC3339Nano)
+
+	table := []struct {
+		msg  string
+		want *Message
+	}{
+		{
+			msg: fmt.Sprintf("<1>1 %s 3.4.5.6 APP-7 PID-8 FD9 - message body", tss),
+			want: &Message{
+				Header: Header{
+					Facility:  0,
+					Severity:  1,
+					Version:   1,
+					Timestamp: ts,
+					Hostname:  []byte("3.4.5.6"),
+					AppName:   []byte("APP-7"),
+					ProcID:    []byte("PID-8"),
+					MsgID:     []byte("FD9"),
+				},
+				Msg: []byte("message body"),
+			},
+		},
+
+		// empty message
+		{
+			msg: fmt.Sprintf("<1>1 %s - - - - -", tss),
+			want: &Message{
+				Header: Header{
+					Facility:  0,
+					Severity:  1,
+					Version:   1,
+					Timestamp: ts,
+				},
+			},
+		},
+	}
+
+	for _, test := range table {
+		msg, err := Parse([]byte(test.msg))
+		if err != nil {
+			c.Error(err)
+		}
+
+		c.Assert(msg, DeepEquals, test.want)
+	}
+}


### PR DESCRIPTION
The syslog message parser was including an extra space at the beginning of the message byte slice. It was `panic`ing when the syslog message did not contain a `MSG` field, in which case there is `SP` after `STRUCTURED-DATA`. For fields containing a nil value ('-'), the header member is set to nil instead of `[]byte{'-'}`.

/cc @bgentry