### PR TITLE
cli: Support listing app releases

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -563,6 +563,12 @@ func (c *Client) ReleaseList() ([]*ct.Release, error) {
 	return releases, c.Get("/releases", &releases)
 }
 
+// AppReleaseList returns a list of all releases under appID.
+func (c *Client) AppReleaseList(appID string) ([]*ct.Release, error) {
+	var releases []*ct.Release
+	return releases, c.Get(fmt.Sprintf("/apps/%s/releases", appID), &releases)
+}
+
 // CreateKey uploads pubKey as the ssh public key.
 func (c *Client) CreateKey(pubKey string) (*ct.Key, error) {
 	key := &ct.Key{}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -195,6 +195,7 @@ func appHandler(c handlerConfig) http.Handler {
 
 	httpRouter.PUT("/apps/:apps_id/release", httphelper.WrapHandler(api.appLookup(api.SetAppRelease)))
 	httpRouter.GET("/apps/:apps_id/release", httphelper.WrapHandler(api.appLookup(api.GetAppRelease)))
+	httpRouter.GET("/apps/:apps_id/releases", httphelper.WrapHandler(api.appLookup(api.GetAppReleases)))
 
 	httpRouter.POST("/providers/:providers_id/resources", httphelper.WrapHandler(api.ProvisionResource))
 	httpRouter.GET("/providers/:providers_id/resources", httphelper.WrapHandler(api.GetProviderResources))

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -356,6 +356,33 @@ func (s *S) TestReleaseList(c *C) {
 	c.Assert(list[0].ID, Not(Equals), "")
 }
 
+func (s *S) TestAppReleaseList(c *C) {
+	app := s.createTestApp(c, &ct.App{Name: "app-release-list"})
+
+	// create 2 releases with formations
+	releases := make([]*ct.Release, 2)
+	for i := 0; i < 2; i++ {
+		r := s.createTestRelease(c, &ct.Release{})
+		releases[i] = r
+		s.createTestFormation(c, &ct.Formation{ReleaseID: r.ID, AppID: app.ID})
+	}
+
+	// create a release with no formation
+	s.createTestRelease(c, &ct.Release{})
+
+	// create a release for a different app
+	r := s.createTestRelease(c, &ct.Release{})
+	a := s.createTestApp(c, &ct.App{})
+	s.createTestFormation(c, &ct.Formation{ReleaseID: r.ID, AppID: a.ID})
+
+	// check only the first two releases are returned, and in descending order
+	list, err := s.c.AppReleaseList(app.ID)
+	c.Assert(err, IsNil)
+	c.Assert(list, HasLen, len(releases))
+	c.Assert(list[0], DeepEquals, releases[1])
+	c.Assert(list[1], DeepEquals, releases[0])
+}
+
 func (s *S) TestKeyList(c *C) {
 	s.createTestKey(c, "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqE9AJti/17eigkIhA7+6TF9rdTVxjPv80UxIT6ELaNPHegqib5m94Wab4UoZAGtBPLKJs9o8LRO3H29X5q5eXCU5mwx4qQhcMEYkILWj0Y1T39Xi2RI3jiWcTsphAAYmy+uT2Nt740OK1FaQxfdzYx4cjsjtb8L82e35BkJE2TdjXWkeHxZWDZxMlZXme56jTNsqB2OuC0gfbAbrjSCkolvK1RJbBZSSBgKQrYXiyYjjLfcw2O0ZAKPBeS8ckVf6PO8s/+azZzJZ0Kl7YGHYEX3xRi6sJS0gsI4Y6+sddT1zT5kh0Bg3C8cKnZ1NiVXLH0pPKz68PhjWhwpOVUehD")
 


### PR DESCRIPTION
This lists all releases which have a formation for the given app.

This will aid in adding a `flynn release delete <id>` command to delete a release and related resources (e.g. slugs) by allowing users to identify old releases.