### PR TITLE
gitreceived: adding support for submodules, by switching to full repos (instead of --bare)

### DIFF
--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -191,3 +191,12 @@ func (s *GitDeploySuite) TestRunQuoting(t *c.C) {
 	t.Assert(run, Succeeds)
 	t.Assert(run, Outputs, "foo bar\n")
 }
+
+func (s *GitDeploySuite) TestGitSubmodules(t *c.C) {
+	r := s.newGitRepo(t, "empty")
+	t.Assert(r.git("submodule", "add", "https://github.com/flynn-examples/go-flynn-example.git"), Succeeds)
+	t.Assert(r.git("commit", "-m", "Add Submodule"), Succeeds)
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.git("push", "flynn", "master"), Succeeds)
+	t.Assert(r.flynn("run", "ls", "go-flynn-example"), SuccessfulOutputContains, "main.go")
+}


### PR DESCRIPTION
Switching to full repositories (rather than bare) so that "git checkout" and "git submodule update --init" can be performed prior to passing to the receiver.

(Per conversation with @lmars, we will probably refactor how gitreceived -> receiver -> slugbuilder works, so this went in the simplest-to-implement place. We will still need to address distributing keys into containers, separately.)

Closes #62.