### PR TITLE
test: Skip TestVolumePersistence

### DIFF
--- a/test/test_host.go
+++ b/test/test_host.go
@@ -174,6 +174,8 @@ func (s *HostSuite) TestVolumeCreationFailsForNonexistentProvider(t *c.C) {
 }
 
 func (s *HostSuite) TestVolumePersistence(t *c.C) {
+	t.Skip("test intermittently fails due to host bind mount leaks, see https://github.com/flynn/flynn/issues/1125")
+
 	// most of the volume tests (snapshotting, quotas, etc) are unit tests under their own package.
 	// these tests exist to cover the last mile where volumes are bind-mounted into containers.
 


### PR DESCRIPTION
This test fails quite regularly in CI, we know the fix, and this area of code (i.e. volume management) isn't currently being worked on, so skip for now until we fix the underlying issue.

Ref #1125.