### PR TITLE
cli: Allow arbitrary arguments to psql

### DIFF
--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -12,7 +12,7 @@ var _ = c.ConcurrentSuite(&PostgresSuite{})
 
 // Check postgres config to avoid regressing on https://github.com/flynn/flynn/issues/101
 func (s *PostgresSuite) TestSSLRenegotiationLimit(t *c.C) {
-	query := flynn(t, "/", "-a", "controller", "psql", "-c", "SHOW ssl_renegotiation_limit")
+	query := flynn(t, "/", "-a", "controller", "psql", "--", "-c", "SHOW ssl_renegotiation_limit")
 	t.Assert(query, Succeeds)
 	t.Assert(query, OutputContains, "ssl_renegotiation_limit \n-------------------------\n 0\n(1 row)")
 }


### PR DESCRIPTION
This makes it easier to get machine-readable results out of psql, so that it can be used in shell pipelines, etc.