### PR TITLE
router: add sleep backoff on datastore sync error

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -124,6 +124,8 @@ func (s *HTTPListener) runSync(ctx context.Context, errc chan error) {
 		}
 		log.Printf("router: sync error: %s", err)
 
+		time.Sleep(2 * time.Second)
+
 		s.doSync(ctx, errc)
 
 		err = <-errc

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/router/proxy"
@@ -152,6 +153,8 @@ func (l *TCPListener) runSync(ctx context.Context, errc chan error) {
 			return
 		}
 		log.Printf("router: tcp sync error: %s", err)
+
+		time.Sleep(2 * time.Second)
 
 		l.doSync(ctx, errc)
 


### PR DESCRIPTION
Limit logspam on a datastore sync errors, see #1145. I wasn't able to reproduce the `cannot acquire from closed pool`, but I was able to trigger logspam for `the database system is in recovery mode (SQLSTATE 57P03)`, and this change helped recovery.