### PR TITLE
log aggregation: Log aggregator API, controller actions, and associated clients

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -282,7 +282,11 @@
     "release": {
       "processes": {
         "app": {
-          "cmd": ["logaggregator", "-listenaddr", ":1514"]
+          "cmd": ["logaggregator", "-logaddr", ":514", "-apiaddr", ":80"],
+          "ports": [
+            {"port": 80, "proto": "tcp"},
+            {"port": 514, "proto": "tcp"}
+          ]
         }
       }
     },

--- a/controller/app.go
+++ b/controller/app.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq/hstore"
@@ -242,4 +244,43 @@ func (c *controllerAPI) UpdateApp(ctx context.Context, rw http.ResponseWriter, r
 		return
 	}
 	httphelper.JSON(rw, 200, app)
+}
+
+func (c *controllerAPI) AppLog(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	ctx, cancel := context.WithCancel(ctx)
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+
+	lines, _ := strconv.Atoi(req.FormValue("lines"))
+	follow := req.FormValue("follow") == "true"
+	// TODO(bgentry): support wait, filtering by fields like process type/ID.
+	// wait := req.FormValue("wait") == "true"
+
+	rc, err := c.logaggc.GetLog(params.ByName("apps_id"), lines, follow)
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if cn, ok := w.(http.CloseNotifier); ok {
+		go func() {
+			select {
+			case <-cn.CloseNotify():
+				rc.Close()
+			case <-ctx.Done():
+			}
+		}()
+	}
+	defer cancel()
+	defer rc.Close()
+
+	// TODO(bgentry): use SSE, distinguish between streams like JobLog.
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+	// Send headers right away if following
+	if wf, ok := w.(http.Flusher); ok && follow {
+		wf.Flush()
+	}
+
+	fw := httphelper.FlushWriter{Writer: w, Enabled: follow}
+	io.Copy(fw, rc)
 }

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -267,6 +267,43 @@ func (c *Client) GetApp(appID string) (*ct.App, error) {
 	return app, c.Get(fmt.Sprintf("/apps/%s", appID), app)
 }
 
