### PR TITLE
installer: Resolved issue with wizard in safari

### DIFF
--- a/installer/app/src/views/wizard.js.jsx
+++ b/installer/app/src/views/wizard.js.jsx
@@ -25,7 +25,7 @@ var Wizard = React.createClass({
 				}}>
 					<InstallSteps state={state} style={{ height: 16 }} />
 
-					<Panel style={{ flexGrow: 1, WebkitFlexGrow: 1, height: '100%' }}>
+					<Panel style={{ flexGrow: 1, WebkitFlexGrow: 1 }}>
 						{state.currentStep === 'configure' ? (
 							<AWSLauncher state={state} />
 						) : null}


### PR DESCRIPTION
The right column's background did not have the same height as the content in Safari. Removing
height: 100% from the style solves this issue and works in Chrome and FireFox as well.

Screenshot in safari:
![bildschirmfoto 2015-05-04 um 21 28 20](https://cloud.githubusercontent.com/assets/3372410/7461451/ba3ed5a8-f2aa-11e4-8ed9-ccd0604f595e.png)


ping @jvatic 