### PR TITLE
cli: Output of cluster default now matches cluster

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -122,7 +122,15 @@ func runClusterDefault(args *docopt.Args) error {
 	name := args.String["<cluster-name>"]
 
 	if name == "" {
-		log.Printf("%q is default cluster.", config.Default)
+		w := tabWriter()
+		defer w.Flush()
+		listRec(w, "NAME", "URL")
+		for _, s := range config.Clusters {
+			if s.Name == config.Default {
+				listRec(w, s.Name, s.URL, "(default)")
+				break
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
`flynn cluster default` returns now  
```
$ ./flynn cluster default
NAME     URL
default  https://controller.dev.localflynn.com  (default)
```
instead of  
```
"default" is default cluster.
```

Closes #1517