### PR TITLE
test: Dump the Docker log if it doesn't come up

### DIFF
--- a/test/scripts/wait-for-docker
+++ b/test/scripts/wait-for-docker
@@ -9,7 +9,8 @@ main() {
     sleep 0.2
     elapsed=$(($(date +%s) - $start))
     if [[ $elapsed -gt 60 ]]; then
-      echo "++ $(timestamp) Docker not started after 60s, exiting"
+      echo "++ $(timestamp) Docker not started after 60s, dumping /var/log/upstart/docker.log"
+      sudo cat /var/log/upstart/docker.log
       exit 1
     fi
   done


### PR DESCRIPTION
The timeout was hit in CI (see [here](https://s3.amazonaws.com/flynn-ci-logs/20150308031603-ad79e92d-build-5305600de6dc5095280db6a4fda22d304f20adf3-2015-03-08-03-19-38.txt)), which indicates Docker is failing to start, rather than just being slow to start.