### PR TITLE
cli: fixed command line usages

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -22,7 +22,7 @@ If run from a git repository, a 'flynn' remote will be created or replaced that
 allows deploying the application via git.
 
 Options:
-	-r, --remote <remote>  Name of git remote to create, empty string for none. [default: flynn]
+	-r, --remote=<remote>  Name of git remote to create, empty string for none. [default: flynn]
 	-y, --yes              Skip the confirmation prompt if the git remote already exists.
 
 Examples:
@@ -40,7 +40,7 @@ If run from a git repository with a 'flynn' remote for the app, it will be
 removed.
 
 Options:
-	-r, --remote <remote>  Name of git remote to delete, empty string for none. [default: flynn]
+	-r, --remote=<remote>  Name of git remote to delete, empty string for none. [default: flynn]
 	-y, --yes              Skip the confirmation prompt.
 
 Examples:

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -21,8 +21,8 @@ Manage clusters in the ~/.flynnrc configuration file.
 Options:
 	-f, --force               force add cluster
 	-d, --default             set as default cluster
-	-g, --git-host <githost>  git host (if host differs from api URL host)
-	-p, --tls-pin <tlspin>    SHA256 of the cluster's TLS cert (useful if it is self-signed)
+	-g, --git-host=<githost>  git host (if host differs from api URL host)
+	-p, --tls-pin=<tlspin>    SHA256 of the cluster's TLS cert (useful if it is self-signed)
 
 Commands:
 	With no arguments, shows a list of clusters.

--- a/cli/env.go
+++ b/cli/env.go
@@ -22,7 +22,7 @@ usage: flynn env [-t <proc>]
 Manage app environment variables.
 
 Options:
-	-t, --process-type <proc>  set or read env for specified process type
+	-t, --process-type=<proc>  set or read env for specified process type
 
 Commands:
 	With no arguments, shows a list of environment variables.

--- a/cli/log.go
+++ b/cli/log.go
@@ -22,11 +22,11 @@ Stream log for an app.
 
 Options:
 	-f, --follow               stream new lines after printing log buffer
-	-j, --job <id>             filter logs to a specific job ID
-	-n, --number <lines>       return at most n lines from the log buffer
+	-j, --job=<id>             filter logs to a specific job ID
+	-n, --number=<lines>       return at most n lines from the log buffer
 	-r, --raw-output           output raw log messages with no prefix
 	-s, --split-stderr         send stderr lines to stderr
-	-t, --process-type <type>  filter logs to a specific process type
+	-t, --process-type=<type>  filter logs to a specific process type
 `)
 }
 

--- a/cli/pg.go
+++ b/cli/pg.go
@@ -18,7 +18,7 @@ usage: flynn pg psql [--] [<argument>...]
        flynn pg restore [-q] [-f <file>]
 
 Options:
-	-f, --file <file>  name of dump file
+	-f, --file=<file>  name of dump file
 	-q, --quiet        don't print progress
 
 Commands:

--- a/cli/release.go
+++ b/cli/release.go
@@ -19,7 +19,7 @@ Manage app releases.
 
 Options:
 	-t <type>          type of the release. Currently only 'docker' is supported. [default: docker]
-	-f, --file <file>  release configuration file
+	-f, --file=<file>  release configuration file
 
 Commands:
 	add   add a new release

--- a/cli/route.go
+++ b/cli/route.go
@@ -24,9 +24,9 @@ usage: flynn route
 Manage routes for application.
 
 Options:
-	-s, --service <service>    service name to route domain to (defaults to APPNAME-web)
-	-c, --tls-cert <tls-cert>  path to PEM encoded certificate for TLS, - for stdin (http only)
-	-k, --tls-key <tls-key>    path to PEM encoded private key for TLS, - for stdin (http only)
+	-s, --service=<service>    service name to route domain to (defaults to APPNAME-web)
+	-c, --tls-cert=<tls-cert>  path to PEM encoded certificate for TLS, - for stdin (http only)
+	-k, --tls-key=<tls-key>    path to PEM encoded private key for TLS, - for stdin (http only)
 	--sticky                   enable cookie-based sticky routing (http only)
 
 Commands:

--- a/cli/scale.go
+++ b/cli/scale.go
@@ -22,7 +22,7 @@ Ommitting the arguments will show the current scale.
 
 Options:
 	-n, --no-wait            don't wait for the scaling events to happen
-	-r, --release <release>  id of release to scale (defaults to current app release)
+	-r, --release=<release>  id of release to scale (defaults to current app release)
 
 Example:
 


### PR DESCRIPTION
Currently, it is these two usages don't result in the same output:

```
$ flynn --something a
$ flynn --something=a
```

This PR fixes this.

> Note, writing --input ARG (opposed to --input=ARG) is ambiguous, meaning it is not possible to tell whether ARG is option's argument or positional argument. In usage patterns this will be interpreted as option with argument only if option's description (covered below) for that option is provided. Otherwise it will be interpreted as separate option and positional argument.
[Source](http://docopt.org/)

*Notes:*
* This is the follow-up to #1153
* I wasn't able to test it on my environment, please check if nothing got broken