### PR TITLE
test/cluster: Dump libvirtd log

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -621,6 +621,7 @@ func (c *Cluster) dumpLogs(w io.Writer) {
 		run(inst, "ps faux")
 		run(inst, "cat /tmp/flynn-host.log")
 		run(inst, "cat /tmp/debug-info.log")
+		run(inst, "cat /var/log/libvirt/libvirtd.log")
 	}
 
 	printLogs := func(instances []*Instance) {


### PR DESCRIPTION
This will help diagnose the apparent libvirtd crashes.

/cc @lmars 