### PR TITLE
Add `flynn psql`

### DIFF
--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -11,7 +11,12 @@ RUN apt-get update &&\
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - &&\
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list' &&\
     apt-get update &&\
-    apt-get install -y -q postgresql-9.4 postgresql-contrib-9.4 postgresql-9.4-pgextwlist &&\
+    apt-get install -y -q \
+      postgresql-9.4 \
+      postgresql-contrib-9.4 \
+      postgresql-9.4-pgextwlist \
+      postgresql-9.4-plv8 \
+      postgresql-9.4-postgis &&\
     apt-get clean &&\
     apt-get autoremove -y
 

--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update &&\
       postgresql-9.4-plv8 \
       postgresql-9.4-postgis &&\
     apt-get clean &&\
-    apt-get autoremove -y
+    apt-get autoremove -y &&\
+    echo "\set HISTFILE /dev/null" > /root/.psqlrc
 
 ADD bin/flynn-postgres /bin/flynn-postgres
 ADD bin/flynn-postgres-api /bin/flynn-postgres-api

--- a/appliance/postgresql/api/server.go
+++ b/appliance/postgresql/api/server.go
@@ -19,7 +19,7 @@ var serviceHost string
 
 func init() {
 	if serviceName == "" {
-		serviceName = "pg"
+		serviceName = "postgres"
 	}
 	serviceHost = fmt.Sprintf("leader.%s.discoverd", serviceName)
 }

