### PR TITLE
controller: Retry requests after dial errors

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -48,10 +48,32 @@ func newClient(key string, url string, http *http.Client) *Client {
 	return c
 }
 
+var defaultDialer = net.Dialer{
+	Timeout:   time.Second,
+	KeepAlive: 30 * time.Second,
+}
+
+var retryAttempts = attempt.Strategy{
+	Total: 30 * time.Second,
+	Delay: 500 * time.Millisecond,
+}
+
+func retryDial(network, addr string) (net.Conn, error) {
+	var conn net.Conn
+	if err := retryAttempts.Run(func() (err error) {
+		conn, err = defaultDialer.Dial(network, addr)
+		return
+	}); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
 // NewClient creates a new Client pointing at uri and using key for
 // authentication.
 func NewClient(uri, key string) (*Client, error) {
-	return NewClientWithHTTP(uri, key, http.DefaultClient)
+	httpClient := &http.Client{Transport: &http.Transport{Dial: retryDial}}
+	return NewClientWithHTTP(uri, key, httpClient)
 }
 
 func NewClientWithHTTP(uri, key string, httpClient *http.Client) (*Client, error) {


### PR DESCRIPTION
There is a chance that service discovery could return an address of a controller and that instance subsequently goes down, meaning when a HTTP request is actually made, there will be an i/o timeout.

Previously the client would use a connect timeout of 30s (set by `http.DefaultTransport`) which is too long to wait in this case.

This change lowers the connect timeout to 1s, and retries dialling the controller multiple times if an error occurs, giving up after 30s.