### PR TITLE
Use less for psql paging

### DIFF
--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update &&\
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list' &&\
     apt-get update &&\
     apt-get install -y -q \
+      less \
       postgresql-9.4 \
       postgresql-contrib-9.4 \
       postgresql-9.4-pgextwlist \

--- a/cli/psql.go
+++ b/cli/psql.go
@@ -42,8 +42,11 @@ func runPsql(args *docopt.Args, client *controller.Client) error {
 		App:        mustApp(),
 		Release:    pgRelease.ID,
 		Entrypoint: []string{"psql"},
-		Env:        make(map[string]string, 4),
-		Args:       args.All["<argument>"].([]string),
+		Env: map[string]string{
+			"PAGER": "less",
+			"LESS":  "--ignore-case --LONG-PROMPT --SILENT --tabs=4 --quit-if-one-screen --no-init --quit-at-eof",
+		},
+		Args: args.All["<argument>"].([]string),
 	}
 	for _, k := range []string{"PGHOST", "PGUSER", "PGPASSWORD", "PGDATABASE"} {
 		v := appRelease.Env[k]


### PR DESCRIPTION
`psql` uses `more` by default, most distros/people use `less`. This patch adds environment variables that configure `psql` to use `less` for paging along with some basic, sane `less` configuration defaults.