### PR TITLE
controller: Fix ignoring job event uniqueness errors

### DIFF
--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -84,9 +84,9 @@ func (r *JobRepo) Add(job *ct.Job) error {
 	// create a job event, ignoring possible duplications
 	err = r.db.Exec("INSERT INTO job_events (job_id, host_id, app_id, state) VALUES ($1, $2, $3, $4)", jobID, hostID, job.AppID, job.State)
 	if postgres.IsUniquenessError(err, "") {
-		return err
+		return nil
 	}
-	return nil
+	return err
 }
 
 func scanJob(s postgres.Scanner) (*ct.Job, error) {

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -57,6 +57,9 @@ func (s *S) TestJobStateTransition(c *C) {
 	job.State = "up"
 	c.Assert(s.c.PutJob(job), IsNil)
 
+	// duplicates are ignored
+	c.Assert(s.c.PutJob(job), IsNil)
+
 	job.State = "starting"
 	c.Assert(s.c.PutJob(job), ErrorMatches, ".*invalid job state transition.*")
 


### PR DESCRIPTION
This logic was broken in https://github.com/flynn/flynn/commit/bc37712.