--- a/appliance/postgresql/main.go
+++ b/appliance/postgresql/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	serviceName := os.Getenv("FLYNN_POSTGRES")
 	if serviceName == "" {
-		serviceName = "pg"
+		serviceName = "postgres"
 	}
 	singleton := os.Getenv("SINGLETON") == "true"
 	password := os.Getenv("PGPASSWORD")

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -64,7 +64,7 @@
   {
     "id": "postgres-wait",
     "action": "wait",
-    "url": "http://pg-api.discoverd/ping"
+    "url": "http://postgres-api.discoverd/ping"
   },
   {
     "id": "controller",
@@ -101,7 +101,7 @@
     "processes": {
       "web": 1
     },
-    "resources": [{"name":"postgres", "url":"http://pg-api.discoverd/databases"}]
+    "resources": [{"name":"postgres", "url":"http://postgres-api.discoverd/databases"}]
   },
   {
     "id": "controller-wait",
@@ -167,7 +167,7 @@
     "processes": {
       "web": 2
     },
-    "resources": [{"name":"postgres", "url":"http://pg-api.discoverd/databases"}]
+    "resources": [{"name":"postgres", "url":"http://postgres-api.discoverd/databases"}]
   },
   {
     "id": "router",
@@ -192,7 +192,7 @@
     "processes": {
       "app": 1
     },
-    "resources": [{"name":"postgres", "url":"http://pg-api.discoverd/databases"}]
+    "resources": [{"name":"postgres", "url":"http://postgres-api.discoverd/databases"}]
   },
   {
     "id": "gitreceive-key",

--- a/cli/env.go
+++ b/cli/env.go
@@ -128,6 +128,9 @@ func runEnvGet(args *docopt.Args, client *controller.Client) error {
 	if err == controller.ErrNotFound {
 		return errors.New("no app release found")
 	}
+	if err != nil {
+		return err
+	}
 
 	if _, ok := release.Processes[envProc]; envProc != "" && !ok {
 		return fmt.Errorf("process type %q not found in release %s", envProc, release.ID)

--- a/cli/main.go
+++ b/cli/main.go
@@ -52,6 +52,7 @@ Commands:
 	run       run a job
 	env       manage env variables
 	route     manage routes
+	psql      open a postgres console
 	provider  manage resource providers
 	resource  provision a new resource
 	key       manage SSH public keys

--- a/cli/psql.go
+++ b/cli/psql.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/controller/client"
+)
+
+func init() {
+	register("psql", runPsql, `
+usage: flynn psql [-c <command>]
+
+Open a console to a Flynn postgres database.
+
+Options:
+	-c, --command <command>  SQL command to run
+`)
+}
+
+func runPsql(args *docopt.Args, client *controller.Client) error {
+	appRelease, err := client.GetAppRelease(mustApp())
+	if err != nil {
+		return fmt.Errorf("error getting app release: %s", err)
+	}
+
+	pgApp := appRelease.Env["FLYNN_POSTGRES"]
+	if pgApp == "" {
+		return fmt.Errorf("No postgres database found. Provision one with `flynn resource add postgres`")
+	}
+
+	pgRelease, err := client.GetAppRelease(pgApp)
+	if err != nil {
+		return fmt.Errorf("error getting postgres release: %s", err)
+	}
+
+	config := runConfig{
+		App:        mustApp(),
+		Release:    pgRelease.ID,
+		Entrypoint: []string{"psql"},
+		Env:        make(map[string]string, 4),
+	}
+	for _, k := range []string{"PGHOST", "PGUSER", "PGPASSWORD", "PGDATABASE"} {
+		v := appRelease.Env[k]
+		if v == "" {
+			return fmt.Errorf("missing %s in app environment", k)
+		}
+		config.Env[k] = v
+	}
+	if cmd := args.String["--command"]; cmd != "" {
+		config.Args = []string{"-c", cmd}
+	}
+
+	return runJob(client, config)
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -37,10 +37,11 @@ const SIGWINCH syscall.Signal = 28
 
 func runRun(args *docopt.Args, client *controller.Client) error {
 	config := runConfig{
-		App:      mustApp(),
-		Detached: args.Bool["--detached"],
-		Release:  args.String["-r"],
-		Args:     append([]string{args.String["<command>"]}, args.All["<argument>"].([]string)...),
+		App:        mustApp(),
+		Detached:   args.Bool["--detached"],
+		Release:    args.String["-r"],
+		Args:       append([]string{args.String["<command>"]}, args.All["<argument>"].([]string)...),
+		ReleaseEnv: true,
 	}
 	if config.Release == "" {
 		release, err := client.GetAppRelease(config.App)
@@ -62,6 +63,7 @@ type runConfig struct {
 	App        string
 	Detached   bool
 	Release    string
+	ReleaseEnv bool
 	Entrypoint []string
 	Args       []string
 	Env        map[string]string
@@ -74,6 +76,7 @@ func runJob(client *controller.Client, config runConfig) error {
 		ReleaseID:  config.Release,
 		Entrypoint: config.Entrypoint,
 		Env:        config.Env,
+		ReleaseEnv: config.ReleaseEnv,
 	}
 	if req.TTY {
 		if req.Env == nil {

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -435,8 +435,10 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 	attach := strings.Contains(req.Header.Get("Upgrade"), "flynn-attach/0")
 
 	env := make(map[string]string, len(release.Env)+len(newJob.Env))
-	for k, v := range release.Env {
-		env[k] = v
+	if newJob.ReleaseEnv {
+		for k, v := range release.Env {
+			env[k] = v
+		}
 	}
 	for k, v := range newJob.Env {
 		env[k] = v

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -219,10 +219,11 @@ func (s *S) TestRunJobDetached(c *C) {
 
 	cmd := []string{"foo", "bar"}
 	req := &ct.NewJob{
-		ReleaseID: release.ID,
-		Cmd:       cmd,
-		Env:       map[string]string{"JOB": "true", "FOO": "baz"},
-		Meta:      map[string]string{"foo": "baz"},
+		ReleaseID:  release.ID,
+		ReleaseEnv: true,
+		Cmd:        cmd,
+		Env:        map[string]string{"JOB": "true", "FOO": "baz"},
+		Meta:       map[string]string{"foo": "baz"},
 	}
 	res, err := s.c.RunJobDetached(app.ID, req)
 	c.Assert(err, IsNil)
@@ -284,13 +285,14 @@ func (s *S) TestRunJobAttached(c *C) {
 	})
 
 	data := &ct.NewJob{
-		ReleaseID: release.ID,
-		Cmd:       []string{"foo", "bar"},
-		Env:       map[string]string{"JOB": "true", "FOO": "baz"},
-		Meta:      map[string]string{"foo": "baz"},
-		TTY:       true,
-		Columns:   10,
-		Lines:     20,
+		ReleaseID:  release.ID,
+		ReleaseEnv: true,
+		Cmd:        []string{"foo", "bar"},
+		Env:        map[string]string{"JOB": "true", "FOO": "baz"},
+		Meta:       map[string]string{"foo": "baz"},
+		TTY:        true,
+		Columns:    10,
+		Lines:      20,
 	}
 	rwc, err := s.c.RunJobAttached(app.ID, data)
 	c.Assert(err, IsNil)

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -103,6 +103,7 @@ func (e *JobEvent) IsDown() bool {
 
 type NewJob struct {
 	ReleaseID  string            `json:"release,omitempty"`
+	ReleaseEnv bool              `json:"release_env,omitempty"`
 	Cmd        []string          `json:"cmd,omitempty"`
 	Entrypoint []string          `json:"entrypoint,omitempty"`
 	Env        map[string]string `json:"env,omitempty"`

--- a/dashboard/app/lib/javascripts/dashboard/stores/app.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/app.js
@@ -11,6 +11,7 @@ function createTaffyJob (client, taffyReleaseId, appID, appName, meta, appData) 
 	var sha = meta.sha;
 	return client.createTaffyJob({
 		release: taffyReleaseId,
+		release_env: true,
 		cmd: [appName, cloneURL, ref, sha],
 		meta: Marbles.Utils.extend({}, meta, {
 			app: appID,

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -27,6 +27,12 @@
         "type": "string"
       }
     },
+    "entrypoint": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "strategy": {
       "type": "string",
       "enum": ["all-at-once", "one-by-one"]

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -34,6 +34,10 @@
     "tty_lines": {
       "description": "number of lines/rows in tty",
       "type": "integer"
+    },
+    "release_env": {
+      "description": "include the release environment",
+      "type": "boolean"
     }
   }
 }

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -17,6 +17,9 @@
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"
     },
+    "entrypoint": {
+      "$ref": "/schema/controller/common#/definitions/entrypoint"
+    },
     "env": {
       "$ref": "/schema/controller/common#/definitions/env"
     },

--- a/schema/controller/process_type.json
+++ b/schema/controller/process_type.json
@@ -14,10 +14,7 @@
       "$ref": "/schema/controller/common#/definitions/env"
     },
     "entrypoint": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "$ref": "/schema/controller/common#/definitions/entrypoint"
     },
     "ports": {
       "type": "array",

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
-
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
-	"github.com/flynn/flynn/pkg/exec"
 )
 
 type PostgresSuite struct {
@@ -15,20 +12,7 @@ var _ = c.ConcurrentSuite(&PostgresSuite{})
 
 // Check postgres config to avoid regressing on https://github.com/flynn/flynn/issues/101
 func (s *PostgresSuite) TestSSLRenegotiationLimit(t *c.C) {
-	pgRelease, err := s.controllerClient(t).GetAppRelease("postgres")
-	t.Assert(err, c.IsNil)
-
-	cmd := exec.Command(exec.DockerImage(imageURIs["postgresql"]),
-		"--tuples-only", "--command", "show ssl_renegotiation_limit;")
-	cmd.Entrypoint = []string{"psql"}
-	cmd.Env = map[string]string{
-		"PGDATABASE": "postgres",
-		"PGHOST":     "leader.pg.discoverd",
-		"PGUSER":     "flynn",
-		"PGPASSWORD": pgRelease.Env["PGPASSWORD"],
-	}
-
-	res, err := cmd.CombinedOutput()
-	t.Assert(err, c.IsNil)
-	t.Assert(string(bytes.TrimSpace(res)), c.Equals, "0")
+	query := flynn(t, "/", "-a", "controller", "psql", "-c", "SHOW ssl_renegotiation_limit")
+	t.Assert(query, Succeeds)
+	t.Assert(query, OutputContains, "ssl_renegotiation_limit \n-------------------------\n 0\n(1 row)")
 }

--- a/test/test_taffy_deploy.go
+++ b/test/test_taffy_deploy.go
@@ -21,7 +21,8 @@ func (s *TaffyDeploySuite) deployWithTaffy(t *c.C, app *ct.App, github map[strin
 	t.Assert(err, c.IsNil)
 
 	rwc, err := client.RunJobAttached("taffy", &ct.NewJob{
-		ReleaseID: taffyRelease.ID,
+		ReleaseID:  taffyRelease.ID,
+		ReleaseEnv: true,
 		Cmd: []string{
 			app.Name,
 			github["clone_url"],


### PR DESCRIPTION
This adds a new `flynn psql` command that opens a console to the Flynn Postgres database configured for the application.

It retrieves the postgres details from the app’s current release and then uses the release from the referenced postgres service for a one-off job that runs the psql command.

I also added a few bug fixes while implementing this and a commit that adds plv8 and postgis as they are the only extensions we didn't have installed that are supported on Heroku Postgres.
