### PR TITLE
updater: Deploy taffy as part of the update process

### DIFF
--- a/test/test_release.go
+++ b/test/test_release.go
@@ -14,6 +14,7 @@ import (
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/controller/client"
 	tc "github.com/flynn/flynn/test/cluster"
+	"github.com/flynn/flynn/updater/types"
 )
 
 type ReleaseSuite struct {
@@ -171,8 +172,7 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	t.Assert(err, c.IsNil)
 
 	// check system apps were deployed correctly
-	systemApps := []string{"blobstore", "dashboard", "router", "gitreceive", "controller"}
-	for _, app := range systemApps {
+	for _, app := range updater.SystemApps {
 		expected := fmt.Sprintf(`"finished deploy of system app" name=%s`, app)
 		if !strings.Contains(updateOutput.String(), expected) {
 			t.Fatalf(`expected update to deploy %s`, app)

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -1,0 +1,9 @@
+package updater
+
+var SystemApps = []string{
+	"blobstore",
+	"dashboard",
+	"router",
+	"gitreceive",
+	"controller",
+}

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -2,6 +2,7 @@ package updater
 
 var SystemApps = []string{
 	"blobstore",
+	"taffy",
 	"dashboard",
 	"router",
 	"gitreceive",

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/updater/types"
 )
 
 var slugbuilderURI, slugrunnerURI string
@@ -27,14 +28,6 @@ func main() {
 	if err := run(); err != nil {
 		os.Exit(1)
 	}
-}
-
-var systemApps = []string{
-	"blobstore",
-	"dashboard",
-	"router",
-	"gitreceive",
-	"controller",
 }
 
 func run() error {
@@ -61,8 +54,8 @@ func run() error {
 	}
 
 	log.Info("validating images")
-	uris := make(map[string]string, len(systemApps)+2)
-	for _, name := range append(systemApps, "slugbuilder", "slugrunner") {
+	uris := make(map[string]string, len(updater.SystemApps)+2)
+	for _, name := range append(updater.SystemApps, "slugbuilder", "slugrunner") {
 		image := "flynn/" + name
 		if name == "gitreceive" {
 			image = "flynn/receiver"
@@ -79,7 +72,7 @@ func run() error {
 	slugrunnerURI = uris["slugrunner"]
 
 	// deploy system apps in order first
-	for _, name := range systemApps {
+	for _, name := range updater.SystemApps {
 		log := log.New("name", name)
 		log.Info("starting deploy of system app")
 


### PR DESCRIPTION
Although taffy does not have any processes, it needs to be deployed so that it's release uses the latest image.