### PR TITLE
host/logmux: Fix nil pointer dereference

### DIFF
--- a/host/logmux/logmux.go
+++ b/host/logmux/logmux.go
@@ -92,8 +92,10 @@ func (m *LogMux) Close() {
 	case <-m.donec:
 	case <-time.NewTimer(3 * time.Second).C:
 		// logs did not drain to logaggregator in 3 seconds, drain them to the local logger
-		close(m.sc.closec)
-		<-m.donec
+		if m.sc != nil {
+			close(m.sc.closec)
+			<-m.donec
+		}
 	}
 }
 


### PR DESCRIPTION
`m.sc` can be nil if discoverd failed to boot.

Tested manually by causing discoverd to not boot correctly, killing flynn-host and seeing the panic avoided.

Fixes #1386.