### PR TITLE
Cluster resurrection

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -25,7 +25,8 @@
           "cmd": ["postgres"],
           "env": {
             "SINGLETON": "{{ .Singleton }}"
-          }
+          },
+		  "resurrect": true
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
@@ -82,12 +83,14 @@
       "processes": {
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["controller"]
+          "cmd": ["controller"],
+		  "resurrect": true
         },
         "scheduler": {
           "cmd": ["scheduler"],
           "omni": true,
-          "service": "flynn-controller-scheduler"
+          "service": "flynn-controller-scheduler",
+		  "resurrect": true
         },
         "deployer": {
           "cmd": ["deployer"]

--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -119,7 +119,14 @@ func (a *RunAppAction) Run(s *State) error {
 		}
 		sort.Sort(schedutil.HostSlice(hosts))
 		for i := 0; i < count; i++ {
-			job, err := startJob(s, hosts[i%len(hosts)].ID, utils.JobConfig(a.ExpandedFormation, typ))
+			hostID := hosts[i%len(hosts)].ID
+			config := utils.JobConfig(a.ExpandedFormation, typ)
+			if a.ExpandedFormation.Release.Processes[typ].Data {
+				if err := utils.ProvisionVolume(cc, hostID, config); err != nil {
+					return err
+				}
+			}
+			job, err := startJob(s, hostID, config)
 			if err != nil {
 				return err
 			}

--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -797,6 +797,13 @@ func (f *Formation) start(typ string, hostID string) (job *Job, err error) {
 		h = sh[0].Host
 	}
 
+	// Provision a data volume on the host if needed.
+	if f.Release.Processes[typ].Data {
+		if err := utils.ProvisionVolume(f.c.clusterClient, h.ID, config); err != nil {
+			return nil, err
+		}
+	}
+
 	job = f.jobs.Add(typ, h.ID, config.ID)
 	job.Formation = f
 	f.c.jobs.Add(job)

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -49,6 +49,7 @@ type ProcessType struct {
 	Omni        bool              `json:"omni,omitempty"` // omnipresent - present on all hosts
 	HostNetwork bool              `json:"host_network,omitempty"`
 	Service     string            `json:"service,omitempty"`
+	Resurrect   bool              `json:"resurrect,omitempty"`
 }
 
 type Port struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -37,6 +37,7 @@ func JobConfig(f *ct.ExpandedFormation, name string) *host.Job {
 			Env:         env,
 			HostNetwork: t.HostNetwork,
 		},
+		Resurrect: t.Resurrect,
 	}
 	if len(t.Entrypoint) > 0 {
 		job.Config.Entrypoint = t.Entrypoint

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -47,8 +47,26 @@ func JobConfig(f *ct.ExpandedFormation, name string) *host.Job {
 		job.Config.Ports[i].Port = p.Port
 		job.Config.Ports[i].Service = p.Service
 	}
-	if t.Data {
-		job.Config.Mounts = []host.Mount{{Location: "/data", Writeable: true}}
-	}
 	return job
+}
+
+type HostDialer interface {
+	DialHost(id string) (cluster.Host, error)
+}
+
+func ProvisionVolume(c HostDialer, hostID string, job *host.Job) error {
+	h, err := c.DialHost(hostID)
+	if err != nil {
+		return err
+	}
+	vol, err := h.CreateVolume("default")
+	if err != nil {
+		return err
+	}
+	job.Config.Volumes = []host.VolumeBinding{{
+		Target:    "/data",
+		VolumeID:  vol.ID,
+		Writeable: true,
+	}}
+	return nil
 }

--- a/discoverd/server/etcd_backend_test.go
+++ b/discoverd/server/etcd_backend_test.go
@@ -298,3 +298,17 @@ func (s *EtcdSuite) TestManualLeaderInitialSync(c *C) {
 	c.Assert(s.backend.StartSync(), IsNil)
 	assertEvent(c, events, "a", discoverd.EventKindLeader, inst2)
 }
+
+func (s *EtcdSuite) TestManualLeaderInitialSyncDelayedRegister(c *C) {
+	events := make(chan *discoverd.Event, 1)
+	s.state.Subscribe("a", false, discoverd.EventKindLeader, events)
+
+	c.Assert(s.backend.AddService("a", &discoverd.ServiceConfig{LeaderType: discoverd.LeaderTypeManual}), IsNil)
+	inst1 := fakeInstance()
+	c.Assert(s.backend.SetLeader("a", inst1.ID), IsNil)
+
+	c.Assert(s.backend.StartSync(), IsNil)
+	c.Assert(s.backend.AddInstance("a", inst1), IsNil)
+	assertEvent(c, events, "a", discoverd.EventKindLeader, inst1)
+	assertInstanceEqual(c, s.state.GetLeader("a"), inst1)
+}

--- a/host/backend.go
+++ b/host/backend.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"net"
 
 	"github.com/flynn/flynn/host/types"
 )
