### PR TITLE
cli: Fix scaling processes down

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -86,11 +86,13 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 	for _, arg := range typeCounts {
 		i := strings.IndexRune(arg, '=')
 		if i < 0 {
-			fmt.Println(commands["scale"].usage)
+			return fmt.Errorf("ERROR: scale args must be of the form <typ>=<qty>")
 		}
 		val, err := strconv.Atoi(arg[i+1:])
 		if err != nil {
-			fmt.Println(commands["scale"].usage)
+			return fmt.Errorf("ERROR: could not parse quantity in %q", arg)
+		} else if val < 0 {
+			return fmt.Errorf("ERROR: process quantities cannot be negative in %q", arg)
 		}
 		processType := arg[:i]
 		if _, ok := release.Processes[processType]; ok {
@@ -100,7 +102,7 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 		}
 	}
 	if len(invalid) > 0 {
-		return errors.New(fmt.Sprintf("ERROR: Unknown process types: %s", strings.Join(invalid, ", ")))
+		return fmt.Errorf("ERROR: unknown process types: %s", strings.Join(invalid, ", "))
 	}
 	formation.Processes = processes
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -452,7 +452,7 @@ func (c *Client) ExpectedScalingEvents(actual, expected map[string]int, releaseP
 		}
 		if diff > 0 {
 			events[typ] = map[string]int{"up": diff}
-		} else if count < 0 {
+		} else if diff < 0 {
 			events[typ] = map[string]int{"down": -diff}
 		}
 	}

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -633,7 +633,7 @@ func (s *CLISuite) TestRelease(t *c.C) {
 
 	scaleCmd := app.flynn("scale", "--no-wait", "env=1", "foo=1")
 	t.Assert(scaleCmd, c.Not(Succeeds))
-	t.Assert(scaleCmd, OutputContains, "ERROR: Unknown process types: \"foo\"")
+	t.Assert(scaleCmd, OutputContains, "ERROR: unknown process types: \"foo\"")
 	scaleCmd = app.flynn("scale", "--no-wait", "env=1")
 	app.waitFor(ct.JobEvents{"env": {"up": 1}})
 	envLog := app.flynn("log")

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -194,28 +194,37 @@ func (s *CLISuite) TestPs(t *c.C) {
 	for _, j := range jobs {
 		t.Assert(j, Matches, "echoer")
 	}
-	scale := app.flynn("scale", "echoer=0")
-	app.waitFor(ct.JobEvents{"echoer": {"down": 3}})
-	t.Assert(scale, Succeeds)
+	t.Assert(app.flynn("scale", "echoer=0"), Succeeds)
 	t.Assert(ps(), c.HasLen, 0)
 }
 
 func (s *CLISuite) TestScale(t *c.C) {
 	app := s.newCliTestApp(t)
 
+	assertEventOutput := func(scale *CmdResult, events ct.JobEvents) {
+		var actual []*ct.JobEvent
+		f := func(e *ct.JobEvent) error {
+			actual = append(actual, e)
+			return nil
+		}
+		t.Assert(app.watcher.WaitFor(events, scaleTimeout, f), c.IsNil)
+		for _, e := range actual {
+			t.Assert(scale, OutputContains, fmt.Sprintf("==> %s %s %s", e.Type, e.JobID, e.State))
+		}
+	}
+
 	scale := app.flynn("scale", "echoer=1")
-	jobID := app.waitFor(ct.JobEvents{"echoer": {"up": 1}})
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "scaling echoer: 0=>1")
-	t.Assert(scale, SuccessfulOutputContains, fmt.Sprintf("==> echoer %s up", jobID))
 	t.Assert(scale, SuccessfulOutputContains, "scale completed")
+	assertEventOutput(scale, ct.JobEvents{"echoer": {"up": 1}})
 
 	scale = app.flynn("scale", "echoer=3", "printer=1")
-	app.waitFor(ct.JobEvents{"echoer": {"up": 2}, "printer": {"up": 1}})
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "echoer: 1=>3")
 	t.Assert(scale, SuccessfulOutputContains, "printer: 0=>1")
 	t.Assert(scale, SuccessfulOutputContains, "scale completed")
+	assertEventOutput(scale, ct.JobEvents{"echoer": {"up": 2}, "printer": {"up": 1}})
 
 	// no args should show current scale
 	scale = app.flynn("scale")
@@ -227,10 +236,10 @@ func (s *CLISuite) TestScale(t *c.C) {
 
 	// scale should only affect specified processes
 	scale = app.flynn("scale", "printer=2")
-	app.waitFor(ct.JobEvents{"printer": {"up": 1}})
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "printer: 1=>2")
 	t.Assert(scale, SuccessfulOutputContains, "scale completed")
+	assertEventOutput(scale, ct.JobEvents{"printer": {"up": 1}})
 	scale = app.flynn("scale")
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "echoer=3")
@@ -240,18 +249,17 @@ func (s *CLISuite) TestScale(t *c.C) {
 
 	// unchanged processes shouldn't appear in output
 	scale = app.flynn("scale", "echoer=3", "printer=0")
-	app.waitFor(ct.JobEvents{"printer": {"down": 2}})
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "printer: 2=>0")
 	t.Assert(scale, c.Not(OutputContains), "echoer")
 	t.Assert(scale, SuccessfulOutputContains, "scale completed")
+	assertEventOutput(scale, ct.JobEvents{"printer": {"down": 2}})
 
 	// --no-wait should not wait for scaling to complete
 	scale = app.flynn("scale", "--no-wait", "echoer=0")
 	t.Assert(scale, Succeeds)
 	t.Assert(scale, SuccessfulOutputContains, "scaling echoer: 3=>0")
 	t.Assert(scale, c.Not(OutputContains), "scale completed")
-	app.waitFor(ct.JobEvents{"echoer": {"down": 3}})
 }
 
 func (s *CLISuite) TestRun(t *c.C) {

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -70,10 +70,7 @@ func (a *cliTestApp) waitFor(events ct.JobEvents) string {
 		return nil
 	}
 
-	err := a.watcher.WaitFor(events, scaleTimeout, idSetter)
-	if err != nil {
-		return err.Error()
-	}
+	a.t.Assert(a.watcher.WaitFor(events, scaleTimeout, idSetter), c.IsNil)
 	return id
 }
 


### PR DESCRIPTION
The previous check of `count < 0` was never true, meaning down events were not being waited for.

I have updated the tests to check all the expected events appear in the scale output.

@jzila FYI this was the cause of the intermittent failures in #1502.