### PR TITLE
Improve viewing logs in CI

### DIFF
--- a/test/buildlog/log.go
+++ b/test/buildlog/log.go
@@ -1,0 +1,37 @@
+package buildlog
+
+import (
+	"io"
+	"mime/multipart"
+	"time"
+
+	"github.com/flynn/flynn/pkg/iotool"
+)
+
+type Log struct {
+	mw *multipart.Writer
+}
+
+func NewLog(w io.Writer) *Log {
+	return &Log{multipart.NewWriter(w)}
+}
+
+func (l *Log) NewFile(name string) (io.Writer, error) {
+	return l.mw.CreateFormFile(name, name)
+}
+
+func (l *Log) NewFileWithTimeout(name string, timeout time.Duration) (io.Writer, error) {
+	w, err := l.NewFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return iotool.NewTimeoutWriter(w, timeout), nil
+}
+
+func (l *Log) Boundary() string {
+	return l.mw.Boundary()
+}
+
+func (l *Log) Close() error {
+	return l.mw.Close()
+}

--- a/test/runner/assets/build-log.html
+++ b/test/runner/assets/build-log.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/style.css">
+    <title>Flynn CI Build</title>
+  </head>
+
+  <body>
+    <div class="container-fluid">
+      <div class="row">
+        <div id="list">
+        </div>
+        <div id="logs">
+        </div>
+      </div>
+    </div>
+
+    <script type="text/template" id="list-template">
+      <a href="#<%= name %>"><%= filename %></a>
+    </script>
+
+    <script type="text/template" id="logs-template">
+      <div id="<%= name %>">
+        <pre><code></code></pre>
+      </div>
+    </script>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script src="/assets/build-log.js"></script>
+  </body>
+</html>

--- a/test/runner/assets/build-log.js
+++ b/test/runner/assets/build-log.js
@@ -1,0 +1,113 @@
+/* globals $:false, _:false, EventSource:false */
+$(function() {
+  "use strict";
+  var files         = {};
+  var offsets       = [];
+  var offsetIndex   = {};
+  var listHovered   = false;
+  var list          = $("#list");
+  var logs          = $("#logs");
+  var listTemplate  = _.template($("#list-template").html());
+  var logsTemplate  = _.template($("#logs-template").html());
+  var stream        = new EventSource(document.location.href);
+
+  var adjustOffsetsTimeout = null;
+  var adjustOffsets = function () {
+    clearTimeout(adjustOffsetsTimeout);
+    adjustOffsetsTimeout = setTimeout(function () {
+      offsets = [];
+      offsetIndex = {};
+      for (var name in files) {
+        if ( !files.hasOwnProperty(name) ) {
+          continue;
+        }
+        files[name].calcOffset();
+      }
+      findActiveFile();
+    }, 30);
+  };
+
+  var findActiveFile = function () {
+    var scrollY = window.scrollY;
+    var _offsets = offsets.sort(function (a, b) {
+      return a - b;
+    }).reverse();
+    for (var i = 0, len = _offsets.length; i < len; i++) {
+      if (scrollY >= (_offsets[i] - window.innerHeight / 2)) {
+        offsetIndex[_offsets[i]].setActive();
+        break;
+      }
+    }
+  };
+
+  var File = function (props) {
+    files[props.filename] = this;
+    this.filename = props.filename;
+    this.$lines = props.$el.find('code');
+    this.$el = props.$el;
+    this.listItem = props.listItem;
+    this.calcOffset();
+  };
+
+  File.prototype.calcOffset = function () {
+    this.offsetTop = Math.round(this.$el.offset().top, 10);
+    offsets.push(this.offsetTop);
+    offsetIndex[this.offsetTop] = this;
+  };
+
+  File.prototype.appendLine = function (line) {
+    this.$lines.append(line.text + "\n");
+    adjustOffsets(this.offsetTop);
+  };
+
+  File.prototype.setActive = function () {
+    for (var name in files) {
+      if ( !files.hasOwnProperty(name) ) {
+        continue;
+      }
+      files[name].unsetActive();
+    }
+    $(this.listItem).addClass('active');
+    if ( !listHovered ) {
+      this.listItem.scrollIntoView();
+    }
+  };
+
+  File.prototype.unsetActive = function () {
+    $(this.listItem).removeClass('active');
+  };
+
+  window.addEventListener('scroll', findActiveFile, false);
+  list.hover(function () {
+    listHovered = true;
+  }, function () {
+    listHovered = false;
+  });
+
+  stream.onmessage = function(e) {
+    var listItem;
+    var file;
+    var line = JSON.parse(e.data);
+    line.name = line.filename.slice(0, -4);
+
+    if (files.hasOwnProperty(line.filename)) {
+      file = files[line.filename];
+    } else {
+      listItem = document.createElement('p');
+      listItem.innerHTML = listTemplate(line);
+      list.append(listItem);
+      logs.append(logsTemplate(line));
+      file = new File({
+        filename: line.filename,
+        $el: $('#'+ line.name),
+        listItem: listItem
+      });
+    }
+
+    file.appendLine(line);
+  };
+
+  stream.onerror = function() {
+    stream.close();
+  };
+});

