### PR TITLE
Fix event notify

### DIFF
--- a/controller/events.go
+++ b/controller/events.go
@@ -175,7 +175,7 @@ func (e *EventListener) Notify(event *ct.AppEvent) {
 	defer e.subMtx.RUnlock()
 	if subs, ok := e.subscribers[event.AppID]; ok {
 		for sub := range subs {
-			go sub.Notify(event)
+			sub.Notify(event)
 		}
 	}
 }

--- a/controller/worker/deployment/context.go
+++ b/controller/worker/deployment/context.go
@@ -49,7 +49,7 @@ func (c *context) HandleDeployment(job *que.Job) (e error) {
 	log.Info("getting old formation")
 	f, err := c.client.GetFormation(deployment.AppID, deployment.OldReleaseID)
 	if err != nil {
-		log.Error("error getting old formation", "err", err)
+		log.Error("error getting old formation", "release_id", deployment.OldReleaseID, "err", err)
 		return err
 	}
 


### PR DESCRIPTION
One logging fix, and a fix for out-of-order event delivery introduced in #1667.