### PR TITLE
script: Set noninteractive env var in install script

### DIFF
--- a/script/install-flynn.tmpl
+++ b/script/install-flynn.tmpl
@@ -33,6 +33,8 @@ main() {
   local assume_yes=false
   local repo_url
 
+  export DEBIAN_FRONTEND=noninteractive
+
   while true; do
     case "$1" in
       --clean)


### PR DESCRIPTION
This ensures that our apt-get installs don’t get stuck waiting for input.

Closes #1665