### PR TITLE
host: Remove default max procs limit

### DIFF
--- a/host/resource/resource.go
+++ b/host/resource/resource.go
@@ -35,9 +35,8 @@ const (
 )
 
 var defaults = Resources{
-	TypeMemory:   {Request: typeconv.Int64Ptr(1 * units.GiB), Limit: typeconv.Int64Ptr(1 * units.GiB)},
-	TypeMaxFD:    {Request: typeconv.Int64Ptr(10000), Limit: typeconv.Int64Ptr(10000)},
-	TypeMaxProcs: {Request: typeconv.Int64Ptr(256), Limit: typeconv.Int64Ptr(256)},
+	TypeMemory: {Request: typeconv.Int64Ptr(1 * units.GiB), Limit: typeconv.Int64Ptr(1 * units.GiB)},
+	TypeMaxFD:  {Request: typeconv.Int64Ptr(10000), Limit: typeconv.Int64Ptr(10000)},
 }
 
 type Resources map[Type]Spec

--- a/host/resource/resource_test.go
+++ b/host/resource/resource_test.go
@@ -38,14 +38,14 @@ func (S) TestSetDefaultsNil(c *C) {
 func (S) TestSetDefaultsEmpty(c *C) {
 	r := make(Resources)
 	SetDefaults(&r)
-	assertDefault(c, r, TypeMemory, TypeMaxFD, TypeMaxProcs)
+	assertDefault(c, r, TypeMemory, TypeMaxFD)
 }
 
 func (S) TestSetDefaultsRequest(c *C) {
 	// not specifying Request should default it to the value of Limit
 	r := Resources{TypeMemory: Spec{Limit: typeconv.Int64Ptr(512 * units.MiB)}}
 	SetDefaults(&r)
-	assertDefault(c, r, TypeMaxFD, TypeMaxProcs)
+	assertDefault(c, r, TypeMaxFD)
 	mem, ok := r[TypeMemory]
 	if !ok {
 		c.Fatal("memory resource not set")

--- a/test/helper.go
+++ b/test/helper.go
@@ -123,17 +123,15 @@ func (h *Helper) sshKeys(t *c.C) *sshData {
 }
 
 const (
-	resourceMem      int64 = 256 * units.MiB
-	resourceMaxFD    int64 = 1024
-	resourceMaxProcs int64 = 512
-	resourceCmd            = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes; ulimit -n; ulimit -p"
+	resourceMem   int64 = 256 * units.MiB
+	resourceMaxFD int64 = 1024
+	resourceCmd         = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes; ulimit -n"
 )
 
 func testResources() resource.Resources {
 	r := resource.Resources{
-		resource.TypeMemory:   resource.Spec{Limit: typeconv.Int64Ptr(resourceMem)},
-		resource.TypeMaxFD:    resource.Spec{Limit: typeconv.Int64Ptr(resourceMaxFD)},
-		resource.TypeMaxProcs: resource.Spec{Limit: typeconv.Int64Ptr(resourceMaxProcs)},
+		resource.TypeMemory: resource.Spec{Limit: typeconv.Int64Ptr(resourceMem)},
+		resource.TypeMaxFD:  resource.Spec{Limit: typeconv.Int64Ptr(resourceMaxFD)},
 	}
 	resource.SetDefaults(&r)
 	return r
@@ -141,10 +139,9 @@ func testResources() resource.Resources {
 
 func assertResourceLimits(t *c.C, out string) {
 	limits := strings.Split(strings.TrimSpace(out), "\n")
-	t.Assert(limits, c.HasLen, 3)
+	t.Assert(limits, c.HasLen, 2)
 	t.Assert(limits[0], c.Equals, strconv.FormatInt(resourceMem, 10))
 	t.Assert(limits[1], c.Equals, strconv.FormatInt(resourceMaxFD, 10))
-	t.Assert(limits[2], c.Equals, strconv.FormatInt(resourceMaxProcs, 10))
 }
 
 func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {


### PR DESCRIPTION
The nprocs rlimit limits the process count of the user id of the process
it is applied to. This makes it useless currently, as most jobs end up
running as either root or nobody, resulting in errors like:

    fork: Resource temporarily unavailable

When there are more than nproc process running for a specific uid. In
practice, this can happen when scaling a single app to a dozen or so
instances.

The long-term solution is to make sure every job has a different uid,
but this is a complex undertaking, so for now we’ll just remove the
default limit.