### PR TITLE
deployer: Support deploying postgres

### DIFF
--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -57,3 +57,7 @@ func (c *Client) Status() (*Status, error) {
 	res := &Status{}
 	return res, c.c.Get("/status", res)
 }
+
+func (c *Client) Stop() error {
+	return c.c.Post("/stop", nil, nil)
+}

--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -17,6 +17,7 @@ type PostgresInfo struct {
 	Running          bool                `json:"running"`
 	SyncedDownstream *discoverd.Instance `json:"synced_downstream"`
 	XLog             string              `json:"xlog,omitempty"`
+	UserExists       bool                `json:"user_exists,omitempty"`
 	Replicas         []*Replica          `json:"replicas,omitempty"`
 }
 

--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -1,20 +1,23 @@
 package pgmanager
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/flynn/flynn/appliance/postgresql/state"
+	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/httpclient"
 )
 
 type PostgresInfo struct {
-	Config   *state.PgConfig `json:"config"`
-	Running  bool            `json:"running"`
-	XLog     string          `json:"xlog,omitempty"`
-	Replicas []*Replica      `json:"replicas,omitempty"`
+	Config           *state.PgConfig     `json:"config"`
+	Running          bool                `json:"running"`
+	SyncedDownstream *discoverd.Instance `json:"synced_downstream"`
+	XLog             string              `json:"xlog,omitempty"`
+	Replicas         []*Replica          `json:"replicas,omitempty"`
 }
 
 type Replica struct {
@@ -60,4 +63,20 @@ func (c *Client) Status() (*Status, error) {
 
 func (c *Client) Stop() error {
 	return c.c.Post("/stop", nil, nil)
+}
+
+func (c *Client) WaitForReplSync(downstream *discoverd.Instance, timeout time.Duration) error {
+	start := time.Now()
+	for {
+		status, err := c.Status()
+		if err != nil {
+			return err
+		} else if status.Postgres.SyncedDownstream != nil && status.Postgres.SyncedDownstream.ID == downstream.ID {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+		if time.Now().Sub(start) > timeout {
+			return errors.New("timed out waiting for replication sync")
+		}
+	}
 }

--- a/appliance/postgresql/main.go
+++ b/appliance/postgresql/main.go
@@ -50,6 +50,6 @@ func main() {
 	shutdown.BeforeExit(func() { peer.Close() })
 
 	go peer.Run()
-	shutdown.Fatal(ServeHTTP(pg.(*Postgres), peer, log.New("component", "http")))
+	shutdown.Fatal(ServeHTTP(pg.(*Postgres), peer, hb, log.New("component", "http")))
 	// TODO(titanous): clean shutdown of postgres
 }

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -541,11 +541,6 @@ func (p *Postgres) stop() error {
 		}
 	}
 
-	// Wait for all clients to terminate before shutting down cleanly
-	if tryExit(syscall.SIGTERM) {
-		return nil
-	}
-
 	// Forcefully disconnect all clients and shut down cleanly
 	if tryExit(syscall.SIGINT) {
 		return nil

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -416,6 +416,11 @@ func (p *Postgres) assumeStandby(upstream, downstream *discoverd.Instance) error
 		))
 		if err != nil {
 			log.Error("error pulling basebackup", "err", err)
+			if files, err := ioutil.ReadDir("/data"); err == nil {
+				for _, file := range files {
+					os.RemoveAll(filepath.Join("/data", file.Name()))
+				}
+			}
 			return err
 		}
 		// the upstream could be performing a takeover, so we need to

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -465,6 +465,10 @@ func (p *Postgres) assumeStandby(upstream, downstream *discoverd.Instance) error
 	return nil
 }
 
