### PR TITLE
Installer: Fixed typo in AWS credentials dialogue

### DIFF
--- a/installer/app/src/views/modal/credentials.js.jsx
+++ b/installer/app/src/views/modal/credentials.js.jsx
@@ -80,7 +80,7 @@ var Credentials = React.createClass({
 					{cloud === 'aws' ? (
 						<div>
 							<input ref="key_id" type="text" placeholder="AWS_ACCESS_KEY_ID" />
-							<input ref="key" type="password" placeholder="AWS_ACCESS_KEY_ID" />
+							<input ref="key" type="password" placeholder="AWS_SECRET_ACCESS_KEY" />
 						</div>
 					) : null}
 


### PR DESCRIPTION
The installer showed two times `AWS_ACCESS_KEY_ID` instead of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for each the key and the secret