### PR TITLE
test: Wait for Docker to start before using it

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -439,6 +439,7 @@ git config user.name "CI"
 git merge origin/master
 {{ end }}
 
+test/scripts/wait-for-docker
 make
 
 if [[ -f test/scripts/debug-info.sh ]]; then

--- a/test/scripts/wait-for-docker
+++ b/test/scripts/wait-for-docker
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# A script to wait for Docker to start listening for requests. Used in CI where tests
+# intermittently fail with `dial unix /var/run/docker.sock: no such file or directory`.
+
+main() {
+  start=$(date +%s)
+  while ! [[ -S /var/run/docker.sock ]]; do
+    sleep 0.2
+    elapsed=$(($(date +%s) - $start))
+    if [[ $elapsed -gt 60 ]]; then
+      echo "++ $(timestamp) Docker not started after 60s, exiting"
+      exit 1
+    fi
+  done
+}
+
+timestamp() {
+  date "+%H:%M:%S.%3N"
+}
+
+main $@

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -55,6 +55,7 @@ src="${GOPATH}/src/github.com/flynn/flynn"
   sed "s/{{FLYNN-HOST-CHECKSUM}}/$(sha512sum host/bin/flynn-host.gz | cut -d " " -f 1)/g" script/install-flynn.tmpl > script/install-flynn
 
   # create new images
+  test/scripts/wait-for-docker
   for name in $(docker images | grep ^flynn | awk '{print $1}'); do
     docker build -t $name - < <(echo -e "FROM $name\nRUN /bin/true")
   done


### PR DESCRIPTION
Tests were intermittently failing in CI with:

`dial unix /var/run/docker.sock: no such file or directory`

Closes #1102 
Closes #1104