### PR TITLE
host,pkg/cluster: Add SignalJob

### DIFF
--- a/appliance/postgresql/main.go
+++ b/appliance/postgresql/main.go
@@ -21,7 +21,7 @@ func main() {
 	err := discoverd.DefaultClient.AddService(serviceName, &discoverd.ServiceConfig{
 		LeaderType: discoverd.LeaderTypeManual,
 	})
-	if je, ok := err.(httphelper.JSONError); err != nil && (!ok || je.Code != httphelper.ObjectExistsError) {
+	if err != nil && !httphelper.IsObjectExistsError(err) {
 		shutdown.Fatal(err)
 	}
 	inst := &discoverd.Instance{Addr: ":5432"}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -183,7 +183,7 @@ loop:
 		case <-updates:
 			instances, err := service.Instances()
 			if err != nil {
-				if e, ok := err.(httphelper.JSONError); ok && e.Code == httphelper.ObjectNotFoundError {
+				if httphelper.IsObjectNotFoundError(err) {
 					continue
 				}
 				return err

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -4,7 +4,6 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -107,16 +106,7 @@ type handlerConfig struct {
 func respondWithError(w http.ResponseWriter, err error) {
 	switch v := err.(type) {
 	case ct.ValidationError:
-		var detail []byte
-		if v.Field != "" {
-			detail, _ = json.Marshal(map[string]string{"field": v.Field})
-		}
-		err = httphelper.JSONError{
-			Code:    httphelper.ValidationError,
-			Message: fmt.Sprintf("%s %s", v.Field, v.Message),
-			Detail:  detail,
-		}
-		httphelper.Error(w, err)
+		httphelper.ValidationError(w, v.Field, v.Message)
 	default:
 		if err == ErrNotFound {
 			w.WriteHeader(404)

--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -190,10 +190,7 @@ func (c *controllerAPI) CreateDeployment(ctx context.Context, w http.ResponseWri
 
 	if err := c.deploymentRepo.Add(deployment); err != nil {
 		if e, ok := err.(*pq.Error); ok && e.Code.Name() == "unique_violation" && e.Constraint == "isolate_deploys" {
-			httphelper.Error(w, httphelper.JSONError{
-				Code:    httphelper.ValidationError,
-				Message: "Cannot create deploy, there is already one in progress for this app.",
-			})
+			httphelper.ValidationError(w, "", "Cannot create deploy, there is already one in progress for this app.")
 			return
 		}
 		respondWithError(w, err)

--- a/controller/deployment_test.go
+++ b/controller/deployment_test.go
@@ -37,7 +37,7 @@ func (s *S) TestCreateDeployment(c *C) {
 
 	// quickly recreating a deployment should error
 	_, err = s.c.CreateDeployment(app.ID, newRelease.ID)
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.ValidationError)
+	c.Assert(hh.IsValidationError(err), Equals, true)
 	c.Assert(err.(hh.JSONError).Message, Equals, "Cannot create deploy, there is already one in progress for this app.")
 }
 

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -72,6 +72,10 @@ func (c *FakeHostClient) StopJob(id string) error {
 	return nil
 }
 
+func (c *FakeHostClient) SignalJob(string, int) error {
+	return nil
+}
+
 func (c *FakeHostClient) IsStopped(id string) bool {
 	return c.stopped[id]
 }

--- a/discoverd/client/client.go
+++ b/discoverd/client/client.go
@@ -97,8 +97,7 @@ func (c *Client) Service(name string) Service {
 }
 
 func IsNotFound(err error) bool {
-	je, ok := err.(hh.JSONError)
-	return ok && je.Code == hh.ObjectNotFoundError
+	return hh.IsObjectNotFoundError(err)
 }
 
 func (c *Client) Instances(service string, timeout time.Duration) ([]*Instance, error) {

--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -28,7 +28,7 @@ type Heartbeater interface {
 
 func (c *Client) maybeAddService(service string) error {
 	if err := c.AddService(service, nil); err != nil {
-		if je, ok := err.(hh.JSONError); !ok || je.Code != hh.ObjectExistsError {
+		if !hh.IsObjectExistsError(err) {
 			return err
 		}
 	}

--- a/discoverd/server/etcd_backend.go
+++ b/discoverd/server/etcd_backend.go
@@ -128,23 +128,14 @@ func (b *etcdBackend) SetServiceMeta(service string, meta *discoverd.ServiceMeta
 	if meta.Index == 0 {
 		res, err = b.etcd.Create(key, string(meta.Data), 0)
 		if isEtcdExists(err) {
-			err = hh.JSONError{
-				Code:    hh.ObjectExistsError,
-				Message: fmt.Sprintf("Service metadata for %q already exists, use index=n to set", service),
-			}
+			err = hh.ObjectExistsErr(fmt.Sprintf("Service metadata for %q already exists, use index=n to set", service))
 		}
 	} else {
 		res, err = b.etcd.CompareAndSwap(key, string(meta.Data), 0, "", meta.Index)
 		if isEtcdNotFound(err) {
-			err = hh.JSONError{
-				Code:    hh.PreconditionFailedError,
-				Message: fmt.Sprintf("Service metadata for %q does not exist, use index=0 to set", service),
-			}
+			err = hh.PreconditionFailedErr(fmt.Sprintf("Service metadata for %q does not exist, use index=0 to set", service))
 		} else if isEtcdCompareFailed(err) {
-			err = hh.JSONError{
-				Code:    hh.PreconditionFailedError,
-				Message: fmt.Sprintf("Service metadata for %q exists, but wrong index provided", service),
-			}
+			err = hh.PreconditionFailedErr(fmt.Sprintf("Service metadata for %q exists, but wrong index provided", service))
 		}
 	}
 	if err != nil {

--- a/discoverd/server/etcd_backend_test.go
+++ b/discoverd/server/etcd_backend_test.go
@@ -259,8 +259,7 @@ func (s *EtcdSuite) TestSetMeta(c *C) {
 
 	// new with wrong index
 	err = s.backend.SetServiceMeta("a", &discoverd.ServiceMeta{Data: []byte("foo"), Index: 1})
-	c.Assert(err, FitsTypeOf, hh.JSONError{})
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.PreconditionFailedError)
+	c.Assert(hh.IsPreconditionFailedError(err), Equals, true)
 
 	// new
 	meta := &discoverd.ServiceMeta{Data: []byte("foo"), Index: 0}
@@ -269,8 +268,7 @@ func (s *EtcdSuite) TestSetMeta(c *C) {
 
 	// index=0 set with existing
 	err = s.backend.SetServiceMeta("a", &discoverd.ServiceMeta{Data: []byte("foo"), Index: 0})
-	c.Assert(err, FitsTypeOf, hh.JSONError{})
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.ObjectExistsError)
+	c.Assert(hh.IsObjectExistsError(err), Equals, true)
 
 	// set with existing, valid index
 	meta.Data = []byte("bar")
@@ -281,8 +279,7 @@ func (s *EtcdSuite) TestSetMeta(c *C) {
 	meta.Index--
 	meta.Data = []byte("baz")
 	err = s.backend.SetServiceMeta("a", meta)
-	c.Assert(err, FitsTypeOf, hh.JSONError{})
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.PreconditionFailedError)
+	c.Assert(hh.IsPreconditionFailedError(err), Equals, true)
 }
 
 func (s *EtcdSuite) TestManualLeaderInitialSync(c *C) {

--- a/discoverd/server/http_test.go
+++ b/discoverd/server/http_test.go
@@ -366,15 +366,13 @@ func (s *HTTPSuite) TestServiceMeta(c *C) {
 	meta.Index--
 	err = srv.SetMeta(meta)
 	c.Assert(err, NotNil)
-	c.Assert(err, FitsTypeOf, hh.JSONError{})
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.PreconditionFailedError)
+	c.Assert(hh.IsPreconditionFailedError(err), Equals, true)
 }
 
 func (s *HTTPSuite) TestManualLeaderElection(c *C) {
 	// service with auto election should not support manual leader
 	err := s.client.Service("a").SetLeader("123")
-	c.Assert(err, NotNil)
-	c.Assert(err.(hh.JSONError).Code, Equals, hh.ValidationError)
+	c.Assert(hh.IsValidationError(err), Equals, true)
 
 	// create service with manual config
 	err = s.client.AddService("b", &discoverd.ServiceConfig{LeaderType: discoverd.LeaderTypeManual})

--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -430,7 +430,7 @@ func monitor(port host.Port, container *ContainerInit, env map[string]string, lo
 		// TODO: maybe reuse maybeAddService() from the client
 		log.Info("creating service")
 		if err := client.AddService(config.Name, nil); err != nil {
-			if je, ok := err.(hh.JSONError); !ok || je.Code != hh.ObjectExistsError {
+			if !hh.IsObjectExistsError(err) {
 				log.Error("error creating service", "err", err)
 				return nil, fmt.Errorf("something went wrong with discoverd: %s", err)
 			}

--- a/host/volume/api/http.go
+++ b/host/volume/api/http.go
@@ -52,28 +52,19 @@ func (api *HTTPAPI) CreateProvider(w http.ResponseWriter, r *http.Request, ps ht
 		pspec.ID = random.UUID()
 	}
 	if pspec.Kind == "" {
-		httphelper.Error(w, httphelper.JSONError{
-			Code:    httphelper.ValidationError,
-			Message: fmt.Sprintf("volume provider 'kind' field must not be blank"),
-		})
+		httphelper.ValidationError(w, "kind", "must not be blank")
 		return
 	}
 	provider, err := volumemanager.NewProvider(pspec)
 	if err == volume.UnknownProviderKind {
-		httphelper.Error(w, httphelper.JSONError{
-			Code:    httphelper.ValidationError,
-			Message: fmt.Sprintf("volume provider kind %q is not known", pspec.Kind),
-		})
+		httphelper.ValidationError(w, "kind", fmt.Sprintf("%q is not known", pspec.Kind))
 		return
 	}
 
 	if err := api.vman.AddProvider(pspec.ID, provider); err != nil {
 		switch err {
 		case volumemanager.ProviderAlreadyExists:
-			httphelper.Error(w, httphelper.JSONError{
-				Code:    httphelper.ObjectExistsError,
-				Message: fmt.Sprintf("provider %q already exists", pspec.ID),
-			})
+			httphelper.ObjectExistsError(w, fmt.Sprintf("provider %q already exists", pspec.ID))
 			return
 		default:
 			httphelper.Error(w, err)
@@ -89,10 +80,7 @@ func (api *HTTPAPI) Create(w http.ResponseWriter, r *http.Request, ps httprouter
 
 	vol, err := api.vman.NewVolumeFromProvider(providerID)
 	if err == volumemanager.NoSuchProvider {
-		httphelper.Error(w, httphelper.JSONError{
-			Code:    httphelper.ObjectNotFoundError,
-			Message: fmt.Sprintf("No volume provider by id %q", providerID),
-		})
+		httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume provider with id %q", providerID))
 		return
 	}
 
@@ -112,10 +100,7 @@ func (api *HTTPAPI) Inspect(w http.ResponseWriter, r *http.Request, ps httproute
 	volumeID := ps.ByName("volume_id")
 	vol := api.vman.GetVolume(volumeID)
 	if vol == nil {
-		httphelper.Error(w, httphelper.JSONError{
-			Code:    httphelper.ObjectNotFoundError,
-			Message: fmt.Sprintf("No volume by id %q", volumeID),
-		})
+		httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 		return
 	}
 
@@ -128,10 +113,7 @@ func (api *HTTPAPI) Destroy(w http.ResponseWriter, r *http.Request, ps httproute
 	if err != nil {
 		switch err {
 		case volumemanager.NoSuchVolume:
-			httphelper.Error(w, httphelper.JSONError{
-				Code:    httphelper.ObjectNotFoundError,
-				Message: fmt.Sprintf("No volume by id %q", volumeID),
-			})
+			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:
 			httphelper.Error(w, err)
@@ -148,10 +130,7 @@ func (api *HTTPAPI) Snapshot(w http.ResponseWriter, r *http.Request, ps httprout
 	if err != nil {
 		switch err {
 		case volumemanager.NoSuchVolume:
-			httphelper.Error(w, httphelper.JSONError{
-				Code:    httphelper.ObjectNotFoundError,
-				Message: fmt.Sprintf("No volume by id %q", volumeID),
-			})
+			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:
 			httphelper.Error(w, err)
@@ -202,10 +181,7 @@ func (api *HTTPAPI) Send(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	volumeID := ps.ByName("volume_id")
 
 	if !strings.Contains(r.Header.Get("Accept"), snapshotContentType) {
-		httphelper.Error(w, httphelper.JSONError{
-			Code:    httphelper.ValidationError,
-			Message: fmt.Sprintf("Must be prepared to accept a content type of %q", snapshotContentType),
-		})
+		httphelper.ValidationError(w, "", fmt.Sprintf("must be prepared to accept a content type of %q", snapshotContentType))
 		return
 	}
 	w.Header().Set("Content-Type", snapshotContentType)
@@ -220,10 +196,7 @@ func (api *HTTPAPI) Send(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	if err != nil {
 		switch err {
 		case volumemanager.NoSuchVolume:
-			httphelper.Error(w, httphelper.JSONError{
-				Code:    httphelper.ObjectNotFoundError,
-				Message: fmt.Sprintf("No volume by id %q", volumeID),
-			})
+			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:
 			httphelper.Error(w, err)

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -27,6 +27,9 @@ type Host interface {
 	// StopJob stops a running job.
 	StopJob(id string) error
 
+	// SignalJob sends a signal to a running job.
+	SignalJob(id string, sig int) error
+
 	// StreamEvents about job state changes to ch. id may be "all" or a single
 	// job ID.
 	StreamEvents(id string, ch chan<- *host.Event) (stream.Stream, error)
@@ -94,6 +97,10 @@ func (c *hostClient) GetJob(id string) (*host.ActiveJob, error) {
 
 func (c *hostClient) StopJob(id string) error {
 	return c.c.Delete(fmt.Sprintf("/host/jobs/%s", id))
+}
+
+func (c *hostClient) SignalJob(id string, sig int) error {
+	return c.c.Put(fmt.Sprintf("/host/jobs/%s/signal/%d", id, sig), nil, nil)
 }
 
 func (c *hostClient) StreamEvents(id string, ch chan<- *host.Event) (stream.Stream, error) {


### PR DESCRIPTION
Signalling a job can be achieved via the attach protocol but only when also requesting logs.

Sending a signal without requesting logs currently fails as the remote end hangs up the connection, but in this case establishing an attach connection is overkill, so I've added a simpler host API method.

I also refactored `pkg/httphelper` along the way.

Fixes #1196.