### PR TITLE
router: Show useful error when listen fails

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -268,7 +268,7 @@ func (s *HTTPListener) listenAndServe() error {
 	var err error
 	s.listener, err = listenFunc("tcp4", s.Addr)
 	if err != nil {
-		return err
+		return listenErr{s.Addr, err}
 	}
 
 	server := &http.Server{
@@ -302,7 +302,7 @@ func (s *HTTPListener) listenAndServeTLS() error {
 
 	l, err := listenFunc("tcp4", s.TLSAddr)
 	if err != nil {
-		return err
+		return listenErr{s.Addr, err}
 	}
 	s.tlsListener = tls.NewListener(l, tlsConfig)
 

--- a/router/server.go
+++ b/router/server.go
@@ -141,7 +141,7 @@ func main() {
 
 	listener, err := listenFunc("tcp4", *apiAddr)
 	if err != nil {
-		shutdown.Fatal(err)
+		shutdown.Fatal(listenErr{*apiAddr, err})
 	}
 
 	services := map[string]string{
@@ -157,4 +157,13 @@ func main() {
 	}
 
 	shutdown.Fatal(http.Serve(listener, apiHandler(&r)))
+}
+
+type listenErr struct {
+	Addr string
+	Err  error
+}
+
+func (e listenErr) Error() string {
+	return fmt.Sprintf("error binding to port (check if another service is listening on %s): %s", e.Addr, e.Err)
 }

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -112,10 +112,11 @@ func (l *TCPListener) Start() error {
 
 	if l.startPort != 0 && l.endPort != 0 {
 		for i := l.startPort; i <= l.endPort; i++ {
-			listener, err := listenFunc("tcp4", fmt.Sprintf("%s:%d", l.IP, i))
+			addr := fmt.Sprintf("%s:%d", l.IP, i)
+			listener, err := listenFunc("tcp4", addr)
 			if err != nil {
 				l.Close()
-				return err
+				return listenErr{addr, err}
 			}
 			l.listeners[i] = listener
 		}
@@ -278,6 +279,9 @@ func (r *tcpRoute) Serve(started chan<- error) {
 	// TODO: close the listener while there are no backends available
 	if r.l == nil {
 		r.l, err = listenFunc("tcp4", r.addr)
+	}
+	if err != nil {
+		err = listenErr{r.addr, err}
 	}
 	started <- err
 	if err != nil {


### PR DESCRIPTION
Errors from listen don't include the bound address, so wrap it in an error that prints the address along with an error.

Closes #1149