+// upstreamTimeout is of the order of the discoverd heartbeat to prevent
+// waiting for an upstream which has gone down.
+var upstreamTimeout = 10 * time.Second
+
 func (p *Postgres) waitForUpstream(upstream *discoverd.Instance) error {
 	log := p.log.New("fn", "waitForUpstream", "upstream", upstream.Addr)
 	log.Info("waiting for upstream to come online")
@@ -480,7 +484,7 @@ func (p *Postgres) waitForUpstream(upstream *discoverd.Instance) error {
 			return nil
 		}
 		time.Sleep(checkInterval)
-		if time.Now().Sub(start) > p.opTimeout {
+		if time.Now().Sub(start) > upstreamTimeout {
 			log.Error("upstream did not come online in time")
 			return errors.New("upstream is offline")
 		}

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -418,6 +418,10 @@ func (p *Postgres) assumeStandby(upstream, downstream *discoverd.Instance) error
 			log.Error("error pulling basebackup", "err", err)
 			return err
 		}
+		// the upstream could be performing a takeover, so we need to
+		// remove the trigger file if we have synced it across so we
+		// don't also start a takeover.
+		os.Remove(p.triggerPath())
 	}
 
 	if err := p.writeConfig(configData{ReadOnly: true}); err != nil {

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -46,9 +46,10 @@ type Postgres struct {
 
 	events chan state.PostgresEvent
 
-	configVal     atomic.Value // *state.PgConfig
-	runningVal    atomic.Value // bool
-	configApplied bool
+	configVal           atomic.Value // *state.PgConfig
+	runningVal          atomic.Value // bool
+	syncedDownstreamVal atomic.Value // *discoverd.Instance
+	configApplied       bool
 
 	// config options
 	id           string
@@ -71,7 +72,7 @@ type Postgres struct {
 	// daemonExit is closed when the daemon exits
 	daemonExit chan struct{}
 
-	// cancelSyncWait cancels the goroutine that is waiting for the sync to
+	// cancelSyncWait cancels the goroutine that is waiting for the downstream to
 	// catch up, if running
 	cancelSyncWait func()
 
@@ -100,6 +101,7 @@ func NewPostgres(c Config) state.Postgres {
 	}
 	p.setRunning(false)
 	p.setConfig(nil)
+	p.setSyncedDownstream(nil)
 	if p.log == nil {
 		p.log = log15.New("app", "postgres", "id", p.id)
 	}
@@ -141,10 +143,19 @@ func (p *Postgres) setConfig(config *state.PgConfig) {
 	p.configVal.Store(config)
 }
 
+func (p *Postgres) syncedDownstream() *discoverd.Instance {
+	return p.syncedDownstreamVal.Load().(*discoverd.Instance)
+}
+
+func (p *Postgres) setSyncedDownstream(inst *discoverd.Instance) {
+	p.syncedDownstreamVal.Store(inst)
+}
+
 func (p *Postgres) Info() (*pgmanager.PostgresInfo, error) {
 	res := &pgmanager.PostgresInfo{
-		Config:  p.config(),
-		Running: p.running(),
+		Config:           p.config(),
+		Running:          p.running(),
+		SyncedDownstream: p.syncedDownstream(),
 	}
 	xlog, err := p.XLogPosition()
 	res.XLog = string(xlog)
@@ -231,6 +242,8 @@ func (p *Postgres) Ready() <-chan state.PostgresEvent {
 }
 
 func (p *Postgres) reconfigure(config *state.PgConfig) (err error) {
+	log := p.log.New("fn", "reconfigure")
+
 	defer func() {
 		if err == nil {
 			p.setConfig(config)
@@ -239,26 +252,37 @@ func (p *Postgres) reconfigure(config *state.PgConfig) (err error) {
 	}()
 
 	if config != nil && config.Role == state.RoleNone {
+		log.Info("nothing to do", "reason", "null role")
 		return nil
 	}
 
 	// If we've already applied the same postgres config, we don't need to do anything
 	if p.configApplied && config != nil && p.config() != nil && config.Equal(p.config()) {
+		log.Info("nothing to do", "reason", "config already applied")
 		return nil
 	}
 
 	// If we're already running and it's just a change from async to sync with the same node, we don't need to restart
 	if p.configApplied && p.running() && p.config() != nil && config != nil &&
 		p.config().Role == state.RoleAsync && config.Role == state.RoleSync && config.Upstream.ID == p.config().Upstream.ID {
+		log.Info("nothing to do", "reason", "becoming sync with same upstream")
 		return nil
 	}
 
-	// Make sure that we don't keep waiting for a sync to come up while reconfiguring
+	// Make sure that we don't keep waiting for replication sync while reconfiguring
 	p.cancelSyncWait()
+	p.setSyncedDownstream(nil)
 
 	// If we're already running and this is only a sync change, we just need to update the config.
 	if p.running() && p.config() != nil && config != nil && p.config().Role == state.RolePrimary && config.Role == state.RolePrimary {
 		return p.updateSync(config.Downstream)
+	}
+
+	// If we're already running and this is only a downstream change, just wait for the new downstream to catch up
+	if p.running() && p.config().IsNewDownstream(config) {
+		log.Info("downstream changed", "to", config.Downstream.Addr)
+		p.waitForSync(config.Downstream, false)
+		return
 	}
 
 	if config == nil {
@@ -269,7 +293,7 @@ func (p *Postgres) reconfigure(config *state.PgConfig) (err error) {
 		return p.assumePrimary(config.Downstream)
 	}
 
-	return p.assumeStandby(config.Upstream)
+	return p.assumeStandby(config.Upstream, config.Downstream)
 }
 
 func (p *Postgres) assumePrimary(downstream *discoverd.Instance) (err error) {
@@ -286,7 +310,7 @@ func (p *Postgres) assumePrimary(downstream *discoverd.Instance) (err error) {
 			return err
 		}
 
-		p.waitForSync(downstream)
+		p.waitForSync(downstream, true)
 
 		return nil
 	}
@@ -349,13 +373,13 @@ func (p *Postgres) assumePrimary(downstream *discoverd.Instance) (err error) {
 	}
 
 	if downstream != nil {
-		p.waitForSync(downstream)
+		p.waitForSync(downstream, true)
 	}
 
 	return nil
 }
 
-func (p *Postgres) assumeStandby(upstream *discoverd.Instance) error {
+func (p *Postgres) assumeStandby(upstream, downstream *discoverd.Instance) error {
 	log := p.log.New("fn", "assumeStandby", "upstream", upstream.Addr)
 	log.Info("starting up as standby")
 
@@ -405,7 +429,15 @@ func (p *Postgres) assumeStandby(upstream *discoverd.Instance) error {
 		return err
 	}
 
-	return p.start()
+	if err := p.start(); err != nil {
+		return err
+	}
+
+	if downstream != nil {
+		p.waitForSync(downstream, false)
+	}
+
+	return nil
 }
 
 func (p *Postgres) waitForUpstream(upstream *discoverd.Instance) error {
@@ -449,7 +481,7 @@ func (p *Postgres) updateSync(downstream *discoverd.Instance) error {
 		return err
 	}
 
-	p.waitForSync(downstream)
+	p.waitForSync(downstream, true)
 
 	return nil
 }
@@ -564,7 +596,7 @@ func (p *Postgres) sighup() error {
 	return p.daemon.Process.Signal(syscall.SIGHUP)
 }
 
-func (p *Postgres) waitForSync(inst *discoverd.Instance) {
+func (p *Postgres) waitForSync(inst *discoverd.Instance, enableWrites bool) {
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
 
@@ -607,7 +639,7 @@ func (p *Postgres) waitForSync(inst *discoverd.Instance) {
 			}
 		}
 
-		log.Info("waiting for sync replication to catch up")
+		log.Info("waiting for downstream replication to catch up")
 
 		for {
 			if shouldStop() {
@@ -641,10 +673,11 @@ func (p *Postgres) waitForSync(inst *discoverd.Instance) {
 			}
 
 			if sent == flushed {
-				log.Info("sync caught up")
+				log.Info("downstream caught up")
+				p.setSyncedDownstream(inst)
 				break
 			} else if elapsedTime > p.replTimeout {
-				log.Error("error checking replication status", "err", "sync unable to make forward progress")
+				log.Error("error checking replication status", "err", "downstream unable to make forward progress")
 				return
 			} else {
 				log.Debug("continuing replication check")
@@ -655,15 +688,17 @@ func (p *Postgres) waitForSync(inst *discoverd.Instance) {
 			}
 		}
 
-		// sync caught up, enable write transactions
-		if err := p.writeConfig(configData{Sync: inst.ID}); err != nil {
-			log.Error("error writing postgres.conf", "err", err)
-			return
-		}
+		if enableWrites {
+			// sync caught up, enable write transactions
+			if err := p.writeConfig(configData{Sync: inst.ID}); err != nil {
+				log.Error("error writing postgres.conf", "err", err)
+				return
+			}
 
-		if err := p.sighup(); err != nil {
-			log.Error("error calling sighup")
-			return
+			if err := p.sighup(); err != nil {
+				log.Error("error calling sighup", "err", err)
+				return
+			}
 		}
 	}()
 }

--- a/appliance/postgresql/state/state.go
+++ b/appliance/postgresql/state/state.go
@@ -121,20 +121,30 @@ type PgConfig struct {
 	Downstream *discoverd.Instance `json:"downstream"`
 }
 
+func peersEqual(a, b *discoverd.Instance) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.ID == b.ID
+
+}
+
 func (x *PgConfig) Equal(y *PgConfig) bool {
 	if x == nil || y == nil {
 		return x == y
 	}
 
-	peersEqual := func(a, b *discoverd.Instance) bool {
-		if a == nil || b == nil {
-			return a == b
-		}
-		return a.ID == b.ID
-
-	}
-
 	return x.Role == y.Role && peersEqual(x.Upstream, y.Upstream) && peersEqual(x.Downstream, y.Downstream)
+}
+
+func (x *PgConfig) IsNewDownstream(y *PgConfig) bool {
+	if x == nil || y == nil {
+		return false
+	}
+	if !peersEqual(x.Upstream, y.Upstream) {
+		return false
+	}
+	return y.Downstream != nil && !peersEqual(x.Downstream, y.Downstream)
 }
 
 type Postgres interface {
@@ -201,10 +211,11 @@ type Peer struct {
 	updatingState *State       // new state object
 	stateIndex    uint64       // last received cluster state index
 
-	pgOnline   *bool               // nil for unknown
-	pgSetup    bool                // whether db existed at start
-	pgApplied  *PgConfig           // last configuration applied
-	pgUpstream *discoverd.Instance // upstream replication target
+	pgOnline     *bool               // nil for unknown
+	pgSetup      bool                // whether db existed at start
+	pgApplied    *PgConfig           // last configuration applied
+	pgUpstream   *discoverd.Instance // upstream replication target
+	pgDownstream *discoverd.Instance // downstream replication target
 
 	evalStateCh chan struct{}
 	applyConfCh chan struct{}
@@ -530,7 +541,9 @@ func (p *Peer) evalClusterState() {
 			p.assumeUnassigned()
 		} else {
 			upstream := p.upstream(whichAsync)
-			if upstream.ID != p.pgUpstream.ID {
+			downstream := p.downstream(whichAsync)
+			if upstream.ID != p.pgUpstream.ID ||
+				downstream != nil && (p.pgDownstream == nil || downstream.ID != p.pgDownstream.ID) {
 				p.assumeAsync(whichAsync)
 			}
 		}
@@ -543,6 +556,8 @@ func (p *Peer) evalClusterState() {
 	if p.Info().Role == RoleSync {
 		if !p.peerIsPresent(p.Info().State.Primary) {
 			p.startTakeover("primary gone", p.Info().State.InitWAL)
+		} else if len(p.Info().State.Async) > 0 && (p.pgDownstream == nil || p.pgDownstream.ID != p.Info().State.Async[0].ID) {
+			p.assumeSync()
 		}
 		return
 	}
@@ -662,6 +677,7 @@ func (p *Peer) assumeUnassigned() {
 	p.log.Info("assuming unassigned role", "role", "unassigned", "fn", "assumeUnassigned")
 	p.setRole(RoleUnassigned)
 	p.pgUpstream = nil
+	p.pgDownstream = nil
 	p.triggerApplyConfig()
 }
 
@@ -669,6 +685,7 @@ func (p *Peer) assumeDeposed() {
 	p.log.Info("assuming deposed role", "role", "deposed", "fn", "assumeDeposed")
 	p.setRole(RoleDeposed)
 	p.pgUpstream = nil
+	p.pgDownstream = nil
 	p.triggerApplyConfig()
 }
 
@@ -676,6 +693,7 @@ func (p *Peer) assumePrimary() {
 	p.log.Info("assuming primary role", "role", "primary", "fn", "assumePrimary")
 	p.setRole(RolePrimary)
 	p.pgUpstream = nil
+	p.pgDownstream = p.Info().State.Sync
 
 	// It simplifies things to say that evalClusterState() only deals with one
 	// change at a time. Now that we've handled the change to become primary,
@@ -702,6 +720,9 @@ func (p *Peer) assumeSync() {
 
 	p.setRole(RoleSync)
 	p.pgUpstream = p.Info().State.Primary
+	if len(p.Info().State.Async) > 0 {
+		p.pgDownstream = p.Info().State.Async[0]
+	}
 	// See assumePrimary()
 	p.evalClusterState()
 	p.triggerApplyConfig()
@@ -715,6 +736,7 @@ func (p *Peer) assumeAsync(i int) {
 
 	p.setRole(RoleAsync)
 	p.pgUpstream = p.upstream(i)
+	p.pgDownstream = p.downstream(i)
 
 	// See assumePrimary(). We don't need to check the cluster state here
 	// because there's never more than one thing to do when becoming the async
@@ -1014,10 +1036,8 @@ func (p *Peer) pgApplyConfig() (err error) {
 func (p *Peer) pgConfig() *PgConfig {
 	role := p.Info().Role
 	switch role {
-	case RolePrimary:
-		return &PgConfig{Role: role, Downstream: p.Info().State.Sync}
-	case RoleSync, RoleAsync:
-		return &PgConfig{Role: role, Upstream: p.pgUpstream}
+	case RolePrimary, RoleSync, RoleAsync:
+		return &PgConfig{Role: role, Upstream: p.pgUpstream, Downstream: p.pgDownstream}
 	case RoleUnassigned, RoleDeposed:
 		return &PgConfig{Role: RoleNone}
 	default:
@@ -1041,6 +1061,15 @@ func (p *Peer) upstream(whichAsync int) *discoverd.Instance {
 		return p.Info().State.Sync
 	}
 	return p.Info().State.Async[whichAsync-1]
+}
+
+// Return the downstream peer for a given one of the async peers
+func (p *Peer) downstream(whichAsync int) *discoverd.Instance {
+	async := p.Info().State.Async
+	if whichAsync == len(async)-1 {
+		return nil
+	}
+	return async[whichAsync+1]
 }
 
 // Returns true if the given other peer appears to be present in the most

--- a/appliance/postgresql/state/state.go
+++ b/appliance/postgresql/state/state.go
@@ -252,10 +252,6 @@ func (p *Peer) Run() {
 	postgresCh := p.postgres.Ready()
 	for {
 		select {
-		// try to run any pending configuration first
-		case <-p.applyConfCh:
-			p.pgApplyConfig()
-			continue
 		// drain discoverdCh to avoid evaluating out-of-date state
 		case e := <-discoverdCh:
 			p.handleDiscoverdEvent(e)

--- a/appliance/postgresql/state/state_test.go
+++ b/appliance/postgresql/state/state_test.go
@@ -137,6 +137,16 @@ func TestBasic(t *testing.T) {
 		XLog:        xlog.Zero,
 		XLogWaiting: "0/0000000A",
 	}
+	pgSync2 := &simulator.PostgresInfo{
+		Config: &state.PgConfig{
+			Role:       state.RoleSync,
+			Upstream:   node(3, 2),
+			Downstream: node(2, 1),
+		},
+		Online:      true,
+		XLog:        xlog.Zero,
+		XLogWaiting: "0/0000000A",
+	}
 	pgPrimary := &simulator.PostgresInfo{
 		Config: &state.PgConfig{
 			Role:       state.RolePrimary,
@@ -250,7 +260,7 @@ func TestBasic(t *testing.T) {
 					Peers: peers,
 					State: gen2_1,
 				},
-				Postgres: pgSync,
+				Postgres: pgSync2,
 			},
 		},
 
@@ -267,7 +277,7 @@ func TestBasic(t *testing.T) {
 					Peers: []*discoverd.Instance{node(2, 1), node(1, 3)},
 					State: gen2_1,
 				},
-				Postgres: pgSync,
+				Postgres: pgSync2,
 			},
 		},
 		{Cmd: "addpeer node3"},
@@ -280,7 +290,7 @@ func TestBasic(t *testing.T) {
 					Peers: []*discoverd.Instance{node(2, 1), node(1, 3), node(3, 4)},
 					State: gen2_1,
 				},
-				Postgres: pgSync,
+				Postgres: pgSync2,
 			},
 		},
 
@@ -1219,8 +1229,9 @@ func TestStartSync(t *testing.T) {
 				Postgres: &simulator.PostgresInfo{
 					Online: true,
 					Config: &state.PgConfig{
-						Role:     state.RoleSync,
-						Upstream: node(3, 3),
+						Role:       state.RoleSync,
+						Upstream:   node(3, 3),
+						Downstream: node(2, 2),
 					},
 					XLog:        xlog.Zero,
 					XLogWaiting: xlog.Zero,
@@ -1499,8 +1510,9 @@ func TestStartUnassigned(t *testing.T) {
 				Postgres: &simulator.PostgresInfo{
 					Online: true,
 					Config: &state.PgConfig{
-						Role:     state.RoleSync,
-						Upstream: node(3, 3),
+						Role:       state.RoleSync,
+						Upstream:   node(3, 3),
+						Downstream: node(4, 4),
 					},
 					XLog:        xlog.Zero,
 					XLogWaiting: "0/0000000A",
@@ -1829,8 +1841,9 @@ func TestFreezeSync(t *testing.T) {
 	gen1pg := &simulator.PostgresInfo{
 		Online: true,
 		Config: &state.PgConfig{
-			Role:     state.RoleSync,
-			Upstream: node(2, 1),
+			Role:       state.RoleSync,
+			Upstream:   node(2, 1),
+			Downstream: node(3, 3),
 		},
 		XLog: "0/0000000A",
 	}
@@ -2098,8 +2111,9 @@ func TestRemovedSync(t *testing.T) {
 				Postgres: &simulator.PostgresInfo{
 					Online: true,
 					Config: &state.PgConfig{
-						Role:     state.RoleSync,
-						Upstream: node(2, 1),
+						Role:       state.RoleSync,
+						Upstream:   node(2, 1),
+						Downstream: node(3, 3),
 					},
 					XLog:        xlog.Zero,
 					XLogWaiting: xlog.Zero,

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -23,6 +23,7 @@
           "ports": [{"port": 5432, "proto": "tcp"}],
           "data": true,
           "cmd": ["postgres"],
+          "service": "postgres",
           "env": {
             "SINGLETON": "{{ .Singleton }}"
           },
@@ -133,7 +134,8 @@
     "from_step": "postgres",
     "app": {
       "name": "postgres",
-      "meta": {"flynn-system-app": "true"}
+      "meta": {"flynn-system-app": "true"},
+      "strategy": "postgres"
     }
   },
   {

--- a/controller/deployer/strategies/main.go
+++ b/controller/deployer/strategies/main.go
@@ -277,6 +277,9 @@ func (d *Deploy) waitForJobEvents(releaseID string, expected jobEvents, log log1
 	for {
 		select {
 		case event := <-d.serviceEvents:
+			if event.Kind != discoverd.EventKindUp {
+				continue
+			}
 			if id, ok := event.Instance.Meta["FLYNN_APP_ID"]; !ok || id != d.AppID {
 				continue
 			}
@@ -295,9 +298,7 @@ func (d *Deploy) waitForJobEvents(releaseID string, expected jobEvents, log log1
 				continue
 			}
 			log.Info("got service event", "job_id", jobID, "type", typ, "state", event.Kind)
-			if event.Kind == discoverd.EventKindUp {
-				handleEvent(jobID, typ, "up")
-			}
+			handleEvent(jobID, typ, "up")
 			if expected.Equals(actual) {
 				return nil
 			}

--- a/controller/deployer/strategies/main.go
+++ b/controller/deployer/strategies/main.go
@@ -32,6 +32,7 @@ type Deploy struct {
 	jobEvents       chan *ct.JobEvent
 	jobStream       stream.Stream
 	serviceEvents   chan *discoverd.Event
+	serviceMeta     *discoverd.ServiceMeta
 	useJobEvents    map[string]struct{}
 	logger          log15.Logger
 	oldReleaseState map[string]int
@@ -75,6 +76,7 @@ type PerformFunc func(d *Deploy) error
 var performFuncs = map[string]PerformFunc{
 	"all-at-once": allAtOnce,
 	"one-by-one":  oneByOne,
+	"postgres":    postgres,
 }
 
 func Perform(d *ct.Deployment, client *controller.Client, deployEvents chan<- ct.DeploymentEvent, logger log15.Logger) error {
@@ -150,6 +152,8 @@ func Perform(d *ct.Deployment, client *controller.Client, deployEvents chan<- ct
 				switch event.Kind {
 				case discoverd.EventKindCurrent:
 					break outer
+				case discoverd.EventKindServiceMeta:
+					deploy.serviceMeta = event.ServiceMeta
 				case discoverd.EventKindUp:
 					releaseID, ok := event.Instance.Meta["FLYNN_RELEASE_ID"]
 					if !ok {

--- a/controller/deployer/strategies/postgres.go
+++ b/controller/deployer/strategies/postgres.go
@@ -1,0 +1,219 @@
+package strategy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flynn/flynn/appliance/postgresql/client"
+	"github.com/flynn/flynn/appliance/postgresql/state"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
+)
+
+func postgres(d *Deploy) error {
+	log := d.logger.New("fn", "postgres")
+	log.Info("starting postgres deployment")
+
+	loggedErr := func(e string) error {
+		log.Error(e)
+		return errors.New(e)
+	}
+
+	if d.serviceMeta == nil {
+		return loggedErr("missing pg cluster state")
+	}
+
+	var state state.State
+	log.Info("decoding pg cluster state")
+	if err := json.Unmarshal(d.serviceMeta.Data, &state); err != nil {
+		log.Error("error decoding pg cluster state", "err", err)
+		return err
+	}
+
+	// abort if in singleton mode or not deploying from a clean state
+	if state.Singleton {
+		return loggedErr("pg cluster in singleton mode")
+	}
+	if len(state.Async) == 0 {
+		return loggedErr("pg cluster in unhealthy state (has no asyncs)")
+	}
+	if 2+len(state.Async) != d.Processes["postgres"] {
+		return loggedErr(fmt.Sprintf("pg cluster in unhealthy state (too few asyncs)"))
+	}
+	if d.newReleaseState["postgres"] > 0 {
+		return loggedErr("pg cluster in unexpected state")
+	}
+
+	stopInstance := func(inst *discoverd.Instance) error {
+		log := log.New("job_id", inst.Meta["FLYNN_JOB_ID"])
+
+		d.deployEvents <- ct.DeploymentEvent{
+			ReleaseID: d.OldReleaseID,
+			JobState:  "stopping",
+			JobType:   "postgres",
+		}
+		pg := pgmanager.NewClient(inst.Addr)
+		log.Info("stopping postgres")
+		if err := pg.Stop(); err != nil {
+			log.Error("error stopping postgres", "err", err)
+			return err
+		}
+		log.Info("waiting for postgres to stop")
+		for {
+			select {
+			case event := <-d.serviceEvents:
+				if event.Kind == discoverd.EventKindDown && event.Instance.ID == inst.ID {
+					d.deployEvents <- ct.DeploymentEvent{
+						ReleaseID: d.OldReleaseID,
+						JobState:  "down",
+						JobType:   "postgres",
+					}
+					return nil
+				}
+			case <-time.After(60 * time.Second):
+				return loggedErr("timed out waiting for postgres to stop")
+			}
+		}
+	}
+
+	// newPrimary is the first new instance started, newSync the second
+	var newPrimary, newSync *discoverd.Instance
+	startInstance := func() (*discoverd.Instance, error) {
+		log.Info("starting new instance")
+		d.deployEvents <- ct.DeploymentEvent{
+			ReleaseID: d.NewReleaseID,
+			JobState:  "starting",
+			JobType:   "postgres",
+		}
+		d.newReleaseState["postgres"]++
+		if err := d.client.PutFormation(&ct.Formation{
+			AppID:     d.AppID,
+			ReleaseID: d.NewReleaseID,
+			Processes: d.newReleaseState,
+		}); err != nil {
+			log.Error("error scaling postgres formation up by one", "err", err)
+			return nil, err
+		}
+		log.Info("waiting for new instance to come up")
+		var inst *discoverd.Instance
+	loop:
+		for {
+			select {
+			case event := <-d.serviceEvents:
+				if event.Kind == discoverd.EventKindUp &&
+					event.Instance.Meta != nil &&
+					event.Instance.Meta["FLYNN_RELEASE_ID"] == d.NewReleaseID &&
+					event.Instance.Meta["FLYNN_PROCESS_TYPE"] == "postgres" {
+					inst = event.Instance
+					break loop
+				}
+			case <-time.After(60 * time.Second):
+				return nil, loggedErr("timed out waiting for new instance to come up")
+			}
+		}
+		if newPrimary == nil {
+			newPrimary = inst
+		} else if newSync == nil {
+			newSync = inst
+		}
+		return inst, nil
+	}
+	waitForSync := func(upstream, downstream *discoverd.Instance) error {
+		log.Info("waiting for replication sync", "upstream", upstream.Addr, "downstream", downstream.Addr)
+		client := pgmanager.NewClient(upstream.Addr)
+		if err := client.WaitForReplSync(downstream, 3*time.Minute); err != nil {
+			log.Error("error waiting for replication sync", "err", err)
+			return err
+		}
+		d.deployEvents <- ct.DeploymentEvent{
+			ReleaseID: d.NewReleaseID,
+			JobState:  "up",
+			JobType:   "postgres",
+		}
+		return nil
+	}
+
+	// asyncUpstream is the instance we will query for replication status
+	// of the new async, which will be the sync if there is only one
+	// async, or the tail async otherwise.
+	asyncUpstream := state.Sync
+	if len(state.Async) > 1 {
+		asyncUpstream = state.Async[len(state.Async)-1]
+	}
+	for i := 0; i < len(state.Async); i++ {
+		log.Info("replacing an Async node")
+		if err := stopInstance(state.Async[i]); err != nil {
+			return err
+		}
+		newInst, err := startInstance()
+		if err != nil {
+			return err
+		}
+		if err := waitForSync(asyncUpstream, newInst); err != nil {
+			return err
+		}
+		// the new instance is now the tail async
+		asyncUpstream = newInst
+	}
+
+	log.Info("replacing the Sync node")
+	if err := stopInstance(state.Sync); err != nil {
+		return err
+	}
+	_, err := startInstance()
+	if err != nil {
+		return err
+	}
+	if err := waitForSync(state.Primary, newPrimary); err != nil {
+		return err
+	}
+
+	log.Info("replacing the Primary node")
+	if err := stopInstance(state.Primary); err != nil {
+		return err
+	}
+	_, err = startInstance()
+	if err != nil {
+		return err
+	}
+	if err := waitForSync(newPrimary, newSync); err != nil {
+		return err
+	}
+
+	log.Info("stopping old postgres jobs")
+	d.oldReleaseState["postgres"] = 0
+	if err := d.client.PutFormation(&ct.Formation{
+		AppID:     d.AppID,
+		ReleaseID: d.OldReleaseID,
+		Processes: d.oldReleaseState,
+	}); err != nil {
+		log.Error("error scaling old formation", "err", err)
+		return err
+	}
+
+	log.Info(fmt.Sprintf("waiting for %d job down events", d.Processes["postgres"]))
+	actual := 0
+loop:
+	for {
+		select {
+		case event, ok := <-d.jobEvents:
+			if !ok {
+				return loggedErr("unexpected close of job event stream")
+			}
+			log.Info("got job event", "job_id", event.JobID, "type", event.Type, "state", event.State)
+			if event.State == "down" && event.Type == "postgres" && event.Job.ReleaseID == d.OldReleaseID {
+				actual++
+				if actual == d.Processes["postgres"] {
+					break loop
+				}
+			}
+		case <-time.After(60 * time.Second):
+			return loggedErr("timed out waiting for job events")
+		}
+	}
+
+	// do a one-by-one deploy for the other process types
+	return oneByOne(d)
+}

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -28,7 +28,7 @@ func migrateDB(db *sql.DB) error {
     deleted_at timestamptz
 )`,
 
-		`CREATE TYPE deployment_strategy AS ENUM ('all-at-once', 'one-by-one')`,
+		`CREATE TYPE deployment_strategy AS ENUM ('all-at-once', 'one-by-one', 'postgres')`,
 
 		`CREATE TABLE apps (
     app_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -35,7 +35,7 @@
     },
     "strategy": {
       "type": "string",
-      "enum": ["all-at-once", "one-by-one"]
+      "enum": ["all-at-once", "one-by-one", "postgres"]
     },
     "meta": {
       "description": "client-specified metadata",

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/appliance/postgresql/state"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/postgres"
 )
 
 type PostgresSuite struct {
@@ -37,4 +45,278 @@ func (s *PostgresSuite) TestDumpRestore(t *c.C) {
 	query := r.flynn("pg", "psql", "--", "-c", "SELECT * FROM foos")
 	t.Assert(query, Succeeds)
 	t.Assert(query, OutputContains, "foobar")
+}
+
+type pgDeploy struct {
+	name     string
+	pgJobs   int
+	webJobs  int
+	expected func(string, string) []expectedPgState
+}
+
+type expectedPgState struct {
+	Primary, Sync string
+	Async         []string
+}
+
+func (s *PostgresSuite) TestDeployMultipleAsync(t *c.C) {
+	s.testDeploy(t, &pgDeploy{
+		name:    "postgres-multiple-async",
+		pgJobs:  5,
+		webJobs: 2,
+		expected: func(oldRelease, newRelease string) []expectedPgState {
+			return []expectedPgState{
+				// kill Async[0], new Async[2]
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{oldRelease, oldRelease}},
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{oldRelease, oldRelease, newRelease}},
+
+				// kill Async[0], new Async[2]
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{oldRelease, newRelease}},
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{oldRelease, newRelease, newRelease}},
+
+				// kill Async[0], new Async[2]
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{newRelease, newRelease}},
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{newRelease, newRelease, newRelease}},
+
+				// kill Sync, new Async[2]
+				{Primary: oldRelease, Sync: newRelease, Async: []string{newRelease, newRelease}},
+				{Primary: oldRelease, Sync: newRelease, Async: []string{newRelease, newRelease, newRelease}},
+
+				// kill Primary, new Async[2]
+				{Primary: newRelease, Sync: newRelease, Async: []string{newRelease, newRelease}},
+				{Primary: newRelease, Sync: newRelease, Async: []string{newRelease, newRelease, newRelease}},
+			}
+		},
+	})
+}
+
+func (s *PostgresSuite) TestDeploySingleAsync(t *c.C) {
+	s.testDeploy(t, &pgDeploy{
+		name:    "postgres-single-async",
+		pgJobs:  3,
+		webJobs: 2,
+		expected: func(oldRelease, newRelease string) []expectedPgState {
+			return []expectedPgState{
+				// kill Async, new Async
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{}},
+				{Primary: oldRelease, Sync: oldRelease, Async: []string{newRelease}},
+
+				// kill Sync, new Async
+				{Primary: oldRelease, Sync: newRelease, Async: []string{}},
+				{Primary: oldRelease, Sync: newRelease, Async: []string{newRelease}},
+
+				// kill Primary, new Async
+				{Primary: newRelease, Sync: newRelease, Async: []string{}},
+				{Primary: newRelease, Sync: newRelease, Async: []string{newRelease}},
+			}
+		},
+	})
+}
+
+func (s *PostgresSuite) testDeploy(t *c.C, d *pgDeploy) {
+	// create postgres app
+	client := s.controllerClient(t)
+	app := &ct.App{Name: d.name, Strategy: "postgres"}
+	t.Assert(client.CreateApp(app), c.IsNil)
+
+	// copy release from default postgres app
+	release, err := client.GetAppRelease("postgres")
+	t.Assert(err, c.IsNil)
+	release.ID = ""
+	proc := release.Processes["postgres"]
+	delete(proc.Env, "SINGLETON")
+	proc.Env["FLYNN_POSTGRES"] = d.name
+	proc.Service = d.name
+	release.Processes["postgres"] = proc
+	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.SetAppRelease(app.ID, release.ID), c.IsNil)
+	oldRelease := release.ID
+
+	// create formation
+	discEvents := make(chan *discoverd.Event)
+	discStream, err := s.discoverdClient(t).Service(d.name).Watch(discEvents)
+	t.Assert(err, c.IsNil)
+	defer discStream.Close()
+	jobEvents := make(chan *ct.JobEvent)
+	jobStream, err := client.StreamJobEvents(d.name, 0, jobEvents)
+	t.Assert(err, c.IsNil)
+	defer jobStream.Close()
+	t.Assert(client.PutFormation(&ct.Formation{
+		AppID:     app.ID,
+		ReleaseID: release.ID,
+		Processes: map[string]int{"postgres": d.pgJobs, "web": d.webJobs},
+	}), c.IsNil)
+
+	// watch cluster state changes
+	type stateChange struct {
+		state *state.State
+		err   error
+	}
+	stateCh := make(chan stateChange)
+	go func() {
+		for event := range discEvents {
+			if event.Kind != discoverd.EventKindServiceMeta {
+				continue
+			}
+			var state state.State
+			if err := json.Unmarshal(event.ServiceMeta.Data, &state); err != nil {
+				stateCh <- stateChange{err: err}
+				return
+			}
+			primary := ""
+			if state.Primary != nil {
+				primary = state.Primary.Addr
+			}
+			sync := ""
+			if state.Sync != nil {
+				sync = state.Sync.Addr
+			}
+			var async []string
+			for _, a := range state.Async {
+				async = append(async, a.Addr)
+			}
+			debugf(t, "got pg cluster state: index=%d primary=%s sync=%s async=%s",
+				event.ServiceMeta.Index, primary, sync, strings.Join(async, ","))
+			stateCh <- stateChange{state: &state}
+		}
+	}()
+
+	// wait for correct cluster state and number of web processes
+	var pgState state.State
+	var webJobs int
+	ready := func() bool {
+		if webJobs != d.webJobs {
+			return false
+		}
+		if pgState.Primary == nil {
+			return false
+		}
+		if d.pgJobs > 1 && pgState.Sync == nil {
+			return false
+		}
+		if d.pgJobs > 2 && len(pgState.Async) != d.pgJobs-2 {
+			return false
+		}
+		return true
+	}
+	for {
+		if ready() {
+			break
+		}
+		select {
+		case s := <-stateCh:
+			t.Assert(s.err, c.IsNil)
+			pgState = *s.state
+		case e, ok := <-jobEvents:
+			if !ok {
+				t.Fatalf("job event stream closed: %s", jobStream.Err())
+			}
+			debugf(t, "got job event: %s %s %s", e.Type, e.JobID, e.State)
+			if e.Type == "web" && e.State == "up" {
+				webJobs++
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for postgres formation")
+		}
+	}
+
+	// connect to the db so we can test writes
+	db := postgres.Wait(d.name, fmt.Sprintf("dbname=postgres user=flynn password=%s", release.Env["PGPASSWORD"]))
+	dbname := "deploy-test"
+	t.Assert(db.Exec(fmt.Sprintf(`CREATE DATABASE "%s" WITH OWNER = "flynn"`, dbname)), c.IsNil)
+	db.Close()
+	db, err = postgres.Open(d.name, fmt.Sprintf("dbname=%s user=flynn password=%s", dbname, release.Env["PGPASSWORD"]))
+	t.Assert(err, c.IsNil)
+	defer db.Close()
+	t.Assert(db.Exec(`CREATE TABLE deploy_test ( data text)`), c.IsNil)
+	assertWriteable := func() {
+		debug(t, "writing to postgres database")
+		t.Assert(db.Exec(`INSERT INTO deploy_test (data) VALUES ('data')`), c.IsNil)
+	}
+
+	// check currently writeable
+	assertWriteable()
+
+	// check a deploy completes with expected cluster state changes
+	release.ID = ""
+	t.Assert(client.CreateRelease(release), c.IsNil)
+	newRelease := release.ID
+	deployment, err := client.CreateDeployment(app.ID, newRelease)
+	t.Assert(err, c.IsNil)
+	deployEvents := make(chan *ct.DeploymentEvent)
+	deployStream, err := client.StreamDeployment(deployment.ID, deployEvents)
+	t.Assert(err, c.IsNil)
+	defer deployStream.Close()
+
+	assertNextState := func(expected expectedPgState) {
+		var state state.State
+		select {
+		case s := <-stateCh:
+			t.Assert(s.err, c.IsNil)
+			state = *s.state
+		case <-time.After(60 * time.Second):
+			t.Fatal("timed out waiting for postgres cluster state")
+		}
+		if state.Primary == nil {
+			t.Fatal("no primary configured")
+		}
+		if state.Primary.Meta["FLYNN_RELEASE_ID"] != expected.Primary {
+			t.Fatal("primary has incorrect release")
+		}
+		if expected.Sync == "" {
+			return
+		}
+		if state.Sync == nil {
+			t.Fatal("no sync configured")
+		}
+		if state.Sync.Meta["FLYNN_RELEASE_ID"] != expected.Sync {
+			t.Fatal("sync has incorrect release")
+		}
+		if expected.Async == nil {
+			return
+		}
+		if len(state.Async) != len(expected.Async) {
+			t.Fatalf("expected %d asyncs, got %d", len(expected.Async), len(state.Async))
+		}
+		for i, release := range expected.Async {
+			if state.Async[i].Meta["FLYNN_RELEASE_ID"] != release {
+				t.Fatalf("async[%d] has incorrect release", i)
+			}
+		}
+	}
+	expected := d.expected(oldRelease, newRelease)
+	var expectedIndex, newWebJobs int
+loop:
+	for {
+		select {
+		case e := <-deployEvents:
+			switch e.Status {
+			case "complete":
+				break loop
+			case "failed":
+				t.Fatalf("deployment failed: %s", e.Error)
+			}
+			debugf(t, "got deployment event: %s %s", e.JobType, e.JobState)
+			if e.JobState != "up" && e.JobState != "down" {
+				continue
+			}
+			switch e.JobType {
+			case "postgres":
+				assertNextState(expected[expectedIndex])
+				expectedIndex++
+			case "web":
+				if e.JobState == "up" && e.ReleaseID == newRelease {
+					newWebJobs++
+				}
+			}
+		case <-time.After(2 * time.Minute):
+			t.Fatal("timed out waiting for deployment")
+		}
+	}
+
+	// check we have the correct number of new web jobs
+	t.Assert(newWebJobs, c.Equals, d.webJobs)
+
+	// check writeable now deploy is complete
+	assertWriteable()
 }


### PR DESCRIPTION
To minimise the impact of deploying postgres (i.e. to minimise the time in read-only mode), I have added a new deploy strategy which stops postgres jobs in a particular order, waiting for specific service discovery events before moving on.

To summarise the strategy:

* While the head async is from the old release, replace it
* If sync is present, replace it
* Replace the primary

Replacing a job involves:

* calling `Stop` via the API to stop postgres and unregister the service
* waiting for a service down event
* scaling up the new release (the new job will either become the sync or be appended to the asyncs)
* waiting for the new job to set `PG_ONLINE=true` in service discovery (which happens once it has run `pg_basebackup`)

Ideally this would just be a one-by-one deployment with the scheduler being flexible enough to be able to stop jobs in a particular order, and the deployer's job waiting flexible enough to wait for specific instance metadata before declaring a job is up, but this will need to wait until the scheduler is refactored.