### PR TITLE
Fix toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ GIT_COMMIT=`git rev-parse --short HEAD`
 GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 GIT_TAG=`git describe --tags --exact-match --match "v*" 2>/dev/null || echo "none"`
 GIT_DIRTY=`test -n "$(git status --porcelain)" && echo true || echo false`
+GIT_DEV=GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false
+GO_ENV=GOROOT=`readlink -f util/_toolchain/go`
 
 all: toolchain
-	@GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false tup
+	@$(GIT_DEV) $(GO_ENV) tup
 
 release: toolchain
 	@GIT_COMMIT=$(GIT_COMMIT) GIT_BRANCH=$(GIT_BRANCH) GIT_TAG=$(GIT_TAG) GIT_DIRTY=$(GIT_DIRTY) tup
@@ -15,8 +17,8 @@ clean:
 test: test-unit test-integration
 
 test-unit:
-	@GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false tup appliance/etcd discoverd
-	@GOROOT=`readlink -f util/_toolchain/go` util/_toolchain/go/bin/go test ./...
+	@$(GIT_DEV) tup appliance/etcd discoverd
+	@$(GO_ENV) util/_toolchain/go/bin/go test ./...
 
 test-integration:
 	script/run-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,14 @@ clean:
 
 test: test-unit test-integration
 
-test-unit:
-	@$(GIT_DEV) tup appliance/etcd discoverd
-	@$(GO_ENV) util/_toolchain/go/bin/go test ./...
+test-unit-deps:
+	@$(GIT_DEV) $(GO_ENV) tup appliance/etcd discoverd
+
+test-unit: test-unit-deps
+	@$(GO_ENV) PATH=${PWD}/appliance/etcd/bin:${PWD}/discoverd/bin:${PATH} util/_toolchain/go/bin/go test -race -cover ./...
+
+test-unit-root: test-unit
+	@$(GO_ENV) util/_toolchain/go/bin/go test -race -cover ./host/volume/zfs
 
 test-integration:
 	script/run-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: test-unit test-integration
 
 test-unit:
 	@GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false tup appliance/etcd discoverd
-	go test ./...
+	@GOROOT=`readlink -f util/_toolchain/go` util/_toolchain/go/bin/go test ./...
 
 test-integration:
 	script/run-integration-tests

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -1,4 +1,5 @@
 export GOPATH
+export GOROOT
 export GIT_COMMIT
 export GIT_BRANCH
 export GIT_TAG
@@ -7,11 +8,11 @@ export GO_BUILD_TAGS
 
 VPKG = github.com/flynn/flynn/pkg/version
 ROOT = $(TUP_CWD)
-GO_ENV = GOROOT=\$(readlink -f $(ROOT)/util/_toolchain/go)
 GO_LDFLAGS = -ldflags="-X $(VPKG).commit=$GIT_COMMIT -X $(VPKG).branch=$GIT_BRANCH -X $(VPKG).tag=$GIT_TAG -X $(VPKG).dirty=$GIT_DIRTY"
+GO = $(ROOT)/util/_toolchain/go/bin/go
 
-!go = |> ^c go build %o^ $(GO_ENV) CGO_ENABLED=0 $(ROOT)/util/_toolchain/go/bin/go build $(GO_LDFLAGS) -o %o -tags="$GO_BUILD_TAGS" |>
-!cgo = |> ^c go build %o^ $(GO_ENV) $(ROOT)/util/_toolchain/go/bin/go build -o %o $(GO_LDFLAGS) -tags="$GO_BUILD_TAGS" |>
+!go = |> ^c go build %o^ CGO_ENABLED=0 $(GO) build $(GO_LDFLAGS) -o %o -tags="$GO_BUILD_TAGS" |>
+!cgo = |> ^c go build %o^ $(GO) build -o %o $(GO_LDFLAGS) -tags="$GO_BUILD_TAGS" |>
 !docker = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-%d.log <docker>
 !docker-bootstrapped = |> ^ docker build %d^ docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-bootstrapped/%d.log $(ROOT)/<bootstrapped>
 !docker-cedarish = |> ^ docker build %d^ cat $(ROOT)/log/docker-cedarish.log > /dev/null && docker build -t flynn/%d . | tee %o |> $(ROOT)/log/docker-bootstrapped/%d.log $(ROOT)/<bootstrapped>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "shell", privileged: false, inline: <<-SCRIPT
     grep '^export GOPATH' ~/.bashrc || echo export GOPATH=~/go >> ~/.bashrc
-    grep '^export PATH' ~/.bashrc || echo export PATH=\\\$PATH:~/go/bin:~/go/src/github.com/flynn/flynn/appliance/etcd/bin:~/go/src/github.com/flynn/flynn/discoverd/bin:/vagrant/script >> ~/.bashrc
+    grep '^export GOROOT' ~/.bashrc || echo export GOROOT=/vagrant/util/_toolchain/go >> ~/.bashrc
+    grep '^export PATH' ~/.bashrc || echo export PATH=~/go/bin:/vagrant/util/_toolchain/go/bin:/vagrant/appliance/etcd/bin:/vagrant/discoverd/bin:/vagrant/cli/bin:/vagrant/host/bin:/vagrant/script:\\\$PATH: >> ~/.bashrc
     GOPATH=~/go go get github.com/tools/godep
 
     # For script unit tests

