### PR TITLE
controller: Convert the deployer to a generic worker

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -99,8 +99,8 @@
           "service": "flynn-controller-scheduler",
           "resurrect": true
         },
-        "deployer": {
-          "cmd": ["deployer"]
+        "worker": {
+          "cmd": ["worker"]
         }
       }
     },
@@ -150,7 +150,7 @@
     "app_step": "controller-inception",
     "processes": {
       "scheduler": 1,
-      "deployer": 2,
+      "worker": 2,
       "web": 2
     }
   },

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,7 +2,7 @@ FROM flynn/busybox
 
 ADD bin/flynn-controller /bin/flynn-controller
 ADD bin/flynn-scheduler /bin/flynn-scheduler
-ADD bin/flynn-deployer /bin/flynn-deployer
+ADD bin/flynn-worker /bin/flynn-worker
 ADD start.sh /bin/start-flynn-controller
 ADD bin/jsonschema /etc/flynn-controller/jsonschema
 

--- a/controller/Tupfile
+++ b/controller/Tupfile
@@ -1,7 +1,7 @@
 include_rules
 : |> !go |> bin/flynn-controller
 : |> !go ./scheduler |> bin/flynn-scheduler
-: |> !go ./deployer |> bin/flynn-deployer
+: |> !go ./worker |> bin/flynn-worker
 : foreach $(ROOT)/schema/*.json |> !cp |> bin/jsonschema/%g.json
 : foreach $(ROOT)/schema/controller/*.json |> !cp |> bin/jsonschema/controller/%g.json
 : foreach $(ROOT)/schema/router/*.json |> !cp |> bin/jsonschema/router/%g.json

--- a/controller/start.sh
+++ b/controller/start.sh
@@ -3,9 +3,9 @@
 case $1 in
   controller) exec /bin/flynn-controller ;;
   scheduler)  exec /bin/flynn-scheduler ;;
-  deployer)  exec /bin/flynn-deployer ;;
+  worker)  exec /bin/flynn-worker ;;
   *)
-    echo "Usage: $0 {controller|scheduler|deployer}"
+    echo "Usage: $0 {controller|scheduler|worker}"
     exit 2
     ;;
 esac

--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -1,9 +1,9 @@
-package strategy
+package deployment
 
 import ct "github.com/flynn/flynn/controller/types"
 
-func allAtOnce(d *Deploy) error {
-	log := d.logger.New("fn", "allAtOnce")
+func (d *DeployJob) deployAllAtOnce() error {
+	log := d.logger.New("fn", "deployAllAtOnce")
 	log.Info("starting all-at-once deployment")
 
 	expected := make(jobEvents)

--- a/controller/worker/deployment/errors.go
+++ b/controller/worker/deployment/errors.go
@@ -1,0 +1,24 @@
+package deployment
+
+import "fmt"
+
+type ErrSkipRollback struct {
+	Err string
+}
+
+func (e ErrSkipRollback) Error() string {
+	return e.Err
+}
+
+func IsSkipRollback(err error) bool {
+	_, ok := err.(ErrSkipRollback)
+	return ok
+}
+
+type UnknownStrategyError struct {
+	Strategy string
+}
+
+func (e UnknownStrategyError) Error() string {
+	return fmt.Sprintf("deployment: unknown strategy %q", e.Strategy)
+}

--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -1,4 +1,4 @@
-package strategy
+package deployment
 
 import (
 	"fmt"
@@ -6,8 +6,8 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 )
 
-func oneByOne(d *Deploy) error {
-	log := d.logger.New("fn", "oneByOne")
+func (d *DeployJob) deployOneByOne() error {
+	log := d.logger.New("fn", "deployOneByOne")
 	log.Info("starting one-by-one deployment")
 
 	oldScale := make(map[string]int, len(d.oldReleaseState))

--- a/controller/worker/deployment/postgres.go
+++ b/controller/worker/deployment/postgres.go
@@ -1,4 +1,4 @@
-package strategy
+package deployment
 
 import (
 	"encoding/json"
@@ -12,8 +12,8 @@ import (
 	"github.com/flynn/flynn/discoverd/client"
 )
 
-func postgres(d *Deploy) (err error) {
-	log := d.logger.New("fn", "postgres")
+func (d *DeployJob) deployPostgres() (err error) {
+	log := d.logger.New("fn", "deployPostgres")
 	log.Info("starting postgres deployment")
 
 	defer func() {
@@ -236,5 +236,5 @@ loop:
 	}
 
 	// do a one-by-one deploy for the other process types
-	return oneByOne(d)
+	return d.deployOneByOne()
 }

--- a/controller/worker/main.go
+++ b/controller/worker/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/que-go"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/controller/client"
+	"github.com/flynn/flynn/controller/worker/deployment"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/shutdown"
+)
+
+const workerCount = 10
+
+var logger = log15.New("app", "worker")
+
+func main() {
+	log := logger.New("fn", "main")
+
+	log.Info("creating controller client")
+	client, err := controller.NewClient("", os.Getenv("AUTH_KEY"))
+	if err != nil {
+		log.Error("error creating controller client", "err", err)
+		shutdown.Fatal()
+	}
+
+	log.Info("connecting to postgres")
+	db := postgres.Wait("", "")
+
+	log.Info("creating postgres connection pool")
+	pgxpool, err := pgx.NewConnPool(pgx.ConnPoolConfig{
+		ConnConfig: pgx.ConnConfig{
+			Host:     os.Getenv("PGHOST"),
+			User:     os.Getenv("PGUSER"),
+			Password: os.Getenv("PGPASSWORD"),
+			Database: os.Getenv("PGDATABASE"),
+		},
+		AfterConnect:   que.PrepareStatements,
+		MaxConnections: workerCount,
+	})
+	if err != nil {
+		log.Error("error creating postgres connection pool", "err", err)
+		shutdown.Fatal()
+	}
+	shutdown.BeforeExit(func() { pgxpool.Close() })
+
+	workers := que.NewWorkerPool(
+		que.NewClient(pgxpool),
+		que.WorkMap{
+			"deployment": deployment.JobHandler(db, client, logger),
+		},
+		workerCount,
+	)
+	workers.Interval = 5 * time.Second
+
+	log.Info("starting workers", "count", workerCount, "interval", workers.Interval)
+	workers.Start()
+	shutdown.BeforeExit(func() { workers.Shutdown() })
+
+	select {} // block and keep running
+}

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -414,7 +414,7 @@ loop:
 	}
 	expected := map[string]map[string]int{release.ID: {
 		"web":       2,
-		"deployer":  2,
+		"worker":    2,
 		"scheduler": testCluster.Size(),
 	}}
 	t.Assert(actual, c.DeepEquals, expected)


### PR DESCRIPTION
This will make it easier to handle more background jobs (e.g. #993).