### PR TITLE
all: Use new redirect endpoint for CLI download

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,7 @@ available.
 To install a pre-built binary release, run the following one-liner:
 
 ```bash
-L=/usr/local/bin/flynn && curl -sL -A "`uname -sp`" https://cli.flynn.io/flynn.gz | zcat >$L && chmod +x $L
+L=/usr/local/bin/flynn && curl -sL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >$L && chmod +x $L
 ```
 
 ## Usage

--- a/docs/content/installation.html.md
+++ b/docs/content/installation.html.md
@@ -9,7 +9,7 @@ Before starting, you should install the Flynn command-line interface by running
 this command:
 
 ```bash
-L=/usr/local/bin/flynn && curl -sL -A "`uname -sp`" https://cli.flynn.io/flynn.gz | zcat >$L && chmod +x $L
+L=/usr/local/bin/flynn && curl -sL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >$L && chmod +x $L
 ```
 
 If you want to run Flynn on your local machine, the easiest way is to install the

--- a/test/README.md
+++ b/test/README.md
@@ -62,7 +62,7 @@ The tests interact with the VM cluster using the Flynn CLI, so you will need it 
 Download it into the current directory:
 
 ```text
-curl -sL -A "`uname -sp`" https://cli.flynn.io/flynn.gz | zcat >flynn
+curl -sL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >flynn
 chmod +x flynn
 ```
 


### PR DESCRIPTION
The `cli.flynn.io` server is deprecated and will serve one last update, the first release of the CLI with the TUF updater. A new redirect endpoint is provisioned at `https://dl.flynn.io/cli` that serves the same function and reads from the TUF repo.

Refs #1250