### PR TITLE
all: Add resource specifications

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -9,6 +9,7 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
+	hostresource "github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/random"
@@ -124,6 +125,7 @@ func (a *RunAppAction) Run(s *State) error {
 		for i := 0; i < count; i++ {
 			hostID := hosts[i%len(hosts)].ID
 			config := utils.JobConfig(a.ExpandedFormation, typ, hostID)
+			hostresource.SetDefaults(&config.Resources)
 			if a.ExpandedFormation.Release.Processes[typ].Data {
 				if err := utils.ProvisionVolume(cc, hostID, config); err != nil {
 					return err

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -397,6 +397,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 			Stdin:      attach,
 			DisableLog: newJob.DisableLog,
 		},
+		Resources: newJob.Resources,
 	}
 	if len(newJob.Entrypoint) > 0 {
 		job.Config.Entrypoint = newJob.Entrypoint

--- a/controller/log_test.go
+++ b/controller/log_test.go
@@ -14,6 +14,7 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
+	"github.com/flynn/flynn/pkg/typeconv"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 )
@@ -116,10 +117,6 @@ func (f *fakeLogAggregatorClient) GetLog(channelID string, options *logaggc.LogO
 	return pr, nil
 }
 
-func strPtr(s string) *string { return &s }
-
-func intPtr(i int) *int { return &i }
-
 func (s *S) TestGetAppLog(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "get-app-log-test"})
 
@@ -131,15 +128,15 @@ func (s *S) TestGetAppLog(c *C) {
 			expected: sampleMessages,
 		},
 		{
-			opts:     &ct.LogOpts{Lines: intPtr(1)},
+			opts:     &ct.LogOpts{Lines: typeconv.IntPtr(1)},
 			expected: sampleMessages[2:],
 		},
 		{
-			opts:     &ct.LogOpts{ProcessType: strPtr("web")},
+			opts:     &ct.LogOpts{ProcessType: typeconv.StringPtr("web")},
 			expected: sampleMessages[1:2],
 		},
 		{
-			opts:     &ct.LogOpts{ProcessType: strPtr("")},
+			opts:     &ct.LogOpts{ProcessType: typeconv.StringPtr("")},
 			expected: sampleMessages[:1],
 		},
 		{

--- a/controller/release.go
+++ b/controller/release.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
@@ -49,6 +50,12 @@ func (r *ReleaseRepo) Add(data interface{}) error {
 	releaseCopy.ID = ""
 	releaseCopy.ArtifactID = ""
 	releaseCopy.CreatedAt = nil
+
+	for typ, proc := range releaseCopy.Processes {
+		resource.SetDefaults(&proc.Resources)
+		releaseCopy.Processes[typ] = proc
+	}
+
 	data, err := json.Marshal(&releaseCopy)
 	if err != nil {
 		return err

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 )
 
@@ -41,15 +42,16 @@ type Release struct {
 }
 
 type ProcessType struct {
-	Cmd         []string          `json:"cmd,omitempty"`
-	Entrypoint  []string          `json:"entrypoint,omitempty"`
-	Env         map[string]string `json:"env,omitempty"`
-	Ports       []Port            `json:"ports,omitempty"`
-	Data        bool              `json:"data,omitempty"`
-	Omni        bool              `json:"omni,omitempty"` // omnipresent - present on all hosts
-	HostNetwork bool              `json:"host_network,omitempty"`
-	Service     string            `json:"service,omitempty"`
-	Resurrect   bool              `json:"resurrect,omitempty"`
+	Cmd         []string           `json:"cmd,omitempty"`
+	Entrypoint  []string           `json:"entrypoint,omitempty"`
+	Env         map[string]string  `json:"env,omitempty"`
+	Ports       []Port             `json:"ports,omitempty"`
+	Data        bool               `json:"data,omitempty"`
+	Omni        bool               `json:"omni,omitempty"` // omnipresent - present on all hosts
+	HostNetwork bool               `json:"host_network,omitempty"`
+	Service     string             `json:"service,omitempty"`
+	Resurrect   bool               `json:"resurrect,omitempty"`
+	Resources   resource.Resources `json:"resources,omitempty"`
 }
 
 type Port struct {
@@ -103,16 +105,17 @@ func (e *JobEvent) IsDown() bool {
 }
 
 type NewJob struct {
-	ReleaseID  string            `json:"release,omitempty"`
-	ReleaseEnv bool              `json:"release_env,omitempty"`
-	Cmd        []string          `json:"cmd,omitempty"`
-	Entrypoint []string          `json:"entrypoint,omitempty"`
-	Env        map[string]string `json:"env,omitempty"`
-	Meta       map[string]string `json:"meta,omitempty"`
-	TTY        bool              `json:"tty,omitempty"`
-	Columns    int               `json:"tty_columns,omitempty"`
-	Lines      int               `json:"tty_lines,omitempty"`
-	DisableLog bool              `json:"disable_log,omitempty"`
+	ReleaseID  string             `json:"release,omitempty"`
+	ReleaseEnv bool               `json:"release_env,omitempty"`
+	Cmd        []string           `json:"cmd,omitempty"`
+	Entrypoint []string           `json:"entrypoint,omitempty"`
+	Env        map[string]string  `json:"env,omitempty"`
+	Meta       map[string]string  `json:"meta,omitempty"`
+	TTY        bool               `json:"tty,omitempty"`
+	Columns    int                `json:"tty_columns,omitempty"`
+	Lines      int                `json:"tty_lines,omitempty"`
+	DisableLog bool               `json:"disable_log,omitempty"`
+	Resources  resource.Resources `json:"resources,omitempty"`
 }
 
 type Deployment struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -38,6 +38,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
 			HostNetwork: t.HostNetwork,
 		},
 		Resurrect: t.Resurrect,
+		Resources: t.Resources,
 	}
 	if len(t.Entrypoint) > 0 {
 		job.Config.Entrypoint = t.Entrypoint

--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -51,7 +51,7 @@ type IDMapping struct {
 }
 
 type UnitInt struct {
-	Value int    `xml:",chardata"`
+	Value int64  `xml:",chardata"`
 	Unit  string `xml:"unit,attr,omitempty"`
 }
 

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -29,6 +29,7 @@ import (
 	lt "github.com/flynn/flynn/host/libvirt"
 	"github.com/flynn/flynn/host/logbuf"
 	"github.com/flynn/flynn/host/logmux"
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/pinkerton"
@@ -512,6 +513,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 		TTY:       job.Config.TTY,
 		OpenStdin: job.Config.Stdin,
 		WorkDir:   job.Config.WorkingDir,
+		Resources: job.Resources,
 	}
 	if !job.Config.HostNetwork {
 		config.IP = container.IP.String() + "/24"
@@ -579,6 +581,9 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 		},
 		OnPoweroff: "preserve",
 		OnCrash:    "preserve",
+	}
+	if spec, ok := job.Resources[resource.TypeMemory]; ok && spec.Limit != nil {
+		domain.Memory = lt.UnitInt{Value: *spec.Limit, Unit: "bytes"}
 	}
 
 	if !job.Config.HostNetwork {

--- a/host/manifest.go
+++ b/host/manifest.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/technoweenie/grohl"
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume/manager"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -227,6 +228,7 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 				Volumes:     volumeBindings,
 			},
 			Resurrect: true,
+			Resources: resource.Defaults(),
 		}
 		if job.Config.Env == nil {
 			job.Config.Env = make(map[string]string)

--- a/host/resource/resource.go
+++ b/host/resource/resource.go
@@ -1,0 +1,65 @@
+package resource
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/pkg/units"
+	"github.com/flynn/flynn/pkg/typeconv"
+)
+
+type Spec struct {
+	// Request, if set, is the amount of resource a job expects to consume,
+	// so the job should only be placed on a host with at least this amount
+	// of resource available, and once scheduled this amount of resource
+	// should then be unavailable on the given host.
+	Request *int64 `json:"request"`
+
+	// Limit, if set, is an upper limit on the amount of resource a job can
+	// consume, the outcome of hitting this limit being implementation
+	// defined (e.g. a system error, throttling, catchable / uncatchable
+	// signals etc.)
+	Limit *int64 `json:"limit"`
+}
+
+type Type string
+
+const (
+	// TypeMemory specifies the available memory in bytes inside a container.
+	TypeMemory Type = "memory"
+
+	// TypeMaxFD specifies a value one greater than the maximum file
+	// descriptor number that can be opened inside a container.
+	TypeMaxFD Type = "max_fd"
+
+	// TypeMaxProcs specifies the maximum number of processes which can
+	// be started inside a container.
+	TypeMaxProcs Type = "max_procs"
+)
+
+var defaults = Resources{
+	TypeMemory:   {Request: typeconv.Int64Ptr(1 * units.GiB), Limit: typeconv.Int64Ptr(1 * units.GiB)},
+	TypeMaxFD:    {Request: typeconv.Int64Ptr(10000), Limit: typeconv.Int64Ptr(10000)},
+	TypeMaxProcs: {Request: typeconv.Int64Ptr(256), Limit: typeconv.Int64Ptr(256)},
+}
+
+type Resources map[Type]Spec
+
+func Defaults() Resources {
+	r := make(Resources)
+	SetDefaults(&r)
+	return r
+}
+
+func SetDefaults(r *Resources) {
+	if *r == nil {
+		*r = make(Resources, len(defaults))
+	}
+	for typ, s := range defaults {
+		spec := (*r)[typ]
+		if spec.Limit == nil {
+			spec.Limit = typeconv.Int64Ptr(*s.Limit)
+		}
+		if spec.Request == nil {
+			spec.Request = spec.Limit
+		}
+		(*r)[typ] = spec
+	}
+}

--- a/host/resource/resource_test.go
+++ b/host/resource/resource_test.go
@@ -1,0 +1,54 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/pkg/units"
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/pkg/typeconv"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(S{})
+
+func assertDefault(c *C, r Resources, types ...Type) {
+	for _, typ := range types {
+		actual, ok := r[typ]
+		if !ok {
+			c.Fatalf("%s resource not set", typ)
+		}
+		expected := defaults[typ]
+		if !reflect.DeepEqual(actual, expected) {
+			c.Fatalf("%s resource is not default, expected: %+v, actual: %+v", typ, expected, actual)
+		}
+	}
+}
+
+func (S) TestSetDefaultsNil(c *C) {
+	var r Resources
+	SetDefaults(&r)
+	c.Assert(r, NotNil)
+}
+
+func (S) TestSetDefaultsEmpty(c *C) {
+	r := make(Resources)
+	SetDefaults(&r)
+	assertDefault(c, r, TypeMemory, TypeMaxFD, TypeMaxProcs)
+}
+
+func (S) TestSetDefaultsRequest(c *C) {
+	// not specifying Request should default it to the value of Limit
+	r := Resources{TypeMemory: Spec{Limit: typeconv.Int64Ptr(512 * units.MiB)}}
+	SetDefaults(&r)
+	assertDefault(c, r, TypeMaxFD, TypeMaxProcs)
+	mem, ok := r[TypeMemory]
+	if !ok {
+		c.Fatal("memory resource not set")
+	}
+	c.Assert(*mem.Request, Equals, *mem.Limit)
+}

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"time"
+
+	"github.com/flynn/flynn/host/resource"
 )
 
 type Job struct {
@@ -9,8 +11,8 @@ type Job struct {
 
 	Metadata map[string]string `json:"metadata,omitempty"`
 
-	Artifact  Artifact     `json:"artifact,omitempty"`
-	Resources JobResources `json:"resources,omitempty"`
+	Artifact  Artifact           `json:"artifact,omitempty"`
+	Resources resource.Resources `json:"resources,omitempty"`
 
 	Config ContainerConfig `json:"config,omitempty"`
 

--- a/logaggregator/api_test.go
+++ b/logaggregator/api_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/logaggregator/client"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+	"github.com/flynn/flynn/pkg/typeconv"
 )
 
 func (s *LogAggregatorTestSuite) TestAPIGetLogWithNoResults(c *C) {
@@ -21,10 +22,6 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogWithNoResults(c *C) {
 
 	assertAllLogsEquals(c, logrc, "")
 }
-
-func strPtr(s string) *string { return &s }
-
-func intPtr(i int) *int { return &i }
 
 func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
 	appID := "test-app"
@@ -64,31 +61,31 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
 		expected    []*rfc5424.Message
 	}{
 		{
-			numLogs:  intPtr(-1),
+			numLogs:  typeconv.IntPtr(-1),
 			expected: []*rfc5424.Message{msg1, msg2, msg3, msg4, msg5},
 		},
 		{
-			numLogs:  intPtr(1),
+			numLogs:  typeconv.IntPtr(1),
 			expected: []*rfc5424.Message{msg5},
 		},
 		{
-			numLogs:  intPtr(1),
+			numLogs:  typeconv.IntPtr(1),
 			jobID:    "3",
 			expected: []*rfc5424.Message{msg3},
 		},
 		{
-			numLogs:  intPtr(-1),
+			numLogs:  typeconv.IntPtr(-1),
 			jobID:    "1",
 			expected: []*rfc5424.Message{msg1, msg4},
 		},
 		{
-			numLogs:     intPtr(-1),
-			processType: strPtr("web"),
+			numLogs:     typeconv.IntPtr(-1),
+			processType: typeconv.StringPtr("web"),
 			expected:    []*rfc5424.Message{msg1, msg2, msg4},
 		},
 		{
-			numLogs:     intPtr(-1),
-			processType: strPtr(""),
+			numLogs:     typeconv.IntPtr(-1),
+			processType: typeconv.StringPtr(""),
 			expected:    []*rfc5424.Message{msg5},
 		},
 	}

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -1,0 +1,4 @@
+package typeconv
+
+func IntPtr(i int) *int          { return &i }
+func StringPtr(s string) *string { return &s }

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -1,4 +1,5 @@
 package typeconv
 
 func IntPtr(i int) *int          { return &i }
+func Int64Ptr(i int64) *int64    { return &i }
 func StringPtr(s string) *string { return &s }

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -50,6 +50,10 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "resources": {
+      "description": "resource request and limits",
+      "type": "object"
     }
   }
 }

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -45,6 +45,9 @@
     "disable_log": {
       "description": "don't copy stdout/stdin to log stream",
       "type": "boolean"
+    },
+    "resources": {
+      "$ref": "/schema/controller/common#/definitions/resources"
     }
   }
 }

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flynn/flynn/cli/config"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/stream"
@@ -600,6 +601,10 @@ func (s *CLISuite) TestRelease(t *c.C) {
 	}`)
 	release := &ct.Release{}
 	t.Assert(json.Unmarshal(releaseJSON, &release), c.IsNil)
+	for typ, proc := range release.Processes {
+		resource.SetDefaults(&proc.Resources)
+		release.Processes[typ] = proc
+	}
 
 	file, err := ioutil.TempFile("", "")
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
This implements what was proposed in #1496 except for hosts declaring available resources.

You will notice calls to `resource.SetDefaults` in the controller / host code which I am using to explicitly fill in the resource specifications (rather than blank ones meaning default) so that it is clear to the end user from job / release config what the limits are, defaults or not.