### PR TITLE
Revert "Added the FreeTDS library to the default cedarish image."

### DIFF
--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -54,7 +54,6 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.li
       telnet \
       zip \
       zlib1g-dev \
-      pigz \
-      freetds-dev &&\
+      pigz &&\
 
     rm /etc/ssh/ssh_host_*


### PR DESCRIPTION
Reverts flynn/flynn#1129

We need to keep the `cedarish` image inline with Heroku's `cedar-14` image.