### PR TITLE
test: Wrap release update script in a timeout

### DIFF
--- a/test/test_release.go
+++ b/test/test_release.go
@@ -91,9 +91,11 @@ bash -e /tmp/install-flynn -r "http://{{ .Blobstore }}"
 `))
 
 var updateScript = template.Must(template.New("update-script").Parse(`
+timeout --signal=QUIT --kill-after=10 10m bash -ex <<-SCRIPT
 cd ~/go/src/github.com/flynn/flynn
 tuf --dir test/release root-keys | tuf-client init --store /tmp/tuf.db http://{{ .Blobstore }}/tuf
 flynn-host update --repository http://{{ .Blobstore }}/tuf --tuf-db /tmp/tuf.db
+SCRIPT
 `))
 
 func (s *ReleaseSuite) TestReleaseImages(t *c.C) {


### PR DESCRIPTION
The update script has timed out a few times in CI, e.g.:

* https://s3.amazonaws.com/flynn-ci-logs/20150414220413-d9f8d7b9-build-9759f3cf65d2ee7cabbbe28df08a3c3d50a7c975-2015-04-14-22-26-31.txt
* https://s3.amazonaws.com/flynn-ci-logs/20150414220216-7d69dd7b-build-721727af900c0d430a4400f691b9f2a9ae874265-2015-04-14-22-24-44.txt
* https://s3.amazonaws.com/flynn-ci-logs/20150414211133-b285e88b-build-54b66f84443be75e42ddc5460cdef1306bae1713-2015-04-14-21-33-57.txt

Each build failure has the following in the stack trace:

```
goroutine 181 [chan receive, 16 minutes]:
github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/ssh.(*Session).Wait(0xc20838f200, 0x0, 0x0)
	/home/ubuntu/go/src/github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/ssh/session.go:380 +0x168
github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/ssh.(*Session).Run(0xc20838f200, 0xa85c90, 0x8, 0x0, 0x0)
	/home/ubuntu/go/src/github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/crypto/ssh/session.go:292 +0x85
github.com/flynn/flynn/test/cluster.(*Instance).run(0xc20827eb80, 0xa85c90, 0x8, 0xc2083c8150, 0x0, 0x0, 0x0)
	/home/ubuntu/go/src/github.com/flynn/flynn/test/cluster/instance.go:296 +0x395
github.com/flynn/flynn/test/cluster.(*Instance).Run(0xc20827eb80, 0xa85c90, 0x8, 0xc2083c8150, 0x0, 0x0)
	/home/ubuntu/go/src/github.com/flynn/flynn/test/cluster/instance.go:267 +0x61
main.(*ReleaseSuite).TestReleaseImages(0xc20802e720, 0xc20812ac30)
	/home/ubuntu/go/src/github.com/flynn/flynn/test/test_release.go:159 +0x177d
```

Which is a wait [here](https://github.com/flynn/flynn/blob/master/test/test_release.go#L159).