### PR TITLE
dashboard: Remove puma from app Gemfile

### DIFF
--- a/dashboard/app/Gemfile
+++ b/dashboard/app/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'puma'
 gem 'rake'
 gem 'yajl-ruby'
 gem 'mimetype-fu'

--- a/dashboard/app/Gemfile.lock
+++ b/dashboard/app/Gemfile.lock
@@ -66,8 +66,6 @@ GEM
     json (1.8.1)
     mimetype-fu (0.1.2)
     multi_json (1.10.1)
-    puma (2.9.0)
-      rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
@@ -95,7 +93,6 @@ DEPENDENCIES
   flynn-dashboard-web-icons!
   marbles-js!
   mimetype-fu
-  puma
   rack-putty!
   rake
   react-jsx-sprockets!


### PR DESCRIPTION
I'm not sure why it was in there, but puma isn't used.