### PR TITLE
host: Stop setting the libvirt VCPU option

### DIFF
--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -14,7 +14,6 @@ type Domain struct {
 	IDMap *IDMap `xml:"idmap,omitempty"`
 
 	Memory UnitInt `xml:"memory"`
-	VCPU   int     `xml:"vcpu"`
 
 	OnPoweroff string `xml:"on_poweroff,omitempty"`
 	OnReboot   string `xml:"on_reboot,omitempty"`

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -565,7 +565,6 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 		Type:   "lxc",
 		Name:   job.ID,
 		Memory: lt.UnitInt{Value: 1, Unit: "GiB"},
-		VCPU:   1,
 		OS: lt.OS{
 			Type: lt.OSType{Value: "exe"},
 			Init: "/.containerinit",


### PR DESCRIPTION
The `VCPU` option has no effect on containers.

Under libvirt, container CPU restrictions should be specified using "cputune" options:

https://libvirt.org/formatdomain.html#elementsCPUTuning

I have just removed the VCPU option rather than replacing with appropriate CPU tune options as it is unclear how we will expose the parameters to users.