### PR TITLE
host: Don't save state database in /tmp

### DIFF
--- a/host/upstart.conf
+++ b/host/upstart.conf
@@ -4,4 +4,4 @@ description "Flynn layer 0"
 #respawn
 #respawn limit 1000 60
 
-exec /usr/local/bin/flynn-host daemon --manifest /etc/flynn/host-manifest.json --state /tmp/flynn-host-state.bolt
+exec /usr/local/bin/flynn-host daemon --manifest /etc/flynn/host-manifest.json


### PR DESCRIPTION
The upstart job saves the state database in `/tmp`, which will not persist between reboots. Since the default is in `/var/lib/flynn` we can just remove the flag to fix this.

Refs #235.