### PR TITLE
test: Wrap interactive job in timeout

### DIFF
--- a/test/test_host.go
+++ b/test/test_host.go
@@ -50,14 +50,14 @@ func (s *HostSuite) TestAttachFinishedInteractiveJob(t *c.C) {
 
 	// Getting the logs for the job should fail, as it has none because it was
 	// interactive
-	done := make(chan struct{})
+	attachErr := make(chan error)
 	go func() {
 		_, err = h.Attach(&host.AttachReq{JobID: cmd.Job.ID, Flags: host.AttachFlagLogs}, false)
-		t.Assert(err, c.NotNil)
-		close(done)
+		attachErr <- err
 	}()
 	select {
-	case <-done:
+	case err := <-attachErr:
+		t.Assert(err, c.NotNil)
 	case <-time.After(time.Second):
 		t.Error("timed out waiting for attach")
 	}


### PR DESCRIPTION
The job started by `TestAttachFinishedInteractiveJob` hung in the following CI failure:

https://ci.flynn.io/builds/20150314222600-99faafa7

```
goroutine 135 [chan receive, 19 minutes]:
github.com/flynn/flynn/pkg/exec.(*Cmd).Wait(0xc2080fa000, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/flynn/flynn/pkg/exec/exec.go:286 +0x265
github.com/flynn/flynn/pkg/exec.(*Cmd).Run(0xc2080fa000, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/flynn/flynn/pkg/exec/exec.go:315 +0x71
main.(*HostSuite).TestAttachFinishedInteractiveJob(0xc20802e660, 0xc208358960)
        /home/ubuntu/go/src/github.com/flynn/flynn/test/test_host.go:45 +0x28c
```