### PR TITLE
host/cli: Don't print error if logs do not exist

### DIFF
--- a/host/cli/upload-debug-info.go
+++ b/host/cli/upload-debug-info.go
@@ -44,7 +44,7 @@ func runUploadDebugInfo() error {
 	}
 
 	for name, filepath := range logs {
-		if err := gist.AddLocalFile(name, filepath); err != nil {
+		if err := gist.AddLocalFile(name, filepath); err != nil && !os.IsNotExist(err) {
 			log.Printf("error adding %s: %s", name, err)
 		}
 	}


### PR DESCRIPTION
Fixes #1215.