### PR TITLE
Fix installer log

### DIFF
--- a/installer/http.go
+++ b/installer/http.go
@@ -251,7 +251,7 @@ func (s *httpInstaller) handleEvents() {
 				Description: event.Description,
 			})
 		case err := <-s.Stack.ErrChan:
-			s.logger.Info(err.Error())
+			s.logger.Error(err.Error())
 			s.handleError(err)
 		case <-s.Stack.Done:
 			s.handleDone()

--- a/installer/http.go
+++ b/installer/http.go
@@ -255,7 +255,11 @@ func (s *httpInstaller) handleEvents() {
 			s.handleError(err)
 		case <-s.Stack.Done:
 			s.handleDone()
-			s.logger.Info(s.Stack.DashboardLoginMsg())
+			msg, err := s.Stack.DashboardLoginMsg()
+			if err != nil {
+				panic(err)
+			}
+			s.logger.Info(msg)
 			return
 		}
 	}


### PR DESCRIPTION
The second return value from `DashboardLoginMsg` (an error which shouldn’t occur) was causing the log15 context to be unbalanced.

Closes #1395

/cc @jvatic 