### PR TITLE
test: Fix potential timeout in PostgresSuite

### DIFF
--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -340,6 +340,10 @@ loop:
 			}
 			switch e.JobType {
 			case "postgres":
+				// move on if we have seen all the expected events
+				if expectedIndex >= len(expected) {
+					continue
+				}
 				skipped := assertNextState(expected[expectedIndex:])
 				expectedIndex += 1 + skipped
 			case "web":


### PR DESCRIPTION
Now that we can potentially skip received states (commit 3000177), we may have already received all the expected states when we receive a deployment event, so we need to make sure we do not wait for further states when we do not expect them.