### PR TITLE
script: Install linux-headers package before ubuntu-zfs

### DIFF
--- a/script/install-flynn.tmpl
+++ b/script/install-flynn.tmpl
@@ -56,6 +56,11 @@ main() {
   echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
   run apt-get update
 
+  # install linux-headers explicitly before ubuntu-zfs to avoid skipping
+  # building kernel modules due to absent kernel headers.
+  info "installing linux-headers"
+  run apt-get install -y "linux-headers-$(uname -r)"
+
   local packages=(
     "aufs-tools"
     "iptables"


### PR DESCRIPTION
ubuntu-zfs does not depend on linux-headers, but it needs the headers to compile the kernel modules, giving the following warning when absent:

```
Module build for the currently running kernel was skipped since the
kernel source for this kernel does not seem to be installed.
```

so install them explicitly first to ensure they are present when building the kernel modules.

Fixes #1231.