### PR TITLE
test: Timeout the unit tests after 5 minutes

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -470,7 +470,7 @@ flynn=$GOPATH/src/github.com/flynn/flynn
 cd $flynn
 
 if [[ -f test/scripts/test-unit.sh ]]; then
-  test/scripts/test-unit.sh
+  timeout --signal=QUIT --kill-after=10 5m test/scripts/test-unit.sh
 fi
 `[1:]
 


### PR DESCRIPTION
CI is intermittently hanging indefinitely running `go test`. We need to investigate why, but we should also not allow the test to hang indefinitely.