### PR TITLE
cli: Make releases more visible

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -17,10 +17,10 @@ List flynn jobs.
 Example:
 
 	$ flynn ps
-	ID                                      TYPE
-	flynn-bb97c7dac2fa455dad73459056fabac2  web
-	flynn-c59e02b3e6ad49809424848809d4749a  web
-	flynn-46f0d715a9684e4c822e248e84a5a418  web
+	ID                                      TYPE  RELEASE
+	flynn-bb97c7dac2fa455dad73459056fabac2  web   b69d7fb5308a4684a09b160b82d267ec
+	flynn-c59e02b3e6ad49809424848809d4749a  web   b69d7fb5308a4684a09b160b82d267ec
+	flynn-46f0d715a9684e4c822e248e84a5a418  web   b69d7fb5308a4684a09b160b82d267ec
 `)
 }
 
@@ -34,7 +34,7 @@ func runPs(args *docopt.Args, client *controller.Client) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	listRec(w, "ID", "TYPE")
+	listRec(w, "ID", "TYPE", "RELEASE")
 	for _, j := range jobs {
 		if j.Type == "" {
 			j.Type = "run"
@@ -42,7 +42,7 @@ func runPs(args *docopt.Args, client *controller.Client) error {
 		if j.State != "up" {
 			continue
 		}
-		listRec(w, j.ID, j.Type)
+		listRec(w, j.ID, j.Type, j.ReleaseID)
 	}
 
 	return nil

--- a/cli/release.go
+++ b/cli/release.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	"github.com/flynn/flynn/controller/client"
@@ -14,6 +17,7 @@ import (
 func init() {
 	register("release", runRelease, `
 usage: flynn release add [-t <type>] [-f <file>] <uri>
+       flynn release show [<id>]
 
 Manage app releases.
 
@@ -30,6 +34,10 @@ Commands:
 		configuration in a JSON format. It's primarily used for specifying the
 		release environment and processes (similar to a Procfile). It can take any
 		of the arguments the controller Release type can take.
+
+	show  show information about a release
+
+		Omit the ID to show information about the current release.
 
 Examples:
 
@@ -48,11 +56,21 @@ Examples:
 		}
 	}
 	$ flynn release add -f config.json https://registry.hub.docker.com?name=flynn/slugbuilder&id=15d72b7f573b
-	Created release f55fde802170.
+	Created release 427537e78be4417fae2e24d11bc993eb.
+
+	$ flynn release show
+	ID:             427537e78be4417fae2e24d11bc993eb
+	Artifact:       docker+https://registry.hub.docker.com?name=flynn/slugbuilder&id=15d72b7f573b
+	Process Types:  echo
+	Created At:     2015-05-06 21:58:12.751741 +0000 UTC
+	ENV[MY_VAR]:    Hello World, this will be available in all process types.
 `)
 }
 
 func runRelease(args *docopt.Args, client *controller.Client) error {
+	if args.Bool["show"] {
+		return runReleaseShow(args, client)
+	}
 	if args.Bool["add"] {
 		if args.String["-t"] == "docker" {
 			return runReleaseAddDocker(args, client)
@@ -61,6 +79,41 @@ func runRelease(args *docopt.Args, client *controller.Client) error {
 		}
 	}
 	return fmt.Errorf("Top-level command not implemented.")
+}
+
+func runReleaseShow(args *docopt.Args, client *controller.Client) error {
+	var release *ct.Release
+	var err error
+	if args.String["<id>"] != "" {
+		release, err = client.GetRelease(args.String["<id>"])
+	} else {
+		release, err = client.GetAppRelease(mustApp())
+	}
+	if err != nil {
+		return err
+	}
+	var artifactDesc string
+	if release.ArtifactID != "" {
+		artifact, err := client.GetArtifact(release.ArtifactID)
+		if err != nil {
+			return err
+		}
+		artifactDesc = fmt.Sprintf("%s+%s", artifact.Type, artifact.URI)
+	}
+	types := make([]string, 0, len(release.Processes))
+	for typ := range release.Processes {
+		types = append(types, typ)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	listRec(w, "ID:", release.ID)
+	listRec(w, "Artifact:", artifactDesc)
+	listRec(w, "Process Types:", strings.Join(types, ", "))
+	listRec(w, "Created At:", release.CreatedAt)
+	for k, v := range release.Env {
+		listRec(w, fmt.Sprintf("ENV[%s]", k), v)
+	}
+	return nil
 }
 
 func runReleaseAddDocker(args *docopt.Args, client *controller.Client) error {


### PR DESCRIPTION
This adds the release ID to the `flynn ps` output, as well as adding `flynn release show` which together will help diagnosing rogue processes in #1434.