### PR TITLE
host/cli: Optionally create tarball in upload-debug-info

### DIFF
--- a/docs/content/development.html.md
+++ b/docs/content/development.html.md
@@ -210,6 +210,21 @@ INFO[03-11|19:25:38] debug information uploaded to: https://gist.github.com/4737
 You can then post the gist in the `#flynn` IRC room when asking for assistance to make it easier for
 someone to help you.
 
+If you would rather not use the GitHub gist service, or your logs are too big to fit into a single gist,
+you can create a tarball of the information by specifying the `--tarball` flag:
+
+```
+$ flynn-host collect-debug-info --tarball
+INFO[03-11|19:28:58] creating a tarball containing logs and debug information
+INFO[03-11|19:28:58] this may take a while depending on the size of your logs
+INFO[03-11|19:28:58] getting flynn-host logs
+INFO[03-11|19:28:58] getting job logs
+INFO[03-11|19:28:58] getting system information
+INFO[03-11|19:28:59] created tarball containing debug information at /tmp/flynn-host-debug407848418/flynn-host-debug.tar.gz
+```
+
+You can then send this to a Flynn developer after speaking to them in IRC.
+
 ## Running tests
 
 Flynn has two types of tests:

--- a/docs/content/development.html.md
+++ b/docs/content/development.html.md
@@ -190,14 +190,21 @@ Assuming the app has name `example`:
 $ flynn-host ps | awk -F " {2,}" '$4=="example" {print $1}' | xargs flynn-host stop
 ```
 
-### upload logs and system information to a gist
+### upload logs and system information to a GitHub gist
 
 If you want to get help diagnosing issues on your system, run the following to upload some
-useful information to an anonymous gist:
+useful information to an anonymous GitHub gist:
 
 ```
-$ flynn-host upload-debug-info
-14:45:55.596680 upload-debug-info.go:69: Debug information uploaded to: https://gist.github.com/877117544439b0acaf0e
+$ flynn-host collect-debug-info
+INFO[03-11|19:25:29] uploading logs and debug information to a private, anonymous gist
+INFO[03-11|19:25:29] this may take a while depending on the size of your logs
+INFO[03-11|19:25:29] getting flynn-host logs
+INFO[03-11|19:25:29] getting job logs
+INFO[03-11|19:25:29] getting system information
+INFO[03-11|19:25:30] creating anonymous gist
+789.50 KB / 789.50 KB [=======================================================] 100.00 % 93.39 KB/s 8s
+INFO[03-11|19:25:38] debug information uploaded to: https://gist.github.com/47379bd4604442cac820
 ```
 
 You can then post the gist in the `#flynn` IRC room when asking for assistance to make it easier for

--- a/host/cli/cli.go
+++ b/host/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -29,6 +30,8 @@ func Register(cmd string, f interface{}, usage string) *command {
 
 var localAddr = "127.0.0.1:1113"
 
+var ErrInvalidCommand = errors.New("invalid command")
+
 func Run(name string, args []string) error {
 	argv := make([]string, 1, 1+len(args))
 	argv[0] = name
@@ -36,7 +39,7 @@ func Run(name string, args []string) error {
 
 	cmd, ok := commands[name]
 	if !ok {
-		return fmt.Errorf("%s is not a valid command", name)
+		return ErrInvalidCommand
 	}
 	parsedArgs, err := docopt.Parse(cmd.usage, argv, true, "", strings.Contains(cmd.usage, "[--]"))
 	if err != nil {

--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -30,13 +30,13 @@ var debugCmds = [][]string{
 }
 
 func init() {
-	Register("upload-debug-info", runUploadDebugInfo, `
-usage: flynn-host upload-debug-info
+	Register("collect-debug-info", runCollectDebugInfo, `
+usage: flynn-host collect-debug-info
 
-Upload debug information to an anonymous gist`)
+Collect debug information into an anonymous gist`)
 }
 
-func runUploadDebugInfo() error {
+func runCollectDebugInfo() error {
 	log := log15.New()
 	log.Info("uploading logs and debug information to a private, anonymous gist")
 	log.Info("this may take a while depending on the size of your logs")

--- a/host/host.go
+++ b/host/host.go
@@ -76,7 +76,7 @@ Commands:
   ps                         List jobs
   stop                       Stop running jobs
   destroy-volumes            Destroys the local volume database
-  collect-debug-info         Collect debug information into an anonymous gist
+  collect-debug-info         Collect debug information into an anonymous gist or tarball
   version                    Show current version
 
 See 'flynn-host help <command>' for more information on a specific command.

--- a/host/host.go
+++ b/host/host.go
@@ -121,6 +121,11 @@ See 'flynn-host help <command>' for more information on a specific command.
 	}
 
 	if err := cli.Run(cmd, cmdArgs); err != nil {
+		if err == cli.ErrInvalidCommand {
+			fmt.Printf("ERROR: %q is not a valid command\n\n", cmd)
+			fmt.Println(usage)
+			shutdown.ExitWithCode(1)
+		}
 		shutdown.Fatal(err)
 	}
 }

--- a/host/host.go
+++ b/host/host.go
@@ -76,7 +76,7 @@ Commands:
   ps                         List jobs
   stop                       Stop running jobs
   destroy-volumes            Destroys the local volume database
-  upload-debug-info          Upload debug information to an anonymous gist
+  collect-debug-info         Collect debug information into an anonymous gist
   version                    Show current version
 
 See 'flynn-host help <command>' for more information on a specific command.


### PR DESCRIPTION
This is useful if the logs are too big for a gist, or if the gist service is unavailable.

Closes #401.