### PR TITLE
cli: Don't scale unspecified types

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -77,7 +77,11 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 		return nil
 	}
 
-	processes := make(map[string]int, len(typeCounts))
+	current := formation.Processes
+	processes := make(map[string]int, len(current)+len(typeCounts))
+	for k, v := range current {
+		processes[k] = v
+	}
 	for _, arg := range typeCounts {
 		i := strings.IndexRune(arg, '=')
 		if i < 0 {
@@ -89,8 +93,6 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 		}
 		processes[arg[:i]] = val
 	}
-
-	current := formation.Processes
 	formation.Processes = processes
 
 	if scalingComplete(current, processes) {

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -217,10 +217,22 @@ func (s *CLISuite) TestScale(t *c.C) {
 	t.Assert(scale, OutputContains, "crasher=0")
 	t.Assert(scale, OutputContains, "omni=0")
 
+	// scale should only affect specified processes
+	scale = app.flynn("scale", "printer=2")
+	t.Assert(scale, Succeeds)
+	t.Assert(scale, OutputContains, "printer: 1=>2")
+	t.Assert(scale, OutputContains, "scale completed")
+	scale = app.flynn("scale")
+	t.Assert(scale, Succeeds)
+	t.Assert(scale, OutputContains, "echoer=3")
+	t.Assert(scale, OutputContains, "printer=2")
+	t.Assert(scale, OutputContains, "crasher=0")
+	t.Assert(scale, OutputContains, "omni=0")
+
 	// unchanged processes shouldn't appear in output
 	scale = app.flynn("scale", "echoer=3", "printer=0")
 	t.Assert(scale, Succeeds)
-	t.Assert(scale, OutputContains, "printer: 1=>0")
+	t.Assert(scale, OutputContains, "printer: 2=>0")
 	t.Assert(scale, c.Not(OutputContains), "echoer")
 	t.Assert(scale, OutputContains, "scale completed")
 


### PR DESCRIPTION
If a process type is not specified when running `flynn scale foo=2` it should not touch it, otherwise we need to specify every process type for every scale action.

Closes #1140