### PR TITLE
cli: Fix example image URI

### DIFF
--- a/cli/release.go
+++ b/cli/release.go
@@ -47,7 +47,7 @@ Examples:
 			}
 		}
 	}
-	$ flynn release add -f config.json https://registry.hub.docker.com/flynn/slugbuilder?id=15d72b7f573b
+	$ flynn release add -f config.json https://registry.hub.docker.com?name=flynn/slugbuilder&id=15d72b7f573b
 	Created release f55fde802170.
 `)
 }


### PR DESCRIPTION
Image URIs must contain a `name` parameter.