### PR TITLE
test: Remove Gradle buildpack test

### DIFF
--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -107,10 +107,6 @@ func (s *GitDeploySuite) TestClojureBuildpack(t *c.C) {
 	s.runBuildpackTest(t, "clojure-flynn-example", nil)
 }
 
-func (s *GitDeploySuite) TestGradleBuildpack(t *c.C) {
-	s.runBuildpackTest(t, "gradle-flynn-example", nil)
-}
-
 func (s *GitDeploySuite) TestPlayBuildpack(t *c.C) {
 	s.runBuildpackTest(t, "play-flynn-example", nil)
 }


### PR DESCRIPTION
The deploy fails with:

    Downloading https://services.gradle.org/distributions/gradle-2.1-bin.zip

    Exception in thread "main" javax.net.ssl.SSLHandshakeException:
    java.security.cert.CertificateException: No subject alternative
    DNS name matching services.gradle.org found.