### PR TITLE
Prevented scaling process types that do not exist in the release

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -82,6 +82,7 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 	for k, v := range current {
 		processes[k] = v
 	}
+	invalid := make([]string, 0, len(release.Processes))
 	for _, arg := range typeCounts {
 		i := strings.IndexRune(arg, '=')
 		if i < 0 {
@@ -91,7 +92,15 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 		if err != nil {
 			fmt.Println(commands["scale"].usage)
 		}
-		processes[arg[:i]] = val
+		processType := arg[:i]
+		if _, ok := release.Processes[processType]; ok {
+			processes[processType] = val
+		} else {
+			invalid = append(invalid, fmt.Sprintf("%q", processType))
+		}
+	}
+	if len(invalid) > 0 {
+		return errors.New(fmt.Sprintf("ERROR: Unknown process types: %s", strings.Join(invalid, ", ")))
 	}
 	formation.Processes = processes
 

--- a/controller/deployment_test.go
+++ b/controller/deployment_test.go
@@ -11,7 +11,9 @@ import (
 
 func (s *S) TestCreateDeployment(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "create-deployment"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, &ct.Release{
+		Processes: map[string]ct.ProcessType{"web": {}},
+	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
 		AppID:     app.ID,
 		ReleaseID: release.ID,
@@ -43,7 +45,9 @@ func (s *S) TestCreateDeployment(c *C) {
 
 func (s *S) TestStreamDeployment(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "stream-deployment"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, &ct.Release{
+		Processes: map[string]ct.ProcessType{"web": {}},
+	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
 		AppID:     app.ID,
 		ReleaseID: release.ID,

--- a/controller/formation_test.go
+++ b/controller/formation_test.go
@@ -29,7 +29,9 @@ func (s *S) TestFormationStreaming(c *C) {
 	c.Assert(streamCtrl.Err(), IsNil)
 	c.Assert(existingFound, Equals, true)
 
-	release = s.createTestRelease(c, &ct.Release{})
+	release = s.createTestRelease(c, &ct.Release{
+		Processes: map[string]ct.ProcessType{"foo": {}},
+	})
 	app = s.createTestApp(c, &ct.App{Name: "streamtest"})
 	formation := s.createTestFormation(c, &ct.Formation{
 		ReleaseID: release.ID,

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -614,7 +614,10 @@ func (s *CLISuite) TestRelease(t *c.C) {
 	t.Assert(r.Env, c.DeepEquals, release.Env)
 	t.Assert(r.Processes, c.DeepEquals, release.Processes)
 
-	t.Assert(app.flynn("scale", "--no-wait", "env=1"), Succeeds)
+	scaleCmd := app.flynn("scale", "--no-wait", "env=1", "foo=1")
+	t.Assert(scaleCmd, c.Not(Succeeds))
+	t.Assert(scaleCmd, OutputContains, "ERROR: Unknown process types: \"foo\"")
+	scaleCmd = app.flynn("scale", "--no-wait", "env=1")
 	app.waitFor(jobEvents{"env": {"up": 1}})
 	envLog := app.flynn("log")
 	t.Assert(envLog, Succeeds)


### PR DESCRIPTION
Blocked scaling nonexisting process types both in the controller and CLI. Tested both independently.

Fixes #1172 