### PR TITLE
Makefile: Don’t clean up if there is no reason to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-integration:
 toolchain: util/_toolchain/go/bin/go
 
 util/_toolchain/go/bin/go: util/_toolchain/bin/gonative
-	cd util/_toolchain && rm -rf go && bin/gonative build -version=1.4.2 && ls | grep -v "^\(bin\|go\)$$" | xargs rm -r
+	cd util/_toolchain && rm -rf go && bin/gonative build -version=1.4.2 && ls | grep -v "^\(bin\|go\)$$" | xargs --no-run-if-empty rm -r
 
 
 util/_toolchain/bin/gonative: Godeps/_workspace/src/github.com/inconshreveable/gonative/*.go


### PR DESCRIPTION
`xargs` runs the command once by default even if there is no input, which results in an error from `rm`, because no arguments are provided.