### PR TITLE
host: Clean up mounts that leak into libvirt_lxc

### DIFF
--- a/host/Tupfile
+++ b/host/Tupfile
@@ -4,3 +4,4 @@ include_rules
 : bin/flynn-host |> gzip -9 --keep bin/flynn-host |> bin/flynn-host.gz
 : |> !go ./flynn-init |> bin/flynn-init
 : bin/flynn-host.gz $(ROOT)/script/install-flynn.tmpl |> sed "s/{{FLYNN-HOST-CHECKSUM}}/\$(sha512sum bin/flynn-host.gz | cut -d " " -f 1)/g" $(ROOT)/script/install-flynn.tmpl > %o |> $(ROOT)/script/install-flynn
+: nsumount/nsumount.c |> gcc -o %o -Wall -std=c99 %f |> bin/flynn-nsumount

--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -75,7 +75,7 @@ func runDownload(args *docopt.Args) error {
 	if err := os.MkdirAll(args.String["--bin-dir"], 0755); err != nil {
 		return fmt.Errorf("error creating bin dir: %s", err)
 	}
-	for _, path := range []string{"/flynn-linux-amd64", "/flynn-init"} {
+	for _, path := range []string{"/flynn-linux-amd64", "/flynn-init", "/flynn-nsumount"} {
 		dst, err := downloadGzippedFile(client, path, args.String["--bin-dir"])
 		if err != nil {
 			return err

--- a/host/host.go
+++ b/host/host.go
@@ -40,6 +40,7 @@ options:
   --volpath=PATH         directory to create volumes in [default: /var/lib/flynn/volumes]
   --backend=BACKEND      runner backend [default: libvirt-lxc]
   --flynn-init=PATH      path to flynn-init binary [default: /usr/local/bin/flynn-init]
+  --nsumount=PATH        path to flynn-nsumount binary [default: /usr/local/bin/flynn-nsumount]
   --log-dir=DIR          directory to store job logs [default: /var/log/flynn]
   --discovery=TOKEN      join cluster with discovery token
   --peer-ips=IPLIST      join existing cluster using IPs
@@ -131,6 +132,7 @@ func runDaemon(args *docopt.Args) {
 	volPath := args.String["--volpath"]
 	backendName := args.String["--backend"]
 	flynnInit := args.String["--flynn-init"]
+	nsumount := args.String["--nsumount"]
 	logDir := args.String["--log-dir"]
 	discoveryToken := args.String["--discovery"]
 	peerIPs := strings.Split(args.String["--peer-ips"], ",")
@@ -206,7 +208,7 @@ func runDaemon(args *docopt.Args) {
 
 	switch backendName {
 	case "libvirt-lxc":
-		backend, err = NewLibvirtLXCBackend(state, vman, logDir, flynnInit, mux)
+		backend, err = NewLibvirtLXCBackend(state, vman, logDir, flynnInit, nsumount, mux)
 	default:
 		log.Fatalf("unknown backend %q", backendName)
 	}

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -9,8 +9,10 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,6 +37,7 @@ import (
 	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/iptables"
+	"github.com/flynn/flynn/pkg/mounts"
 	"github.com/flynn/flynn/pkg/random"
 )
 
@@ -42,9 +45,10 @@ const (
 	libvirtNetName = "flynn"
 	bridgeName     = "flynnbr0"
 	imageRoot      = "/var/lib/docker"
+	flynnRoot      = "/var/lib/flynn"
 )
 
-func NewLibvirtLXCBackend(state *State, vman *volumemanager.Manager, logPath, initPath string, mux *logmux.LogMux) (Backend, error) {
+func NewLibvirtLXCBackend(state *State, vman *volumemanager.Manager, logPath, initPath, umountPath string, mux *logmux.LogMux) (Backend, error) {
 	libvirtc, err := libvirt.NewVirConnection("lxc:///")
 	if err != nil {
 		return nil, err
@@ -58,6 +62,7 @@ func NewLibvirtLXCBackend(state *State, vman *volumemanager.Manager, logPath, in
 	return &LibvirtLXCBackend{
 		LogPath:             logPath,
 		InitPath:            initPath,
+		UmountPath:          umountPath,
 		libvirt:             libvirtc,
 		state:               state,
 		vman:                vman,
@@ -74,13 +79,14 @@ func NewLibvirtLXCBackend(state *State, vman *volumemanager.Manager, logPath, in
 }
 
 type LibvirtLXCBackend struct {
-	LogPath   string
-	InitPath  string
-	libvirt   libvirt.VirConnection
-	state     *State
-	vman      *volumemanager.Manager
-	pinkerton *pinkerton.Context
-	ipalloc   *ipallocator.IPAllocator
+	LogPath    string
+	InitPath   string
+	UmountPath string
+	libvirt    libvirt.VirConnection
+	state      *State
+	vman       *volumemanager.Manager
+	pinkerton  *pinkerton.Context
+	ipalloc    *ipallocator.IPAllocator
 
 	ifaceMTU   int
 	bridgeAddr net.IP
@@ -103,6 +109,7 @@ type LibvirtLXCBackend struct {
 
 type libvirtContainer struct {
 	RootPath string
+	domain   *lt.Domain
 	IP       net.IP
 	job      *host.Job
 	l        *LibvirtLXCBackend
@@ -589,8 +596,8 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 		g.Log(grohl.Data{"at": "get_domain_xml", "status": "error", "err": err})
 		return err
 	}
-	domain = &lt.Domain{}
-	if err := xml.Unmarshal([]byte(domainXML), domain); err != nil {
+	container.domain = &lt.Domain{}
+	if err := xml.Unmarshal([]byte(domainXML), container.domain); err != nil {
 		g.Log(grohl.Data{"at": "unmarshal_domain_xml", "status": "error", "err": err})
 		return err
 	}
@@ -610,6 +617,32 @@ func (l *LibvirtLXCBackend) openLog(id string) *logbuf.Log {
 	}
 	// TODO: do reference counting and remove logs that are not in use from memory
 	return l.logs[id]
+}
+
+func (c *libvirtContainer) cleanupMounts(pid int) error {
+	list, err := mounts.ParseFile(fmt.Sprintf("/proc/%d/mounts", pid))
+	if err != nil {
+		return err
+	}
+	sort.Sort(mounts.ByDepth(list))
+
+	args := make([]string, 1, len(list)+1)
+	args[0] = strconv.Itoa(pid)
+	for _, m := range list {
+		if strings.HasPrefix(m.Mountpoint, imageRoot) || strings.HasPrefix(m.Mountpoint, flynnRoot) {
+			args = append(args, m.Mountpoint)
+		}
+	}
+
+	out, err := exec.Command(c.l.UmountPath, args...).CombinedOutput()
+	if err != nil {
+		desc := err.Error()
+		if len(out) > 0 {
+			desc = string(out)
+		}
+		return fmt.Errorf("host: error running nsumount %d: %s", pid, desc)
+	}
+	return nil
 }
 
 func (c *libvirtContainer) watch(ready chan<- error) error {
@@ -664,6 +697,17 @@ func (c *libvirtContainer) watch(ready chan<- error) error {
 		return err
 	}
 	defer c.Client.Close()
+
+	go func() {
+		// Workaround for mounts leaking into the libvirt_lxc supervisor process,
+		// see https://github.com/flynn/flynn/issues/1125 for details. Remove
+		// nsumount from the tree when deleting.
+		g.Log(grohl.Data{"at": "cleanup_mounts", "status": "start"})
+		if err := c.cleanupMounts(c.domain.ID); err != nil {
+			g.Log(grohl.Data{"at": "cleanup_mounts", "status": "error", "err": err})
+		}
+		g.Log(grohl.Data{"at": "cleanup_mounts", "status": "finish"})
+	}()
 
 	c.l.containersMtx.Lock()
 	c.l.containers[c.job.ID] = c

--- a/host/nsumount/nsumount.c
+++ b/host/nsumount/nsumount.c
@@ -1,0 +1,39 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <fcntl.h>
+#include <sys/mount.h>
+
+#define errExit(msg)  do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    fprintf(stderr, "%s pid mount ...\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  int pid = atoi(argv[1]);
+  char file[64];
+  sprintf(file, "/proc/%d/ns/mnt", pid);
+  int fd = open(file, O_RDONLY);
+  if (fd == -1) {
+    errExit("open");
+  }
+
+  if (setns(fd, 0) == -1) {
+    errExit("setns");
+  }
+
+  int error = 0;
+  for (int i = 2; i < argc; i++) {
+    if (umount(argv[i]) != 0) {
+      error = 1;
+      perror(argv[i]);
+    }
+  }
+
+  if (error) {
+    exit(EXIT_FAILURE);
+  }
+}

--- a/pkg/mounts/mounts.go
+++ b/pkg/mounts/mounts.go
@@ -1,0 +1,47 @@
+package mounts
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Mount struct {
+	Device          string
+	Mountpoint      string
+	MountpointDepth int
+	Type            string
+	Flags           string
+}
+
+func ParseFile(name string) ([]Mount, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	var res []Mount
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.SplitN(line, " ", 5)
+		if len(fields) != 5 {
+			return nil, fmt.Errorf("mounts: error parsing line: %q", line)
+		}
+		res = append(res, Mount{
+			Device:          fields[0],
+			Mountpoint:      fields[1],
+			MountpointDepth: strings.Count(fields[1], "/"),
+			Type:            fields[2],
+			Flags:           fields[3],
+		})
+	}
+	return res, scanner.Err()
+}
+
+type ByDepth []Mount
+
+func (p ByDepth) Len() int           { return len(p) }
+func (p ByDepth) Less(i, j int) bool { return p[i].MountpointDepth > p[j].MountpointDepth }
+func (p ByDepth) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -97,6 +97,7 @@ boot_libvirt_lxc() {
     --backend libvirt-lxc \
     --state /tmp/flynn-host-state.bolt \
     --flynn-init "${host_dir}/bin/flynn-init" \
+    --nsumount "${host_dir}/bin/flynn-nsumount" \
     &>"${log}"
 
   info "bootstrapping Flynn"

--- a/script/export-components
+++ b/script/export-components
@@ -33,6 +33,7 @@ main() {
   tuf clean
   cp "${ROOT}/host/bin/flynn-host.gz"                      "staged/targets/flynn-host.gz"
   gzip -9 --stdout "${ROOT}/host/bin/flynn-init"         > "staged/targets/flynn-init.gz"
+  gzip -9 --stdout "${ROOT}/host/bin/flynn-nsumount"     > "staged/targets/flynn-nsumount.gz"
   gzip -9 --stdout "${ROOT}/host/upstart.conf"           > "staged/targets/upstart.conf.gz"
   gzip -9 --stdout "${ROOT}/bootstrap/bin/manifest.json" > "staged/targets/bootstrap-manifest.json.gz"
   gzip -9 --stdout "${ROOT}/version.json"                > "staged/targets/version.json.gz"

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -183,8 +183,6 @@ func (s *HostSuite) TestVolumeCreationFailsForNonexistentProvider(t *c.C) {
 }
 
 func (s *HostSuite) TestVolumePersistence(t *c.C) {
-	t.Skip("test intermittently fails due to host bind mount leaks, see https://github.com/flynn/flynn/issues/1125")
-
 	// most of the volume tests (snapshotting, quotas, etc) are unit tests under their own package.
 	// these tests exist to cover the last mile where volumes are bind-mounted into containers.
 


### PR DESCRIPTION
When a mount namespace is created, it inherits all of the mounts from its parent. If they are not `umount(2)`'ed, they will remain and prevent devices from being cleaned up. This currently causes problems when destroying ZFS volumes and cleaning up temporary container rootfs mountpoints.

The libvirt-lxc container system creates two mount namespaces for each container: one in the `libvirt_lxc` supervisor process, and one in the process that execs the actual container process. The latter cleans up the mounts that leak in, but the former does not. This is tracked upstream at https://bugzilla.redhat.com/show_bug.cgi?id=1067489

We work around this issue by adding a small `flynn-nsumount` executable that can reach into an arbitrary mount namespace (using a pid) and call `umount(2)` against a list of paths. This executable is called immediately after launching each libvirt-lxc container to clean up any leaked mountpoints that are known to cause trouble with flynn.

Note that this is not a complete fix, just a temporary band-aid. The following issues remain:

- Any devices such as USB drives will not be automatically cleaned
  up, as we only unmount paths that we know we control. This could
  probably be solved, but the hope is that this workaround will not
  be required for very long.
- There is a non-zero time period between creating the namespace and
  unmounting the leaked mounts, which could cause a race with
  processes that are destroying mounts. In practice this probably
  won't happen and can be worked around by retrying requests.

Closes #1125