### PR TITLE
script: Don't force release tag

### DIFF
--- a/script/release-components
+++ b/script/release-components
@@ -118,7 +118,7 @@ main() {
 
   info "building flynn"
   git checkout --force --quiet $commit
-  git tag --force "v${version}"
+  git tag "v${version}"
 
   make release
 


### PR DESCRIPTION
If the tag already exists, we end up overwriting the previous release and the tag doesn't end up being written to GitHub.