### PR TITLE
Fix dev VM concurrency

### DIFF
--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -62,7 +62,7 @@ main() {
 
   cd "${ROOT}/test"
 
-  test_args="--flynnrc ${FLYNNRC} --cli ${flynn} --debug"
+  test_args="--concurrency 1 --flynnrc ${FLYNNRC} --cli ${flynn} --debug"
   if [[ -n "${filter}" ]]; then
     test_args="${test_args} --run ${filter}"
   fi

--- a/test/arg/arg.go
+++ b/test/arg/arg.go
@@ -25,6 +25,7 @@ type Args struct {
 	Run         string
 	Gist        bool
 	ClusterAPI  string
+	Concurrency int
 }
 
 func Parse() *Args {
@@ -52,6 +53,7 @@ func Parse() *Args {
 	flag.BoolVar(&args.Kill, "kill", true, "kill the cluster after running the tests")
 	flag.BoolVar(&args.BuildRootFS, "build-rootfs", false, "just build the rootfs (leaving it behind for future use) without running tests")
 	flag.BoolVar(&args.Gist, "gist", false, "upload debug info to a gist")
+	flag.IntVar(&args.Concurrency, "concurrency", 5, "max number of concurrent tests")
 	flag.Parse()
 
 	return args

--- a/test/main.go
+++ b/test/main.go
@@ -114,7 +114,7 @@ func main() {
 		Stream:           args.Stream,
 		Verbose:          args.Debug,
 		KeepWorkDir:      args.Debug,
-		ConcurrencyLevel: 5,
+		ConcurrencyLevel: args.Concurrency,
 	})
 	fmt.Println(res)
 }


### PR DESCRIPTION
The default of five parallel jobs is too much for the dev VM.