### PR TITLE
discoverd/health: Avoid deadlock in register test

### DIFF
--- a/discoverd/health/register_test.go
+++ b/discoverd/health/register_test.go
@@ -192,7 +192,9 @@ func (RegisterSuite) TestRegister(c *C) {
 			if step.setMeta {
 				go func() {
 					call := <-metaChan
-					call.returnVal <- step.success
+					if call.returnVal != nil {
+						call.returnVal <- step.success
+					}
 				}()
 				// SetMeta needs to succeed every time, regardless of the situation
 				currentMeta["TEST"] = random.UUID()


### PR DESCRIPTION
I don't understand the code well enough to know *why* this is sometimes nil, but I think it's a scheduling race with one of the empty calls.

This guard prevents an occasional deadlock.

Closes #1203