### PR TITLE
Revert "test: Support booting multiple clusters"

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -92,7 +92,7 @@ func main() {
 		} else {
 			defer os.RemoveAll(rootFS)
 		}
-		if _, err = c.Boot(3, nil, args.Kill); err != nil {
+		if err = c.Boot(rootFS, 3, nil, args.Kill); err != nil {
 			log.Println("could not boot cluster: ", err)
 			return
 		}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -166,7 +166,6 @@ func (r *Runner) start() error {
 	router.ServeFiles("/assets/*filepath", http.Dir(args.AssetsDir))
 	router.GET("/cluster/:cluster", r.clusterAPI(r.getCluster))
 	router.POST("/cluster/:cluster", r.clusterAPI(r.addHost))
-	router.POST("/cluster/:cluster/release", r.clusterAPI(r.addReleaseHosts))
 	router.DELETE("/cluster/:cluster/:host", r.clusterAPI(r.removeHost))
 	router.GET("/cluster/:cluster/dump-logs", r.clusterAPI(r.dumpLogs))
 
@@ -279,7 +278,7 @@ func (r *Runner) build(b *Build) (err error) {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 
-	if _, err := c.Boot(3, out, true); err != nil {
+	if err := c.Boot(rootFS, 3, out, true); err != nil {
 		return fmt.Errorf("could not boot cluster: %s", err)
 	}
 
@@ -632,19 +631,6 @@ func (r *Runner) addHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values
 		return err
 	}
 	return json.NewEncoder(w).Encode(instance)
-}
-
-func (r *Runner) addReleaseHosts(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {
-	res, err := c.Boot(3, nil, true)
-	if err != nil {
-		return err
-	}
-	instance, err := c.AddVanillaHost(args.RootFS)
-	if err != nil {
-		return err
-	}
-	res.Instances = append(res.Instances, instance)
-	return json.NewEncoder(w).Encode(res)
 }
 
 func (r *Runner) removeHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {


### PR DESCRIPTION
Reverts flynn/flynn#1110

This change is being reverted due to `AddHosts` not working (new hosts do not get any flynn-host peers). The patch needs re-thinking.