@@ -22,7 +23,7 @@ type AttachRequest struct {
 }
 
 type Backend interface {
-	Run(*host.Job) error
+	Run(*host.Job, *RunConfig) error
 	Stop(string) error
 	Signal(string, int) error
 	ResizeTTY(id string, height, width uint16) error
@@ -30,6 +31,11 @@ type Backend interface {
 	Cleanup() error
 	UnmarshalState(map[string]*host.ActiveJob, map[string][]byte, []byte) error
 	ConfigureNetworking(strategy NetworkStrategy, job string) (*NetworkInfo, error)
+}
+
+type RunConfig struct {
+	IP         net.IP
+	ManifestID string
 }
 
 type NetworkInfo struct {

--- a/host/host.go
+++ b/host/host.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +166,7 @@ func runDaemon(args *docopt.Args) {
 				DatasetName: "flynn-default",
 				Make: &zfsVolume.MakeDev{
 					BackingFilename: filepath.Join(volPath, "zfs/vdev/flynn-default-zpool.vdev"),
-					Size:            int64(math.Pow(2, float64(30))),
+					Size:            100000000000, // Provision a 100GB sparse file
 				},
 				WorkingDir: filepath.Join(volPath, "zfs"),
 			})

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -522,7 +522,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job) (err error) {
 		return err
 	}
 
