### PR TITLE
CLI updates with TUF

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -316,23 +316,23 @@
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf/client",
-			"Rev": "e897c1d45b1dd430b064bcc6874bc2c3922cd248"
+			"Rev": "8652ae8af61522e0ec526fd1f151d239335cdf1b"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf/data",
-			"Rev": "e897c1d45b1dd430b064bcc6874bc2c3922cd248"
+			"Rev": "8652ae8af61522e0ec526fd1f151d239335cdf1b"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf/keys",
-			"Rev": "e897c1d45b1dd430b064bcc6874bc2c3922cd248"
+			"Rev": "8652ae8af61522e0ec526fd1f151d239335cdf1b"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf/signed",
-			"Rev": "e897c1d45b1dd430b064bcc6874bc2c3922cd248"
+			"Rev": "8652ae8af61522e0ec526fd1f151d239335cdf1b"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf/util",
-			"Rev": "e897c1d45b1dd430b064bcc6874bc2c3922cd248"
+			"Rev": "8652ae8af61522e0ec526fd1f151d239335cdf1b"
 		},
 		{
 			"ImportPath": "github.com/flynn/pq",

--- a/Godeps/_workspace/src/github.com/flynn/go-tuf/data/types.go
+++ b/Godeps/_workspace/src/github.com/flynn/go-tuf/data/types.go
@@ -102,9 +102,9 @@ func NewSnapshot() *Snapshot {
 type Hashes map[string]HexBytes
 
 type FileMeta struct {
-	Length int64           `json:"length"`
-	Hashes Hashes          `json:"hashes"`
-	Custom json.RawMessage `json:"custom,omitempty"`
+	Length int64            `json:"length"`
+	Hashes Hashes           `json:"hashes"`
+	Custom *json.RawMessage `json:"custom,omitempty"`
 }
 
 func (f FileMeta) HashAlgorithms() []string {

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,2 +1,3 @@
 cli
 bin/
+tuf.go

--- a/cli/Tupfile.lua
+++ b/cli/Tupfile.lua
@@ -1,17 +1,29 @@
 tup.export("GOPATH")
+tup.export("GIT_COMMIT")
+tup.export("GIT_BRANCH")
+tup.export("GIT_TAG")
+tup.export("GIT_DIRTY")
 
 tup.rule({"../util/rubyassetbuilder/*", "../util/cedarish/<docker>"},
           "^ docker build installer-builder^ cat ../log/docker-cedarish.log > /dev/null && ../util/rubyassetbuilder/build.sh image installer | tee %o",
           {"../log/docker-installer-builder.log", "<docker>"})
+
 tup.rule("go build -o ../installer/bin/go-bindata ../Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata",
           {"../installer/bin/go-bindata"})
+
 tup.rule({"../installer/bin/go-bindata", "../log/docker-installer-builder.log"},
           "../util/rubyassetbuilder/build.sh app installer",
           {"../installer/bindata.go"})
+
+tup.rule({"tuf.go.tmpl"},
+         "cat %f | sed 's|{{TUF-ROOT-KEYS}}|@(TUF_ROOT_KEYS)|' | sed 's|{{TUF-REPO}}|@(IMAGE_REPOSITORY)|' > %o",
+         {"tuf.go"})
+
+vpkg = "github.com/flynn/flynn/pkg/version"
 for i, os in ipairs({"darwin", "linux"}) do
   for j, arch in ipairs({"amd64", "386"}) do
-    tup.rule({"../installer/bindata.go", "../util/release/flynn-release"},
-             "^c go build %o^ GOOS="..os.." GOARCH="..arch.." ../util/_toolchain/go/bin/go build -o %o",
+    tup.rule({"../installer/bindata.go", "../util/release/flynn-release", "tuf.go"},
+             "^c go build %o^ GOOS="..os.." GOARCH="..arch.." ../util/_toolchain/go/bin/go build -o %o -ldflags=\"-X "..vpkg..".commit $GIT_COMMIT -X "..vpkg..".branch $GIT_BRANCH -X "..vpkg..".tag $GIT_TAG -X "..vpkg..".dirty $GIT_DIRTY\"",
              {string.format("bin/flynn-%s-%s", os, arch)})
   end
 end

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -1,9 +1,0 @@
-// +build !release
-
-package main
-
-const (
-	Version = "dev"
-)
-
-var updater *Updater

--- a/cli/main.go
+++ b/cli/main.go
@@ -18,6 +18,7 @@ import (
 	cfg "github.com/flynn/flynn/cli/config"
 	"github.com/flynn/flynn/controller/client"
 	"github.com/flynn/flynn/pkg/shutdown"
+	"github.com/flynn/flynn/pkg/version"
 )
 
 var (
@@ -61,7 +62,7 @@ Commands:
 
 See 'flynn help <command>' for more information on a specific command.
 `[1:]
-	args, _ := docopt.Parse(usage, nil, true, Version, true)
+	args, _ := docopt.Parse(usage, nil, true, version.String(), true)
 
 	cmd := args.String["<command>"]
 	cmdArgs := args.All["<args>"].([]string)
@@ -90,9 +91,11 @@ See 'flynn help <command>' for more information on a specific command.
 	// Run the update command as early as possible to avoid the possibility of
 	// installations being stranded without updates due to errors in other code
 	if cmd == "update" {
-		runUpdate(cmdArgs)
+		if err := runUpdate(); err != nil {
+			shutdown.Fatal(err)
+		}
 		return
-	} else if updater != nil {
+	} else {
 		defer updater.backgroundRun() // doesn't run if os.Exit is called
 	}
 

--- a/cli/tuf.go.tmpl
+++ b/cli/tuf.go.tmpl
@@ -1,0 +1,12 @@
+package main
+
+import "encoding/json"
+
+func init() {
+	updater = &Updater{
+		repo: "{{TUF-REPO}}",
+	}
+	if err := json.Unmarshal([]byte(`{{TUF-ROOT-KEYS}}`), &updater.rootKeys); err != nil {
+		panic("error decoding root keys")
+	}
+}

--- a/cli/update.go
+++ b/cli/update.go
@@ -83,7 +83,11 @@ func (u *Updater) update() error {
 	if err != nil {
 		return err
 	}
-	remote, err := tuf.HTTPRemoteStore(u.repo, nil)
+	plat := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
+	opts := &tuf.HTTPRemoteOptions{
+		UserAgent: fmt.Sprintf("flynn-cli/%s %s", version.String(), plat),
+	}
+	remote, err := tuf.HTTPRemoteStore(u.repo, opts)
 	if err != nil {
 		return err
 	}
@@ -96,7 +100,7 @@ func (u *Updater) update() error {
 		return err
 	}
 
-	name := fmt.Sprintf("/flynn-%s-%s.gz", runtime.GOOS, runtime.GOARCH)
+	name := fmt.Sprintf("/flynn-%s.gz", plat)
 	target, ok := targets[name]
 	if !ok {
 		return fmt.Errorf("missing %q in tuf targets", name)

--- a/cli/update.go
+++ b/cli/update.go
@@ -3,96 +3,67 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"time"
 
+	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
+	tufdata "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/data"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/inconshreveable/go-update"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kardianos/osext"
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kr/binarydist"
 	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/version"
 )
 
-func runUpdate(args []string) error {
-	if updater == nil {
+const upcktimePath = "cktime"
+
+var updateDir = filepath.Join(homedir(), ".flynn", "update")
+var updater *Updater
+
+func runUpdate() error {
+	if updater == nil || !version.Tagged() {
 		return errors.New("Dev builds don't support auto-updates")
 	}
 	return updater.update()
 }
 
-const (
-	upcktimePath = "cktime"
-	plat         = runtime.GOOS + "-" + runtime.GOARCH
-)
-
-var ErrHashMismatch = errors.New("new file hash mismatch after patch")
-
-// Update protocol.
-//
-//   GET https://cli.flynn.io/flynn/current/linux-amd64.json
-//
-//   200 ok
-//   {
-//       "Version": "2",
-//       "Sha256": "..." // base64
-//   }
-//
-// then
-//
-//   GET https://flynn-cli-patch.s3.amazonaws.com/flynn/1/2/linux-amd64
-//
-//   200 ok
-//   [bsdiff data]
-//
-// or
-//
-//   GET https://flynn-cli-dist.s3.amazonaws.com/flynn/2/linux-amd64.gz
-//
-//   200 ok
-//   [gzipped executable data]
 type Updater struct {
-	apiURL  string
-	cmdName string
-	binURL  string
-	diffURL string
-	dir     string
-	info    struct {
-		Version string
-		Sha256  []byte
-	}
+	repo     string
+	rootKeys []*tufdata.Key
 }
 
 func (u *Updater) backgroundRun() {
-	os.MkdirAll(u.dir, 0777)
-	if u.wantUpdate() {
-		self, err := osext.Executable()
-		if err != nil {
-			// fail update, couldn't figure out path to self
-			return
-		}
-		// TODO(bgentry): logger isn't on Windows. Replace w/ proper error reports.
-		l := exec.Command("logger", "-tflynn")
-		c := exec.Command(self, "update")
-		if w, err := l.StdinPipe(); err == nil && l.Start() == nil {
-			c.Stdout = w
-			c.Stderr = w
-		}
-		c.Start()
+	if u == nil {
+		return
 	}
+	if !u.wantUpdate() {
+		return
+	}
+	self, err := osext.Executable()
+	if err != nil {
+		// fail update, couldn't figure out path to self
+		return
+	}
+	// TODO(titanous): logger isn't on Windows. Replace with proper error reports.
+	l := exec.Command("logger", "-tflynn")
+	c := exec.Command(self, "update")
+	if w, err := l.StdinPipe(); err == nil && l.Start() == nil {
+		c.Stdout = w
+		c.Stderr = w
+	}
+	c.Start()
 }
 
 func (u *Updater) wantUpdate() bool {
-	path := u.dir + upcktimePath
-	if Version == "dev" || readTime(path).After(time.Now()) {
+	path := filepath.Join(updateDir, upcktimePath)
+	if !version.Tagged() || readTime(path).After(time.Now()) {
 		return false
 	}
 	wait := 12*time.Hour + randDuration(8*time.Hour)
@@ -100,147 +71,89 @@ func (u *Updater) wantUpdate() bool {
 }
 
 func (u *Updater) update() error {
-	path, err := osext.Executable()
-	if err != nil {
+	up := update.New()
+	if err := up.CanUpdate(); err != nil {
 		return err
 	}
-	old, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer old.Close()
 
-	err = u.fetchInfo()
+	if err := os.MkdirAll(updateDir, 0755); err != nil {
+		return err
+	}
+	local, err := tuf.FileLocalStore(filepath.Join(updateDir, "tuf.db"))
 	if err != nil {
 		return err
 	}
-	if u.info.Version == Version {
+	remote, err := tuf.HTTPRemoteStore(u.repo, nil)
+	if err != nil {
+		return err
+	}
+	client := tuf.NewClient(local, remote)
+	if err := u.updateTUFClient(client); err != nil {
+		return err
+	}
+	targets, err := client.Targets()
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("/flynn-%s-%s.gz", runtime.GOOS, runtime.GOARCH)
+	target, ok := targets[name]
+	if !ok {
+		return fmt.Errorf("missing %q in tuf targets", name)
+	}
+	if target.Custom == nil || len(*target.Custom) == 0 {
+		return errors.New("missing custom metadata in tuf target")
+	}
+	var data struct {
+		Version string
+	}
+	json.Unmarshal(*target.Custom, &data)
+	if data.Version == "" {
+		return errors.New("missing version in tuf target")
+	}
+	if data.Version == version.String() {
 		return nil
 	}
-	bin, err := u.fetchAndVerifyPatch(old)
+
+	bin := &tufBuffer{}
+	if err := client.Download(name, bin); err != nil {
+		return err
+	}
+	gr, err := gzip.NewReader(bin)
 	if err != nil {
-		switch err {
-		case ErrNoPatchAvailable:
-			log.Println("update: no patch available, falling back to full binary")
-		case ErrHashMismatch:
-			log.Println("update: hash mismatch from patched binary")
-		default:
-			log.Println("update: patching binary,", err)
-		}
-		bin, err = u.fetchAndVerifyFullBin()
-		if err != nil {
-			if err == ErrHashMismatch {
-				log.Println("update: hash mismatch from full binary")
-			} else {
-				log.Println("update: fetching full binary,", err)
-			}
-			return err
-		}
+		return err
 	}
 
-	// close the old binary before installing because on windows
-	// it can't be renamed if a handle to the file is still open
-	old.Close()
-
-	err, errRecover := update.New().FromStream(bytes.NewBuffer(bin))
+	err, errRecover := up.FromStream(gr)
 	if errRecover != nil {
 		return fmt.Errorf("update and recovery errors: %q %q", err, errRecover)
 	}
 	if err != nil {
 		return err
 	}
-	log.Printf("Updated v%s -> v%s.", Version, u.info.Version)
+	log.Printf("Updated %s -> %s.", version.String(), data.Version)
 	return nil
 }
 
-func (u *Updater) fetchInfo() error {
-	r, err := fetch(u.apiURL + u.cmdName + "/current/" + plat + ".json")
-	if err != nil {
-		return err
+// updateTUFClient updates the given client, initializing and re-running the
+// update if ErrNoRootKeys is returned.
+func (u *Updater) updateTUFClient(client *tuf.Client) error {
+	_, err := client.Update()
+	if err == nil || tuf.IsLatestSnapshot(err) {
+		return nil
 	}
-	defer r.Close()
-	err = json.NewDecoder(r).Decode(&u.info)
-	if err != nil {
-		return err
+	if err == tuf.ErrNoRootKeys {
+		if err := client.Init(u.rootKeys, len(u.rootKeys)); err != nil {
+			return err
+		}
+		return u.updateTUFClient(client)
 	}
-	if len(u.info.Sha256) != sha256.Size {
-		return errors.New("bad cmd hash in info")
-	}
-	return nil
-}
-
-func (u *Updater) fetchAndVerifyPatch(old io.Reader) ([]byte, error) {
-	bin, err := u.fetchAndApplyPatch(old)
-	if err != nil {
-		return nil, err
-	}
-	if !verifySha(bin, u.info.Sha256) {
-		return nil, ErrHashMismatch
-	}
-	return bin, nil
-}
-
-func (u *Updater) fetchAndApplyPatch(old io.Reader) ([]byte, error) {
-	r, err := fetch(u.diffURL + u.cmdName + "/" + Version + "/" + u.info.Version + "/" + plat)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	var buf bytes.Buffer
-	err = binarydist.Patch(old, &buf, r)
-	return buf.Bytes(), err
-}
-
-func (u *Updater) fetchAndVerifyFullBin() ([]byte, error) {
-	bin, err := u.fetchBin()
-	if err != nil {
-		return nil, err
-	}
-	verified := verifySha(bin, u.info.Sha256)
-	if !verified {
-		return nil, ErrHashMismatch
-	}
-	return bin, nil
-}
-
-func (u *Updater) fetchBin() ([]byte, error) {
-	r, err := fetch(u.binURL + u.cmdName + "/" + u.info.Version + "/" + plat + ".gz")
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	buf := new(bytes.Buffer)
-	gz, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, err
-	}
-	if _, err = io.Copy(buf, gz); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return err
 }
 
 // returns a random duration in [0,n).
 func randDuration(n time.Duration) time.Duration {
 	return time.Duration(random.Math.Int63n(int64(n)))
-}
-
-var ErrNoPatchAvailable = errors.New("no patch available")
-
-func fetch(url string) (io.ReadCloser, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	switch resp.StatusCode {
-	case 200:
-		return resp.Body, nil
-	case 401, 403, 404:
-		return nil, ErrNoPatchAvailable
-	default:
-		return nil, fmt.Errorf("bad http status from %s: %v", url, resp.Status)
-	}
 }
 
 func readTime(path string) time.Time {
@@ -258,12 +171,15 @@ func readTime(path string) time.Time {
 	return t
 }
 
-func verifySha(bin []byte, sha []byte) bool {
-	h := sha256.New()
-	h.Write(bin)
-	return bytes.Equal(h.Sum(nil), sha)
-}
-
 func writeTime(path string, t time.Time) bool {
 	return ioutil.WriteFile(path, []byte(t.Format(time.RFC3339)), 0644) == nil
+}
+
+type tufBuffer struct {
+	bytes.Buffer
+}
+
+func (b *tufBuffer) Delete() error {
+	b.Reset()
+	return nil
 }

--- a/cli/version.go
+++ b/cli/version.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/flynn/flynn/pkg/version"
 )
 
 func init() {
@@ -13,5 +15,5 @@ Show flynn version string.
 }
 
 func runVersion() {
-	fmt.Println(Version)
+	fmt.Println(version.String())
 }

--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	tuf "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-tuf/client"
 	"github.com/flynn/flynn/pinkerton"
 	"github.com/flynn/flynn/pkg/tufutil"
+	"github.com/flynn/flynn/pkg/version"
 )
 
 func init() {
@@ -39,7 +41,7 @@ func runDownload(args *docopt.Args) error {
 	if err != nil {
 		return err
 	}
-	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], nil)
+	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], tufHTTPOpts("downloader"))
 	if err != nil {
 		return err
 	}
@@ -83,6 +85,12 @@ func runDownload(args *docopt.Args) error {
 		}
 	}
 	return nil
+}
+
+func tufHTTPOpts(name string) *tuf.HTTPRemoteOptions {
+	return &tuf.HTTPRemoteOptions{
+		UserAgent: fmt.Sprintf("flynn-host/%s %s-%s %s", version.String(), runtime.GOOS, runtime.GOARCH, name),
+	}
 }
 
 func downloadGzippedFile(client *tuf.Client, path, dir string) (string, error) {

--- a/host/cli/update.go
+++ b/host/cli/update.go
@@ -41,7 +41,7 @@ func runUpdate(args *docopt.Args) error {
 		log.Error("error creating local TUF client", "err", err)
 		return err
 	}
-	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], nil)
+	remote, err := tuf.HTTPRemoteStore(args.String["--repository"], tufHTTPOpts("updater"))
 	if err != nil {
 		log.Error("error creating remote TUF client", "err", err)
 		return err

--- a/pinkerton/context.go
+++ b/pinkerton/context.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/daemon/graphdriver"
@@ -20,6 +21,7 @@ import (
 	"github.com/flynn/flynn/pinkerton/registry"
 	"github.com/flynn/flynn/pinkerton/store"
 	"github.com/flynn/flynn/pkg/tufutil"
+	"github.com/flynn/flynn/pkg/version"
 )
 
 func init() {
@@ -174,7 +176,10 @@ func PullImages(tufDB, repository, driver, root string, progress chan<- layer.Pu
 	if err != nil {
 		return err
 	}
-	remote, err := tuf.HTTPRemoteStore(repository, nil)
+	opts := &tuf.HTTPRemoteOptions{
+		UserAgent: fmt.Sprintf("pinkerton/%s %s-%s pull", version.String(), runtime.GOOS, runtime.GOARCH),
+	}
+	remote, err := tuf.HTTPRemoteStore(repository, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,11 +8,15 @@ func String() string {
 	if commit == "" {
 		return "dev"
 	}
-	if tag != "none" && dirty == "false" {
+	if Tagged() {
 		return tag
 	}
 	if dirty == "true" {
 		commit += "+"
 	}
 	return fmt.Sprintf("%s (%s)", commit, branch)
+}
+
+func Tagged() bool {
+	return tag != "none" && dirty == "false"
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,7 +5,7 @@ import "fmt"
 var commit, branch, tag, dirty string
 
 func String() string {
-	if commit == "" {
+	if commit == "" || commit == "dev" {
 		return "dev"
 	}
 	if Tagged() {

--- a/script/export-components
+++ b/script/export-components
@@ -28,18 +28,25 @@ main() {
   fi
 
   local tuf_dir=$1
-
   cd "${tuf_dir}"
+
   tuf clean
   cp "${ROOT}/host/bin/flynn-host.gz"                      "staged/targets/flynn-host.gz"
   gzip -9 --stdout "${ROOT}/host/bin/flynn-init"         > "staged/targets/flynn-init.gz"
-  gzip -9 --stdout "${ROOT}/cli/bin/flynn"               > "staged/targets/flynn-linux-amd64.gz"
   gzip -9 --stdout "${ROOT}/host/upstart.conf"           > "staged/targets/upstart.conf.gz"
   gzip -9 --stdout "${ROOT}/host/bin/manifest.json"      > "staged/targets/host-manifest.json.gz"
   gzip -9 --stdout "${ROOT}/bootstrap/bin/manifest.json" > "staged/targets/bootstrap-manifest.json.gz"
   gzip -9 --stdout "${ROOT}/version.json"                > "staged/targets/version.json.gz"
   "${ROOT}/util/release/flynn-release" export "${ROOT}/version.json" "staged/targets"
   tuf add
+
+  local version=$("${ROOT}/cli/bin/flynn" version)
+  for f in ${ROOT}/cli/bin/flynn-{linux,darwin}-{amd64,386}; do
+    local name="$(basename "${f}").gz"
+    gzip -9 --stdout "${f}" > "staged/targets/${name}"
+    tuf add --custom="{\"version\": \"${version}\"}" "${name}"
+  done
+
   tuf snapshot
   tuf timestamp
   tuf commit

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -50,7 +50,7 @@ src="${GOPATH}/src/github.com/flynn/flynn"
   pushd "${src}" >/dev/null
   sed "s/{{TUF-ROOT-KEYS}}/$(tuf --dir test/release root-keys)/g" host/cli/root_keys.go.tmpl > host/cli/root_keys.go
   vpkg="github.com/flynn/flynn/pkg/version"
-  go build -o host/bin/flynn-host -ldflags="-X ${vpkg}.commit dev -X ${vpkg}.branch dev -X ${vpkg}.tag v20150131.0-test -X ${vpkg}.dirty false" ./host
+  go build -o host/bin/flynn-host -ldflags="-X ${vpkg}.commit notdev -X ${vpkg}.branch dev -X ${vpkg}.tag v20150131.0-test -X ${vpkg}.dirty false" ./host
   gzip -9 --keep --force host/bin/flynn-host
   sed "s/{{FLYNN-HOST-CHECKSUM}}/$(sha512sum host/bin/flynn-host.gz | cut -d " " -f 1)/g" script/install-flynn.tmpl > script/install-flynn
 


### PR DESCRIPTION
This removes the old distribution toolchain inherited from hk and replaces it with an updater that uses TUF. The same TUF repo that is used to distribute the rest of the container images and binaries is used.

`script/export-components` is updated to add the cross-compiled flynn CLI binaries to the repo tagged with their version. The CLI will be released and versioned as part of the nightly build process instead of using a separate version tag and build system.

Closes #1087 

**TODO**

- [x] Set `User-Agent` for flynn-host and flynn-cli TUF clients
- [ ] Implement redirect server and replace CLI installation snippets in docs
