### PR TITLE
pkg/cluster: Retry requests with dial failures

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -48,31 +47,10 @@ func newClient(key string, url string, http *http.Client) *Client {
 	return c
 }
 
-var defaultDialer = net.Dialer{
-	Timeout:   time.Second,
-	KeepAlive: 30 * time.Second,
-}
-
-var retryAttempts = attempt.Strategy{
-	Total: 30 * time.Second,
-	Delay: 500 * time.Millisecond,
-}
-
-func retryDial(network, addr string) (net.Conn, error) {
-	var conn net.Conn
-	if err := retryAttempts.Run(func() (err error) {
-		conn, err = defaultDialer.Dial(network, addr)
-		return
-	}); err != nil {
-		return nil, err
-	}
-	return conn, nil
-}
-
 // NewClient creates a new Client pointing at uri and using key for
 // authentication.
 func NewClient(uri, key string) (*Client, error) {
-	httpClient := &http.Client{Transport: &http.Transport{Dial: retryDial}}
+	httpClient := &http.Client{Transport: &http.Transport{Dial: httpclient.RetryDial}}
 	return NewClientWithHTTP(uri, key, httpClient)
 }
 

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -40,7 +40,8 @@ type ServiceFunc func(name string) discoverd.Service
 // leader and return a Client. If services is nil, the default discoverd
 // client is used.
 func NewClientWithServices(services ServiceFunc) (*Client, error) {
-	return NewClientWithHTTP(services, http.DefaultClient)
+	httpClient := &http.Client{Transport: &http.Transport{Dial: httpclient.RetryDial}}
+	return NewClientWithHTTP(services, httpClient)
 }
 
 func NewClientWithHTTP(services ServiceFunc, hc *http.Client) (*Client, error) {

--- a/pkg/httpclient/retry_dial.go
+++ b/pkg/httpclient/retry_dial.go
@@ -1,0 +1,29 @@
+package httpclient
+
+import (
+	"net"
+	"time"
+
+	"github.com/flynn/flynn/pkg/attempt"
+)
+
+var defaultDialer = net.Dialer{
+	Timeout:   time.Second,
+	KeepAlive: 30 * time.Second,
+}
+
+var retryAttempts = attempt.Strategy{
+	Total: 30 * time.Second,
+	Delay: 500 * time.Millisecond,
+}
+
+func RetryDial(network, addr string) (net.Conn, error) {
+	var conn net.Conn
+	if err := retryAttempts.Run(func() (err error) {
+		conn, err = defaultDialer.Dial(network, addr)
+		return
+	}); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}


### PR DESCRIPTION
There is a small time window between a flynn-host leader being elected and the leader accepting sampi API requests, in which time `cluster.RegisterHost` will fail with:

```
dial tcp 10.76.22.3:1113: connection refused
```

In this case, and in general, the request should just be retried.