### PR TITLE
host: fix shutdown

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -186,6 +186,7 @@ func runDaemon(args *docopt.Args) {
 	}
 
 	mux := logmux.New(1000)
+	shutdown.BeforeExit(func() { mux.Close() })
 
 	switch backendName {
 	case "libvirt-lxc":
@@ -279,7 +280,6 @@ func runDaemon(args *docopt.Args) {
 	if err := mux.Connect(disc, "flynn-logaggregator"); err != nil {
 		shutdown.Fatal(err)
 	}
-	shutdown.BeforeExit(func() { mux.Close() })
 
 	cluster, err := cluster.NewClient()
 	if err != nil {

--- a/host/logmux/service_conn.go
+++ b/host/logmux/service_conn.go
@@ -57,13 +57,14 @@ func (c *serviceConn) Write(p []byte) (int, error) {
 	defer c.cond.L.Unlock()
 
 	for {
+		if c.closed {
+			return 0, errors.New("connection closed")
+		}
+
 		if c.Conn != nil {
 			n, err := c.Conn.Write(p)
 			if err == nil {
 				return n, nil
-			}
-			if c.closed {
-				return 0, errors.New("connection closed")
 			}
 
 			c.errc <- err


### PR DESCRIPTION
Avoid hanging on termination of `flynn-host` by passing EOF's to stream readers, and fix the check in logmux for closed connections. 

fixes #1177