--- a/test/runner/assets/index.html
+++ b/test/runner/assets/index.html
@@ -44,11 +44,7 @@
     <script type="text/template" id="row-template">
       <tr>
         <td>
-          <% if(log_url) { %>
-            <a href="<%= log_url %>"><%= commit.substring(0, 7) %></a>
-          <% } else { %>
-            <a href="/builds/<%= id %>.log"><%= commit.substring(0, 7) %></a>
-          <% } %>
+          <a href="/builds/<%= id %>"><%= commit.substring(0, 7) %></a>
         </td>
         <td><%= description %></td>
         <td><%= created_at.fromNow() %> (<%= created_at.format("lll") %>)</td>

--- a/test/runner/assets/style.css
+++ b/test/runner/assets/style.css
@@ -15,3 +15,41 @@ p.more-btn {
   width: 100%;
   padding: 10px 20px;
 }
+
+#list {
+  box-sizing: border-box;
+  position: fixed;
+  height: 100%;
+  word-break: break-all;
+  overflow-y: auto;
+  margin-top: 1.5rem;
+  width: 25%;
+}
+
+#list:after {
+  display: block;
+  content: ' ';
+  padding-bottom: 2rem;
+}
+
+#list > .active {
+  background-color: #F5F5F5;
+  border-color: #CCCCCC;
+}
+
+#list > * {
+  box-sizing: border-box;
+  border-top: 1px solid #ffffff;
+  border-bottom: 1px solid #ffffff;
+}
+
+#list > * > a {
+  display: block;
+  padding: 0.125em 0.75em;
+}
+
+#logs {
+  width: 75%;
+  margin-top: 1rem;
+  margin-left: 25%;
+}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -598,7 +598,11 @@ func (r *Runner) restartBuild(w http.ResponseWriter, req *http.Request, ps httpr
 		return
 	}
 	if build.State != "pending" {
-		b := newBuild(build.Commit, "Restart: "+build.Description, build.Merge)
+		desc := build.Description
+		if !strings.HasPrefix(desc, "Restart: ") {
+			desc = "Restart: " + desc
+		}
+		b := newBuild(build.Commit, desc, build.Merge)
 		go r.build(b)
 	}
 	http.Redirect(w, req, "/builds", 301)


### PR DESCRIPTION
The file in S3 is now a multipart document and the output of each command from `DumpLogs` gets added to a separate part with an appropriate filename.

I chose to use a single multipart file rather than uploading multiple files to S3 so that we can easily fallback to viewing the raw log in S3 if necessary (it will just include some extra multipart header lines which can be ignored).

Once a build has finished, rather than redirecting to the log in S3, I have added a new page which shows a list of generated files on the left, and the corresponding logs on the right. The logs are delivered to the browser via an SSE stream, one line at a time.

I have added a `-f` flag to `flynn-host ps` to format the output so that `DumpLogs` can create descriptive filenames (e.g. `blobstore-web-b4d8e10b-4ec7d4d73bce40d897395848c30db097.log`).

The UI could do with some improvements:

* Make the list of files "sticky", so clicking a file only scrolls the logs div, not the whole window
* When scrolling the logs, highlight the current file being viewed

@jvatic could you help with the improvements?

I will leave my custom CI running with these changes, you can see a log page here:

https://ci.flynn.io:8443/builds/20150620141337-8efc25bd