+// GetAppLog returns a ReadCloser log stream of the app with ID appID. If lines is
+// above zero, the number of lines returned will be capped at that value.
+// Otherwise, all available logs are returned. If follow is true, new log lines
+// are streamed after the buffered log.
+func (c *Client) GetAppLog(appID string, lines int, follow bool) (io.ReadCloser, error) {
+	return c.getAppLog(appID, lines, follow, false)
+}
+
+// GetAppLogWithWait is just like GetAppLog, except that it will wait for a
+// non-existent log stream to be created rather than simply returning empty
+// results.
+func (c *Client) GetAppLogWithWait(appID string, lines int, follow bool) (io.ReadCloser, error) {
+	return c.getAppLog(appID, lines, follow, true)
+}
+
+func (c *Client) getAppLog(appID string, lines int, follow, wait bool) (io.ReadCloser, error) {
+	path := fmt.Sprintf("/apps/%s/log", appID)
+	query := url.Values{}
+	if lines > 0 {
+		query.Add("lines", strconv.Itoa(lines))
+	}
+	if follow {
+		query.Add("follow", "true")
+	}
+	if wait {
+		query.Add("wait", "true")
+	}
+	if encodedQuery := query.Encode(); encodedQuery != "" {
+		path = fmt.Sprintf("%s?%s", path, encodedQuery)
+	}
+	res, err := c.RawReq("GET", path, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, nil
+}
+
 // GetDeployment returns a deployment queued on the deployer.
 func (c *Client) GetDeployment(deploymentID string) (*ct.Deployment, error) {
 	res := &ct.Deployment{}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -74,7 +74,7 @@ func main() {
 		shutdown.Fatal(err)
 	}
 
-	sc := routerc.New()
+	rc := routerc.New()
 
 	hb, err := discoverd.DefaultClient.AddServiceAndRegisterInstance("flynn-controller", &discoverd.Instance{
 		Addr:  addr,
@@ -91,14 +91,14 @@ func main() {
 		hb.Close()
 	})
 
-	handler := appHandler(handlerConfig{db: db, cc: cc, sc: sc, pgxpool: pgxpool, key: os.Getenv("AUTH_KEY")})
+	handler := appHandler(handlerConfig{db: db, cc: cc, rc: rc, pgxpool: pgxpool, key: os.Getenv("AUTH_KEY")})
 	shutdown.Fatal(http.ListenAndServe(addr, handler))
 }
 
 type handlerConfig struct {
 	db      *postgres.DB
 	cc      clusterClient
-	sc      routerc.Client
+	rc      routerc.Client
 	pgxpool *pgx.ConnPool
 	key     string
 }
@@ -135,7 +135,7 @@ func appHandler(c handlerConfig) http.Handler {
 	providerRepo := NewProviderRepo(c.db)
 	keyRepo := NewKeyRepo(c.db)
 	resourceRepo := NewResourceRepo(c.db)
-	appRepo := NewAppRepo(c.db, os.Getenv("DEFAULT_ROUTE_DOMAIN"), c.sc)
+	appRepo := NewAppRepo(c.db, os.Getenv("DEFAULT_ROUTE_DOMAIN"), c.rc)
 	artifactRepo := NewArtifactRepo(c.db)
 	releaseRepo := NewReleaseRepo(c.db)
 	jobRepo := NewJobRepo(c.db)
@@ -152,7 +152,7 @@ func appHandler(c handlerConfig) http.Handler {
 		resourceRepo:   resourceRepo,
 		deploymentRepo: deploymentRepo,
 		clusterClient:  c.cc,
-		routerc:        c.sc,
+		routerc:        c.rc,
 	}
 
 	httpRouter := httprouter.New()

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	tu "github.com/flynn/flynn/controller/testutils"
 	ct "github.com/flynn/flynn/controller/types"
+	logaggc "github.com/flynn/flynn/logaggregator/client"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/testutils/postgres"
@@ -33,6 +34,7 @@ type S struct {
 	srv *httptest.Server
 	hc  handlerConfig
 	c   *controller.Client
+	fla *httptest.Server
 }
 
 var _ = Suite(&S{})
@@ -66,13 +68,30 @@ func (s *S) SetUpSuite(c *C) {
 		c.Fatal(err)
 	}
 
+	s.fla = newFakeLogAggregator()
+	lc, err := logaggc.New(s.fla.URL)
+	if err != nil {
+		c.Fatal(err)
+	}
+
 	s.cc = tu.NewFakeCluster()
-	s.hc = handlerConfig{db: pg, cc: s.cc, rc: newFakeRouter(), pgxpool: pgxpool, key: authKey}
+	s.hc = handlerConfig{
+		db:      pg,
+		cc:      s.cc,
+		lc:      *lc,
+		rc:      newFakeRouter(),
+		pgxpool: pgxpool,
+		key:     authKey,
+	}
 	handler := appHandler(s.hc)
 	s.srv = httptest.NewServer(handler)
 	client, err := controller.NewClient(s.srv.URL, authKey)
 	c.Assert(err, IsNil)
 	s.c = client
+}
+
+func (s *S) TearDownSuite(c *C) {
+	s.fla.Close()
 }
 
 func (s *S) TestBadAuth(c *C) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -67,7 +67,7 @@ func (s *S) SetUpSuite(c *C) {
 	}
 
 	s.cc = tu.NewFakeCluster()
-	s.hc = handlerConfig{db: pg, cc: s.cc, sc: newFakeRouter(), pgxpool: pgxpool, key: authKey}
+	s.hc = handlerConfig{db: pg, cc: s.cc, rc: newFakeRouter(), pgxpool: pgxpool, key: authKey}
 	handler := appHandler(s.hc)
 	s.srv = httptest.NewServer(handler)
 	client, err := controller.NewClient(s.srv.URL, authKey)

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -67,6 +67,7 @@ func main() {
 		{"app_initial_release_get", e.getInitialAppRelease},
 		{"app_get", e.getApp},
 		{"app_list", e.listApps},
+		{"app_log", e.getAppLog},
 		{"app_update", e.updateApp},
 		{"app_resource_list", e.listAppResources},
 		{"route_create", e.createRoute},
@@ -207,6 +208,14 @@ func (e *generator) updateApp() {
 		},
 	}
 	e.client.UpdateApp(app)
+}
+
+func (e *generator) getAppLog() {
+	res, err := e.client.GetAppLogWithWait(e.resourceIds["app"], 0, false)
+	if err == nil {
+		defer res.Close()
+		io.Copy(ioutil.Discard, res)
+	}
 }
 
 func (e *generator) listAppResources() {

--- a/controller/log_test.go
+++ b/controller/log_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"time"
+
+	ct "github.com/flynn/flynn/controller/types"
+	logaggc "github.com/flynn/flynn/logaggregator/client"
+	"github.com/flynn/flynn/pkg/ctxhelper"
+	"github.com/flynn/flynn/pkg/httphelper"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+var sampleMessages = []logaggc.Message{
+	{
+		HostID:      "server1.flynn.local",
+		JobID:       "flynn-11111111111111111111111111111111",
+		Msg:         "a log message",
+		ProcessType: "web",
+		Source:      "app",
+		Stream:      "stdout",
+		Timestamp:   time.Now().UTC(),
+	},
+	{
+		HostID:      "server2.flynn.local",
+		JobID:       "flynn-22222222222222222222222222222222",
+		Msg:         "another log message",
+		ProcessType: "worker",
+		Source:      "app",
+		Stream:      "stderr",
+		Timestamp:   time.Now().UTC(),
+	},
+}
+
+func newFakeLogAggregator() *httptest.Server {
+	f := &fakeLogAggregator{
+		logs: map[string][]logaggc.Message{
+			"get-app-log-test": sampleMessages,
+		},
+	}
+	r := httprouter.New()
+	r.GET("/log/:channel_id", httphelper.WrapHandler(f.serveLogs))
+	return httptest.NewServer(httphelper.ContextInjector(
+		"logaggregator-fake-api",
+		httphelper.NewRequestLogger(r),
+	))
+}
+
+type fakeLogAggregator struct {
+	logs map[string][]logaggc.Message
+	s    *httptest.Server
+}
+
+func (f *fakeLogAggregator) Close() {
+	f.s.Close()
+}
+
+func (f *fakeLogAggregator) serveLogs(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	channelID := params.ByName("channel_id")
+	allLogs := f.logs[channelID]
+
+	vals := req.URL.Query()
+
+	lines, _ := strconv.Atoi(vals.Get("lines"))
+	if lines == 0 {
+		lines = len(allLogs)
+	}
+
+	w.WriteHeader(200)
+
+	enc := json.NewEncoder(w)
+	for i := 0; i < lines; i++ {
+		if err := enc.Encode(allLogs[i]); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (s *S) TestGetAppLog(c *C) {
+	s.createTestApp(c, &ct.App{Name: "get-app-log-test"})
+
+	rc, err := s.c.GetAppLog("get-app-log-test", 0, false)
+	c.Assert(err, IsNil)
+	defer rc.Close()
+
+	msgs := make([]logaggc.Message, 0)
+	dec := json.NewDecoder(rc)
+	for {
+		var msg logaggc.Message
+		err := dec.Decode(&msg)
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, IsNil)
+		msgs = append(msgs, msg)
+	}
+
+	c.Assert(msgs, DeepEquals, sampleMessages)
+}

--- a/docs/api-examples/controller.json
+++ b/docs/api-examples/controller.json
@@ -64,6 +64,22 @@
 			"body": "{\"id\":\"7406a4d71a0c43d3ac4b39f006cb0342\",\"name\":\"my-app-1422557606845347930\",\"protected\":false,\"strategy\":\"all-at-once\",\"created_at\":\"2015-01-29T18:53:26.845896Z\",\"updated_at\":\"2015-01-29T18:53:26.845896Z\"}"
 		}
 	},
+	"app_log": {
+		"request": {
+			"method": "GET",
+			"url": "/apps/7406a4d71a0c43d3ac4b39f006cb0342/log?wait=true",
+			"headers": {
+				"Authorization": "Basic OnMzY3IzdA==",
+				"Content-Type": "application/json"
+			}
+		},
+		"response": {
+			"headers": {
+				"Content-Type": "text/plain"
+			},
+			"body": "{\"hostname\":\"my.flynn.local\",\"job_id\":\"flynn-cef74685c83b47889c69fa95451e75b3\",\"msg\":\"a log message\",\"process_type\":\"web\",\"source\":\"app\",\"stream\":\"stderr\",\"timestamp\":\"2009-11-10T23:00:00.123450Z\"}"
+		}
+	},
 	"app_initial_release_get": {
 		"request": {
 			"method": "GET",

--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -48,7 +48,6 @@ func (a *aggregatorAPI) GetLog(ctx context.Context, w http.ResponseWriter, req *
 		}
 	}
 
-	// TODO(bgentry): sort here, or sort w/ heap in buffer...
 	w.WriteHeader(200)
 	messages := a.agg.ReadLastN(channelID, lines)
 	enc := json.NewEncoder(w)

--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/flynn/flynn/logaggregator/client"
+	"github.com/flynn/flynn/pkg/ctxhelper"
+	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
+	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+)
+
+func apiHandler(agg *Aggregator) http.Handler {
+	api := aggregatorAPI{agg: agg}
+	r := httprouter.New()
+
+	r.GET("/log/:channel_id", httphelper.WrapHandler(api.GetLog))
+	return httphelper.ContextInjector(
+		"logaggregator-api",
+		httphelper.NewRequestLogger(r),
+	)
+}
+
+type aggregatorAPI struct {
+	agg *Aggregator
+}
+
+func (a *aggregatorAPI) GetLog(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	channelID := params.ByName("channel_id")
+	vals := req.URL.Query()
+
+	// TODO(bgentry): tail -f support
+
+	lines := 0
+	if strLines := vals.Get("lines"); strLines != "" {
+		var err error
+		lines, err = strconv.Atoi(strLines)
+		if err != nil || lines < 0 || lines > 10000 {
+			respondWithError(w, "lines", "lines must be an integer between 0 and 10000")
+			return
+		}
+	}
+
+	// TODO(bgentry): sort here, or sort w/ heap in buffer...
+	w.WriteHeader(200)
+	messages := a.agg.ReadLastN(channelID, lines)
+	enc := json.NewEncoder(w)
+	for _, syslogMsg := range messages {
+		if err := enc.Encode(NewMessageFromSyslog(syslogMsg)); err != nil {
+			log15.Error("error writing msg", "err", err)
+			return
+		}
+	}
+}
+
+func NewMessageFromSyslog(m *rfc5424.Message) client.Message {
+	processType, jobID := splitProcID(m.ProcID)
+	return client.Message{
+		HostID:      string(m.Hostname),
+		JobID:       jobID,
+		Msg:         string(m.Msg),
+		ProcessType: processType,
+		// TODO(bgentry): source is always "app" for now, could be router in future
+		Source:    "app",
+		Stream:    streamFromMessage(m),
+		Timestamp: m.Timestamp,
+	}
+}
+
+// TODO(bgentry): does this belong in the syslog package?
+func splitProcID(procID []byte) (processType, jobID string) {
+	split := bytes.Split(procID, []byte{'.'})
+	if len(split) > 0 {
+		processType = string(split[0])
+	}
+	if len(split) > 1 {
+		jobID = string(split[1])
+	}
+	return
+}
+
+func streamFromMessage(m *rfc5424.Message) string {
+	switch m.Severity {
+	case 3:
+		return "stderr"
+	case 6:
+		return "stdout"
+	default:
+		return "unknown"
+	}
+}
+
+func respondWithError(w http.ResponseWriter, field, msg string) {
+	detail, _ := json.Marshal(map[string]string{"field": field})
+	httphelper.Error(w, httphelper.JSONError{
+		Code:    httphelper.ValidationError,
+		Message: msg,
+		Detail:  detail,
+	})
+}

--- a/logaggregator/api_test.go
+++ b/logaggregator/api_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/logaggregator/client"
+	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+)
+
+func (s *LogAggregatorTestSuite) TestAPIGetLogWithNoResults(c *C) {
+	logrc, err := s.client.GetLog("id", 0, false)
+	c.Assert(err, IsNil)
+	defer logrc.Close()
+
+	assertAllLogsEquals(c, logrc, "")
+}
+
+func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
+	appID := "test-app"
+	msg1 := newMessageForApp(appID, "web.1", "log message 1")
+	msg2 := newMessageForApp(appID, "web.2", "log message 2")
+	buf := s.agg.getOrInitializeBuffer(appID)
+	buf.Add(msg1)
+	buf.Add(msg2)
+
+	runtest := func(numLogs int, expected string) {
+		logrc, err := s.client.GetLog(appID, numLogs, false)
+		c.Assert(err, IsNil)
+		defer logrc.Close()
+
+		assertAllLogsEquals(c, logrc, expected)
+	}
+
+	tests := []struct {
+		numLogs  int
+		expected string
+	}{
+		{
+			numLogs:  0,
+			expected: marshalMessage(msg1) + marshalMessage(msg2),
+		},
+		{
+			numLogs:  1,
+			expected: marshalMessage(msg2),
+		},
+	}
+	for _, test := range tests {
+		runtest(test.numLogs, test.expected)
+	}
+}
+
+func (s *LogAggregatorTestSuite) TestNewMessageFromSyslog(c *C) {
+	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123450789Z")
+	c.Assert(err, IsNil)
+	m := NewMessageFromSyslog(rfc5424.NewMessage(
+		&rfc5424.Header{
+			Hostname:  []byte("a.b.flynn.local"),
+			ProcID:    []byte("web.flynn-abcd1234"),
+			Severity:  6,
+			Timestamp: timestamp,
+		},
+		[]byte("testing message"),
+	))
+
+	c.Assert(m.HostID, Equals, "a.b.flynn.local")
+	c.Assert(m.JobID, Equals, "flynn-abcd1234")
+	c.Assert(m.ProcessType, Equals, "web")
+	c.Assert(m.Source, Equals, "app")
+	c.Assert(m.Stream, Equals, "stdout")
+	c.Assert(m.Timestamp, Equals, timestamp)
+}
+
+func (s *LogAggregatorTestSuite) TestMessageMarshalJSON(c *C) {
+	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123450789Z")
+	c.Assert(err, IsNil)
+
+	m := client.Message{
+		HostID:      "my.flynn.local",
+		JobID:       "deadbeef1234",
+		Msg:         "a log message",
+		ProcessType: "web",
+		Source:      "app",
+		Stream:      "stderr",
+		Timestamp:   timestamp,
+	}
+	expected := `{"host_id":"my.flynn.local","job_id":"deadbeef1234","msg":"a log message","process_type":"web","source":"app","stream":"stderr","timestamp":"2009-11-10T23:00:00.123450789Z"}`
+
+	b, err := json.Marshal(m)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(b), Equals, expected)
+}
+
+func assertAllLogsEquals(c *C, r io.Reader, expected string) {
+	donec := make(chan struct{})
+	go func() {
+		logb, err := ioutil.ReadAll(r)
+		c.Assert(err, IsNil)
+		result := string(logb)
+		c.Assert(result, Equals, expected)
+		close(donec)
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		c.Fatal("timeout waiting for logs")
+	case <-donec:
+	}
+}
+
+func newMessageForApp(appname, procID, msg string) *rfc5424.Message {
+	return rfc5424.NewMessage(
+		&rfc5424.Header{
+			AppName: []byte(appname),
+			ProcID:  []byte(procID),
+		},
+		[]byte(msg),
+	)
+}
+
+func marshalMessage(m *rfc5424.Message) string {
+	b, err := json.Marshal(NewMessageFromSyslog(m))
+	if err != nil {
+		panic(err)
+	}
+	return string(b) + "\n"
+}

