### PR TITLE
appliance/postgresql: Don't error if sync xlog is greater than primary

### DIFF
--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -576,12 +576,6 @@ func (p *Postgres) waitForSync(inst *discoverd.Instance) {
 				log.Debug("flushed row incremented, resetting startTime")
 				startTime = time.Now().UTC()
 				lastFlushed = flushed
-			} else if cmp == 1 {
-				// Fail fast if the remote flushed location is greater than our
-				// current location. This means that we (the primary) is behind
-				// the sync and will never catch up.
-				log.Error("error checking replication status", "err", "sync xlog position is greater than the primary position")
-				return
 			}
 
 			if sent == flushed {


### PR DESCRIPTION
There are some scenarios where this can be the case, and it isn't an error. See https://smartos.org/bugview/MANATEE-263 for details.

This most likely happens when postgres is setting up replication and trying to figure out exactly what it has most recently sent to the remote peer.

Upstream change: https://github.com/joyent/manatee/commit/fb8d0f788000cdc24be5eb7b43a286c19f38fb69