### PR TITLE
test: Dump logs in runner

### DIFF
--- a/test/arg/arg.go
+++ b/test/arg/arg.go
@@ -15,7 +15,6 @@ type Args struct {
 	Build       bool
 	Debug       bool
 	Stream      bool
-	DumpLogs    bool
 	Kill        bool
 	BuildRootFS bool
 	DBPath      string
@@ -50,7 +49,6 @@ func Parse() *Args {
 	flag.BoolVar(&args.Build, "build", true, "build Flynn")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
 	flag.BoolVar(&args.Stream, "stream", false, "stream debug output (implies --debug)")
-	flag.BoolVar(&args.DumpLogs, "dump-logs", false, "dump logs on error")
 	flag.BoolVar(&args.Kill, "kill", true, "kill the cluster after running the tests")
 	flag.BoolVar(&args.BuildRootFS, "build-rootfs", false, "just build the rootfs (leaving it behind for future use) without running tests")
 	flag.BoolVar(&args.Gist, "gist", false, "upload debug info to a gist")

--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -88,13 +87,4 @@ func (c *Client) AddReleaseHosts() (*tc.BootResult, error) {
 func (c *Client) RemoveHost(host *tc.Instance) error {
 	c.size--
 	return c.Delete("/" + host.ID)
-}
-
-func (c *Client) DumpLogs(out io.Writer) error {
-	res, err := c.RawReq("GET", "/dump-logs", nil, nil, nil)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(out, res.Body)
-	return err
 }

--- a/test/main.go
+++ b/test/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/ssh"
-	"github.com/flynn/flynn/pkg/iotool"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/test/arg"
 	"github.com/flynn/flynn/test/cluster"
@@ -58,13 +57,6 @@ func main() {
 	// defer exiting here so it runs after all other defers
 	defer func() {
 		if err != nil || res != nil && !res.Passed() {
-			if args.DumpLogs {
-				if args.Gist {
-					exec.Command("flynn-host", "upload-debug-info").Run()
-				} else if testCluster != nil {
-					testCluster.DumpLogs(&iotool.SafeWriter{W: os.Stdout})
-				}
-			}
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
This is so that logs are dumped if the test binary exits abnormally (e.g. due to a `SIGQUIT` timeout).