### PR TITLE
docs: Fix DATABASE_URL snippet on old versions of bash

### DIFF
--- a/docs/content/postgres.html.md
+++ b/docs/content/postgres.html.md
@@ -35,7 +35,7 @@ If your application expects a `DATABASE_URL` environment variable, you can
 create one by combining the `PG*` variables:
 
 ```text
-flynn env set DATABASE_URL=$(. <(flynn env); echo "postgres://$PGUSER:$PGPASSWORD@$PGHOST:5432/$PGDATABASE")
+flynn env set DATABASE_URL=$(export $(flynn env | xargs); echo "postgres://$PGUSER:$PGPASSWORD@$PGHOST:5432/$PGDATABASE")
 ```
 
 ### Connecting to a console


### PR DESCRIPTION
Old versions of bash (like the versions that ship with OS X) are not capable of sourcing a fd (like the one created during process substitution). This alternative that uses export should work with all versions of ZSH and Bash.