### PR TITLE
cli: release add is now able to resolve tags to ids.

### DIFF
--- a/pinkerton/registry/docker.go
+++ b/pinkerton/registry/docker.go
@@ -138,6 +138,10 @@ func (s *dockerSession) get(path string, out interface{}) (*http.Response, error
 		if out != nil {
 			defer res.Body.Close()
 		}
+		if res.StatusCode == 404 {
+			err = fmt.Errorf("registry: image not found")
+			continue
+		}
 		if res.StatusCode != 200 {
 			err = fmt.Errorf("registry: unexpected status %d", res.StatusCode)
 			continue

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -630,7 +630,7 @@ func (s *CLISuite) TestRelease(t *c.C) {
 	file.Close()
 
 	app := s.newCliTestApp(t)
-	t.Assert(app.flynn("release", "add", "-f", file.Name(), imageURIs["test-apps"]), Succeeds)
+	t.Assert(app.flynn("release", "add", "--validate=false", "-f", file.Name(), imageURIs["test-apps"]), Succeeds)
 
 	r, err := s.controller.GetAppRelease(app.name)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
This is the first part of #509 and also #1568 . If a tag is not resolvable,
the cli returns an error.

```
$ ./cli/bin/flynn -a mgotest release add -f ~/c.json "https://registry.hub.docker.com?name=mongo&tag=5.0"
registry: tag "5.0" not found

$ ./cli/bin/flynn -a mgotest release add -f ~/c.json "https://registry.hub.docker.com?name=mongo&tag=3.0"
Resolved tag 3.0 => https://registry.hub.docker.com?id=077c6501ee1803efe213a9031a7d7a9ab9798f28bbf57cca579eb90b58297806&name=mongo
Created release 1844f52971b34c5eaa128351670e71ac.

$ ./cli/bin/flynn -a mgotest scale server=1 --no-wait

$ ./cli/bin/flynn -a mgotest run mongo --host mongo.discoverd --port 27017
MongoDB shell version: 3.0.3
connecting to: mongo.discoverd:27017/test
Welcome to the MongoDB shell.
```

This PR does not solve that the host accepts `https://registry.hub.docker.com?name=mongo&tag=3.0` and `http://notadockerimage.com` mentioned in #1568 . However, when using the cli to resolve a tag, it has error detection:

```
$ ./cli/bin/flynn -a mgotest release add -f ~/c.json "https://registry.hub.docker.com?name=mongo&tag=5.0"
registry: tag "5.0" not found
```