### PR TITLE
Add status endpoint to postgres, use it to wait for upstream

### DIFF
--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -47,7 +47,7 @@ func NewClient(addr string) *Client {
 
 	return &Client{
 		c: &httpclient.Client{
-			URL:  fmt.Sprintf("http://%s:5433", addr),
+			URL:  fmt.Sprintf("http://%s:5433", host),
 			HTTP: http.DefaultClient,
 		},
 	}

--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -1,0 +1,59 @@
+package pgmanager
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/flynn/flynn/appliance/postgresql/state"
+	"github.com/flynn/flynn/pkg/httpclient"
+)
+
+type PostgresInfo struct {
+	Config   *state.PgConfig `json:"config"`
+	Running  bool            `json:"running"`
+	XLog     string          `json:"xlog,omitempty"`
+	Replicas []*Replica      `json:"replicas,omitempty"`
+}
+
+type Replica struct {
+	ID             string    `json:"id"`
+	Addr           string    `json:"addr"`
+	Start          time.Time `json:'start"`
+	State          string    `json:"state"`
+	Sync           bool      `json:"sync"`
+	SentLocation   string    `json:"sent_location"`
+	WriteLocation  string    `json:"write_location"`
+	FlushLocation  string    `json:"flush_location"`
+	ReplayLocation string    `json:"replay_location"`
+}
+
+type Status struct {
+	Peer     *state.PeerInfo `json:"peer"`
+	Postgres *PostgresInfo   `json:"postgres"`
+}
+
+type Client struct {
+	c *httpclient.Client
+}
+
+func NewClient(addr string) *Client {
+	// remove port, if any
+	host, _, _ := net.SplitHostPort(addr)
+	if host == "" {
+		host = addr
+	}
+
+	return &Client{
+		c: &httpclient.Client{
+			URL:  fmt.Sprintf("http://%s:5433", addr),
+			HTTP: http.DefaultClient,
+		},
+	}
+}
+
+func (c *Client) Status() (*Status, error) {
+	res := &Status{}
+	return res, c.c.Get("/status", res)
+}

--- a/appliance/postgresql/http.go
+++ b/appliance/postgresql/http.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/appliance/postgresql/client"
+	"github.com/flynn/flynn/appliance/postgresql/state"
+	"github.com/flynn/flynn/pkg/httphelper"
+)
+
+func ServeHTTP(pg *Postgres, peer *state.Peer, log log15.Logger) error {
+	api := &HTTP{
+		pg:   pg,
+		peer: peer,
+		log:  log,
+	}
+	r := httprouter.New()
+	r.GET("/status", api.GetStatus)
+	return http.ListenAndServe(":5433", r)
+}
+
+type HTTP struct {
+	pg   *Postgres
+	peer *state.Peer
+	log  log15.Logger
+}
+
+func (h *HTTP) GetStatus(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	res := &pgmanager.Status{
+		Peer: h.peer.Info(),
+	}
+	var err error
+	res.Postgres, err = h.pg.Info()
+	if err != nil {
+		// Log the error, but don't return a 500. We will always have some
+		// information to return, but postgres may not be online.
+		h.log.Error("error getting postgres info", "err", err)
+	}
+	httphelper.JSON(w, 200, res)
+}

--- a/appliance/postgresql/main.go
+++ b/appliance/postgresql/main.go
@@ -40,6 +40,7 @@ func main() {
 		Password:     password,
 		Logger:       log.New("component", "postgres"),
 		ExtWhitelist: true,
+		WaitUpstream: true,
 		// TODO(titanous) investigate this:
 		SHMType: "sysv", // the default on 9.4, 'posix' is not currently supported in our containers
 	})

--- a/appliance/postgresql/main.go
+++ b/appliance/postgresql/main.go
@@ -48,6 +48,7 @@ func main() {
 	peer := state.NewPeer(inst, singleton, dd, pg, log.New("component", "peer"))
 	shutdown.BeforeExit(func() { peer.Close() })
 
-	peer.Run()
+	go peer.Run()
+	shutdown.Fatal(ServeHTTP(pg.(*Postgres), peer, log.New("component", "http")))
 	// TODO(titanous): clean shutdown of postgres
 }


### PR DESCRIPTION
This adds an HTTP API and `/status` endpoint to the postgres instance manager. The first use for the endpoint is waiting for the upstream server to come up before pulling a base backup.