### PR TITLE
slugbuilder: Bump buildpacks

### DIFF
--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,12 +1,12 @@
 https://github.com/heroku/heroku-buildpack-multi.git#26fa21ac
 https://github.com/cloudfoundry/staticfile-buildpack.git#16b2bb2c
-https://github.com/heroku/heroku-buildpack-ruby.git#d2d08e2b
+https://github.com/heroku/heroku-buildpack-ruby.git#4b493f80
 https://github.com/heroku/heroku-buildpack-nodejs.git#d8fbb5b0
 https://github.com/heroku/heroku-buildpack-clojure.git#de48a684
-https://github.com/heroku/heroku-buildpack-python.git#3ea07357
+https://github.com/heroku/heroku-buildpack-python.git#7fd3a047
 https://github.com/heroku/heroku-buildpack-java.git#18eeafc7
 https://github.com/heroku/heroku-buildpack-gradle.git#47dc93f2
-https://github.com/heroku/heroku-buildpack-scala.git#230cbfa3
+https://github.com/heroku/heroku-buildpack-scala.git#9e8907d5
 https://github.com/heroku/heroku-buildpack-play.git#1cf304b4
-https://github.com/heroku/heroku-buildpack-php.git#8da6b92a
+https://github.com/heroku/heroku-buildpack-php.git#04a7e4f8
 https://github.com/heroku/heroku-buildpack-go.git#6eeb09f5


### PR DESCRIPTION
Big news is that the Ruby buildpack now uses Bundler 1.9. Also, new PHP versions and GDAL for Python.

https://github.com/heroku/heroku-buildpack-ruby/compare/d2d08e2b...4b493f80
https://github.com/heroku/heroku-buildpack-python/compare/3ea07357...7fd3a047
https://github.com/heroku/heroku-buildpack-scala/compare/230cbfa3...9e8907d5
https://github.com/heroku/heroku-buildpack-php/compare/8da6b92a...04a7e4f8