### PR TITLE
Add an option to not exclude .git directories when tarballing slug

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -166,25 +166,20 @@ fi
 
 
 ## Produce slug
+tar_args=("-C ${build_root}" "-cf ${slug_file}")
 
+# Allow $build_root/.slugignore to be excluded
 if [[ -f "${build_root}/.slugignore" ]]; then
-  tar \
-    --exclude='.git' \
-    --use-compress-program=pigz \
-    -X "${build_root}/.slugignore" \
-    -C ${build_root} \
-    -cf ${slug_file} \
-    . \
-    | cat
-else
-  tar \
-    --exclude='.git' \
-    --use-compress-program=pigz \
-    -C ${build_root} \
-    -cf ${slug_file} \
-    . \
-    | cat
+  tar_args+=("-X ${build_root}/.slugignore")
 fi
+
+# If env SLUG_INCLUDE_GIT, don't strip .git directories
+if [[ ! -s "${env_dir}/SLUG_INCLUDE_GIT" ]]; then
+  tar_args+=("--exclude='.git'")
+fi
+
+# Build slug
+tar ${tar_args[@]} . | cat
 
 if [[ "${slug_file}" != "-" ]]; then
   slug_size=$(du -Sh "${slug_file}" | cut -f1)


### PR DESCRIPTION
For certain applications (e.g. Elixir applications), the `.git` directories are important and cannot be excluded (Elixir relies on them to check dependencies are up to date). This patch allows you to specify an environment flag, `SLUG_INCLUDE_GIT`, which will build a slug including the `.git` directories.  Additionally, this cleans up some repeated code for building the `tar` argument list.