### PR TITLE
dashboard: Fix dashboard css to accommodate many process types

### DIFF
--- a/dashboard/app/lib/stylesheets/dashboard/app-processes.css.scss
+++ b/dashboard/app/lib/stylesheets/dashboard/app-processes.css.scss
@@ -13,15 +13,18 @@
     padding: 0;
     list-style: none;
 
-    height: 41px;
+    min-height: 41px;
 
     display: -webkit-flex;
     display: flex;
     flex-flow: row;
     -webkit-flex-flow: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
 
     > li {
       margin-right: 1rem;
+      margin-top: 0.5rem;
 
       display: -webkit-flex;
       display: flex;


### PR DESCRIPTION
Wrap process types onto multiple lines instead of allowing a single line
to grow off the page.