--- a/logaggregator/client/client.go
+++ b/logaggregator/client/client.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/flynn/flynn/pkg/httpclient"
+)
+
+type Client struct {
+	*httpclient.Client
+}
+
+// ErrNotFound is returned when a resource is not found (HTTP status 404).
+var ErrNotFound = errors.New("logaggregator: resource not found")
+
+// newClient creates a generic Client object, additional attributes must
+// be set by the caller
+func newClient(url string, http *http.Client) *Client {
+	c := &Client{
+		Client: &httpclient.Client{
+			ErrNotFound: ErrNotFound,
+			URL:         url,
+			HTTP:        http,
+		},
+	}
+	return c
+}
+
+// NewClient creates a new Client pointing at uri.
+func New(uri string) (*Client, error) {
+	return NewWithHTTP(uri, http.DefaultClient)
+}
+
+// NewClient creates a new Client pointing at uri with the specified http client.
+func NewWithHTTP(uri string, httpClient *http.Client) (*Client, error) {
+	if uri == "" {
+		uri = "http://flynn-logaggregator-api.discoverd"
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+	return newClient(u.String(), httpClient), nil
+}
+
+// GetLog returns a ReadCloser log stream of the log channel with ID channelID.
+// Each line returned will be a JSON serialized Message.
+//
+// If lines is above zero, the number of lines returned will be capped at that
+// value. Otherwise, all available logs are returned. If follow is true, new log
+// lines are streamed after the buffered log.
+func (c *Client) GetLog(channelID string, lines int, follow bool) (io.ReadCloser, error) {
+	path := fmt.Sprintf("/log/%s", channelID)
+	query := url.Values{}
+	if lines > 0 {
+		query.Add("lines", strconv.Itoa(lines))
+	}
+	if follow {
+		query.Add("follow", "true")
+	}
+	if encodedQuery := query.Encode(); encodedQuery != "" {
+		path = fmt.Sprintf("%s?%s", path, encodedQuery)
+	}
+	res, err := c.RawReq("GET", path, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, nil
+}
+
+// Message represents a single log message.
+type Message struct {
+	// Hostname is the host that the job was running on when this log message was
+	// emitted.
+	HostID string `json:"host_id,omitempty"`
+	// JobID is the ID of the job that emitted this log message.
+	JobID string `json:"job_id,omitempty"`
+	// Msg is the actual content of this log message.
+	Msg string `json:"msg,omitempty"`
+	// ProcessType is the type of process that emitted this log message.
+	ProcessType string `json:"process_type,omitempty"`
+	// Source is the source of this log message, such as "app" or "router".
+	Source string `json:"source,omitempty"`
+	// Stream is the I/O stream that emitted this message, such as "stdout" or
+	// "stderr".
+	Stream string `json:"stream,omitempty"`
+	// Timestamp is the time that this log line was emitted.
+	Timestamp time.Time `json:"timestamp,omitempty"`
+}

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -61,13 +61,10 @@ type Aggregator struct {
 	// Addr is the address (host:port) to listen on for incoming syslog messages.
 	Addr string
 
-	bmu          sync.Mutex // protects buffers
-	buffers      map[string]*ring.Buffer
-	listener     net.Listener
-	logc         chan []byte
-	numConsumers int
-	consumerwg   sync.WaitGroup
-	producerwg   sync.WaitGroup
+	bmu        sync.Mutex // protects buffers
+	buffers    map[string]*ring.Buffer
+	listener   net.Listener
+	producerwg sync.WaitGroup
 
 	once     sync.Once // protects the following:
 	shutdown chan struct{}
@@ -76,11 +73,9 @@ type Aggregator struct {
 // NewAggregator creates a new unstarted Aggregator that will listen on addr.
 func NewAggregator(addr string) *Aggregator {
 	return &Aggregator{
-		Addr:         addr,
-		buffers:      make(map[string]*ring.Buffer),
-		logc:         make(chan []byte),
-		numConsumers: 10,
-		shutdown:     make(chan struct{}),
+		Addr:     addr,
+		buffers:  make(map[string]*ring.Buffer),
+		shutdown: make(chan struct{}),
 	}
 }
 
@@ -92,14 +87,6 @@ func (a *Aggregator) Start() error {
 		return err
 	}
 	a.Addr = a.listener.Addr().String()
-
-	for i := 0; i < a.numConsumers; i++ {
-		a.consumerwg.Add(1)
-		go func() {
-			defer a.consumerwg.Done()
-			a.consumeLogs()
-		}()
-	}
 
 	a.producerwg.Add(1)
 	go func() {
@@ -116,8 +103,6 @@ func (a *Aggregator) Shutdown() {
 		close(a.shutdown)
 		a.listener.Close()
 		a.producerwg.Wait()
-		close(a.logc)
-		a.consumerwg.Wait()
 	})
 }
 
@@ -156,25 +141,6 @@ func (a *Aggregator) accept() {
 	}
 }
 
-// testing hook:
-var afterMessage func()
-
-func (a *Aggregator) consumeLogs() {
-	for line := range a.logc {
-		// TODO: forward message to follower aggregator
-		msg, err := rfc5424.Parse(line)
-		if err != nil {
-			log15.Error("rfc5424 parse error", "err", err)
-			continue
-		}
-		a.getOrInitializeBuffer(string(msg.AppName)).Add(msg)
-
-		if afterMessage != nil {
-			afterMessage()
-		}
-	}
-}
-
 func (a *Aggregator) getBuffer(id string) *ring.Buffer {
 	a.bmu.Lock()
 	defer a.bmu.Unlock()
@@ -195,6 +161,9 @@ func (a *Aggregator) getOrInitializeBuffer(id string) *ring.Buffer {
 	return buf
 }
 
+// testing hook:
+var afterMessage func()
+
 func (a *Aggregator) readLogsFromConn(conn net.Conn) {
 	defer conn.Close()
 
@@ -212,10 +181,20 @@ func (a *Aggregator) readLogsFromConn(conn net.Conn) {
 	s := bufio.NewScanner(conn)
 	s.Split(rfc6587.Split)
 	for s.Scan() {
-		msg := s.Bytes()
-		// slice in msg could get modified on next Scan(), need to copy it
-		msgCopy := make([]byte, len(msg))
-		copy(msgCopy, msg)
-		a.logc <- msgCopy
+		msgBytes := s.Bytes()
+		// slice in msgBytes could get modified on next Scan(), need to copy it
+		msgCopy := make([]byte, len(msgBytes))
+		copy(msgCopy, msgBytes)
+
+		msg, err := rfc5424.Parse(msgCopy)
+		if err != nil {
+			log15.Error("rfc5424 parse error", "err", err)
+			continue
+		}
+
+		a.getOrInitializeBuffer(string(msg.AppName)).Add(msg)
+		if afterMessage != nil {
+			afterMessage()
+		}
 	}
 }

--- a/logaggregator/main_test.go
+++ b/logaggregator/main_test.go
@@ -57,12 +57,6 @@ func (s *LogAggregatorTestSuite) TestAggregatorShutdown(c *C) {
 
 	conn.Write([]byte(sampleLogLine1))
 	s.agg.Shutdown()
-
-	select {
-	case <-s.agg.logc:
-	default:
-		c.Errorf("logc was not closed")
-	}
 }
 
 func (s *LogAggregatorTestSuite) TestAggregatorBuffersMessages(c *C) {

--- a/schema/controller/app.json
+++ b/schema/controller/app.json
@@ -10,7 +10,8 @@
     "schema/examples/controller/app_get#",
     "schema/examples/controller/app_list#",
     "schema/examples/controller/app_update#",
-    "schema/examples/controller/app_delete#"
+    "schema/examples/controller/app_delete#",
+    "schema/examples/controller/app_log#"
   ],
   "additionalProperties": false,
   "properties": {

--- a/schema/examples/controller/app_log.json
+++ b/schema/examples/controller/app_log.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://flynn.io/schema/examples/controller/app_log#",
+  "title": "Get app log",
+  "description": "",
+  "allOf": [
+    { "$ref": "/schema/examples/base#" },
+    {
+      "type": "object",
+      "properties": {
+        "request": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string",
+              "enum": ["GET"]
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds an API to the logaggregator, as well as a Client for that API. It also adds a controller action to be able to access that API and return logs to external clients, and attempts to add JSON schema for that action.

### Questions:

#### What should the output to the user look like?

Currently, I'm somewhat mimicking the output of Heroku's log tails:

```
2009-11-10T23:00:00.123450Z app[web.12345]: testing message
```
    
That's what is actually returned by the logaggregator API as of now. It's nice that it's concise, but it loses a lot of metadata that might be important to be able to get from places like the controller. For example, the hostname and stream ID (as encoded in the syslog message's `SEVERITY` field) are both lost before the controller gets ahold of the messages. That means the controller can't currently do things like return SSE events that distinguish between `STDOUT`/`STDERR` as the job log API currently offers.

#### Are the JSON schema changes correct and complete?

I'm still a bit lost on this and not sure if I made the right additions to the schema in the right places, including the examples. Don't know how I'm supposed to test that either.

#### For testing, do I need to create a fake logaggregator API?

Some components like the host service and router API have fake implementations in the controller for testing against. What's the current best practice for that sort of thing? The good news is that the logaggregator API is very simple, currently just a single action (and may stay that way).

#### Follow, wait, and filtering features

None of these have been added yet. Not sure if I should try to add them to this PR or just tackle them separately once we get the bare essentials merged. Leaning towards punting on it until we've got a very basic end-to-end setup going.

### Remaining:

* [x] Refactor to preserve metadata outside of logaggregator
* [x] Add logaggregator service to bootstrap process
* [x] Stub service for logaggregator API to use in controller tests
* [x] Tests for controller action
* [ ] Fetch logs from CLI (moved to #1158)
* [ ] Integration / CI tests (moved to #1158)