### PR TITLE
Add support for controller key rotation

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -222,6 +222,12 @@
       "uri": "$image_repository?name=flynn/receiver&id=$image_id[receiver]"
     },
     "release": {
+      "env": {
+        "SSH_PRIVATE_KEYS": "{{ (index .StepData \"gitreceive-key\").PrivateKeys }}",
+        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
+        "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
+        "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
+      },
       "processes": {
         "app": {
           "ports": [{
@@ -231,13 +237,7 @@
               "create": true,
               "check": {"type": "tcp"}
             }
-          }],
-          "env": {
-            "SSH_PRIVATE_KEYS": "{{ (index .StepData \"gitreceive-key\").PrivateKeys }}",
-            "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
-            "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
-            "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
-          }
+          }]
         }
       }
     },

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -234,7 +234,7 @@
           }],
           "env": {
             "SSH_PRIVATE_KEYS": "{{ (index .StepData \"gitreceive-key\").PrivateKeys }}",
-            "CONTROLLER_AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
+            "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
             "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
             "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
           }
@@ -315,7 +315,7 @@
     },
     "release": {
       "env": {
-        "CONTROLLER_AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
+        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
         "SLUGBUILDER_IMAGE_URI": "$image_repository?name=flynn/slugbuilder&id=$image_id[slugbuilder]",
         "SLUGRUNNER_IMAGE_URI": "$image_repository?name=flynn/slugrunner&id=$image_id[slugrunner]"
       }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -75,7 +75,7 @@ func (s *S) SetUpSuite(c *C) {
 		lc:      s.flac,
 		rc:      newFakeRouter(),
 		pgxpool: pgxpool,
-		key:     authKey,
+		keys:    []string{authKey},
 	}
 	handler := appHandler(s.hc)
 	s.srv = httptest.NewServer(handler)

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -187,7 +187,7 @@ func (e *generator) createAppError() {
 func (e *generator) getInitialAppRelease() {
 	appRelease, err := e.client.GetAppRelease("gitreceive")
 	if err == nil {
-		e.resourceIds["SLUGRUNNER_IMAGE_URI"] = appRelease.Processes["app"].Env["SLUGRUNNER_IMAGE_URI"]
+		e.resourceIds["SLUGRUNNER_IMAGE_URI"] = appRelease.Env["SLUGRUNNER_IMAGE_URI"]
 	}
 }
 

--- a/gitreceived/gitreceived.go
+++ b/gitreceived/gitreceived.go
@@ -272,8 +272,13 @@ func handleChannel(conn *ssh.ServerConn, newChan ssh.NewChannel) {
 var ErrUnauthorized = errors.New("gitreceive: user is unauthorized")
 
 func checkAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-	status, err := exitStatus(exec.Command(*authChecker,
-		conn.User(), string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(key)))).Run())
+	cmd := exec.Command(*authChecker,
+		conn.User(),
+		string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(key))),
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	status, err := exitStatus(cmd.Run())
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/cache-key/main.go
+++ b/receiver/cache-key/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	appName := os.Args[2]
 
-	client, err := controller.NewClient("", os.Getenv("CONTROLLER_AUTH_KEY"))
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
 	if err != nil {
 		log.Fatalln("Unable to connect to controller:", err)
 	}

--- a/receiver/flynn-receive.go
+++ b/receiver/flynn-receive.go
@@ -37,7 +37,7 @@ var typesPattern = regexp.MustCompile("types.* -> (.+)\n")
 const blobstoreURL = "http://blobstore.discoverd"
 
 func main() {
-	client, err := controller.NewClient("", os.Getenv("CONTROLLER_AUTH_KEY"))
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
 	if err != nil {
 		log.Fatalln("Unable to connect to controller:", err)
 	}

--- a/receiver/key-check/main.go
+++ b/receiver/key-check/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	key := os.Args[2]
 
-	client, err := controller.NewClient("", os.Getenv("CONTROLLER_AUTH_KEY"))
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
 	if err != nil {
 		log.Fatalln("Unable to connect to controller:", err)
 	}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -146,18 +145,7 @@ func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Log
 	skipDeploy := artifact.URI == uri
 	// deploy the gitreceive / taffy apps if builder / runner images have changed
 	switch app.Name {
-	case "gitreceive":
-		proc, ok := release.Processes["app"]
-		if !ok {
-			e := "missing app process in gitreceive release"
-			log.Error(e)
-			return errors.New(e)
-		}
-		if updateSlugURIs(proc.Env) {
-			skipDeploy = false
-		}
-		release.Processes["app"] = proc
-	case "taffy":
+	case "taffy", "gitreceive":
 		if updateSlugURIs(release.Env) {
 			skipDeploy = false
 		}


### PR DESCRIPTION
Changing the controller key looks like this:

```text
NEW_KEY=$(openssl rand -hex 16)
flynn -a controller env set -t web AUTH_KEY=$NEW_KEY,$(flynn -a controller env get AUTH_KEY)
flynn -a gitreceive env set CONTROLLER_KEY=$NEW_KEY
flynn -a taffy env set CONTROLLER_KEY=$NEW_KEY
flynn -a dashboard env set CONTROLLER_KEY=$NEW_KEY
# change key in ~/.flynnrc
flynn -a controller env set AUTH_KEY=$NEW_KEY
flynn -a controller env unset -t web AUTH_KEY
```

Closes #1324