-	l.state.AddJob(job, container.IP.String())
+	l.state.AddJob(job, container.IP)
 	domain := &lt.Domain{
 		Type:   "lxc",
 		Name:   job.ID,

--- a/host/manifest.go
+++ b/host/manifest.go
@@ -38,7 +38,7 @@ type ManifestData struct {
 	BridgeIP    string
 	Nameservers string
 	TCPPorts    []int
-	Volumes     map[string]string // maps 'mntpath'->'volName'
+	Volumes     map[string]struct{}
 	Env         map[string]string
 	Services    map[string]*ManifestData
 
@@ -60,11 +60,11 @@ func (m *ManifestData) TCPPort(id int) (int, error) {
 	return port, nil
 }
 
-func (m *ManifestData) Volume(volName string, mntPath string) string {
+func (m *ManifestData) Volume(mntPath string) string {
 	if m.Volumes == nil {
-		m.Volumes = make(map[string]string)
+		m.Volumes = make(map[string]struct{})
 	}
-	m.Volumes[mntPath] = volName
+	m.Volumes[mntPath] = struct{}{}
 	return mntPath
 }
 
@@ -198,8 +198,8 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 
 		// prepare named volumes
 		volumeBindings := make([]host.VolumeBinding, 0, len(data.Volumes))
-		for mntPath, volName := range data.Volumes {
-			vol, err := m.vman.CreateOrGetNamedVolume(volName, "")
+		for mntPath := range data.Volumes {
+			vol, err := m.vman.NewVolume()
 			if err != nil {
 				return err
 			}

--- a/host/manifest.go
+++ b/host/manifest.go
@@ -34,7 +34,6 @@ func parseEnviron() map[string]string {
 
 type ManifestData struct {
 	ExternalIP  string
-	InternalIP  string
 	BridgeIP    string
 	Nameservers string
 	TCPPorts    []int
@@ -115,7 +114,6 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 
 		data := &ManifestData{
 			ExternalIP: m.externalAddr,
-			InternalIP: job.InternalIP,
 			Env:        job.Job.Config.Env,
 			Services:   serviceData,
 			readonly:   true,
@@ -247,8 +245,6 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 		}
 
 		m.state.SetManifestID(job.ID, service.ID)
-		activeJob := m.state.GetJob(job.ID)
-		data.InternalIP = activeJob.InternalIP
 		data.readonly = true
 		serviceData[service.ID] = data
 		return nil

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -4,7 +4,7 @@
     "image": "$image_repository?name=flynn/etcd&id=$image_id[etcd]",
     "expose_env": ["ETCD_INITIAL_CLUSTER", "ETCD_INITIAL_CLUSTER_STATE", "ETCD_NAME", "ETCD_DISCOVERY", "ETCD_PROXY"],
     "args": [
-      "-data-dir={{ .Volume \"flynn-etcd-data\" \"/data\" }}",
+      "-data-dir={{ .Volume \"/data\" }}",
       "-advertise-client-urls=http://{{ .ExternalIP }}:{{ .TCPPort 0 }}",
       "-listen-client-urls=http://0.0.0.0:{{ .TCPPort 0 }}",
       "-initial-advertise-peer-urls=http://{{ .ExternalIP }}:{{ .TCPPort 1 }}",

--- a/host/state.go
+++ b/host/state.go
@@ -182,10 +182,13 @@ func (s *State) persistenceDBClose() error {
 	return s.stateDB.Close()
 }
 
-func (s *State) AddJob(j *host.Job, ip string) {
+func (s *State) AddJob(j *host.Job, ip net.IP) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	job := &host.ActiveJob{Job: j, HostID: s.id, InternalIP: ip}
+	job := &host.ActiveJob{Job: j, HostID: s.id}
+	if len(ip) > 0 {
+		job.InternalIP = ip.String()
+	}
 	s.jobs[j.ID] = job
 	s.sendEvent(job, "create")
 	s.persist(j.ID)

--- a/host/state_test.go
+++ b/host/state_test.go
@@ -28,7 +28,7 @@ func (S) TestStateHostID(c *C) {
 
 type MockBackend struct{}
 
-func (MockBackend) Run(*host.Job) error                             { return nil }
+func (MockBackend) Run(*host.Job, *RunConfig) error                 { return nil }
 func (MockBackend) Stop(string) error                               { return nil }
 func (MockBackend) Signal(string, int) error                        { return nil }
 func (MockBackend) ResizeTTY(id string, height, width uint16) error { return nil }

--- a/host/state_test.go
+++ b/host/state_test.go
@@ -19,7 +19,7 @@ func (S) TestStateHostID(c *C) {
 	hostID := "abc123"
 	state := NewState(hostID, filepath.Join(workdir, "host-state-db"))
 	defer state.persistenceDBClose()
-	state.AddJob(&host.Job{ID: "a"}, "1.1.1.1")
+	state.AddJob(&host.Job{ID: "a"}, nil)
 	job := state.GetJob("a")
 	if job.HostID != hostID {
 		c.Errorf("expected job.HostID to equal %s, got %s", hostID, job.HostID)
@@ -43,7 +43,7 @@ func (S) TestStatePersistRestore(c *C) {
 	workdir := c.MkDir()
 	hostID := "abc123"
 	state := NewState(hostID, filepath.Join(workdir, "host-state-db"))
-	state.AddJob(&host.Job{ID: "a"}, "1.1.1.1")
+	state.AddJob(&host.Job{ID: "a"}, nil)
 	state.persistenceDBClose()
 
 	// exercise the restore path.  failures will panic.

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -13,6 +13,10 @@ type Job struct {
 	Resources JobResources `json:"resources,omitempty"`
 
 	Config ContainerConfig `json:"config,omitempty"`
+
+	// If Resurrect is true, the host service will attempt to start the job when
+	// starting after stopping (via crash or shutdown) with the job running.
+	Resurrect bool `json:"resurrect,omitempty"`
 }
 
 func (j *Job) Dup() *Job {

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -58,6 +58,9 @@ main() {
   # kill flynn first
   "${ROOT}/script/kill-flynn" -b "${backend}"
 
+  # delete the old state
+  sudo rm -f /tmp/flynn-host-state.bolt
+
   if $destroy_vols; then
     sudo "${ROOT}/host/bin/flynn-host" destroy-volumes --include-data
   fi


### PR DESCRIPTION
This implements support for full-cluster restarts (both due to hard crashes and clean shutdowns). See the individual commit messages for implementation details. A few bugs found in discoverd and flynn-host were fixed along the way. Named volumes were removed as they are only usable from layer 0 bootstrap.

Closes #235.
Implements resurrection as described in #1170.
Makes #1168 a non-issue, as legacy volumes are no longer used. Legacy volumes will be removed in a future PR.