### PR TITLE
bootstrap: Avoid divide by zero in host selection

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -117,6 +117,9 @@ func (a *RunAppAction) Run(s *State) error {
 		if err != nil {
 			return err
 		}
+		if len(hosts) == 0 {
+			return errors.New("bootstrap: no running hosts found")
+		}
 		sort.Sort(schedutil.HostSlice(hosts))
 		for i := 0; i < count; i++ {
 			hostID := hosts[i%len(hosts)].ID


### PR DESCRIPTION
If there are no hosts running at this point, the host selection will panic with a divide by zero. Instead, if there are no hosts, return an error.