### PR TITLE
router: Don't use SO_REUSEPORT in test suite

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/ctxhelper"
@@ -267,7 +266,7 @@ func (h *httpSyncHandler) Remove(id string) error {
 
 func (s *HTTPListener) listenAndServe() error {
 	var err error
-	s.listener, err = reuseport.NewReusablePortListener("tcp4", s.Addr)
+	s.listener, err = listenFunc("tcp4", s.Addr)
 	if err != nil {
 		return err
 	}
@@ -301,7 +300,7 @@ func (s *HTTPListener) listenAndServeTLS() error {
 		Certificates:   []tls.Certificate{s.keypair},
 	})
 
-	l, err := reuseport.NewReusablePortListener("tcp4", s.TLSAddr)
+	l, err := listenFunc("tcp4", s.TLSAddr)
 	if err != nil {
 		return err
 	}

--- a/router/server.go
+++ b/router/server.go
@@ -42,6 +42,8 @@ func (s *Router) Start() error {
 	return nil
 }
 
+var listenFunc = reuseport.NewReusablePortListener
+
 func main() {
 	defer shutdown.Exit()
 
@@ -137,7 +139,7 @@ func main() {
 		shutdown.Fatal(err)
 	}
 
-	listener, err := reuseport.NewReusablePortListener("tcp4", *apiAddr)
+	listener, err := listenFunc("tcp4", *apiAddr)
 	if err != nil {
 		shutdown.Fatal(err)
 	}

--- a/router/setup_test.go
+++ b/router/setup_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 
 func init() {
 	testMode = true
+	listenFunc = net.Listen
 }
 
 type discoverdClient interface {

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/router/proxy"
 	"github.com/flynn/flynn/router/types"
@@ -113,7 +112,7 @@ func (l *TCPListener) Start() error {
 
 	if l.startPort != 0 && l.endPort != 0 {
 		for i := l.startPort; i <= l.endPort; i++ {
-			listener, err := reuseport.NewReusablePortListener("tcp4", fmt.Sprintf("%s:%d", l.IP, i))
+			listener, err := listenFunc("tcp4", fmt.Sprintf("%s:%d", l.IP, i))
 			if err != nil {
 				l.Close()
 				return err
@@ -278,7 +277,7 @@ func (r *tcpRoute) Serve(started chan<- error) {
 	var err error
 	// TODO: close the listener while there are no backends available
 	if r.l == nil {
-		r.l, err = reuseport.NewReusablePortListener("tcp4", r.addr)
+		r.l, err = listenFunc("tcp4", r.addr)
 	}
 	started <- err
 	if err != nil {


### PR DESCRIPTION
Binding to :0 and specifying the SO_REUSEPORT flag are mutually incompatible, as the kernel may pick a port that is already in use.

Closes #893
Closes #822