--- a/cli/Tupfile.lua
+++ b/cli/Tupfile.lua
@@ -1,16 +1,15 @@
 tup.export("GOPATH")
+tup.export("GOROOT")
 tup.export("GIT_COMMIT")
 tup.export("GIT_BRANCH")
 tup.export("GIT_TAG")
 tup.export("GIT_DIRTY")
 
-goenv = "GOROOT=`readlink -f ../util/_toolchain/go`"
-
 tup.rule({"../util/rubyassetbuilder/*", "../util/cedarish/<docker>"},
           "^ docker build installer-builder^ cat ../log/docker-cedarish.log > /dev/null && ../util/rubyassetbuilder/build.sh image installer | tee %o",
           {"../log/docker-installer-builder.log", "<docker>"})
 
-tup.rule(goenv.." ../util/_toolchain/go/bin/go build -o ../installer/bin/go-bindata ../Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata",
+tup.rule("../util/_toolchain/go/bin/go build -o ../installer/bin/go-bindata ../Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata",
           {"../installer/bin/go-bindata"})
 
 tup.rule({"../installer/bin/go-bindata", "../log/docker-installer-builder.log"},
@@ -25,7 +24,7 @@ vpkg = "github.com/flynn/flynn/pkg/version"
 for i, os in ipairs({"darwin", "linux", "windows"}) do
   for j, arch in ipairs({"amd64", "386"}) do
     tup.rule({"../installer/bindata.go", "tuf.go"},
-             "^c go build %o^ "..goenv.." GOOS="..os.." GOARCH="..arch.." CGO_ENABLED=0  ../util/_toolchain/go/bin/go build -installsuffix nocgo -o %o -ldflags=\"-X "..vpkg..".commit=$GIT_COMMIT -X "..vpkg..".branch=$GIT_BRANCH -X "..vpkg..".tag=$GIT_TAG -X "..vpkg..".dirty=$GIT_DIRTY\"",
+             "^c go build %o^ GOOS="..os.." GOARCH="..arch.." CGO_ENABLED=0  ../util/_toolchain/go/bin/go build -installsuffix nocgo -o %o -ldflags=\"-X "..vpkg..".commit=$GIT_COMMIT -X "..vpkg..".branch=$GIT_BRANCH -X "..vpkg..".tag=$GIT_TAG -X "..vpkg..".dirty=$GIT_DIRTY\"",
              {string.format("bin/flynn-%s-%s", os, arch)})
   end
 end

--- a/dashboard/Tupfile
+++ b/dashboard/Tupfile
@@ -1,6 +1,6 @@
 include_rules
 : $(ROOT)/util/cedarish/<docker> |> ^ docker build dashboard-builder^ cat $(ROOT)/log/docker-cedarish.log > /dev/null && $(ROOT)/util/rubyassetbuilder/build.sh image dashboard | tee %o |> $(ROOT)/log/docker-dashboard-builder.log <docker>
-: |> go build -o $(ROOT)/dashboard/bin/go-bindata $(ROOT)/Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata |> $(ROOT)/dashboard/bin/go-bindata
+: |> $(GO) build -o $(ROOT)/dashboard/bin/go-bindata $(ROOT)/Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata |> $(ROOT)/dashboard/bin/go-bindata
 : foreach $(ROOT)/installer/app/src/images/*.png |> !cp |> ./app/lib/installer/images/%g.png
 : foreach $(ROOT)/installer/app/src/views/*.js.jsx |> !cp |> ./app/lib/installer/views/%g.js.jsx
 : foreach $(ROOT)/installer/app/src/views/css/*.js |> !cp |> ./app/lib/installer/views/css/%g.js

--- a/flannel/build.sh
+++ b/flannel/build.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 commit=e096282d63d1ca8c3d9b6e689da6a7d2b8ea0740
 dir=flannel-${commit}
 tmpdir=$(mktemp --directory)
+PATH=$(readlink -f ../util/_toolchain/go/bin):$PATH
 
 cleanup() {
   rm -rf "${tmpdir}"

--- a/test/scripts/test-unit.sh
+++ b/test/scripts/test-unit.sh
@@ -7,13 +7,9 @@ util/commit-validator/validate-gofmt
 
 bats script/test
 
-GIT_COMMIT=dev GIT_BRANCH=dev GIT_TAG=none GIT_DIRTY=false tup appliance/etcd discoverd
-PATH=$PATH:$PWD/appliance/etcd/bin:$PWD/discoverd/bin
-
 export PGHOST=/var/run/postgresql
 sudo service postgresql start
 
-go test -race -cover ./...
-sudo -E go test -race -cover ./host/volume/zfs # these tests skip unless root
+make test-unit-root
 
 sudo service postgresql stop


### PR DESCRIPTION
Always use the `go` binary from the local toolchain, ensure `GOROOT` is correct everywhere. Also adds the locally built `flynn` and `flynn-host` to the `PATH`.