### PR TITLE
util/release: Move manifest types into separate package

### DIFF
--- a/cli/Tupfile.lua
+++ b/cli/Tupfile.lua
@@ -22,7 +22,7 @@ tup.rule({"tuf.go.tmpl"},
 vpkg = "github.com/flynn/flynn/pkg/version"
 for i, os in ipairs({"darwin", "linux"}) do
   for j, arch in ipairs({"amd64", "386"}) do
-    tup.rule({"../installer/bindata.go", "../util/release/flynn-release", "tuf.go"},
+    tup.rule({"../installer/bindata.go", "tuf.go"},
              "^c go build %o^ GOOS="..os.." GOARCH="..arch.." ../util/_toolchain/go/bin/go build -o %o -ldflags=\"-X "..vpkg..".commit $GIT_COMMIT -X "..vpkg..".branch $GIT_BRANCH -X "..vpkg..".tag $GIT_TAG -X "..vpkg..".dirty $GIT_DIRTY\"",
              {string.format("bin/flynn-%s-%s", os, arch)})
   end

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -25,7 +25,7 @@ import (
 	cfg "github.com/flynn/flynn/cli/config"
 	"github.com/flynn/flynn/pkg/etcdcluster"
 	"github.com/flynn/flynn/pkg/sshkeygen"
-	release "github.com/flynn/flynn/util/release"
+	"github.com/flynn/flynn/util/release/types"
 )
 
 type Event struct {

--- a/util/release/amis.go
+++ b/util/release/amis.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"log"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/aws"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cupcake/goamz/ec2"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/util/release/types"
 )
 
 func amis(args *docopt.Args) {
@@ -18,7 +18,7 @@ func amis(args *docopt.Args) {
 		log.Fatal(err)
 	}
 
-	manifest := &EC2Manifest{}
+	manifest := &release.EC2Manifest{}
 
 	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
 		log.Fatal(err)
@@ -45,7 +45,7 @@ func amis(args *docopt.Args) {
 			log.Fatalln("Could not determine RootDeviceSnapshotID for", regionID[1])
 		}
 
-		manifest.Add(args.String["<version>"], &EC2Image{
+		manifest.Add(args.String["<version>"], &release.EC2Image{
 			ID:                   image.Id,
 			Name:                 image.Name,
 			Region:               regionID[0],
@@ -62,74 +62,4 @@ func amis(args *docopt.Args) {
 	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
 		log.Fatal(err)
 	}
-}
-
-type EC2Manifest struct {
-	Name     string        `json:"name"`
-	Versions []*EC2Version `json:"versions"`
-}
-
-// Add adds an image to the manifest.
-//
-// If the version is already in the manifest, the given image either
-// replaces any existing image with the same region, or is appended to
-// the existing list of images for that version.
-//
-// If the version is not already in the manifest a new version is added
-// containing the image.
-//
-// The number of versions in the manifest is capped at the value of maxVersions.
-func (m *EC2Manifest) Add(version string, image *EC2Image) {
-	versions := make(sortVersions, 0, len(m.Versions)+1)
-	for _, v := range m.Versions {
-		if v.version() == version {
-			images := make([]*EC2Image, len(v.Images))
-			added := false
-			for n, i := range v.Images {
-				if i.Region == image.Region {
-					// replace existing image
-					images[n] = image
-					added = true
-					continue
-				}
-				images[n] = i
-			}
-			if !added {
-				images = append(images, image)
-			}
-			v.Images = images
-			return
-		}
-		versions = append(versions, v)
-	}
-	versions = append(versions, &EC2Version{
-		Version: version,
-		Images:  []*EC2Image{image},
-	})
-	sort.Sort(sort.Reverse(versions))
-	m.Versions = make([]*EC2Version, 0, maxVersions)
-	for i := 0; i < len(versions) && i < maxVersions; i++ {
-		m.Versions = append(m.Versions, versions[i].(*EC2Version))
-	}
-}
-
-type EC2Version struct {
-	Version string      `json:"version"`
-	Images  []*EC2Image `json:"images"`
-}
-
-func (v *EC2Version) version() string {
-	return v.Version
-}
-
-type EC2Image struct {
-	ID                   string `json:"id"`
-	Name                 string `json:"name"`
-	Region               string `json:"region"`
-	OwnerID              string `json:"owner_id"`
-	RootDeviceType       string `json:"root_device_type"`
-	RootDeviceName       string `json:"root_device_name"`
-	RootDeviceSnapshotID string `json:"root_device_snapshot_id"`
-	VirtualizationType   string `json:"virtualization_type"`
-	Hypervisor           string `json:"hypervisor"`
 }

--- a/util/release/types/manifest.go
+++ b/util/release/types/manifest.go
@@ -1,0 +1,199 @@
+package release
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+)
+
+const maxVersions = 5
+
+type EC2Manifest struct {
+	Name     string        `json:"name"`
+	Versions []*EC2Version `json:"versions"`
+}
+
+// Add adds an image to the manifest.
+//
+// If the version is already in the manifest, the given image either
+// replaces any existing image with the same region, or is appended to
+// the existing list of images for that version.
+//
+// If the version is not already in the manifest a new version is added
+// containing the image.
+//
+// The number of versions in the manifest is capped at the value of maxVersions.
+func (m *EC2Manifest) Add(version string, image *EC2Image) {
+	versions := make(sortVersions, 0, len(m.Versions)+1)
+	for _, v := range m.Versions {
+		if v.version() == version {
+			images := make([]*EC2Image, len(v.Images))
+			added := false
+			for n, i := range v.Images {
+				if i.Region == image.Region {
+					// replace existing image
+					images[n] = image
+					added = true
+					continue
+				}
+				images[n] = i
+			}
+			if !added {
+				images = append(images, image)
+			}
+			v.Images = images
+			return
+		}
+		versions = append(versions, v)
+	}
+	versions = append(versions, &EC2Version{
+		Version: version,
+		Images:  []*EC2Image{image},
+	})
+	sort.Sort(sort.Reverse(versions))
+	m.Versions = make([]*EC2Version, 0, maxVersions)
+	for i := 0; i < len(versions) && i < maxVersions; i++ {
+		m.Versions = append(m.Versions, versions[i].(*EC2Version))
+	}
+}
+
+type EC2Version struct {
+	Version string      `json:"version"`
+	Images  []*EC2Image `json:"images"`
+}
+
+func (v *EC2Version) version() string {
+	return v.Version
+}
+
+type EC2Image struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Region               string `json:"region"`
+	OwnerID              string `json:"owner_id"`
+	RootDeviceType       string `json:"root_device_type"`
+	RootDeviceName       string `json:"root_device_name"`
+	RootDeviceSnapshotID string `json:"root_device_snapshot_id"`
+	VirtualizationType   string `json:"virtualization_type"`
+	Hypervisor           string `json:"hypervisor"`
+}
+
+type FlynnManifest struct {
+	Current  *FlynnVersion   `json:"current"`
+	Versions []*FlynnVersion `json:"versions"`
+}
+
+// Add adds a version to the manifest.
+//
+// If the version is already in the manifest, an error is returned.
+//
+// The number of versions in the manifest is capped at the value of maxVersions.
+func (m *FlynnManifest) Add(version, commit string) error {
+	versions := make(sortVersions, 0, len(m.Versions)+1)
+	for _, v := range m.Versions {
+		if v.version() == version {
+			return errors.New("version already in manifest")
+		}
+		versions = append(versions, v)
+	}
+	versions = append(versions, &FlynnVersion{Version: version, Commit: commit})
+	sort.Sort(sort.Reverse(versions))
+	m.Versions = make([]*FlynnVersion, 0, maxVersions)
+	for i := 0; i < len(versions) && i < maxVersions; i++ {
+		m.Versions = append(m.Versions, versions[i].(*FlynnVersion))
+	}
+	m.Current = m.Versions[0]
+	return nil
+}
+
+type FlynnVersion struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+func (v *FlynnVersion) version() string {
+	return v.Version
+}
+
+type Versioner interface {
+	version() string
+}
+
+type sortVersions []Versioner
+
+func (s sortVersions) Len() int {
+	return len(s)
+}
+
+func (s sortVersions) Less(i, j int) bool {
+	return bytes.Compare([]byte(s[i].version()), []byte(s[j].version())) < 0
+}
+
+func (s sortVersions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type VagrantManifest struct {
+	Name     string            `json:"name"`
+	Versions []*VagrantVersion `json:"versions"`
+}
+
+// Add adds a provider to the manifest.
+//
+// If the version is already in the manifest, the given provider either
+// replaces any existing provider with the same name, or is appended to
+// the existing list of providers for that version.
+//
+// If the version is not already in the manifest a new version is added
+// containing the provider.
+//
+// The number of versions in the manifest is capped at the value of maxVersions.
+func (m *VagrantManifest) Add(version string, provider *VagrantProvider) {
+	versions := make(sortVersions, 0, len(m.Versions)+1)
+	for _, v := range m.Versions {
+		if v.version() == version {
+			providers := make([]*VagrantProvider, len(v.Providers))
+			added := false
+			for i, p := range v.Providers {
+				if p.Name == provider.Name {
+					// replace existing provider
+					providers[i] = provider
+					added = true
+					continue
+				}
+				providers[i] = p
+			}
+			if !added {
+				providers = append(providers, provider)
+			}
+			v.Providers = providers
+			return
+		}
+		versions = append(versions, v)
+	}
+	versions = append(versions, &VagrantVersion{
+		Version:   version,
+		Providers: []*VagrantProvider{provider},
+	})
+	sort.Sort(sort.Reverse(versions))
+	m.Versions = make([]*VagrantVersion, 0, maxVersions)
+	for i := 0; i < len(versions) && i < maxVersions; i++ {
+		m.Versions = append(m.Versions, versions[i].(*VagrantVersion))
+	}
+}
+
+type VagrantVersion struct {
+	Version   string             `json:"version"`
+	Providers []*VagrantProvider `json:"providers"`
+}
+
+func (v *VagrantVersion) version() string {
+	return v.Version
+}
+
+type VagrantProvider struct {
+	Name         string `json:"name"`
+	URL          string `json:"url"`
+	ChecksumType string `json:"checksum_type"`
+	Checksum     string `json:"checksum"`
+}

--- a/util/release/vagrant.go
+++ b/util/release/vagrant.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 	"log"
 	"os"
-	"sort"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/util/release/types"
 )
 
 func vagrant(args *docopt.Args) {
-	manifest := &VagrantManifest{}
+	manifest := &release.VagrantManifest{}
 
 	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
 		log.Fatal(err)
 	}
 
-	manifest.Add(args.String["<version>"], &VagrantProvider{
+	manifest.Add(args.String["<version>"], &release.VagrantProvider{
 		Name:         args.String["<provider>"],
 		URL:          args.String["<url>"],
 		Checksum:     args.String["<checksum>"],
@@ -26,69 +26,4 @@ func vagrant(args *docopt.Args) {
 	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
 		log.Fatal(err)
 	}
-}
-
-type VagrantManifest struct {
-	Name     string            `json:"name"`
-	Versions []*VagrantVersion `json:"versions"`
-}
-
-// Add adds a provider to the manifest.
-//
-// If the version is already in the manifest, the given provider either
-// replaces any existing provider with the same name, or is appended to
-// the existing list of providers for that version.
-//
-// If the version is not already in the manifest a new version is added
-// containing the provider.
-//
-// The number of versions in the manifest is capped at the value of maxVersions.
-func (m *VagrantManifest) Add(version string, provider *VagrantProvider) {
-	versions := make(sortVersions, 0, len(m.Versions)+1)
-	for _, v := range m.Versions {
-		if v.version() == version {
-			providers := make([]*VagrantProvider, len(v.Providers))
-			added := false
-			for i, p := range v.Providers {
-				if p.Name == provider.Name {
-					// replace existing provider
-					providers[i] = provider
-					added = true
-					continue
-				}
-				providers[i] = p
-			}
-			if !added {
-				providers = append(providers, provider)
-			}
-			v.Providers = providers
-			return
-		}
-		versions = append(versions, v)
-	}
-	versions = append(versions, &VagrantVersion{
-		Version:   version,
-		Providers: []*VagrantProvider{provider},
-	})
-	sort.Sort(sort.Reverse(versions))
-	m.Versions = make([]*VagrantVersion, 0, maxVersions)
-	for i := 0; i < len(versions) && i < maxVersions; i++ {
-		m.Versions = append(m.Versions, versions[i].(*VagrantVersion))
-	}
-}
-
-type VagrantVersion struct {
-	Version   string             `json:"version"`
-	Providers []*VagrantProvider `json:"providers"`
-}
-
-func (v *VagrantVersion) version() string {
-	return v.Version
-}
-
-type VagrantProvider struct {
-	Name         string `json:"name"`
-	URL          string `json:"url"`
-	ChecksumType string `json:"checksum_type"`
-	Checksum     string `json:"checksum"`
 }

--- a/util/release/version.go
+++ b/util/release/version.go
@@ -1,20 +1,16 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
 	"log"
 	"os"
-	"sort"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/util/release/types"
 )
 
-const maxVersions = 5
-
 func version(args *docopt.Args) {
-	manifest := &FlynnManifest{}
+	manifest := &release.FlynnManifest{}
 
 	if err := json.NewDecoder(os.Stdin).Decode(manifest); err != nil {
 		log.Fatal(err)
@@ -27,59 +23,4 @@ func version(args *docopt.Args) {
 	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
 		log.Fatal(err)
 	}
-}
-
-type FlynnManifest struct {
-	Current  *FlynnVersion   `json:"current"`
-	Versions []*FlynnVersion `json:"versions"`
-}
-
-// Add adds a version to the manifest.
-//
-// If the version is already in the manifest, an error is returned.
-//
-// The number of versions in the manifest is capped at the value of maxVersions.
-func (m *FlynnManifest) Add(version, commit string) error {
-	versions := make(sortVersions, 0, len(m.Versions)+1)
-	for _, v := range m.Versions {
-		if v.version() == version {
-			return errors.New("version already in manifest")
-		}
-		versions = append(versions, v)
-	}
-	versions = append(versions, &FlynnVersion{Version: version, Commit: commit})
-	sort.Sort(sort.Reverse(versions))
-	m.Versions = make([]*FlynnVersion, 0, maxVersions)
-	for i := 0; i < len(versions) && i < maxVersions; i++ {
-		m.Versions = append(m.Versions, versions[i].(*FlynnVersion))
-	}
-	m.Current = m.Versions[0]
-	return nil
-}
-
-type FlynnVersion struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
-}
-
-func (v *FlynnVersion) version() string {
-	return v.Version
-}
-
-type Versioner interface {
-	version() string
-}
-
-type sortVersions []Versioner
-
-func (s sortVersions) Len() int {
-	return len(s)
-}
-
-func (s sortVersions) Less(i, j int) bool {
-	return bytes.Compare([]byte(s[i].version()), []byte(s[j].version())) < 0
-}
-
-func (s sortVersions) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
The installer (and other programs in the future) want to read these manifests. Currently the installer imports the main release package, which is brittle and adds 1-2MB to the binary size.

This patch moves the manifest types into a separate release package to make them easy to work with. No code is changed, just moved.