### PR TITLE
host/cli: Error when creating discovery token for single node

### DIFF
--- a/host/cli/init.go
+++ b/host/cli/init.go
@@ -33,6 +33,9 @@ options:
 func runInit(args *docopt.Args) error {
 	discoveryToken := args.String["--discovery"]
 	if n, ok := args.String["--init-discovery"]; ok {
+		if n == "1" {
+			return errors.New("There is no need for a discovery token when starting a single node cluster.")
+		}
 		var err error
 		discoveryToken, err = etcdcluster.NewDiscoveryToken(n)
 		if err != nil {


### PR DESCRIPTION
This is unnecessary, and can result in etcd failure when restarting the host.

Closes #1262