### PR TITLE
test: Increase timeout for resource limits job

### DIFF
--- a/test/test_host.go
+++ b/test/test_host.go
@@ -279,7 +279,7 @@ func (s *HostSuite) TestResourceLimits(t *c.C) {
 	select {
 	case err := <-runErr:
 		t.Assert(err, c.IsNil)
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for resource limits job")
 	}
 


### PR DESCRIPTION
This job intermittently times out in CI, and it looks as though it is just congestion on the host slowing it down.