### PR TITLE
slugrunner: Don't use a proxy for .discoverd hosts

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -9,7 +9,7 @@ mkdir -p "${HOME}"
 if [[ -n $(ls -A "${HOME}") ]]; then
   true
 elif ! [[ -z "${SLUG_URL}" ]]; then
-  curl -s -L "${SLUG_URL}" | tar -xzC "${HOME}"
+  curl -s -L --noproxy "discoverd"  "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL
 else
   cat | tar -xzC "${HOME}"


### PR DESCRIPTION
discoverd domains are internal to the cluster, so will not work if the user has set http_proxy, as the proxy is most likely not within the cluster.

I tested this by starting a proxy and setting `http_proxy`, then seeing that the build uses the proxy (by viewing the proxy logs) but the slugrunner does not.