### PR TITLE
host/cli: Be more verbose in upload-debug-info

### DIFF
--- a/host/cli/gist.go
+++ b/host/cli/gist.go
@@ -5,8 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cheggaaa/pb"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 )
 
 type Gist struct {
@@ -29,31 +35,48 @@ func (g *Gist) AddFile(name, content string) {
 	g.Files[name] = File{Content: content}
 }
 
-func (g *Gist) Upload() error {
+func (g *Gist) Upload(log log15.Logger) error {
 	if len(g.Files) == 0 {
 		return errors.New("cannot create empty gist")
 	}
 
 	payload, err := json.Marshal(g)
 	if err != nil {
+		log.Error("error preparing gist content", "err", err)
 		return err
 	}
-	req, err := http.NewRequest("POST", "https://api.github.com/gists", bytes.NewReader(payload))
+	var body io.Reader = bytes.NewReader(payload)
+	if term.IsTerminal(os.Stderr.Fd()) {
+		bar := pb.New(len(payload))
+		bar.SetUnits(pb.U_BYTES)
+		bar.ShowSpeed = true
+		bar.Output = os.Stderr
+		bar.Start()
+		defer bar.Finish()
+		body = bar.NewProxyReader(body)
+	}
+	req, err := http.NewRequest("POST", "https://api.github.com/gists", body)
 	if err != nil {
+		log.Error("error preparing HTTP request", "err", err)
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
+	log.Info("creating anonymous gist")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
+		log.Error("error uploading gist content", "err", err)
 		return err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusCreated {
-		return fmt.Errorf("expected %d status, got %d", http.StatusCreated, res.StatusCode)
+		e := fmt.Sprintf("unexpected HTTP status: %d", res.StatusCode)
+		log.Error(e)
+		return errors.New(e)
 	}
 	if err := json.NewDecoder(res.Body).Decode(g); err != nil {
+		log.Error("error decoding HTTP response", "err", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Sample output (has colour in the terminal):

```
INFO[03-11|16:48:56] uploading logs and debug information to a private, anonymous gist 
INFO[03-11|16:48:56] this may take a while depending on the size of your logs 
INFO[03-11|16:48:56] getting flynn-host logs 
EROR[03-11|16:48:56] error getting flynn-host log "/var/log/upstart/flynn-host.log" err="open /var/log/upstart/flynn-host.log: no such file or directory"
INFO[03-11|16:48:56] getting job logs 
INFO[03-11|16:48:56] getting system information 
INFO[03-11|16:48:57] creating anonymous gist 
223.56 KB / 223.56 KB [===========================================================================================================] 100.00 % 51.57 KB/s 4s
INFO[03-11|16:49:01] debug information uploaded to: https://gist.github.com/12d294317f57028232f5
```

The error will be gone once #1218 is merged.

Fixes #1215.