### PR TITLE
cli: Filter git remotes if explicit cluster specified

### DIFF
--- a/cli/git.go
+++ b/cli/git.go
@@ -77,6 +77,9 @@ func gitRemotes() (map[string]remoteApp, error) {
 
 func appFromGitURL(remote string) *remoteApp {
 	for _, s := range config.Clusters {
+		if flagCluster != "" && s.Name != flagCluster {
+			continue
+		}
 		if strings.HasPrefix(remote, gitURLPre(s.GitHost)) && strings.HasSuffix(remote, gitURLSuf) {
 			return &remoteApp{s, remote[len(gitURLPre(s.GitHost)) : len(remote)-len(gitURLSuf)]}
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -218,22 +218,23 @@ func getCluster() (*cfg.Cluster, error) {
 	if len(config.Clusters) == 0 {
 		return nil, ErrNoClusters
 	}
+	name := flagCluster
 	// Get the default cluster
-	if flagCluster == "" {
-		flagCluster = config.Default
+	if name == "" {
+		name = config.Default
 	}
 	// Default cluster not set, pick the first one
-	if flagCluster == "" {
+	if name == "" {
 		clusterConf = config.Clusters[0]
 		return clusterConf, nil
 	}
 	for _, s := range config.Clusters {
-		if s.Name == flagCluster {
+		if s.Name == name {
 			clusterConf = s
 			return s, nil
 		}
 	}
-	return nil, fmt.Errorf("unknown cluster %q", flagCluster)
+	return nil, fmt.Errorf("unknown cluster %q", name)
 }
 
 func app() (string, error) {


### PR DESCRIPTION
This allows unambiguously picking an app if there is a single one for the specific cluster. Before this change, the “multiple remotes” error was always displayed even if one could be chosen automatically.

Fixes #1489