### PR TITLE
host: Store logs in /var/log/flynn rather than /tmp

### DIFF
--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -67,7 +67,7 @@ func runCollectDebugInfo(args *docopt.Args) error {
 	log.Info("getting job logs")
 	if err := captureJobs(gist, args.Bool["--include-env"]); err != nil {
 		log.Error("error getting job logs, falling back to on-disk logs", "err", err)
-		debugCmds = append(debugCmds, []string{"bash", "-c", "tail -n +1 /tmp/flynn-host-logs/**/*.log"})
+		debugCmds = append(debugCmds, []string{"bash", "-c", "tail -n +1 /var/log/flynn/**/*.log"})
 	}
 
 	log.Info("getting system information")

--- a/host/host.go
+++ b/host/host.go
@@ -53,6 +53,7 @@ options:
   --meta=<KEY=VAL>...    key=value pair to add as metadata
   --bind=IP              bind containers to IP
   --flynn-init=PATH      path to flynn-init binary [default: /usr/local/bin/flynn-init]
+  --log-dir              directory to store job logs [default: /var/log/flynn]
 	`)
 }
 
@@ -144,6 +145,7 @@ func runDaemon(args *docopt.Args) {
 	volPath := args.String["--volpath"]
 	backendName := args.String["--backend"]
 	flynnInit := args.String["--flynn-init"]
+	logDir := args.String["--log-dir"]
 	metadata := args.All["--meta"].([]string)
 
 	grohl.AddContext("app", "host")
@@ -191,7 +193,7 @@ func runDaemon(args *docopt.Args) {
 
 	switch backendName {
 	case "libvirt-lxc":
-		backend, err = NewLibvirtLXCBackend(state, vman, legacyVolPath, "/tmp/flynn-host-logs", flynnInit, mux)
+		backend, err = NewLibvirtLXCBackend(state, vman, legacyVolPath, logDir, flynnInit, mux)
 	default:
 		log.Fatalf("unknown backend %q", backendName)
 	}

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -627,7 +627,7 @@ func (c *Cluster) dumpLogs(w io.Writer) {
 		fallback := func() {
 			fmt.Fprintf(w, "\n*** Error getting job logs via flynn-host, falling back to tail log dump\n\n")
 			for _, inst := range instances {
-				run(inst, "sudo bash -c 'tail -n +1 /tmp/flynn-host-logs/**/*.log'")
+				run(inst, "sudo bash -c 'tail -n +1 /var/log/flynn/**/*.log'")
 			}
 		}
 


### PR DESCRIPTION
`/tmp` is commonly a tmpfs so rebooting a node can lose logs which are helpful for debugging purposes.