### PR TITLE
Support for non-default regions and CIDRs in flynn aws install

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	register("install", runInstaller, fmt.Sprintf(`
-usage: flynn install <target> [-n <instances>] [-t <instance-type>] [--aws-access-key-id <key-id>] [--aws-secret-access-key <secret>] [--aws-region <region>]
+  usage: flynn install <target> [-n <instances>] [-t <instance-type>] [--aws-access-key-id <key-id>] [--aws-secret-access-key <secret>] [--aws-region <region>] [--vpc-cidr <cidr>] [--subnet-cidr <cidr>]
 
 Targets:
 	aws  creates a flynn cluster on EC2
@@ -24,7 +24,8 @@ Options:
       --aws-access-key-id <key-id>       AWS access key ID. Defaults to $AWS_ACCESS_KEY_ID
       --aws-secret-access-key <secret>   AWS access key secret. Defaults to $AWS_SECRET_ACCESS_KEY
       --aws-region <region>              AWS region [default: us-east-1]
-
+      --vpc-cidr <cidr>                  CIDR block to assign to the VPC. [default: 10.0.0.0/16]
+      --subnet-cidr <cidr>               CIDR block to assign to the subnet. [default: 10.0.0.0/21]
 Examples:
 
 	$ flynn install aws --aws-access-key-id=asdf --aws-secret-access-key=fdsa
@@ -64,10 +65,22 @@ func runInstaller(args *docopt.Args) error {
 		}
 	}
 
+	vpcCidr := args.String["--vpc-cidr"]
+	if vpcCidr == "" {
+		vpcCidr = "10.0.0.0/21"
+	}
+
+	subnetCidr := args.String["--subnet-cidr"]
+	if subnetCidr == "" {
+		subnetCidr = "10.0.0.0/21"
+	}
+
 	stack := &installer.Stack{
 		NumInstances: instances,
 		InstanceType: instanceType,
 		Region:       region,
+		VpcCidr:      vpcCidr,
+		SubnetCidr:   subnetCidr,
 		Creds:        creds,
 		YesNoPrompt:  promptYesNo,
 		PromptInput:  promptInput,

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -584,7 +584,9 @@ func (s *Stack) fetchStackOutputs() error {
 func (s *Stack) configureDNS() error {
 	// TODO(jvatic): Run directly after receiving zone create complete stack event
 	s.SendEvent("Configuring DNS")
-	r53 := route53.New(s.Creds, s.Region, nil)
+
+	// Set region to us-east-1, since any other region will fail for global services like Route53
+	r53 := route53.New(s.Creds, "us-east-1", nil)
 	res, err := r53.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(s.DNSZoneID)})
 	if err != nil {
 		return err

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -52,16 +52,17 @@ type Stack struct {
 	ErrChan   chan error    `json:"-"`
 	Done      chan struct{} `json:"-"`
 
-	ImageID    string                `json:"image_id,omitempty"`
-	StackID    string                `json:"stack_id,omitempty"`
-	StackName  string                `json:"stack_name,omitempty"`
-	Stack      *cloudformation.Stack `json:"-"`
-	SSHKey     *sshkeygen.SSHKey     `json:"-"`
-	SSHKeyName string                `json:"ssh_key_name,omitempty"`
-
-	DiscoveryToken string   `json:"discovery_token"`
-	InstanceIPs    []string `json:"instance_ips,omitempty"`
-	DNSZoneID      string   `json:"dns_zone_id,omitempty"`
+	ImageID        string                `json:"image_id,omitempty"`
+	StackID        string                `json:"stack_id,omitempty"`
+	StackName      string                `json:"stack_name,omitempty"`
+	Stack          *cloudformation.Stack `json:"-"`
+	SSHKey         *sshkeygen.SSHKey     `json:"-"`
+	SSHKeyName     string                `json:"ssh_key_name,omitempty"`
+	VpcCidr        string                `json:"vpc_cidr_block,omitempty"`
+	SubnetCidr     string                `json:"subnet_cidr_block,omitempty"`
+	DiscoveryToken string                `json:"discovery_token"`
+	InstanceIPs    []string              `json:"instance_ips,omitempty"`
+	DNSZoneID      string                `json:"dns_zone_id,omitempty"`
 
 	persistMutex sync.Mutex
 
@@ -369,6 +370,14 @@ func (s *Stack) createStack() error {
 		{
 			ParameterKey:   aws.String("InstanceType"),
 			ParameterValue: aws.String(s.InstanceType),
+		},
+		{
+			ParameterKey:   aws.String("VpcCidrBlock"),
+			ParameterValue: aws.String(s.VpcCidr),
+		},
+		{
+			ParameterKey:   aws.String("SubnetCidrBlock"),
+			ParameterValue: aws.String(s.SubnetCidr),
 		},
 	}
 

--- a/installer/stack_template.go
+++ b/installer/stack_template.go
@@ -33,6 +33,16 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
     "UserData": {
       "Type": "String",
       "Description": "The user data each instance is started with."
+    },
+    "VpcCidrBlock": {
+      "Type": "String",
+      "Description": "The CIDR block to use for the VPC",
+      "Default": "10.0.0.0/16"
+    },
+    "SubnetCidrBlock": {
+      "Type": "String",
+      "Description": "The CIDR block to use for the subnet",
+      "Default": "10.0.0.0/21"
     }
   },
 
@@ -40,7 +50,7 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
     "VPC": {
       "Type": "AWS::EC2::VPC",
       "Properties": {
-        "CidrBlock": "10.0.0.0/16"
+        "CidrBlock": { "Ref": "VpcCidrBlock" }
       }
     },
 
@@ -76,7 +86,7 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
     "Subnet": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
-        "CidrBlock": "10.0.0.0/21",
+        "CidrBlock": { "Ref": "SubnetCidrBlock" },
         "VpcId": { "Ref": "VPC" }
       }
     },

--- a/installer/stack_template.go
+++ b/installer/stack_template.go
@@ -31,8 +31,8 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
       "Default": "50"
     },
     "UserData": {
-        "Type": "String",
-        "Description": "The user data each instance is started with."
+      "Type": "String",
+      "Description": "The user data each instance is started with."
     }
   },
 


### PR DESCRIPTION
I've added `--vpc-cidr` and `--subnet-cidr` options to `flynn aws install` to allow specifying the IP range to use. This resolves #1162

I've also hardcoded the region to `us-east-1` when configuring DNS, since it was previously failing at that point when using other regions. Resolves #1163 