### PR TITLE
test: Support assigning failed builds to GitHub issues

### DIFF
--- a/test/runner/assets/builds.js
+++ b/test/runner/assets/builds.js
@@ -1,3 +1,5 @@
+window.builds = {}
+
 $(function() {
   var lastID
   var count     = 10
@@ -26,6 +28,7 @@ $(function() {
 
     $.getJSON("/builds/", params, function(builds) {
       _.each(builds, function(build) {
+        window.builds[build.id] = build
         lastID = build.id
         build.created_at = moment(build.created_at)
         build.label_class = label_classes[build.state]
@@ -37,3 +40,10 @@ $(function() {
 
   window.fetch()
 })
+
+function showExplainModal(id) {
+  var build    = window.builds[id]
+  var template = _.template($("#explain-template").html())
+  var modal    = template(build)
+  $(modal).appendTo("body").modal()
+}

--- a/test/runner/assets/builds.js
+++ b/test/runner/assets/builds.js
@@ -26,11 +26,11 @@ $(function() {
 
     $.getJSON("/builds/", params, function(builds) {
       _.each(builds, function(build) {
-	lastID = build.id
-	build.created_at = moment(build.created_at)
-	build.label_class = label_classes[build.state]
-	var row = template(build)
-	tableBody.append(row)
+        lastID = build.id
+        build.created_at = moment(build.created_at)
+        build.label_class = label_classes[build.state]
+        var row = template(build)
+        tableBody.append(row)
       })
     })
   }

--- a/test/runner/assets/index.html
+++ b/test/runner/assets/index.html
@@ -27,6 +27,7 @@
             <th>Created</th>
             <th>Duration</th>
             <th>State</th>
+            <th>Reason</th>
             <th></th>
           </tr>
         </thead>
@@ -60,6 +61,17 @@
         </td>
         <td><span class="label <%= label_class %>"><%= state %></span></td>
         <td>
+          <% if(issue_link) { %>
+            <a href="<%= issue_link %>" class="btn btn-warning" target="_blank">
+              #<%= issue_link.split("/").pop() %>
+            </a>
+          <% } else if(reason) { %>
+            <span class="label label-reason"><%= reason %></span>
+          <% } else if(state == "failure") { %>
+            <a href="javascript:void(0)" class="btn btn-default" onclick="showExplainModal('<%= id %>')">Explain</a>
+          <% } %>
+        </td>
+        <td>
           <form action="/builds/<%= id %>/restart" method="POST">
             <button type="submit" class="btn btn-primary">
               <i class="fa fa-refresh"></i>
@@ -67,6 +79,43 @@
           </form>
         </td>
       </tr>
+    </script>
+
+    <script type="text/template" id="explain-template">
+      <div class="modal fade">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <form action="/builds/<%= id %>/explain" method="POST">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Explain Failure of <%= id %></h4>
+              </div>
+
+              <div class="modal-body">
+                <div class="radio">
+                  <label>
+                    <input type="radio" name="reason" value="expected">
+                    Expected build failure
+                  </label>
+                </div>
+
+                <div class="radio">
+                  <label>
+                    <input type="radio" name="reason" value="issue">
+                    Known GitHub issue
+                    <input type="text" name="issue-link" class="form-control" placeholder="GitHub issue link" width="100%">
+                  </label>
+                </div>
+              </div>
+
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="submit" class="btn btn-primary">Save</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </script>
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>

--- a/test/runner/assets/style.css
+++ b/test/runner/assets/style.css
@@ -6,3 +6,12 @@ p.more-btn {
   display: inline-block;
   padding: 9px 12px;
 }
+
+.label-reason {
+  background-color: #611BBD;
+}
+
+.modal label {
+  width: 100%;
+  padding: 10px 20px;
+}


### PR DESCRIPTION
We are getting a lot of failures in CI and it would be useful if some were marked as either expected (e.g. an expected error which happens locally) or linked to an existing failure via a GitHub issue.

Unexplained failures have a link:

![flynn-ci-explain-1](https://cloud.githubusercontent.com/assets/488515/6611199/a93111c2-c861-11e4-8aeb-023072114ecc.png)


Clicking the link shows a modal:

![flynn-ci-explain-2](https://cloud.githubusercontent.com/assets/488515/6611208/d8cda788-c861-11e4-9b1f-468303d9dffc.png)

Marking a failure as expected shows an "expected" label, and assigning an issue shows a button linking to the issue:

![flynn-ci-explain-3](https://cloud.githubusercontent.com/assets/488515/6611240/13af6e40-c862-11e4-959c-950849df14a8.png)