### PR TITLE
slugbuilder: Add static file buildpack

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/stores/github-repo-buildpack.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/github-repo-buildpack.js
@@ -21,6 +21,11 @@ var buildpackRules = [
 		url: "https://github.com/heroku/heroku-buildpack-multi"
 	},
 	{
+		name: 'staticfile',
+		match: buildpackMatchFn(/^Staticfile$/),
+		url: "https://github.com/cloudfoundry-incubator/staticfile-buildpack"
+	},
+	{
 		name: 'ruby',
 		match: buildpackMatchFn(/^Gemfile$/),
 		url: "https://github.com/heroku/heroku-buildpack-ruby",

--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,4 +1,5 @@
 https://github.com/heroku/heroku-buildpack-multi.git#0ac95a28
+https://github.com/cloudfoundry-incubator/staticfile-buildpack.git#062b8f40
 https://github.com/heroku/heroku-buildpack-ruby.git#bac6cf09
 https://github.com/heroku/heroku-buildpack-nodejs.git#c8cb21e7
 https://github.com/heroku/heroku-buildpack-clojure.git#90fbff0d

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -119,7 +119,15 @@ func (s *GitDeploySuite) TestPythonBuildpack(t *c.C) {
 	s.runBuildpackTest(t, "python-flynn-example", nil)
 }
 
+func (s *GitDeploySuite) TestStaticBuildpack(t *c.C) {
+	s.runBuildpackTestWithResponsePattern(t, "static-flynn-example", nil, `Hello, Flynn!`)
+}
+
 func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []string) {
+	s.runBuildpackTestWithResponsePattern(t, name, resources, `Hello from Flynn on port \d+`)
+}
+
+func (s *GitDeploySuite) runBuildpackTestWithResponsePattern(t *c.C, name string, resources []string, pat string) {
 	r := s.newGitRepo(t, "https://github.com/flynn-examples/"+name)
 
 	t.Assert(r.flynn("create", name), Outputs, fmt.Sprintf("Created %s\n", name))
@@ -160,12 +168,12 @@ func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []strin
 		if res.StatusCode != 200 {
 			return fmt.Errorf("Expected status 200, got %v", res.StatusCode)
 		}
-		m, err := regexp.MatchString(`Hello from Flynn on port \d+`, string(contents))
+		m, err := regexp.MatchString(pat, string(contents))
 		if err != nil {
 			return err
 		}
 		if !m {
-			return fmt.Errorf("Expected `Hello from Flynn on port \\d+`, got `%v`", string(contents))
+			return fmt.Errorf("Expected `%s`, got `%v`", pat, string(contents))
 		}
 		return nil
 	})


### PR DESCRIPTION
When a Staticfile file is present in the root of the repo, this buildpack is used to serve files using nginx.

Closes #1398

/cc @jvatic 