### PR TITLE
cli: Fix log message

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -112,7 +112,7 @@ func runClusterRemove(args *docopt.Args) error {
 			return err
 		}
 
-		log.Printf(msg, name)
+		log.Print(msg)
 	}
 
 	return nil


### PR DESCRIPTION
The string in `msg` is generated with `Sprintf` so it is not a format, which leads to the following being logged:

```
Cluster "default" removed.%!(EXTRA string=default)
```