### PR TITLE
Deploy apps when running `flynn-host update`

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -165,7 +165,7 @@ func runCommand(name string, args []string) (err error) {
 			if err != nil {
 				log.Fatalln("error decoding tls pin:", err)
 			}
-			client, err = controller.NewClientWithPin(cluster.URL, cluster.Key, pin)
+			client, err = controller.NewClientWithConfig(cluster.URL, cluster.Key, controller.Config{Pin: pin})
 		} else {
 			client, err = controller.NewClient(cluster.URL, cluster.Key)
 		}

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -289,8 +289,11 @@ outer:
 	for {
 		select {
 		case e := <-events:
-			if e.Status == "complete" {
+			switch e.Status {
+			case "complete":
 				break outer
+			case "failed":
+				return e.Err()
 			}
 		case <-time.After(10 * time.Second):
 			return fmt.Errorf("Timed out waiting for deployment completion!")

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -315,8 +315,8 @@ outer:
 			case "failed":
 				return e.Err()
 			}
-		case <-time.After(10 * time.Second):
-			return fmt.Errorf("Timed out waiting for deployment completion!")
+		case <-time.After(30 * time.Second):
+			return errors.New("timed out waiting for deployment completion")
 
 		}
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -76,7 +76,13 @@ func main() {
 
 	sc := routerc.New()
 
-	hb, err := discoverd.AddServiceAndRegister("flynn-controller", addr)
+	hb, err := discoverd.DefaultClient.AddServiceAndRegisterInstance("flynn-controller", &discoverd.Instance{
+		Addr:  addr,
+		Proto: "http",
+		Meta: map[string]string{
+			"AUTH_KEY": os.Getenv("AUTH_KEY"),
+		},
+	})
 	if err != nil {
 		shutdown.Fatal(err)
 	}

--- a/controller/deployer/main.go
+++ b/controller/deployer/main.go
@@ -116,10 +116,12 @@ func (c *context) HandleJob(job *que.Job) (e error) {
 		// rollback failed deploy
 		if e != nil {
 			log.Warn("rolling back deployment due to error", "err", e)
+			errMsg := e.Error()
 			e = c.rollback(log, deployment, f)
 			events <- ct.DeploymentEvent{
 				ReleaseID: deployment.NewReleaseID,
 				Status:    "failed",
+				Error:     errMsg,
 			}
 		}
 	}()

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -134,10 +135,18 @@ type DeploymentEvent struct {
 	JobType      string     `json:"job_type"`
 	JobState     string     `json:"job_state"`
 	CreatedAt    *time.Time `json:"created_at"`
+	Error        string     `json:"error"`
 }
 
-func (de *DeploymentEvent) EventID() string {
-	return strconv.FormatInt(de.ID, 10)
+func (e *DeploymentEvent) EventID() string {
+	return strconv.FormatInt(e.ID, 10)
+}
+
+func (e *DeploymentEvent) Err() error {
+	if e.Error == "" {
+		return nil
+	}
+	return errors.New(e.Error)
 }
 
 type Provider struct {

--- a/host/cli/update.go
+++ b/host/cli/update.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/cluster"
 )
@@ -26,47 +26,66 @@ Update Flynn components`)
 }
 
 func runUpdate(args *docopt.Args) error {
+	log := log15.New()
+
 	// create and update a TUF client
+	log.Info("initializing TUF client")
 	local, err := tuf.FileLocalStore(args.String["--tuf-db"])
 	if err != nil {
+		log.Error("error creating local TUF client", "err", err)
 		return err
 	}
 	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], nil)
 	if err != nil {
+		log.Error("error creating remote TUF client", "err", err)
 		return err
 	}
 	client := tuf.NewClient(local, remote)
+
+	log.Info("updating TUF data")
 	if _, err := client.Update(); err != nil && !tuf.IsLatestSnapshot(err) {
+		log.Error("error updating TUF client", "err", err)
 		return err
 	}
 
 	// read the TUF db so we can pass it to hosts
+	log.Info("reading TUF database")
 	tufDB, err := ioutil.ReadFile(args.String["--tuf-db"])
 	if err != nil {
+		log.Error("error reading the TUF database", "err", err)
 		return err
 	}
 
-	// get list of hosts
+	log.Info("getting host list")
 	clusterClient, err := cluster.NewClient()
 	if err != nil {
+		log.Error("error creating cluster client", "err", err)
 		return err
 	}
 	hosts, err := clusterClient.ListHosts()
 	if err != nil {
+		log.Error("error getting host list", "err", err)
 		return err
 	}
 	if len(hosts) == 0 {
 		return errors.New("no hosts found")
 	}
 
+	log.Info("pulling images on all hosts")
 	hostErrs := make(chan error)
 	for _, h := range hosts {
 		go func(hostID string) {
+			log := log.New("host", hostID)
+
+			log.Info("connecting to host")
 			host, err := clusterClient.DialHost(hostID)
 			if err != nil {
+				log.Error("error connecting to host", "err", err)
 				hostErrs <- err
 				return
 			}
+
+			log.Info("pulling images")
 			ch := make(chan *layer.PullInfo)
 			stream, err := host.PullImages(
 				args.String["--repository"],
@@ -76,12 +95,13 @@ func runUpdate(args *docopt.Args) error {
 				ch,
 			)
 			if err != nil {
+				log.Error("error pulling images", "err", err)
 				hostErrs <- err
 				return
 			}
 			defer stream.Close()
 			for info := range ch {
-				fmt.Printf("==> %s : %s %s %s\n", hostID, info.Repo, info.ID, info.Status)
+				log.Info("pulled image layer", "name", info.Repo, "id", info.ID, "status", info.Status)
 			}
 			hostErrs <- stream.Err()
 		}(h.ID)
@@ -89,9 +109,11 @@ func runUpdate(args *docopt.Args) error {
 	var hostErr error
 	for _, h := range hosts {
 		if err := <-hostErrs; err != nil {
-			fmt.Printf("update: error running update on host %s: %s\n", h.ID, err)
+			log.Error("error pulling images", "host", h.ID, "err", err)
 			hostErr = err
+			continue
 		}
+		log.Info("images pulled successfully", "host", h.ID)
 	}
 	return hostErr
 }

--- a/pinkerton/layer/layer.go
+++ b/pinkerton/layer/layer.go
@@ -2,9 +2,17 @@ package layer
 
 type PullInfo struct {
 	Repo   string `json:"repo"`
+	Type   Type   `json:"type"`
 	ID     string `json:"id"`
 	Status Status `json:"status"`
 }
+
+type Type string
+
+const (
+	TypeImage Type = "image"
+	TypeLayer Type = "layer"
+)
 
 type Status string
 

--- a/pkg/httpclient/json.go
+++ b/pkg/httpclient/json.go
@@ -32,6 +32,7 @@ type Client struct {
 	ErrNotFound error
 	URL         string
 	Key         string
+	Host        string
 	HTTP        *http.Client
 	HijackDial  DialFunc
 }
@@ -68,6 +69,9 @@ func (c *Client) prepareReq(method, path string, header http.Header, in interfac
 	req.Header = header
 	if c.Key != "" {
 		req.SetBasicAuth("", c.Key)
+	}
+	if c.Host != "" {
+		req.Host = c.Host
 	}
 	return req, nil
 }

--- a/pkg/pinned/pinned.go
+++ b/pkg/pinned/pinned.go
@@ -48,7 +48,9 @@ func (c *Config) Dial(network, addr string) (net.Conn, error) {
 		Wire: cn,
 	}
 
-	conf.ServerName, _, _ = net.SplitHostPort(addr)
+	if conf.ServerName == "" {
+		conf.ServerName, _, _ = net.SplitHostPort(addr)
+	}
 
 	if err = conn.Handshake(); err != nil {
 		conn.Close()

--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -80,6 +80,11 @@ func (c *Client) AddHost(ch chan *host.HostEvent, vanilla bool) (*tc.Instance, e
 	}
 }
 
+func (c *Client) AddReleaseHosts() (*tc.BootResult, error) {
+	var res tc.BootResult
+	return &res, c.Post("/release", nil, &res)
+}
+
 func (c *Client) RemoveHost(host *tc.Instance) error {
 	c.size--
 	return c.Delete("/" + host.ID)

--- a/test/helper.go
+++ b/test/helper.go
@@ -69,7 +69,7 @@ func (h *Helper) controllerClient(t *c.C) *controller.Client {
 		conf := h.clusterConf(t)
 		pin, err := base64.StdEncoding.DecodeString(conf.TLSPin)
 		t.Assert(err, c.IsNil)
-		client, err := controller.NewClientWithPin(conf.URL, conf.Key, pin)
+		client, err := controller.NewClientWithConfig(conf.URL, conf.Key, controller.Config{Pin: pin})
 		t.Assert(err, c.IsNil)
 		h.controller = client
 	}

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -3,13 +3,16 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"text/template"
 
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/controller/client"
 	tc "github.com/flynn/flynn/test/cluster"
 )
 
@@ -17,7 +20,14 @@ type ReleaseSuite struct {
 	Helper
 }
 
-var _ = c.Suite(&ReleaseSuite{})
+var _ = c.ConcurrentSuite(&ReleaseSuite{})
+
+func (s *ReleaseSuite) addReleaseHosts(t *c.C) *tc.BootResult {
+	res, err := testCluster.AddReleaseHosts()
+	t.Assert(err, c.IsNil)
+	t.Assert(res.Instances, c.HasLen, 4)
+	return res
+}
 
 var releaseScript = bytes.NewReader([]byte(`
 export TUF_TARGETS_PASSPHRASE="flynn-test"
@@ -30,7 +40,7 @@ src="${GOPATH}/src/github.com/flynn/flynn"
 # send all output to stderr so only version.json is output to stdout
 (
 
-  # rebuild layer 0 components.
+  # rebuild components.
   #
   # ideally we would use tup to do this, but it hangs waiting on the
   # FUSE socket after building, so for now we do it manually.
@@ -41,18 +51,21 @@ src="${GOPATH}/src/github.com/flynn/flynn"
   vpkg="github.com/flynn/flynn/pkg/version"
   go build -o host/bin/flynn-host -ldflags="-X ${vpkg}.commit dev -X ${vpkg}.branch dev -X ${vpkg}.tag v20150131.0-test -X ${vpkg}.dirty false" ./host
   gzip -9 --keep --force host/bin/flynn-host
-  docker build --no-cache --tag flynn/etcd appliance/etcd
-  docker build --no-cache --tag flynn/flannel flannel
-  docker build --no-cache --tag flynn/discoverd discoverd
   sed "s/{{FLYNN-HOST-CHECKSUM}}/$(sha512sum host/bin/flynn-host.gz | cut -d " " -f 1)/g" script/install-flynn.tmpl > script/install-flynn
+
+  # create new images
+  for name in $(docker images | grep ^flynn | awk '{print $1}'); do
+    docker build -t $name - < <(echo -e "FROM $name\nRUN /bin/true")
+  done
+
   util/release/flynn-release manifest util/release/version_template.json > version.json
   popd >/dev/null
 
   "${src}/script/export-components" "${src}/test/release"
 
   dir=$(mktemp --directory)
-  mv "${src}/test/release/repository" "${dir}/tuf"
-  mv "${src}/script/install-flynn" "${dir}/install-flynn"
+  ln -s "${src}/test/release/repository" "${dir}/tuf"
+  ln -s "${src}/script/install-flynn" "${dir}/install-flynn"
 
   # start a blobstore to serve the exported components
   sudo start-stop-daemon \
@@ -75,7 +88,17 @@ curl -sL --fail http://{{ .Blobstore }}/install-flynn > /tmp/install-flynn
 bash -e /tmp/install-flynn -r "http://{{ .Blobstore }}"
 `))
 
+var updateScript = template.Must(template.New("update-script").Parse(`
+cd ~/go/src/github.com/flynn/flynn
+tuf --dir test/release root-keys | tuf-client init --store /tmp/tuf.db http://{{ .Blobstore }}/tuf
+flynn-host update --repository http://{{ .Blobstore }}/tuf --tuf-db /tmp/tuf.db
+`))
+
 func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
+	if testCluster == nil {
+		t.Skip("cannot boot release cluster")
+	}
+
 	// stream script output to t.Log
 	logReader, logWriter := io.Pipe()
 	go func() {
@@ -89,18 +112,19 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 		}
 	}()
 
-	// boot a host to release components to a local blobstore, outputting the new version.json
-	buildHost := s.addHost(t)
-	defer s.removeHost(t, buildHost)
+	// boot the release cluster, release components to a blobstore and output the new version.json
+	releaseCluster := s.addReleaseHosts(t)
+	buildHost := releaseCluster.Instances[0]
 	var versionJSON bytes.Buffer
 	t.Assert(buildHost.Run("bash -ex", &tc.Streams{Stdin: releaseScript, Stdout: &versionJSON, Stderr: logWriter}), c.IsNil)
 	var versions map[string]string
 	t.Assert(json.Unmarshal(versionJSON.Bytes(), &versions), c.IsNil)
 
-	// boot a host and install Flynn from the blobstore
-	installHost := s.addVanillaHost(t)
+	// install Flynn from the blobstore on the vanilla host
+	blobstore := struct{ Blobstore string }{buildHost.IP + ":8080"}
+	installHost := releaseCluster.Instances[3]
 	var script bytes.Buffer
-	installScript.Execute(&script, struct{ Blobstore string }{buildHost.IP + ":8080"})
+	installScript.Execute(&script, blobstore)
 	var installOutput bytes.Buffer
 	out := io.MultiWriter(logWriter, &installOutput)
 	t.Assert(installHost.Run("sudo bash -ex", &tc.Streams{Stdin: &script, Stdout: out, Stderr: out}), c.IsNil)
@@ -111,15 +135,58 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	t.Assert(strings.TrimSpace(hostVersion.String()), c.Equals, "v20150131.0-test")
 
 	// check rebuilt images were downloaded
-	images := []string{"flynn/etcd", "flynn/discoverd", "flynn/flannel"}
-	for _, name := range images {
-		id, ok := versions[name]
-		if !ok {
-			t.Fatalf("could not determine id of %s image", name)
-		}
-		expected := fmt.Sprintf("%s %s downloaded", name, id)
+	for name, id := range versions {
+		expected := fmt.Sprintf("%s image %s downloaded", name, id)
 		if !strings.Contains(installOutput.String(), expected) {
-			t.Fatalf(`expected install output to contain "%s"`, expected)
+			t.Fatalf(`expected install to download %s %s`, name, id)
 		}
+	}
+
+	// run a cluster update from the blobstore
+	updateHost := releaseCluster.Instances[1]
+	script = bytes.Buffer{}
+	updateScript.Execute(&script, blobstore)
+	var updateOutput bytes.Buffer
+	out = io.MultiWriter(logWriter, &updateOutput)
+	t.Assert(updateHost.Run("bash -ex", &tc.Streams{Stdin: &script, Stdout: out, Stderr: out}), c.IsNil)
+
+	// check rebuilt images were downloaded
+	for name := range versions {
+		for _, host := range releaseCluster.Instances[0:2] {
+			expected := fmt.Sprintf(`"pulled image" host=%s name=%s`, host.ID, name)
+			if !strings.Contains(updateOutput.String(), expected) {
+				t.Fatalf(`expected update to download %s on host %s`, name, host.ID)
+			}
+		}
+	}
+
+	// create a controller client for the new cluster
+	pin, err := base64.StdEncoding.DecodeString(releaseCluster.ControllerPin)
+	t.Assert(err, c.IsNil)
+	client, err := controller.NewClientWithConfig(
+		"https://"+buildHost.IP,
+		releaseCluster.ControllerKey,
+		controller.Config{Pin: pin, Domain: releaseCluster.ControllerDomain},
+	)
+	t.Assert(err, c.IsNil)
+
+	// check system apps were deployed correctly
+	systemApps := []string{"blobstore", "dashboard", "router", "gitreceive", "controller"}
+	for _, app := range systemApps {
+		expected := fmt.Sprintf(`"finished deploy of system app" name=%s`, app)
+		if !strings.Contains(updateOutput.String(), expected) {
+			t.Fatalf(`expected update to deploy %s`, app)
+		}
+		release, err := client.GetAppRelease(app)
+		t.Assert(err, c.IsNil)
+		artifact, err := client.GetArtifact(release.ArtifactID)
+		t.Assert(err, c.IsNil)
+		image := "flynn/" + app
+		if app == "gitreceive" {
+			image = "flynn/receiver"
+		}
+		uri, err := url.Parse(artifact.URI)
+		t.Assert(err, c.IsNil)
+		t.Assert(uri.Query().Get("id"), c.Equals, versions[image])
 	}
 }

--- a/updater/.gitignore
+++ b/updater/.gitignore
@@ -1,0 +1,1 @@
+updater

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,0 +1,5 @@
+FROM flynn/busybox
+
+ADD updater /bin/updater
+
+ENTRYPOINT ["/bin/updater"]

--- a/updater/Tupfile
+++ b/updater/Tupfile
@@ -1,0 +1,3 @@
+include_rules
+: |> !go |> updater
+: updater |> !docker-layer1 |>

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/mattn/go-colorable"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
+)
+
+var slugbuilderURI, slugrunnerURI string
+
+// use a flag to determine whether to use a TTY log formatter because actually
+// assigning a TTY to the job causes reading images via stdin to fail.
+var isTTY = flag.Bool("tty", false, "use a TTY log formatter")
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
+
+var systemApps = []string{
+	"blobstore",
+	"dashboard",
+	"router",
+	"gitreceive",
+	"controller",
+}
+
+func run() error {
+	log := log15.New()
+	if *isTTY {
+		log.SetHandler(log15.StreamHandler(colorable.NewColorableStdout(), log15.TerminalFormat()))
+	}
+
+	var images map[string]string
+	if err := json.NewDecoder(os.Stdin).Decode(&images); err != nil {
+		log.Error("error decoding images", "err", err)
+		return err
+	}
+
+	instances, err := discoverd.GetInstances("flynn-controller", 10*time.Second)
+	if err != nil {
+		log.Error("error looking up controller in service discovery", "err", err)
+		return err
+	}
+	client, err := controller.NewClient("", instances[0].Meta["AUTH_KEY"])
+	if err != nil {
+		log.Error("error creating controller client", "err", err)
+		return err
+	}
+
+	log.Info("validating images")
+	uris := make(map[string]string, len(systemApps)+2)
+	for _, name := range append(systemApps, "slugbuilder", "slugrunner") {
+		image := "flynn/" + name
+		if name == "gitreceive" {
+			image = "flynn/receiver"
+		}
+		uri, ok := images[image]
+		if !ok {
+			err := fmt.Errorf("missing image: %s", image)
+			log.Error(err.Error())
+			return err
+		}
+		uris[name] = uri
+	}
+	slugbuilderURI = uris["slugbuilder"]
+	slugrunnerURI = uris["slugrunner"]
+
+	// deploy system apps in order first
+	for _, name := range systemApps {
+		log := log.New("name", name)
+		log.Info("starting deploy of system app")
+
+		app, err := client.GetApp(name)
+		if err != nil {
+			log.Error("error getting app", "err", err)
+			return err
+		}
+		if err := deployApp(client, app, uris[name], log); err != nil {
+			if e, ok := err.(errDeploySkipped); ok {
+				log.Info("skipped deploy of system app", "reason", e.reason)
+				continue
+			}
+			return err
+		}
+		log.Info("finished deploy of system app")
+	}
+
+	// deploy all other apps
+	apps, err := client.AppList()
+	if err != nil {
+		log.Error("error getting apps", "err", err)
+		return err
+	}
+	for _, app := range apps {
+		if app.System() {
+			continue
+		}
+		log := log.New("name", app.Name)
+		log.Info("starting deploy of app to update slugrunner")
+		if err := deployApp(client, app, slugrunnerURI, log); err != nil {
+			if e, ok := err.(errDeploySkipped); ok {
+				log.Info("skipped deploy of app", "reason", e.reason)
+				continue
+			}
+			return err
+		}
+		log.Info("finished deploy of app")
+	}
+	return nil
+}
+
+type errDeploySkipped struct {
+	reason string
+}
+
+func (e errDeploySkipped) Error() string {
+	return e.reason
+}
+
+func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Logger) error {
+	release, err := client.GetAppRelease(app.ID)
+	if err != nil {
+		log.Error("error getting release", "err", err)
+		return err
+	}
+	artifact, err := client.GetArtifact(release.ArtifactID)
+	if err != nil {
+		log.Error("error getting release artifact", "err", err)
+		return err
+	}
+	if !app.System() {
+		u, err := url.Parse(artifact.URI)
+		if err != nil {
+			return err
+		}
+		if u.Query().Get("name") != "flynn/slugrunner" {
+			return errDeploySkipped{"app not using slugrunner image"}
+		}
+	}
+	skipDeploy := artifact.URI == uri
+	if app.Name == "gitreceive" {
+		// deploy the gitreceive app if builder / runner images have changed
+		proc, ok := release.Processes["app"]
+		if !ok {
+			e := "missing app process in gitreceive release"
+			log.Error(e)
+			return errors.New(e)
+		}
+		if proc.Env["SLUGBUILDER_IMAGE_URI"] != slugbuilderURI {
+			proc.Env["SLUGBUILDER_IMAGE_URI"] = slugbuilderURI
+			skipDeploy = false
+		}
+		if proc.Env["SLUGRUNNER_IMAGE_URI"] != slugrunnerURI {
+			proc.Env["SLUGRUNNER_IMAGE_URI"] = slugrunnerURI
+			skipDeploy = false
+		}
+		release.Processes["app"] = proc
+	}
+	if skipDeploy {
+		return errDeploySkipped{"app is already using latest images"}
+	}
+	artifact.ID = ""
+	artifact.URI = uri
+	if err := client.CreateArtifact(artifact); err != nil {
+		log.Error("error creating artifact", "err", err)
+		return err
+	}
+	release.ID = ""
+	release.ArtifactID = artifact.ID
+	if err := client.CreateRelease(release); err != nil {
+		log.Error("error creating new release", "err", err)
+		return err
+	}
+	if err := client.DeployAppRelease(app.ID, release.ID); err != nil {
+		log.Error("error deploying app", "err", err)
+		return err
+	}
+	return nil
+}

--- a/util/release/version_template.json
+++ b/util/release/version_template.json
@@ -10,5 +10,6 @@
   "flynn/slugbuilder": "$image_id[slugbuilder]",
   "flynn/slugrunner": "$image_id[slugrunner]",
   "flynn/taffy": "$image_id[taffy]",
-  "flynn/dashboard": "$image_id[dashboard]"
+  "flynn/dashboard": "$image_id[dashboard]",
+  "flynn/updater": "$image_id[updater]"
 }


### PR DESCRIPTION
This will deploy all system apps (except for `postgres`) in a specific order, then will deploy all other apps which use the slugrunner image.