### PR TITLE
test: Support booting multiple clusters

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -92,7 +92,7 @@ func main() {
 		} else {
 			defer os.RemoveAll(rootFS)
 		}
-		if err = c.Boot(rootFS, 3, nil, args.Kill); err != nil {
+		if _, err = c.Boot(cluster.ClusterTypeDefault, 3, nil, args.Kill); err != nil {
 			log.Println("could not boot cluster: ", err)
 			return
 		}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -166,6 +166,7 @@ func (r *Runner) start() error {
 	router.ServeFiles("/assets/*filepath", http.Dir(args.AssetsDir))
 	router.GET("/cluster/:cluster", r.clusterAPI(r.getCluster))
 	router.POST("/cluster/:cluster", r.clusterAPI(r.addHost))
+	router.POST("/cluster/:cluster/release", r.clusterAPI(r.addReleaseHosts))
 	router.DELETE("/cluster/:cluster/:host", r.clusterAPI(r.removeHost))
 	router.GET("/cluster/:cluster/dump-logs", r.clusterAPI(r.dumpLogs))
 
@@ -278,7 +279,7 @@ func (r *Runner) build(b *Build) (err error) {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 
-	if err := c.Boot(rootFS, 3, out, true); err != nil {
+	if _, err := c.Boot(cluster.ClusterTypeDefault, 3, out, true); err != nil {
 		return fmt.Errorf("could not boot cluster: %s", err)
 	}
 
@@ -631,6 +632,19 @@ func (r *Runner) addHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values
 		return err
 	}
 	return json.NewEncoder(w).Encode(instance)
+}
+
+func (r *Runner) addReleaseHosts(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {
+	res, err := c.Boot(cluster.ClusterTypeRelease, 3, nil, true)
+	if err != nil {
+		return err
+	}
+	instance, err := c.AddVanillaHost(args.RootFS)
+	if err != nil {
+		return err
+	}
+	res.Instances = append(res.Instances, instance)
+	return json.NewEncoder(w).Encode(res)
 }
 
 func (r *Runner) removeHost(c *cluster.Cluster, w http.ResponseWriter, q url.Values, ps httprouter.Params) error {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -612,6 +612,7 @@ func (r *Runner) clusterAPI(handle clusterHandle) httprouter.Handle {
 			return
 		}
 		if err := handle(c, w, req.URL.Query(), ps); err != nil {
+			log.Printf("clusterAPI err in %s %s: %s", req.Method, req.URL.Path, err)
 			http.Error(w, err.Error(), 500)
 		}
 	}


### PR DESCRIPTION
This is similar to #1110 but updated so that `AddHosts` adds hosts to the default cluster.