### PR TITLE
slugbuilder: Move back to upstream staticfile buildpack

### DIFF
--- a/slugbuilder/builder/buildpacks.txt
+++ b/slugbuilder/builder/buildpacks.txt
@@ -1,5 +1,5 @@
 https://github.com/heroku/heroku-buildpack-multi.git#26fa21ac
-https://github.com/flynn/staticfile-buildpack.git#712bd179
+https://github.com/cloudfoundry/staticfile-buildpack.git#d00d45d4
 https://github.com/heroku/heroku-buildpack-ruby.git#4b493f80
 https://github.com/heroku/heroku-buildpack-nodejs.git#d8fbb5b0
 https://github.com/heroku/heroku-buildpack-clojure.git#473e9908


### PR DESCRIPTION
They fixed the compatibility issue we forked to work around