### PR TITLE
util/packer: Explicitly install linux-image-generic-lts-vivid

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -15,7 +15,7 @@ if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then
   apt-get remove --purge -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 fi
 
-apt-get install --install-recommends linux-generic-lts-vivid \
+apt-get install --install-recommends linux-generic-lts-vivid linux-image-generic-lts-vivid \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
This should resolve this complaint from the AWS builder:

    linux-generic-lts-vivid : Depends: linux-image-generic-lts-vivid (= 3.19.0.25.12) but it is not going to be installed