### PR TITLE
script,test: Add flynnbr0 to /etc/resolv.conf before running tests

### DIFF
--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -53,6 +53,9 @@ main() {
     exit 1
   fi
 
+  sudo mv /etc/resolv.conf{,.backup}
+  trap 'sudo mv /etc/resolv.conf{.backup,}' EXIT
+  echo "nameserver $(ifconfig flynnbr0 | grep -oP 'inet addr:\S+' | cut -d: -f2)" | sudo tee /etc/resolv.conf
   export FLYNNRC=/tmp/flynnrc
   "${flynn}" cluster remove default
   "${flynn}" ${cluster_add:6}


### PR DESCRIPTION
This is so that the tests can use discoverd DNS (for example to connect to a postgres DB at `leader.postgres.discoverd`).

Extracted from #1301.