### PR TITLE
test: Remove unnecessary scale after git push

### DIFF
--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -119,9 +119,8 @@ func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []strin
 	t.Assert(push, Succeeds)
 	t.Assert(push, OutputContains, "Creating release")
 	t.Assert(push, OutputContains, "Application deployed")
+	t.Assert(push, OutputContains, "Added default web=1 formation")
 	t.Assert(push, OutputContains, "* [new branch]      master -> master")
-
-	t.Assert(r.flynn("scale", "web=1"), Succeeds)
 
 	route := name + ".dev"
 	newRoute := r.flynn("route", "add", "http", route)

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -111,16 +111,19 @@ func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []strin
 
 	t.Assert(r.flynn("create", name), Outputs, fmt.Sprintf("Created %s\n", name))
 
-	for _, resource := range resources {
-		t.Assert(r.flynn("resource", "add", resource), Succeeds)
-	}
-
 	push := r.git("push", "flynn", "master")
 	t.Assert(push, Succeeds)
 	t.Assert(push, OutputContains, "Creating release")
 	t.Assert(push, OutputContains, "Application deployed")
 	t.Assert(push, OutputContains, "Added default web=1 formation")
 	t.Assert(push, OutputContains, "* [new branch]      master -> master")
+
+	// Although not adding the resource before the deploy will result in an
+	// initially crashing release, add it after the git push so that the
+	// initial release gets a default web=1 formation from the receiver.
+	for _, resource := range resources {
+		t.Assert(r.flynn("resource", "add", resource), Succeeds)
+	}
 
 	route := name + ".dev"
 	newRoute := r.flynn("route", "add", "http", route)


### PR DESCRIPTION
The receiver already adds a `web=1` formation, so the scale command after the push always exits with `requested scale equals current scale, nothing to do!`.