### PR TITLE
Set router sticky key in bootstrap

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -64,6 +64,12 @@
     "length": 10
   },
   {
+    "id": "router-sticky-key",
+    "action": "gen-random",
+	"length": 32,
+	"encoding": "base64"
+  },
+  {
     "id": "postgres-wait",
     "action": "wait",
     "url": "http://postgres-api.discoverd/ping"
@@ -193,7 +199,8 @@
     "release": {
       "env": {
         "TLSCERT": "{{ (index .StepData \"controller-cert\").Cert }}",
-        "TLSKEY": "{{ (index .StepData \"controller-cert\").PrivateKey }}"
+        "TLSKEY": "{{ (index .StepData \"controller-cert\").PrivateKey }}",
+        "COOKIE_KEY": "{{ (index .StepData \"router-sticky-key\").Data }}"
       },
       "processes": {
         "app": {

--- a/router/server.go
+++ b/router/server.go
@@ -62,9 +62,15 @@ func main() {
 		if err != nil {
 			shutdown.Fatal("error decoding COOKIE_KEY:", err)
 		}
+		if len(res) != 32 {
+			shutdown.Fatal(fmt.Sprintf("decoded %d bytes from COOKIE_KEY, expected 32", len(res)))
+		}
 		var k [32]byte
 		copy(k[:], res)
 		cookieKey = &k
+	}
+	if cookieKey == nil {
+		shutdown.Fatal("Missing random 32 byte base64-encoded COOKIE_KEY")
 	}
 
 	httpAddr := flag.String("httpaddr", ":8080", "http listen address")


### PR DESCRIPTION
It is now required, as not setting it will result in an all-zero key, which could be used by attackers to cause the router to connect to a specific address.
