### PR TITLE
appliance/etcd: Bump to v2.0.5

### DIFF
--- a/appliance/etcd/build.sh
+++ b/appliance/etcd/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-version=2.0.3
+version=2.0.5
 tmpdir=$(mktemp --directory)
 pkg="etcd-v${version}-linux-amd64"
 


### PR DESCRIPTION
https://github.com/coreos/etcd/compare/v2.0.3...v2.0.5

This may fix i/o timeout errors: https://github.com/coreos/etcd/issues/2338