### PR TITLE
CLI docs fixes

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -511,6 +511,6 @@
   {
     "id": "log-complete",
     "action": "log",
-    "output": "\n\nFlynn bootstrapping complete. Install the flynn-cli (see https://cli.flynn.io for instructions) and paste the line below into a terminal window:\n\nflynn cluster add -g {{ getenv \"CLUSTER_DOMAIN\" }}:2222 -p {{ (index .StepData \"controller-cert\").Pin }} default https://controller.{{ getenv \"CLUSTER_DOMAIN\" }} {{ (index .StepData \"controller-key\").Data }}\n\nThe built-in dashboard can be accessed at http://dashboard.{{ getenv \"CLUSTER_DOMAIN\" }}/login?token={{ (index .StepData \"dashboard-login-token\").Data }}"
+    "output": "\n\nFlynn bootstrapping complete. Install the Flynn CLI (see https://flynn.io/docs/cli for instructions) and paste the line below into a terminal window:\n\nflynn cluster add -g {{ getenv \"CLUSTER_DOMAIN\" }}:2222 -p {{ (index .StepData \"controller-cert\").Pin }} default https://controller.{{ getenv \"CLUSTER_DOMAIN\" }} {{ (index .StepData \"controller-key\").Data }}\n\nThe built-in dashboard can be accessed at http://dashboard.{{ getenv \"CLUSTER_DOMAIN\" }}/login?token={{ (index .StepData \"dashboard-login-token\").Data }}"
   }
 ]

--- a/docs/content/installation.html.md
+++ b/docs/content/installation.html.md
@@ -108,7 +108,7 @@ page for guides on deploying your applications to Flynn.
 
 ## AWS
 
-The [Flynn CLI](https://cli.flynn.io) includes an installer that will boot and
+The [Flynn CLI](/docs/cli) includes an installer that will boot and
 configure a Flynn cluster on Amazon Web Services using CloudFormation. It
 automatically performs all of the steps required to install Flynn.
 


### PR DESCRIPTION
Fix the last two references to `cli.flynn.io`.