### PR TITLE
controller: Move events into single app event stream

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -133,7 +133,7 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 
 	start := time.Now()
 	err = watcher.WaitFor(expected, scaleTimeout, func(e *ct.JobEvent) error {
-		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), e.Job.Type, e.JobID, e.Job.State)
+		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), e.Type, e.JobID, e.State)
 		return nil
 	})
 

--- a/controller/app.go
+++ b/controller/app.go
@@ -220,6 +220,62 @@ func (r *AppRepo) List() (interface{}, error) {
 	return apps, rows.Err()
 }
 
+func (r *AppRepo) ListEvents(appID, typ, objectID string, sinceID int64, count int) ([]*ct.AppEvent, error) {
+	query := "SELECT event_id, app_id, object_id, object_type, data, created_at FROM app_events WHERE app_id = $1 AND event_id > $2"
+	args := []interface{}{appID, sinceID}
+	n := 3
+	if typ != "" {
+		query += fmt.Sprintf(" AND object_type = $%d", n)
+		n++
+		args = append(args, typ)
+	}
+	if objectID != "" {
+		query += fmt.Sprintf(" AND object_id = $%d", n)
+		args = append(args, objectID)
+	}
+	query += " ORDER BY event_id DESC"
+	if count > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", n)
+		args = append(args, count)
+	}
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	var events []*ct.AppEvent
+	for rows.Next() {
+		event, err := scanAppEvent(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (r *AppRepo) GetEvent(id int64) (*ct.AppEvent, error) {
+	row := r.db.QueryRow("SELECT event_id, app_id, object_id, object_type, data, created_at FROM app_events WHERE event_id = $1", id)
+	return scanAppEvent(row)
+}
+
+func scanAppEvent(s postgres.Scanner) (*ct.AppEvent, error) {
+	var event ct.AppEvent
+	var typ string
+	var data []byte
+	err := s.Scan(&event.ID, &event.AppID, &event.ObjectID, &typ, &data, &event.CreatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			err = ErrNotFound
+		}
+		return nil, err
+	}
+	event.AppID = postgres.CleanUUID(event.AppID)
+	event.ObjectType = ct.EventType(typ)
+	event.Data = json.RawMessage(data)
+	return &event, nil
+}
+
 func (r *AppRepo) SetRelease(appID string, releaseID string) error {
 	return r.db.Exec("UPDATE apps SET release_id = $2, updated_at = now() WHERE app_id = $1", appID, releaseID)
 }
@@ -349,6 +405,93 @@ func (c *controllerAPI) AppLog(ctx context.Context, w http.ResponseWriter, req *
 			return
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+func (c *controllerAPI) AppEvents(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	if err := streamAppEvents(ctx, w, req, c.getApp(ctx), c.appRepo); err != nil {
+		respondWithError(w, err)
+	}
+}
+
+func streamAppEvents(ctx context.Context, w http.ResponseWriter, req *http.Request, app *ct.App, repo *AppRepo) (err error) {
+	var lastID int64
+	if req.Header.Get("Last-Event-Id") != "" {
+		lastID, err = strconv.ParseInt(req.Header.Get("Last-Event-Id"), 10, 64)
+		if err != nil {
+			return ct.ValidationError{Field: "Last-Event-Id", Message: "is invalid"}
+		}
+	}
+
+	var count int
+	if req.FormValue("count") != "" {
+		count, err = strconv.Atoi(req.FormValue("count"))
+		if err != nil {
+			return ct.ValidationError{Field: "count", Message: "is invalid"}
+		}
+	}
+
+	objectType := req.FormValue("object_type")
+	objectID := req.FormValue("object_id")
+	past := req.FormValue("past")
+
+	l, _ := ctxhelper.LoggerFromContext(ctx)
+	log := l.New("fn", "AppEvents", "object_type", objectType, "object_id", objectID)
+	ch := make(chan *ct.AppEvent)
+	s := sse.NewStream(w, ch, log)
+	s.Serve()
+	defer func() {
+		if err == nil {
+			s.Close()
+		} else {
+			s.CloseWithError(err)
+		}
+	}()
+
+	listener, err := repo.db.Listen("app_events:"+postgres.FormatUUID(app.ID), log)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	var currID int64
+	if past == "true" || lastID > 0 {
+		events, err := repo.ListEvents(app.ID, objectType, objectID, lastID, count)
+		if err != nil {
+			return err
+		}
+		// events are in ID DESC order, so iterate in reverse
+		for i := len(events) - 1; i >= 0; i-- {
+			e := events[i]
+			ch <- e
+			currID = e.ID
+		}
+	}
+
+	for {
+		select {
+		case <-s.Done:
+			return
+		case n, ok := <-listener.Notify:
+			if !ok {
+				return listener.Err
+			}
+			id, err := strconv.ParseInt(n.Extra, 10, 64)
+			if err != nil {
+				return err
+			}
+			if id <= currID {
+				continue
+			}
+			e, err := repo.GetEvent(id)
+			if err != nil {
+				return err
+			}
+			if objectType != "" && objectType != string(e.ObjectType) {
+				continue
+			}
+			ch <- e
 		}
 	}
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -172,6 +172,7 @@ func appHandler(c handlerConfig) http.Handler {
 
 	httpRouter.POST("/apps/:apps_id", httphelper.WrapHandler(api.UpdateApp))
 	httpRouter.GET("/apps/:apps_id/log", httphelper.WrapHandler(api.appLookup(api.AppLog)))
+	httpRouter.GET("/apps/:apps_id/events", httphelper.WrapHandler(api.appLookup(api.AppEvents)))
 
 	httpRouter.PUT("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.PutFormation)))
 	httpRouter.GET("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.GetFormation)))

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/que-go"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
@@ -245,6 +246,9 @@ type controllerAPI struct {
 	clusterClient  clusterClient
 	logaggc        logaggc.Client
 	routerc        routerc.Client
+
+	eventListener    *EventListener
+	eventListenerMtx sync.Mutex
 }
 
 func (c *controllerAPI) getApp(ctx context.Context) *ct.App {

--- a/controller/events.go
+++ b/controller/events.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+// ErrEventBufferOverflow is returned to clients when the in-memory event
+// buffer is full due to clients not reading events quickly enough.
+var ErrEventBufferOverflow = errors.New("event stream buffer overflow")
+
+// eventBufferSize is the amount of events to buffer in memory.
+const eventBufferSize = 1000
+
+// EventSubscriber receives app events from the EventListener loop and maintains
+// it's own loop to forward those events to the Events channel.
+type EventSubscriber struct {
+	Events chan *ct.AppEvent
+	Err    error
+
+	l          *EventListener
+	queue      chan *ct.AppEvent
+	appID      string
+	objectType string
+	objectID   string
+
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// Notify filters the event based on it's type and objectID and then pushes
+// it to the event queue.
+func (e *EventSubscriber) Notify(event *ct.AppEvent) {
+	if e.objectType != "" && e.objectType != string(event.ObjectType) {
+		return
+	}
+	if e.objectID != "" && e.objectID != event.ObjectID {
+		return
+	}
+	select {
+	case e.queue <- event:
+	default:
+		e.CloseWithError(ErrEventBufferOverflow)
+	}
+}
+
+// loop pops events off the queue and sends them to the Events channel.
+func (e *EventSubscriber) loop() {
+	defer close(e.Events)
+	for {
+		select {
+		case <-e.stop:
+			return
+		case event := <-e.queue:
+			e.Events <- event
+		}
+	}
+}
+
+// Close unsubscribes from the EventListener and stops the loop.
+func (e *EventSubscriber) Close() {
+	e.l.Unsubscribe(e)
+	e.stopOnce.Do(func() { close(e.stop) })
+}
+
+// CloseWithError sets the Err field and then closes the subscriber.
+func (e *EventSubscriber) CloseWithError(err error) {
+	e.Err = err
+	e.Close()
+}
+
+func newEventListener(a *AppRepo) *EventListener {
+	return &EventListener{
+		appRepo:     a,
+		subscribers: make(map[string]map[*EventSubscriber]struct{}),
+	}
+}
+
+// EventListener creates a postgres Listener for app events and forwards them
+// to subscribers.
+type EventListener struct {
+	appRepo *AppRepo
+
+	subscribers map[string]map[*EventSubscriber]struct{}
+	subMtx      sync.RWMutex
+
+	closed    bool
+	closedMtx sync.RWMutex
+}
+
+// Subscribe creates and returns an EventSubscriber for the given app, type and object.
+func (e *EventListener) Subscribe(appID, objectType, objectID string) (*EventSubscriber, error) {
+	e.subMtx.Lock()
+	defer e.subMtx.Unlock()
+	if e.IsClosed() {
+		return nil, errors.New("event listener closed")
+	}
+	s := &EventSubscriber{
+		Events:     make(chan *ct.AppEvent),
+		l:          e,
+		queue:      make(chan *ct.AppEvent, eventBufferSize),
+		stop:       make(chan struct{}),
+		appID:      appID,
+		objectType: objectType,
+		objectID:   objectID,
+	}
+	go s.loop()
+	if _, ok := e.subscribers[appID]; !ok {
+		e.subscribers[appID] = make(map[*EventSubscriber]struct{})
+	}
+	e.subscribers[appID][s] = struct{}{}
+	return s, nil
+}
+
+// Unsubscribe unsubscribes the given subscriber.
+func (e *EventListener) Unsubscribe(s *EventSubscriber) {
+	e.subMtx.Lock()
+	defer e.subMtx.Unlock()
+	if subs, ok := e.subscribers[s.appID]; ok {
+		delete(subs, s)
+		if len(subs) == 0 {
+			delete(e.subscribers, s.appID)
+		}
+	}
+}
+
+// Listen creates a postgres listener for app events and starts a goroutine to
+// forward the events to subscribers.
+func (e *EventListener) Listen() error {
+	log := log15.New("component", "controller", "fn", "EventListener.Listen")
+	listener, err := e.appRepo.db.Listen("app_events", log)
+	if err != nil {
+		e.SetClosed()
+		return err
+	}
+	go func() {
+		for {
+			n, ok := <-listener.Notify
+			if !ok {
+				e.CloseWithError(listener.Err)
+				return
+			}
+			idApp := strings.SplitN(n.Extra, ":", 2)
+			if len(idApp) != 2 {
+				log.Error(fmt.Sprintf("invalid app event notification: %q", n.Extra))
+				continue
+			}
+			id, err := strconv.ParseInt(idApp[0], 10, 64)
+			if err != nil {
+				log.Error(fmt.Sprintf("invalid app event notification: %q", n.Extra), "err", err)
+				continue
+			}
+			event, err := e.appRepo.GetEvent(id)
+			if err != nil {
+				log.Error(fmt.Sprintf("invalid app event notification: %q", n.Extra), "err", err)
+				continue
+			}
+			e.Notify(event)
+		}
+	}()
+	return nil
+}
+
+// Notify notifies all sbscribers of the given event.
+func (e *EventListener) Notify(event *ct.AppEvent) {
+	e.subMtx.RLock()
+	subscribers := e.subscribers
+	e.subMtx.RUnlock()
+	if subs, ok := subscribers[event.AppID]; ok {
+		for sub := range subs {
+			sub.Notify(event)
+		}
+	}
+}
+
+// SetClosed marks the listener as closed.
+func (e *EventListener) SetClosed() {
+	e.closedMtx.Lock()
+	defer e.closedMtx.Unlock()
+	e.closed = true
+}
+
+// IsClosed returns whether or not the listener is closed.
+func (e *EventListener) IsClosed() bool {
+	e.closedMtx.RLock()
+	defer e.closedMtx.RUnlock()
+	return e.closed
+}
+
+// CloseWithError marks the listener as closed and closes all subscribers
+// with the given error.
+func (e *EventListener) CloseWithError(err error) {
+	e.SetClosed()
+	e.subMtx.RLock()
+	subscribers := e.subscribers
+	e.subMtx.RUnlock()
+	for _, subs := range subscribers {
+		for sub := range subs {
+			sub.CloseWithError(err)
+		}
+	}
+}

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+func (s *S) TestAppEvents(c *C) {
+	app1 := s.createTestApp(c, &ct.App{Name: "app1"})
+	app2 := s.createTestApp(c, &ct.App{Name: "app2"})
+	release := s.createTestRelease(c, &ct.Release{})
+
+	jobID1 := "host-job1"
+	jobID2 := "host-job2"
+	jobID3 := "host-job3"
+	jobs := []*ct.Job{
+		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
+		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "up"},
+		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
+		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "up"},
+		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
+		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: "up"},
+	}
+
+	listener := newEventListener(&AppRepo{db: s.hc.db})
+	c.Assert(listener.Listen(), IsNil)
+
+	// sub1 should receive job events for app1, job1
+	sub1, err := listener.Subscribe(app1.ID, string(ct.EventTypeJob), jobID1)
+	c.Assert(err, IsNil)
+	defer sub1.Close()
+
+	// sub2 should receive all job events for app1
+	sub2, err := listener.Subscribe(app1.ID, string(ct.EventTypeJob), "")
+	c.Assert(err, IsNil)
+	defer sub2.Close()
+
+	// sub3 should receive all job events for app2
+	sub3, err := listener.Subscribe(app2.ID, "", "")
+	c.Assert(err, IsNil)
+	defer sub3.Close()
+
+	for _, job := range jobs {
+		s.createTestJob(c, job)
+	}
+
+	assertJobEvents := func(sub *EventSubscriber, expected []*ct.Job) {
+		var index int
+		for {
+			select {
+			case e, ok := <-sub.Events:
+				if !ok {
+					c.Fatalf("unexpected close of event stream: %s", sub.Err)
+				}
+				var jobEvent ct.JobEvent
+				c.Assert(json.Unmarshal(e.Data, &jobEvent), IsNil)
+				job := expected[index]
+				c.Assert(jobEvent, DeepEquals, ct.JobEvent{
+					JobID:     job.ID,
+					AppID:     job.AppID,
+					ReleaseID: job.ReleaseID,
+					Type:      job.Type,
+					State:     job.State,
+				})
+				index += 1
+				if index == len(expected) {
+					return
+				}
+			case <-time.After(time.Second):
+				c.Fatal("timed out waiting for app event")
+			}
+		}
+	}
+	assertJobEvents(sub1, jobs[0:2])
+	assertJobEvents(sub2, jobs[0:4])
+	assertJobEvents(sub3, jobs[4:6])
+}

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-sql"
@@ -22,7 +21,6 @@ import (
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/schedutil"
-	"github.com/flynn/flynn/pkg/sse"
 )
 
 /* SSE Logger */
@@ -81,7 +79,19 @@ func (r *JobRepo) Add(job *ct.Job) error {
 	}
 
 	// create a job event, ignoring possible duplications
-	err = r.db.Exec("INSERT INTO job_events (job_id, host_id, app_id, state) VALUES ($1, $2, $3, $4)", jobID, hostID, job.AppID, job.State)
+	e := ct.JobEvent{
+		JobID:     job.ID,
+		AppID:     job.AppID,
+		ReleaseID: job.ReleaseID,
+		Type:      job.Type,
+		State:     job.State,
+	}
+	uniqueID := strings.Join([]string{e.JobID, e.State}, "|")
+	data, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	err = r.db.Exec("INSERT INTO app_events (app_id, object_id, unique_id, object_type, data) VALUES ($1, $2, $3, $4, $5)", e.AppID, e.JobID, uniqueID, string(ct.EventTypeJob), data)
 	if postgres.IsUniquenessError(err, "") {
 		return nil
 	}
@@ -126,48 +136,6 @@ func (r *JobRepo) List(appID string) ([]*ct.Job, error) {
 	return jobs, nil
 }
 
-func (r *JobRepo) listEvents(appID string, sinceID int64, count int) ([]*ct.JobEvent, error) {
-	query := "SELECT event_id, concat(job_events.host_id, '-', job_events.job_id), job_events.app_id, job_cache.release_id, job_cache.process_type, job_events.state, job_events.created_at FROM job_events INNER JOIN job_cache ON job_events.job_id = job_cache.job_id AND job_events.host_id = job_cache.host_id WHERE job_events.app_id = $1 AND event_id > $2 ORDER BY event_id DESC"
-	args := []interface{}{appID, sinceID}
-	if count > 0 {
-		query += " LIMIT $3"
-		args = append(args, count)
-	}
-	rows, err := r.db.Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	var events []*ct.JobEvent
-	for rows.Next() {
-		event, err := scanJobEvent(rows)
-		if err != nil {
-			rows.Close()
-			return nil, err
-		}
-		events = append(events, event)
-	}
-	return events, nil
-}
-
-func (r *JobRepo) getEvent(eventID int64) (*ct.JobEvent, error) {
-	row := r.db.QueryRow("SELECT event_id, concat(job_events.host_id, '-', job_events.job_id), job_events.app_id, job_cache.release_id, job_cache.process_type, job_events.state, job_events.created_at FROM job_events INNER JOIN job_cache ON job_events.job_id = job_cache.job_id AND job_events.host_id = job_cache.host_id WHERE job_events.event_id = $1", eventID)
-	return scanJobEvent(row)
-}
-
-func scanJobEvent(s postgres.Scanner) (*ct.JobEvent, error) {
-	event := &ct.JobEvent{}
-	err := s.Scan(&event.ID, &event.JobID, &event.AppID, &event.ReleaseID, &event.Type, &event.State, &event.CreatedAt)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			err = ErrNotFound
-		}
-		return nil, err
-	}
-	event.AppID = postgres.CleanUUID(event.AppID)
-	event.ReleaseID = postgres.CleanUUID(event.ReleaseID)
-	return event, nil
-}
-
 type clusterClient interface {
 	ListHosts() ([]host.Host, error)
 	DialHost(string) (cluster.Host, error)
@@ -191,12 +159,6 @@ func (c *controllerAPI) connectHost(ctx context.Context) (cluster.Host, string, 
 
 func (c *controllerAPI) ListJobs(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	app := c.getApp(ctx)
-	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
-		if err := streamJobs(ctx, req, w, app, c.jobRepo); err != nil {
-			respondWithError(w, err)
-		}
-		return
-	}
 	list, err := c.jobRepo.List(app.ID)
 	if err != nil {
 		respondWithError(w, err)
@@ -236,79 +198,6 @@ func (c *controllerAPI) PutJob(ctx context.Context, w http.ResponseWriter, req *
 		return
 	}
 	httphelper.JSON(w, 200, &job)
-}
-
-func streamJobs(ctx context.Context, req *http.Request, w http.ResponseWriter, app *ct.App, repo *JobRepo) (err error) {
-	var lastID int64
-	if req.Header.Get("Last-Event-Id") != "" {
-		lastID, err = strconv.ParseInt(req.Header.Get("Last-Event-Id"), 10, 64)
-		if err != nil {
-			return ct.ValidationError{Field: "Last-Event-Id", Message: "is invalid"}
-		}
-	}
-	var count int
-	if req.FormValue("count") != "" {
-		count, err = strconv.Atoi(req.FormValue("count"))
-		if err != nil {
-			return ct.ValidationError{Field: "count", Message: "is invalid"}
-		}
-	}
-
-	ch := make(chan *ct.JobEvent)
-	l, _ := ctxhelper.LoggerFromContext(ctx)
-	log := l.New("fn", "streamJobs", "app_id", app.ID)
-	s := sse.NewStream(w, ch, log)
-	s.Serve()
-	defer func() {
-		if err == nil {
-			s.Close()
-		} else {
-			s.CloseWithError(err)
-		}
-	}()
-
-	listener, err := repo.db.Listen("job_events:"+postgres.FormatUUID(app.ID), log)
-	if err != nil {
-		return err
-	}
-	defer listener.Close()
-
-	var currID int64
-	if lastID > 0 || count > 0 {
-		events, err := repo.listEvents(app.ID, lastID, count)
-		if err != nil {
-			return err
-		}
-		// events are in ID DESC order, so iterate in reverse
-		for i := len(events) - 1; i >= 0; i-- {
-			e := events[i]
-			ch <- e
-			currID = e.ID
-		}
-	}
-
-	for {
-		select {
-		case <-s.Done:
-			return
-		case n, ok := <-listener.Notify:
-			if !ok {
-				return listener.Err
-			}
-			id, err := strconv.ParseInt(n.Extra, 10, 64)
-			if err != nil {
-				return err
-			}
-			if id <= currID {
-				continue
-			}
-			e, err := repo.getEvent(id)
-			if err != nil {
-				return err
-			}
-			ch <- e
-		}
-	}
 }
 
 func (c *controllerAPI) KillJob(ctx context.Context, w http.ResponseWriter, req *http.Request) {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -56,7 +56,7 @@ func migrateDB(db *sql.DB) error {
 		`CREATE UNIQUE INDEX ON app_events (unique_id)`,
 		`CREATE FUNCTION notify_app_event() RETURNS TRIGGER AS $$
     BEGIN
-	PERFORM pg_notify('app_events:' || NEW.app_id, NEW.event_id || '');
+	PERFORM pg_notify('app_events', NEW.event_id || ':' || NEW.app_id);
 	RETURN NULL;
     END;
 $$ LANGUAGE plpgsql`,

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/flynn/flynn/host/resource"
@@ -95,9 +94,11 @@ type Job struct {
 }
 
 type JobEvent struct {
-	Job
-	ID    int64  `json:"id"`
-	JobID string `json:"job_id,omitempty"`
+	JobID     string `json:"job_id,omitempty"`
+	AppID     string `json:"app,omitempty"`
+	ReleaseID string `json:"release,omitempty"`
+	Type      string `json:"type,omitempty"`
+	State     string `json:"state,omitempty"`
 }
 
 func (e *JobEvent) IsDown() bool {
@@ -136,18 +137,13 @@ type DeployID struct {
 }
 
 type DeploymentEvent struct {
-	ID           int64      `json:"id"`
-	DeploymentID string     `json:"deployment"`
-	ReleaseID    string     `json:"release"`
-	Status       string     `json:"status"`
-	JobType      string     `json:"job_type"`
-	JobState     string     `json:"job_state"`
-	CreatedAt    *time.Time `json:"created_at"`
-	Error        string     `json:"error"`
-}
-
-func (e *DeploymentEvent) EventID() string {
-	return strconv.FormatInt(e.ID, 10)
+	AppID        string `json:"app,omitempty"`
+	DeploymentID string `json:"deployment,omitempty"`
+	ReleaseID    string `json:"release,omitempty"`
+	Status       string `json:"status,omitempty"`
+	JobType      string `json:"job_type,omitempty"`
+	JobState     string `json:"job_state,omitempty"`
+	Error        string `json:"error,omitempty"`
 }
 
 func (e *DeploymentEvent) Err() error {
@@ -194,4 +190,21 @@ type LogOpts struct {
 	JobID       string
 	Lines       *int
 	ProcessType *string
+}
+
+type EventType string
+
+const (
+	EventTypeDeployment EventType = "deployment"
+	EventTypeJob        EventType = "job"
+	EventTypeScale      EventType = "scale"
+)
+
+type AppEvent struct {
+	ID         int64           `json:"id,omitempty"`
+	AppID      string          `json:"app,omitempty"`
+	ObjectType EventType       `json:"object_type,omitempty"`
+	ObjectID   string          `json:"object_id,omitempty"`
+	Data       json.RawMessage `json:"data,omitempty"`
+	CreatedAt  *time.Time      `json:"created_at,omitempty"`
 }

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -264,7 +264,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected jobEvents, log l
 			if !ok {
 				return errors.New("unexpected close of job event stream")
 			}
-			if event.Job.ReleaseID != releaseID {
+			if event.ReleaseID != releaseID {
 				continue
 			}
 

--- a/controller/worker/deployment/postgres.go
+++ b/controller/worker/deployment/postgres.go
@@ -224,7 +224,7 @@ loop:
 				return loggedErr("unexpected close of job event stream")
 			}
 			log.Info("got job event", "job_id", event.JobID, "type", event.Type, "state", event.State)
-			if event.State == "down" && event.Type == "postgres" && event.Job.ReleaseID == d.OldReleaseID {
+			if event.State == "down" && event.Type == "postgres" && event.ReleaseID == d.OldReleaseID {
 				actual++
 				if actual == d.Processes["postgres"] {
 					break loop

--- a/receiver/flynn-receive.go
+++ b/receiver/flynn-receive.go
@@ -152,7 +152,7 @@ func main() {
 		fmt.Println("=====> Waiting for web job to start...")
 
 		err = watcher.WaitFor(ct.JobEvents{"web": {"up": 1}}, scaleTimeout, func(e *ct.JobEvent) error {
-			switch e.Job.State {
+			switch e.State {
 			case "up":
 				fmt.Println("=====> Default web formation scaled to 1")
 			case "down", "crashed":

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -113,7 +113,7 @@ loop:
 func (s *DeployerSuite) TestOneByOneStrategy(t *c.C) {
 	deployment := s.createDeployment(t, "printer", "one-by-one", "")
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := s.controllerClient(t).StreamDeployment(deployment.ID, events)
+	stream, err := s.controllerClient(t).StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	releaseID := deployment.NewReleaseID
@@ -136,7 +136,7 @@ func (s *DeployerSuite) TestOneByOneStrategy(t *c.C) {
 func (s *DeployerSuite) TestAllAtOnceStrategy(t *c.C) {
 	deployment := s.createDeployment(t, "printer", "all-at-once", "")
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := s.controllerClient(t).StreamDeployment(deployment.ID, events)
+	stream, err := s.controllerClient(t).StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	releaseID := deployment.NewReleaseID
@@ -159,7 +159,7 @@ func (s *DeployerSuite) TestAllAtOnceStrategy(t *c.C) {
 func (s *DeployerSuite) TestServiceEvents(t *c.C) {
 	deployment := s.createDeployment(t, "echoer", "all-at-once", "echo-service")
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := s.controllerClient(t).StreamDeployment(deployment.ID, events)
+	stream, err := s.controllerClient(t).StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	releaseID := deployment.NewReleaseID
@@ -211,7 +211,7 @@ func (s *DeployerSuite) TestRollbackFailedJob(t *c.C) {
 
 	// check the deployment fails
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := client.StreamDeployment(deployment.ID, events)
+	stream, err := client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	expected := []*ct.DeploymentEvent{
@@ -256,7 +256,7 @@ func (s *DeployerSuite) TestRollbackNoService(t *c.C) {
 
 	// check the deployment fails
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := client.StreamDeployment(deployment.ID, events)
+	stream, err := client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	expected := []*ct.DeploymentEvent{
@@ -305,7 +305,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 	events := make(chan *ct.DeploymentEvent)
-	stream, err := client.StreamDeployment(deployment.ID, events)
+	stream, err := client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	expected := make([]*ct.DeploymentEvent, 0, 4*totalJobs+1)
@@ -335,7 +335,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	deployment, err = client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 	events = make(chan *ct.DeploymentEvent)
-	stream, err = client.StreamDeployment(deployment.ID, events)
+	stream, err = client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	expected = make([]*ct.DeploymentEvent, 0, 4*totalJobs+1)
 	appendEvents(deployment.NewReleaseID, "starting", testCluster.Size())

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -242,7 +242,7 @@ func (s *PostgresSuite) testDeploy(t *c.C, d *pgDeploy) {
 	deployment, err := client.CreateDeployment(app.ID, newRelease)
 	t.Assert(err, c.IsNil)
 	deployEvents := make(chan *ct.DeploymentEvent)
-	deployStream, err := client.StreamDeployment(deployment.ID, deployEvents)
+	deployStream, err := client.StreamDeployment(deployment, deployEvents)
 	t.Assert(err, c.IsNil)
 	defer deployStream.Close()
 

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -368,7 +368,7 @@ func (s *SchedulerSuite) TestDeployController(t *c.C) {
 	t.Assert(err, c.IsNil)
 
 	events := make(chan *ct.DeploymentEvent)
-	eventStream, err := client.StreamDeployment(deployment.ID, events)
+	eventStream, err := client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	defer eventStream.Close()
 


### PR DESCRIPTION
This will make it easier to add more event types which can be streamed to clients (e.g. app deletion events in #1533), as well as removing duplication in the controller.