### PR TITLE
Revert "test: Use xip.io domains"

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -238,6 +238,8 @@ var testRunScript = template.Must(template.New("test-run").Parse(`
 #!/bin/bash
 set -e -x -o pipefail
 
+echo {{ .Cluster.RouterIP }} {{ .Cluster.ClusterDomain }} {{ .Cluster.ControllerDomain }} | sudo tee -a /etc/hosts
+
 # Wait for the Flynn bridge interface to show up so we can use it as the
 # nameserver to resolve discoverd domains
 iface=flynnbr0


### PR DESCRIPTION
This introduced intermittent failures in CI when trying to resolve `xip.io` domains, e.g:

```
dial tcp: lookup controller.10.69.2.3.xip.io: No address associated with hostname
```

This reverts commit 41b6357c4a5a9dfbcc95b390e47cc2da71f47632.