### PR TITLE
logaggregator: refactor filter interface

### DIFF
--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -63,13 +63,13 @@ func (a *aggregatorAPI) GetLog(ctx context.Context, w http.ResponseWriter, req *
 		}
 	}
 
-	filters := make([]filter, 0)
-	if strJobID := req.FormValue("job_id"); strJobID != "" {
-		filters = append(filters, filterJobID{[]byte(strJobID)})
+	filters := make(filterSlice, 0)
+	if jobID := req.FormValue("job_id"); jobID != "" {
+		filters = append(filters, filterJobID(jobID))
 	}
 	if processTypeVals, ok := req.Form["process_type"]; ok && len(processTypeVals) > 0 {
 		val := processTypeVals[len(processTypeVals)-1]
-		filters = append(filters, filterProcessType{[]byte(val)})
+		filters = append(filters, filterProcessType(val))
 	}
 
 	w.WriteHeader(200)

--- a/logaggregator/api_test.go
+++ b/logaggregator/api_test.go
@@ -68,10 +68,6 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
 			expected: []*rfc5424.Message{msg1, msg2, msg3, msg4, msg5},
 		},
 		{
-			numLogs:  intPtr(0),
-			expected: nil,
-		},
-		{
 			numLogs:  intPtr(1),
 			expected: []*rfc5424.Message{msg5},
 		},


### PR DESCRIPTION
Add the `filterFunc` & `filterSlice` types and the `Filter` func to the `Filter` interface.