### PR TITLE
logaggregator: register one discoverd service

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -276,7 +276,7 @@ func runDaemon(args *docopt.Args) {
 	}
 	shutdown.BeforeExit(func() { hb.Close() })
 
-	if err := mux.Connect(disc, "flynn-logaggregator-syslog"); err != nil {
+	if err := mux.Connect(disc, "flynn-logaggregator"); err != nil {
 		shutdown.Fatal(err)
 	}
 	shutdown.BeforeExit(func() { mux.Close() })

--- a/logaggregator/client/client.go
+++ b/logaggregator/client/client.go
@@ -44,7 +44,7 @@ func New(uri string) (Client, error) {
 // NewClient creates a new Client pointing at uri with the specified http client.
 func NewWithHTTP(uri string, httpClient *http.Client) (Client, error) {
 	if uri == "" {
-		uri = "http://flynn-logaggregator-api.discoverd"
+		uri = "http://flynn-logaggregator.discoverd"
 	}
 	u, err := url.Parse(uri)
 	if err != nil {

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -41,17 +41,11 @@ func main() {
 		shutdown.Fatal(err)
 	}
 
-	services := map[string]string{
-		"flynn-logaggregator-api":    *apiAddr,
-		"flynn-logaggregator-syslog": *logAddr,
+	hb, err := discoverd.AddServiceAndRegister("flynn-logaggregator", *logAddr)
+	if err != nil {
+		shutdown.Fatal(err)
 	}
-	for service, addr := range services {
-		hb, err := discoverd.AddServiceAndRegister(service, addr)
-		if err != nil {
-			shutdown.Fatal(err)
-		}
-		shutdown.BeforeExit(func() { hb.Close() })
-	}
+	shutdown.BeforeExit(func() { hb.Close() })
 
 	shutdown.Fatal(http.Serve(listener, apiHandler(a)))
 }


### PR DESCRIPTION
The logaggregator server listens on two ports, but only registers a single discoverd service for the syslog port. The api port should be inferred by the client.