### PR TITLE
Use start script to pass arguments to etcd

### DIFF
--- a/appliance/etcd/Dockerfile
+++ b/appliance/etcd/Dockerfile
@@ -3,5 +3,6 @@ FROM flynn/busybox
 ADD https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 ADD ./bin/etcd /bin/etcd
 ADD ./bin/etcdctl /bin/etcdctl
+ADD ./start.sh /bin/start-etcd
 
-ENTRYPOINT ["/bin/etcd"]
+ENTRYPOINT ["/bin/start-etcd"]

--- a/appliance/etcd/start.sh
+++ b/appliance/etcd/start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -z "${ETCD_INITIAL_CLUSTER}" ] && [ -z "${ETCD_DISCOVERY}" ]; then
+  initial="-initial-cluster=default=http://${EXTERNAL_IP}:${PORT_1}"
+fi
+
+exec /bin/etcd -data-dir=/data \
+               -advertise-client-urls=http://${EXTERNAL_IP}:${PORT_0} \
+               -listen-client-urls=http://0.0.0.0:${PORT_0} \
+               -initial-advertise-peer-urls=http://${EXTERNAL_IP}:${PORT_1} \
+               -listen-peer-urls=http://0.0.0.0:${PORT_1} \
+               "${initial}"

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -17,7 +17,7 @@
     "release": {
       "env": {
         "PGPASSWORD": "{{ (index .StepData \"pg-password\").Data }}"
-	  },
+      },
       "processes": {
         "postgres": {
           "ports": [{"port": 5432, "proto": "tcp"}],
@@ -26,7 +26,7 @@
           "env": {
             "SINGLETON": "{{ .Singleton }}"
           },
-		  "resurrect": true
+          "resurrect": true
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
@@ -84,13 +84,13 @@
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
           "cmd": ["controller"],
-		  "resurrect": true
+          "resurrect": true
         },
         "scheduler": {
           "cmd": ["scheduler"],
           "omni": true,
           "service": "flynn-controller-scheduler",
-		  "resurrect": true
+          "resurrect": true
         },
         "deployer": {
           "cmd": ["deployer"]

--- a/host/manifest.go
+++ b/host/manifest.go
@@ -85,6 +85,7 @@ type manifestService struct {
 	Env        map[string]string `json:"env"`
 	ExposeEnv  []string          `json:"expose_env"`
 	TCPPorts   []string          `json:"tcp_ports"`
+	Data       bool              `json:"data"`
 }
 
 func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, error) {
@@ -142,6 +143,10 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 			ExternalIP:  m.externalAddr,
 			BridgeIP:    netInfo.BridgeAddr,
 			Nameservers: strings.Join(netInfo.Nameservers, ","),
+		}
+
+		if service.Data {
+			data.Volume("/data")
 		}
 
 		// Add explicit tcp ports to data.TCPPorts

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -3,14 +3,7 @@
     "id": "etcd",
     "image": "$image_repository?name=flynn/etcd&id=$image_id[etcd]",
     "expose_env": ["ETCD_INITIAL_CLUSTER", "ETCD_INITIAL_CLUSTER_STATE", "ETCD_NAME", "ETCD_DISCOVERY", "ETCD_PROXY"],
-    "args": [
-      "-data-dir={{ .Volume \"/data\" }}",
-      "-advertise-client-urls=http://{{ .ExternalIP }}:{{ .TCPPort 0 }}",
-      "-listen-client-urls=http://0.0.0.0:{{ .TCPPort 0 }}",
-      "-initial-advertise-peer-urls=http://{{ .ExternalIP }}:{{ .TCPPort 1 }}",
-      "-listen-peer-urls=http://0.0.0.0:{{ .TCPPort 1 }}",
-      "{{ if and (not .Env.ETCD_INITIAL_CLUSTER) (not .Env.ETCD_DISCOVERY) }}-initial-cluster=default=http://{{ .ExternalIP }}:{{ .TCPPort 1 }}{{ end }}"
-    ],
+    "data": true,
     "tcp_ports": ["2379", "2380"]
   },
   {


### PR DESCRIPTION
This moves the argument building logic out of the bootstrap manifest and into the container image, reducing the knowledge of etcd in the manifest.

Incremental patch for #1170.