### PR TITLE
cli: Clarify multiple remotes error

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -263,7 +263,8 @@ func app() (string, error) {
 func mustApp() string {
 	name, err := app()
 	if err != nil {
-		shutdown.Fatal(err)
+		log.Println(err)
+		shutdown.ExitWithCode(1)
 	}
 	return name
 }


### PR DESCRIPTION
Now it looks like this:

```text
error: Multiple apps listed in git remotes, please specify one with the global -a option to disambiguate.

Available remotes:
production
staging
```

Closes #1419