### PR TITLE
test: Defer pipe close in TestReleaseImages

### DIFF
--- a/test/test_release.go
+++ b/test/test_release.go
@@ -103,14 +103,15 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 
 	// stream script output to t.Log
 	logReader, logWriter := io.Pipe()
+	defer logWriter.Close()
 	go func() {
 		buf := bufio.NewReader(logReader)
 		for {
 			line, err := buf.ReadString('\n')
-			debug(t, line[0:len(line)-1])
 			if err != nil {
 				return
 			}
+			debug(t, line[0:len(line)-1])
 		}
 	}()
 


### PR DESCRIPTION
Otherwise the goroutine sticks around for no reason.