### PR TITLE
Refactored job event waiting to use a new JobWatcher abstraction

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -104,6 +104,8 @@ func (e *JobEvent) IsDown() bool {
 	return e.State == "failed" || e.State == "crashed" || e.State == "down"
 }
 
+type JobEvents map[string]map[string]int
+
 type NewJob struct {
 	ReleaseID  string             `json:"release,omitempty"`
 	ReleaseEnv bool               `json:"release_env,omitempty"`


### PR DESCRIPTION
Fixes #1475

Implemented an abstraction for waiting for job events instead of
re-implementing the channel loop each time we need to watch for jobs.

In instances where we need to multiplex job streams with other channels,
the original code is still in place.