### PR TITLE
all: Always include host ID in job ID

### DIFF
--- a/controller/app.go
+++ b/controller/app.go
@@ -300,14 +300,6 @@ func (c *controllerAPI) AppLog(ctx context.Context, w http.ResponseWriter, req *
 		Follow: req.FormValue("follow") == "true",
 		JobID:  req.FormValue("job_id"),
 	}
-	if opts.JobID != "" {
-		// Temporary handling of combined JobID format. Logs are sent to aggregator
-		// without host- prefix. https://github.com/flynn/flynn/issues/1238
-		index := strings.LastIndex(opts.JobID, "-")
-		if len(opts.JobID) > index {
-			opts.JobID = opts.JobID[index+1:]
-		}
-	}
 	if vals, ok := req.Form["process_type"]; ok && len(vals) > 0 {
 		opts.ProcessType = &vals[len(vals)-1]
 	}

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -85,11 +85,12 @@ func (l *fakeLog) Write([]byte) (int, error) {
 
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
-	hostID, jobID := random.UUID(), random.UUID()
+	hostID := random.UUID()
+	jobID := cluster.GenerateJobID(hostID)
 	hc := tu.NewFakeHostClient(hostID)
 	s.cc.AddHost(hc)
 
-	c.Assert(s.c.DeleteJob(app.ID, hostID+"-"+jobID), IsNil)
+	c.Assert(s.c.DeleteJob(app.ID, jobID), IsNil)
 	c.Assert(hc.IsStopped(jobID), Equals, true)
 }
 
