### PR TITLE
host/cli: Unlink destination path during download

### DIFF
--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -100,6 +100,10 @@ func downloadGzippedFile(client *tuf.Client, path, dir string) (string, error) {
 	}
 	defer file.Close()
 	dst := filepath.Join(dir, path)
+
+	// unlink the destination file in case it is in use
+	os.Remove(dst)
+
 	out, err := os.Create(dst)
 	if err != nil {
 		return "", err

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -145,9 +145,14 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 		}
 	}
 
+	// installing on an instance with Flynn running should not fail
+	script.Reset()
+	installScript.Execute(&script, blobstore)
+	t.Assert(buildHost.Run("sudo bash -ex", &tc.Streams{Stdin: &script, Stdout: logWriter, Stderr: logWriter}), c.IsNil)
+
 	// run a cluster update from the blobstore
 	updateHost := releaseCluster.Instances[1]
-	script = bytes.Buffer{}
+	script.Reset()
 	updateScript.Execute(&script, blobstore)
 	var updateOutput bytes.Buffer
 	out = io.MultiWriter(logWriter, &updateOutput)


### PR DESCRIPTION
This avoids trying to replace a file which is in use.

Fixes #1371.