### PR TITLE
discoverd,host: Move args to start script

### DIFF
--- a/discoverd/start.sh
+++ b/discoverd/start.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
+# Wait for bridge interface to show up, as we may have started before the interface is configured
+iface=flynnbr0
 start=$(date +%s)
-dnsaddr=$(echo "$@" | sed -r 's/.*dns-addr=([0-9.]+):.*/\1/')
-
-# Wait for flannel interface to show up, as we may have started before flannel.
 while true; do
-  ifconfig | grep -qF "$dnsaddr" && break || sleep 0.2
-  elapsed=$(($(date +%s) - $start))
-  if [ $elapsed -gt 60 ]; then
-    echo "$dnsaddr did not appear within 60 seconds"
+  ip=$(ifconfig ${iface} | grep "inet addr:" | cut -d: -f2 | cut -d" " -f0)
+  [ -n "${ip}" ] && break || sleep 0.2
+
+  elapsed=$(($(date +%s) - ${start}))
+  if [ ${elapsed} -gt 60 ]; then
+    echo "${iface} did not appear within 60 seconds"
     exit 1
   fi
 done
 
-exec /bin/discoverd $*
+exec /bin/discoverd -http-addr=:${PORT_0} \
+                    -dns-addr=${ip}:${PORT_1} \
+                    -recursors=${DNS_RECURSORS} \
+                    -etcd=${ETCD_ADDRS}

--- a/host/manifest_template.json
+++ b/host/manifest_template.json
@@ -17,12 +17,10 @@
   {
     "id": "discoverd",
     "image": "$image_repository?name=flynn/discoverd&id=$image_id[discoverd]",
-    "args": [
-      "-http-addr=:{{ .TCPPort 0 }}", 
-      "-dns-addr={{ .BridgeIP }}:{{ .TCPPort 1 }}",
-      "-recursors={{ .Nameservers }}",
-      "-etcd=http://{{ .Services.etcd.ExternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"
-    ],
+    "env": {
+      "DNS_RECURSORS": "{{ .Nameservers }}",
+      "ETCD_ADDRS": "http://{{ .Services.etcd.ExternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"
+    },
     "tcp_ports": ["1111", "53"]
   }
 ]


### PR DESCRIPTION
Move the configuration flags for discoverd from the layer 0 bootstrap manifest to the start script. The start script now waits for the bridge to appear and parses the IP address from it.

This removes knowledge of the flags used by discoverd from the layer 0 manifest and allows the same environment to be used for the discoverd instance on each node.

Incremental patch for #1170.