@@ -122,7 +123,7 @@ func (s *S) TestRunJobDetached(c *C) {
 	c.Assert(res.Cmd, DeepEquals, cmd)
 
 	job := host.Jobs[0]
-	c.Assert(res.ID, Equals, hostID+"-"+job.ID)
+	c.Assert(res.ID, Equals, job.ID)
 	c.Assert(job.Metadata, DeepEquals, map[string]string{
 		"flynn-controller.app":      app.ID,
 		"flynn-controller.app_name": app.Name,
@@ -134,7 +135,7 @@ func (s *S) TestRunJobDetached(c *C) {
 		"FLYNN_APP_ID":       app.ID,
 		"FLYNN_RELEASE_ID":   release.ID,
 		"FLYNN_PROCESS_TYPE": "",
-		"FLYNN_JOB_ID":       hostID + "-" + job.ID,
+		"FLYNN_JOB_ID":       job.ID,
 		"FOO":                "baz",
 		"JOB":                "true",
 		"RELEASE":            "true",
@@ -213,7 +214,7 @@ func (s *S) TestRunJobAttached(c *C) {
 		"FLYNN_APP_ID":       app.ID,
 		"FLYNN_RELEASE_ID":   release.ID,
 		"FLYNN_PROCESS_TYPE": "",
-		"FLYNN_JOB_ID":       hostID + "-" + job.ID,
+		"FLYNN_JOB_ID":       job.ID,
 		"FOO":                "baz",
 		"JOB":                "true",
 		"RELEASE":            "true",

--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -204,7 +204,7 @@ func (c *context) syncCluster() {
 
 			gg.Log(grohl.Data{"at": "addJob"})
 			go c.PutJob(&ct.Job{
-				ID:        h.ID() + "-" + job.ID,
+				ID:        job.ID,
 				AppID:     appID,
 				ReleaseID: releaseID,
 				Type:      jobType,
@@ -248,12 +248,12 @@ func (c *context) syncJobStates() error {
 			if job.State != "up" {
 				continue
 			}
-			hostID, jobID, err := cluster.ParseJobID(job.ID)
+			hostID, err := cluster.ExtractHostID(job.ID)
 			if err != nil {
-				gg.Log(grohl.Data{"at": "parseJobID", "status": "error", "err": err})
+				gg.Log(grohl.Data{"at": "jobHostID", "status": "error", "err": err})
 				continue
 			}
-			if j := c.jobs.Get(hostID, jobID); j != nil {
+			if j := c.jobs.Get(hostID, job.ID); j != nil {
 				continue
 			}
 			job.State = "down"
@@ -429,7 +429,7 @@ func (c *context) watchHost(h *cluster.Host, ready chan struct{}) {
 		}
 
 		job := &ct.Job{
-			ID:        h.ID() + "-" + event.JobID,
+			ID:        event.JobID,
 			AppID:     appID,
 			ReleaseID: releaseID,
 			Type:      jobType,

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -126,16 +126,14 @@ $$ LANGUAGE plpgsql`,
 
 		`CREATE TYPE job_state AS ENUM ('starting', 'up', 'down', 'crashed', 'failed')`,
 		`CREATE TABLE job_cache (
-    job_id text NOT NULL,
-    host_id text NOT NULL,
+    job_id text PRIMARY KEY,
     app_id uuid NOT NULL REFERENCES apps (app_id),
     release_id uuid NOT NULL REFERENCES releases (release_id),
     process_type text,
     state job_state NOT NULL,
     meta hstore,
     created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now(),
-    PRIMARY KEY (job_id, host_id)
+    updated_at timestamptz NOT NULL DEFAULT now()
 )`,
 		`CREATE FUNCTION check_job_state() RETURNS OPAQUE AS $$
     BEGIN

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -15,11 +15,11 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
 	for k, v := range t.Env {
 		env[k] = v
 	}
-	id := cluster.RandomJobID("")
+	id := cluster.GenerateJobID(hostID)
 	env["FLYNN_APP_ID"] = f.App.ID
 	env["FLYNN_RELEASE_ID"] = f.Release.ID
 	env["FLYNN_PROCESS_TYPE"] = name
-	env["FLYNN_JOB_ID"] = hostID + "-" + id
+	env["FLYNN_JOB_ID"] = id
 	job := &host.Job{
 		ID: id,
 		Metadata: map[string]string{

--- a/host/cli/inspect.go
+++ b/host/cli/inspect.go
@@ -24,7 +24,8 @@ options:
 }
 
 func runInspect(args *docopt.Args, client *cluster.Client) error {
-	hostID, jobID, err := cluster.ParseJobID(args.String["ID"])
+	jobID := args.String["ID"]
+	hostID, err := cluster.ExtractHostID(jobID)
 	if err != nil {
 		return err
 	}
@@ -44,7 +45,7 @@ func runInspect(args *docopt.Args, client *cluster.Client) error {
 func printJobDesc(job *host.ActiveJob, out io.Writer, env bool) {
 	w := tabwriter.NewWriter(out, 1, 2, 2, ' ', 0)
 	defer w.Flush()
-	listRec(w, "ID", clusterJobID(*job))
+	listRec(w, "ID", job.Job.ID)
 	listRec(w, "Entrypoint", strings.Join(job.Job.Config.Entrypoint, " "))
 	listRec(w, "Cmd", strings.Join(job.Job.Config.Cmd, " "))
 	listRec(w, "Status", job.Status)

--- a/host/cli/log.go
+++ b/host/cli/log.go
@@ -19,7 +19,8 @@ Get the logs of a job`)
 }
 
 func runLog(args *docopt.Args, client *cluster.Client) error {
-	hostID, jobID, err := cluster.ParseJobID(args.String["ID"])
+	jobID := args.String["ID"]
+	hostID, err := cluster.ExtractHostID(jobID)
 	if err != nil {
 		return err
 	}

--- a/host/cli/ps.go
+++ b/host/cli/ps.go
@@ -48,7 +48,7 @@ func runPs(args *docopt.Args, client *cluster.Client) error {
 				}
 				continue
 			}
-			fmt.Println(clusterJobID(job))
+			fmt.Println(job.Job.ID)
 		}
 		return nil
 	}
@@ -105,15 +105,11 @@ func printJobs(jobs sortJobs, out io.Writer) {
 		}
 
 		listRec(w,
-			clusterJobID(job),
+			job.Job.ID,
 			job.Status,
 			started,
 			job.Job.Metadata["flynn-controller.app_name"],
 			job.Job.Metadata["flynn-controller.type"],
 		)
 	}
-}
-
-func clusterJobID(job host.ActiveJob) string {
-	return job.HostID + "-" + job.Job.ID
 }

--- a/host/cli/stop.go
+++ b/host/cli/stop.go
@@ -19,7 +19,7 @@ func runStop(args *docopt.Args, client *cluster.Client) error {
 	success := true
 	clients := make(map[string]*cluster.Host)
 	for _, id := range args.All["ID"].([]string) {
-		hostID, jobID, err := cluster.ParseJobID(id)
+		hostID, err := cluster.ExtractHostID(id)
 		if err != nil {
 			fmt.Printf("could not parse %s: %s", id, err)
 			success = false
@@ -36,12 +36,12 @@ func runStop(args *docopt.Args, client *cluster.Client) error {
 			}
 			clients[hostID] = hostClient
 		}
-		if err := hostClient.StopJob(jobID); err != nil {
-			fmt.Printf("could not stop job %s: %s\n", jobID, err)
+		if err := hostClient.StopJob(id); err != nil {
+			fmt.Printf("could not stop job %s: %s\n", id, err)
 			success = false
 			continue
 		}
-		fmt.Println(jobID, "stopped")
+		fmt.Println(id, "stopped")
 	}
 	if !success {
 		return errors.New("could not stop all jobs")

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -34,7 +34,6 @@ import (
 	"github.com/flynn/flynn/pinkerton"
 	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/attempt"
-	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/iptables"
 	"github.com/flynn/flynn/pkg/random"
 )
@@ -427,7 +426,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 			return err
 		}
 		if m.Target == "" {
-			m.Target = filepath.Join(l.VolPath, cluster.RandomJobID(""))
+			m.Target = filepath.Join(l.VolPath, random.UUID())
 			job.Config.Mounts[i].Target = m.Target
 			if err := os.MkdirAll(m.Target, 0755); err != nil {
 				g.Log(grohl.Data{"at": "mkdir_vol", "dir": m.Target, "status": "error", "err": err})

--- a/host/state.go
+++ b/host/state.go
@@ -125,7 +125,7 @@ func (s *State) Restore(backend Backend) (func(), error) {
 		for _, job := range resurrect {
 			go func(job *host.ActiveJob) {
 				// generate a new job id, this is a new job
-				newID := cluster.RandomJobID("")
+				newID := cluster.GenerateJobID(s.id)
 				log.Printf("resurrecting %s as %s", job.Job.ID, newID)
 				job.Job.ID = newID
 				config := &RunConfig{

--- a/pkg/cluster/utils.go
+++ b/pkg/cluster/utils.go
@@ -7,15 +7,17 @@ import (
 	"github.com/flynn/flynn/pkg/random"
 )
 
-// ParseJobID splits a compound job ID into its host and job ID components
-// returning an error if the ID is invalid.
-func ParseJobID(id string) (string, string, error) {
+// ExtractHostID returns the host ID component of a job ID, returning an error
+// if the given ID is invalid.
+func ExtractHostID(id string) (string, error) {
 	ids := strings.SplitN(id, "-", 2)
 	if len(ids) != 2 || ids[0] == "" || ids[1] == "" {
-		return "", "", errors.New("invalid ID")
+		return "", errors.New("invalid ID")
 	}
-	return ids[0], ids[1], nil
+	return ids[0], nil
 }
 
-// RandomJobID returns a random job identifier with an optional prefix.
-func RandomJobID(prefix string) string { return prefix + random.UUID() }
+// GenerateJobID returns a random job identifier, prefixed with the given host ID.
+func GenerateJobID(hostID string) string {
+	return hostID + "-" + random.UUID()
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -198,7 +198,7 @@ func (c *Cmd) Start() error {
 		c.Job.Artifact = c.Artifact
 	}
 	if c.Job.ID == "" {
-		c.Job.ID = cluster.RandomJobID("")
+		c.Job.ID = cluster.GenerateJobID(c.HostID)
 	}
 
 	if c.host == nil {

--- a/test/helper.go
+++ b/test/helper.go
@@ -194,9 +194,9 @@ func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {
 
 func (h *Helper) stopJob(t *c.C, id string) {
 	debugf(t, "stopping job %s", id)
-	hostID, jobID, _ := cluster.ParseJobID(id)
+	hostID, _ := cluster.ExtractHostID(id)
 	hc := h.hostClient(t, hostID)
-	t.Assert(hc.StopJob(jobID), c.IsNil)
+	t.Assert(hc.StopJob(id), c.IsNil)
 }
 
 func (h *Helper) addHost(t *c.C) *tc.Instance {

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -90,9 +90,9 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 		}
 	}
 	t.Assert(jobs, c.HasLen, 2)
-	hostID, jobID, _ := cluster.ParseJobID(jobs[0].ID)
+	jobID := jobs[0].ID
+	hostID, _ := cluster.ExtractHostID(jobID)
 	t.Assert(hostID, c.Not(c.Equals), "")
-	t.Assert(jobID, c.Not(c.Equals), "")
 	debugf(t, "current controller app[%s] host[%s] job[%s]", app.ID, hostID, jobID)
 
 	// start another controller and wait for it to come up


### PR DESCRIPTION
This means that job IDs can always be resolved to the host the job is running on.

Closes #1238