### PR TITLE
Add health status endpoints to all services

### DIFF
--- a/blobstore/blobstore.go
+++ b/blobstore/blobstore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/shutdown"
+	"github.com/flynn/flynn/pkg/status"
 )
 
 var (
@@ -43,6 +44,7 @@ type Filesystem interface {
 	Open(name string) (File, error)
 	Put(name string, r io.Reader, typ string) error
 	Delete(name string) error
+	Status() status.Status
 }
 
 var ErrNotFound = errors.New("file not found")
@@ -120,5 +122,9 @@ func main() {
 	}
 
 	log.Println("Blobstore serving files on " + addr + " from " + storageDesc)
-	shutdown.Fatal(http.ListenAndServe(addr, handler(fs)))
+
+	http.Handle("/", handler(fs))
+	status.AddHandler(fs.Status)
+
+	shutdown.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/blobstore/os_filesystem.go
+++ b/blobstore/os_filesystem.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/flynn/flynn/pkg/status"
 )
 
 type osFile struct {
@@ -55,4 +57,8 @@ func (s *OSFilesystem) Delete(name string) error {
 
 func (s *OSFilesystem) path(name string) string {
 	return filepath.Join(s.root, name)
+}
+
+func (*OSFilesystem) Status() status.Status {
+	return status.Healthy
 }

--- a/blobstore/postgres_filesystem.go
+++ b/blobstore/postgres_filesystem.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/pq/oid"
 	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/status"
 )
 
 func NewPostgresFilesystem(db *sql.DB) (Filesystem, error) {
@@ -38,6 +39,13 @@ $$ LANGUAGE plpgsql;`,
 
 type PostgresFilesystem struct {
 	db *sql.DB
+}
+
+func (p *PostgresFilesystem) Status() status.Status {
+	if _, err := p.db.Exec("SELECT 1"); err != nil {
+		return status.Unhealthy
+	}
+	return status.Healthy
 }
 
 func (p *PostgresFilesystem) Put(name string, r io.Reader, typ string) error {

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -184,6 +184,7 @@
           "cmd": ["scheduler"],
           "omni": true,
           "service": "flynn-controller-scheduler",
+          "ports": [{ "proto": "tcp" }],
           "resurrect": true
         },
         "worker": {

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -188,7 +188,8 @@
           "resurrect": true
         },
         "worker": {
-          "cmd": ["worker"]
+          "cmd": ["worker"],
+          "ports": [{ "proto": "tcp" }]
         }
       }
     },

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -358,14 +358,24 @@
       },
       "processes": {
         "app": {
-          "ports": [{
-            "proto": "tcp",
-            "service": {
-              "name": "gitreceive",
-              "create": true,
-              "check": {"type": "tcp"}
+          "ports": [
+            {
+              "proto": "tcp",
+              "service": {
+                "name": "gitreceive",
+                "create": true,
+                "check": {"type": "tcp"}
+              }
+            },
+            {
+              "proto": "tcp",
+              "service": {
+                "name": "gitreceive-http",
+                "create": true,
+                "check": {"type": "tcp"}
+              }
             }
-          }]
+          ]
         }
       }
     },

--- a/dashboard/api.go
+++ b/dashboard/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/binding"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/render"
 	"github.com/flynn/flynn/pkg/cors"
+	"github.com/flynn/flynn/pkg/status"
 )
 
 type LoginInfo struct {
@@ -58,6 +59,8 @@ func APIHandler(conf *Config) http.Handler {
 		AllowCredentials: true,
 		MaxAge:           time.Hour,
 	}))
+
+	r.Get(status.Path, status.HealthyHandler)
 
 	r.Group(conf.PathPrefix, func(r martini.Router) {
 		m.Use(reqHelperMiddleware)

--- a/discoverd/server/backend.go
+++ b/discoverd/server/backend.go
@@ -11,6 +11,7 @@ type Backend interface {
 	SetLeader(service, id string) error
 	StartSync() error
 	Close() error
+	Ping() error
 }
 
 type SyncHandler interface {

--- a/discoverd/server/etcd_backend.go
+++ b/discoverd/server/etcd_backend.go
@@ -90,6 +90,14 @@ func (b *etcdBackend) serviceKey(service string) string {
 	return path.Join(b.prefix, "services", service)
 }
 
+func (b *etcdBackend) Ping() error {
+	_, err := b.etcd.Get("/ping-nonexistent", false, false)
+	if isEtcdNotFound(err) {
+		err = nil
+	}
+	return err
+}
+
 func (b *etcdBackend) AddService(service string, config *discoverd.ServiceConfig) error {
 	if config == nil {
 		config = DefaultServiceConfig

--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flynn/flynn/logaggregator/client"
 	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
@@ -21,6 +22,7 @@ func apiHandler(agg *Aggregator) http.Handler {
 	api := aggregatorAPI{agg: agg}
 	r := httprouter.New()
 
+	r.Handler("GET", status.Path, status.HealthyHandler)
 	r.GET("/log/:channel_id", httphelper.WrapHandler(api.GetLog))
 	return httphelper.ContextInjector(
 		"logaggregator-api",

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 	"github.com/flynn/flynn/pkg/syslog/rfc6587"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kavu/go_reuseport"
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -51,7 +50,7 @@ func main() {
 	}
 	shutdown.BeforeExit(a.Shutdown)
 
-	listener, err := reuseport.NewReusablePortListener("tcp4", *apiAddr)
+	listener, err := net.Listen("tcp4", *apiAddr)
 	if err != nil {
 		shutdown.Fatal(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,91 @@
+package status
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+/*
+
+	GET /.well-known/status
+	Accept: application/json
+
+	{
+	  "data": {
+		"status": "healthy", // ENUM: "health", "unhealthy" (200, 500)
+		"detail": {
+			// ... optional arbitrary service-specific information
+		}
+	  }
+	}
+
+*/
+
+const Path = "/.well-known/status"
+
+type Code string
+
+const (
+	CodeHealthy   Code = "healthy"
+	CodeUnhealthy Code = "unhealthy"
+)
+
+var (
+	Healthy   = Status{Status: CodeHealthy}
+	Unhealthy = Status{Status: CodeUnhealthy}
+
+	HealthyHandler Handler = func() Status { return Healthy }
+)
+
+type Status struct {
+	Status Code             `json:"status"`
+	Detail *json.RawMessage `json:"detail,omitempty"`
+}
+
+func New(code Code, detail interface{}) (Status, error) {
+	s := Status{Status: code}
+	if detail != nil {
+		res, err := json.Marshal(detail)
+		if err != nil {
+			return Status{}, err
+		}
+		data := json.RawMessage(res)
+		s.Detail = &data
+	}
+	return s, nil
+}
+
+func SimpleHandler(f func() error) Handler {
+	return func() Status {
+		if err := f(); err != nil {
+			return Unhealthy
+		}
+		return Healthy
+	}
+}
+
+type Handler func() Status
+
+func (f Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	s := f()
+	if s.Status == CodeHealthy {
+		w.WriteHeader(200)
+	} else {
+		if s.Status == "" {
+			s.Status = CodeUnhealthy
+		}
+		w.WriteHeader(500)
+	}
+
+	res, _ := json.MarshalIndent(struct {
+		Data Status `json:"data"`
+	}{s}, "", "  ")
+	w.Write(res)
+	w.Write([]byte("\n"))
+}
+
+func AddHandler(h Handler) {
+	http.Handle(Path, h)
+}

--- a/router/api.go
+++ b/router/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/binding"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/martini-contrib/render"
 	"github.com/flynn/flynn/pkg/pprof"
+	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/router/types"
 )
 
@@ -22,6 +23,8 @@ func apiHandler(rtr *Router) http.Handler {
 	m.Use(render.Renderer())
 	m.Action(r.Handle)
 	m.Map(rtr)
+
+	r.Get(status.Path, status.SimpleHandler(rtr.HTTP.Ping).ServeHTTP)
 
 	r.Post("/routes", binding.Bind(router.Route{}), createRoute)
 	r.Put("/routes/:route_type/:id", binding.Bind(router.Route{}), updateRoute)

--- a/router/data_store.go
+++ b/router/data_store.go
@@ -19,11 +19,13 @@ type DataStore interface {
 	List() ([]*router.Route, error)
 	Remove(id string) error
 	Sync(ctx context.Context, h SyncHandler, startc chan<- struct{}) error
+	Ping() error
 }
 
 type DataStoreReader interface {
 	Get(id string) (*router.Route, error)
 	List() ([]*router.Route, error)
+	Ping() error
 }
 
 type SyncHandler interface {
@@ -63,6 +65,11 @@ func NewPostgresDataStore(routeType string, pgx *pgx.ConnPool) *pgDataStore {
 		routeType: routeType,
 		tableName: tableName,
 	}
+}
+
+func (d *pgDataStore) Ping() error {
+	_, err := d.pgx.Exec("SELECT 1")
+	return err
 }
 
 const sqlAddRouteHTTP = `


### PR DESCRIPTION
This PR adds health status endpoints at `/.well-known/status` to all services, including a few that didn't have HTTP servers previously. The reasoning for this is that we will want to add more diagnostic endpoints in the future including metrics, debugging, profiling, etc.

The only service that does not have an endpoint is flannel, which will be added in a separate PR to the flannel repo.