### PR TITLE
slugbuilder: Fix parsing release files with no default types

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -153,7 +153,7 @@ if [[ -f "${build_root}/Procfile" ]]; then
 fi
 default_types=""
 if [[ -s "${build_root}/.release" ]]; then
-  default_types=$(ruby -r yaml -e "puts (YAML.load_file('${build_root}/.release')['default_process_types'] || {}).keys.join(', ')")
+  default_types=$(ruby -r yaml -e "puts (YAML.load_file('${build_root}/.release') || {}).fetch('default_process_types', {}).keys.join(', ')")
   if [[ -n "${default_types}" ]]; then
     echo_normal "Default process types for ${buildpack_name} -> ${default_types}"
   fi

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -148,20 +148,15 @@ run_unprivileged ${selected_buildpack}/bin/release \
 
 echo_title "Discovering process types"
 if [[ -f "${build_root}/Procfile" ]]; then
-  types=$(ruby -e "require 'yaml';
-    puts YAML.load_file('${build_root}/Procfile').keys().join(', ')
-  ")
+  types=$(ruby -r yaml -e "puts YAML.load_file('${build_root}/Procfile').keys.join(', ')")
   echo_normal "Procfile declares types -> ${types}"
 fi
 default_types=""
 if [[ -s "${build_root}/.release" ]]; then
-  default_types=$(ruby -e "require 'yaml';
-    puts (YAML.load_file('${build_root}/.release')['default_process_types'] ||
-          {}).keys.join(', ')
-  ")
-  [[ -n "${default_types}" ]] \
-  && echo_normal \
-    "Default process types for ${buildpack_name} -> ${default_types}"
+  default_types=$(ruby -r yaml -e "puts (YAML.load_file('${build_root}/.release')['default_process_types'] || {}).keys.join(', ')")
+  if [[ -n "${default_types}" ]]; then
+    echo_normal "Default process types for ${buildpack_name} -> ${default_types}"
+  fi
 fi
 
 

--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -25,11 +25,13 @@ usermod --home $HOME nobody
 shopt -s nullglob
 mkdir -p .profile.d
 if [[ -s .release ]]; then
-  ruby -e "require 'yaml';
-    (YAML.load_file('.release')['config_vars'] || {}).each do |k, v|
-      puts \"#{k}=\${#{k}:-'#{v}'}\"
-    end" \
-    > .profile.d/config_vars
+  ruby -r yaml > .profile.d/config_vars <<-RUBY
+release = YAML.load_file('.release') || {}
+config = release['config_vars'] || {}
+config.each_pair do |k, v|
+  puts "#{k}=\${#{k}:-'#{v}'}"
+end
+RUBY
 fi
 for file in .profile.d/*; do
   source "${file}"
@@ -41,13 +43,9 @@ hash -r
 case "$1" in
   start)
     if [[ -f Procfile ]]; then
-      command="$(ruby -e "require 'yaml';
-        puts YAML.load_file('Procfile')['$2']"
-      )"
+      command=$(ruby -r yaml -e "puts YAML.load_file('Procfile')['$2']")
     else
-      command="$(ruby -e "require 'yaml';
-        puts (YAML.load_file('.release')['default_process_types'] || {})['$2']"
-      )"
+      command=$(ruby -r yaml -e "puts (YAML.load_file('.release') || {}).fetch('default_process_types', {})['$2']")
     fi
     ;;
   *)

--- a/test/apps/empty-release/bin/compile
+++ b/test/apps/empty-release/bin/compile
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/test/apps/empty-release/bin/detect
+++ b/test/apps/empty-release/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "empty-release"

--- a/test/apps/empty-release/bin/release
+++ b/test/apps/empty-release/bin/release
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cat <<EOF
+---
+EOF

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -36,6 +36,19 @@ func (s *GitDeploySuite) TestEnvDir(t *c.C) {
 	t.Assert(push, OutputContains, "bar")
 }
 
+func (s *GitDeploySuite) TestEmptyRelease(t *c.C) {
+	r := s.newGitRepo(t, "empty-release")
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.flynn("env", "set", "BUILDPACK_URL=https://github.com/kr/heroku-buildpack-inline"), Succeeds)
+
+	push := r.git("push", "flynn", "master")
+	t.Assert(push, Succeeds)
+
+	run := r.flynn("run", "echo", "foo")
+	t.Assert(run, Succeeds)
+	t.Assert(run, Outputs, "foo\n")
+}
+
 func (s *GitDeploySuite) TestBuildCaching(t *c.C) {
 	r := s.newGitRepo(t, "build-cache")
 	t.Assert(r.flynn("create"), Succeeds)


### PR DESCRIPTION
For example the apt buildpack makes a release file containing `---` which is parsed to `nil` by Ruby:

https://github.com/ddollar/heroku-buildpack-apt/blob/master/bin/release