### PR TITLE
controller: Include host ID in job env FLYNN_JOB_ID

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -120,7 +120,7 @@ func (a *RunAppAction) Run(s *State) error {
 		sort.Sort(schedutil.HostSlice(hosts))
 		for i := 0; i < count; i++ {
 			hostID := hosts[i%len(hosts)].ID
-			config := utils.JobConfig(a.ExpandedFormation, typ)
+			config := utils.JobConfig(a.ExpandedFormation, typ, hostID)
 			if a.ExpandedFormation.Release.Processes[typ].Data {
 				if err := utils.ProvisionVolume(cc, hostID, config); err != nil {
 					return err
@@ -142,16 +142,9 @@ func startJob(s *State, hostID string, job *host.Job) (*Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	if hostID == "" {
-		hostID, err = randomHost(cc)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	// TODO: filter by tags
 
-	job.ID = cluster.RandomJobID("")
 	data := &Job{HostID: hostID, JobID: job.ID}
 
 	hc, err := cc.DialHost(hostID)

--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -763,8 +763,6 @@ func (f *Formation) restart(stoppedJob *Job) error {
 }
 
 func (f *Formation) start(typ string, hostID string) (job *Job, err error) {
-	config := f.jobConfig(typ)
-
 	hosts, err := f.c.ListHosts()
 	if err != nil {
 		return nil, err
@@ -796,6 +794,8 @@ func (f *Formation) start(typ string, hostID string) (job *Job, err error) {
 		sh.Sort()
 		h = sh[0].Host
 	}
+
+	config := f.jobConfig(typ, h.ID)
 
 	// Provision a data volume on the host if needed.
 	if f.Release.Processes[typ].Data {
@@ -872,12 +872,12 @@ func (f *Formation) remove(n int, name string, hostID string) {
 	}
 }
 
-func (f *Formation) jobConfig(name string) *host.Job {
+func (f *Formation) jobConfig(name string, hostID string) *host.Job {
 	return utils.JobConfig(&ct.ExpandedFormation{
 		App:      &ct.App{ID: f.AppID, Name: f.AppName},
 		Release:  f.Release,
 		Artifact: f.Artifact,
-	}, name)
+	}, name, hostID)
 }
 
 type sortHost struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flynn/flynn/pkg/cluster"
 )
 
-func JobConfig(f *ct.ExpandedFormation, name string) *host.Job {
+func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
 	t := f.Release.Processes[name]
 	env := make(map[string]string, len(f.Release.Env)+len(t.Env)+4)
 	for k, v := range f.Release.Env {
@@ -19,7 +19,7 @@ func JobConfig(f *ct.ExpandedFormation, name string) *host.Job {
 	env["FLYNN_APP_ID"] = f.App.ID
 	env["FLYNN_RELEASE_ID"] = f.Release.ID
 	env["FLYNN_PROCESS_TYPE"] = name
-	env["FLYNN_JOB_ID"] = id
+	env["FLYNN_JOB_ID"] = hostID + "-" + id
 	job := &host.Job{
 		ID: id,
 		Metadata: map[string]string{


### PR DESCRIPTION
Outside of flynn-host, job IDs must contain the host ID so that operations like attaching to the job know which host to dial.