### PR TITLE
slugrunner: Fix command quoting

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -51,7 +51,7 @@ case "$1" in
     fi
     ;;
   *)
-    command="$@"
+    printf -v command " %q" "$@"
     ;;
 esac
 

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -160,3 +160,13 @@ func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []strin
 
 	t.Assert(r.flynn("scale", "web=0"), Succeeds)
 }
+
+func (s *GitDeploySuite) TestRunQuoting(t *c.C) {
+	r := s.newGitRepo(t, "empty")
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.git("push", "flynn", "master"), Succeeds)
+
+	run := r.flynn("run", "bash", "-c", "echo 'foo bar'")
+	t.Assert(run, Succeeds)
+	t.Assert(run, Outputs, "foo bar\n")
+}


### PR DESCRIPTION
This fixes running commands with simple quoting and spaces like:

    flynn run bash -c "echo 'foo bar'"

I have not tested more advanced cases, as I suspect that this is good enough for the majority of use cases (even this does much quoting does not work on Heroku).

The leading space in the `printf` format string is necessary for some unknown reason that I didn't track down.

The test is in the git deploy suite because it requires an SSH key to be set up and we don't use git anywhere else in the test suite.

Closes #656