### PR TITLE
Health status service

### DIFF
--- a/bootstrap/add_route_action.go
+++ b/bootstrap/add_route_action.go
@@ -33,18 +33,17 @@ func (a *AddRouteAction) Run(s *State) error {
 	if err != nil {
 		return err
 	}
-	if a.CertStep != "" {
-		if a.Route.Type != "http" {
-			return fmt.Errorf("bootstrap: invalid cert_step option for non-http route")
-		}
-		cert, err := getCertStep(s, a.CertStep)
-		if err != nil {
-			return err
-		}
+	if a.Route.Type == "http" {
 		route := a.Route.HTTPRoute()
 		route.Domain = interpolate(s, route.Domain)
-		route.TLSCert = cert.Cert
-		route.TLSKey = cert.PrivateKey
+		if a.CertStep != "" {
+			cert, err := getCertStep(s, a.CertStep)
+			if err != nil {
+				return err
+			}
+			route.TLSCert = cert.Cert
+			route.TLSKey = cert.PrivateKey
+		}
 		a.Route = route.ToRoute()
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -43,7 +43,7 @@ func (s *State) ControllerClient() (*controller.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		instances, err := disc.Instances("flynn-controller", time.Second)
+		instances, err := disc.Instances("controller", time.Second)
 		if err != nil {
 			return nil, err
 		}

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -183,7 +183,7 @@
         "scheduler": {
           "cmd": ["scheduler"],
           "omni": true,
-          "service": "flynn-controller-scheduler",
+          "service": "controller-scheduler",
           "ports": [{ "proto": "tcp" }],
           "resurrect": true
         },
@@ -210,7 +210,7 @@
   {
     "id": "controller-wait",
     "action": "wait",
-    "url": "http://flynn-controller.discoverd",
+    "url": "http://controller.discoverd",
     "status": 401
   },
   {
@@ -403,7 +403,7 @@
     "app_step": "controller-inception",
     "cert_step": "controller-cert",
     "type": "http",
-    "service": "flynn-controller",
+    "service": "controller",
     "domain": "controller.{{ getenv \"CLUSTER_DOMAIN\" }}"
   },
   {

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -46,6 +46,7 @@
       },
       "processes": {
         "app": {
+          "ports": [{"port": 5002, "proto": "tcp"}],
           "resurrect": true,
           "host_network": true,
           "omni": true

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -511,6 +511,43 @@
     "domain": "dashboard.{{ getenv \"CLUSTER_DOMAIN\" }}"
   },
   {
+    "id": "status",
+    "action": "deploy-app",
+    "app": {
+      "name": "status",
+      "meta": {"flynn-system-app": "true"}
+    },
+    "artifact": {
+      "type": "docker",
+      "uri": "$image_repository?name=flynn/status&id=$image_id[status]"
+    },
+    "release": {
+      "processes": {
+        "web": {
+          "ports": [{
+            "port": 80,
+            "proto": "tcp",
+            "service": {
+              "name": "status-web",
+              "create": true
+            }
+          }]
+        }
+      }
+    },
+    "processes": {
+      "web": 2
+    }
+  },
+  {
+    "id": "status-route",
+    "action": "add-route",
+    "app_step": "status",
+    "type": "http",
+    "service": "status-web",
+    "domain": "status.{{ getenv \"CLUSTER_DOMAIN\" }}"
+  },
+  {
     "id": "blobstore-wait",
     "action": "wait",
     "url": "http://blobstore.discoverd",
@@ -520,6 +557,11 @@
     "id": "gitreceive-wait",
     "action": "wait",
     "url": "tcp://gitreceive.discoverd"
+  },
+  {
+    "id": "status-wait",
+    "action": "wait",
+    "url": "http://status-web.discoverd"
   },
   {
     "id": "log-complete",

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -137,7 +137,7 @@ func NewClient(uri, key string) (*Client, error) {
 
 func NewClientWithHTTP(uri, key string, httpClient *http.Client) (*Client, error) {
 	if uri == "" {
-		uri = "http://flynn-controller.discoverd"
+		uri = "http://controller.discoverd"
 	}
 	u, err := url.Parse(uri)
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -80,7 +80,7 @@ func main() {
 	}
 	rc := routerc.New()
 
-	hb, err := discoverd.DefaultClient.AddServiceAndRegisterInstance("flynn-controller", &discoverd.Instance{
+	hb, err := discoverd.DefaultClient.AddServiceAndRegisterInstance("controller", &discoverd.Instance{
 		Addr:  addr,
 		Proto: "http",
 		Meta: map[string]string{

--- a/controller/scheduler/main.go
+++ b/controller/scheduler/main.go
@@ -53,14 +53,14 @@ func main() {
 	c.watchHosts()
 
 	grohl.Log(grohl.Data{"at": "leaderwait"})
-	hb, err := discoverd.AddServiceAndRegister("flynn-controller-scheduler", ":"+os.Getenv("PORT"))
+	hb, err := discoverd.AddServiceAndRegister("controller-scheduler", ":"+os.Getenv("PORT"))
 	if err != nil {
 		shutdown.Fatal(err)
 	}
 	shutdown.BeforeExit(func() { hb.Close() })
 
 	leaders := make(chan *discoverd.Instance)
-	stream, err := discoverd.NewService("flynn-controller-scheduler").Leaders(leaders)
+	stream, err := discoverd.NewService("controller-scheduler").Leaders(leaders)
 	if err != nil {
 		shutdown.Fatal(err)
 	}

--- a/controller/worker/main.go
+++ b/controller/worker/main.go
@@ -60,7 +60,7 @@ func main() {
 			return status.Healthy
 		})
 		addr := ":" + os.Getenv("PORT")
-		hb, err := discoverd.AddServiceAndRegister("flynn-controller-worker", addr)
+		hb, err := discoverd.AddServiceAndRegister("controller-worker", addr)
 		if err != nil {
 			shutdown.Fatal(err)
 		}

--- a/dashboard/api.go
+++ b/dashboard/api.go
@@ -60,7 +60,7 @@ func APIHandler(conf *Config) http.Handler {
 		MaxAge:           time.Hour,
 	}))
 
-	r.Get(status.Path, status.HealthyHandler)
+	r.Get(status.Path, status.HealthyHandler.ServeHTTP)
 
 	r.Group(conf.PathPrefix, func(r martini.Router) {
 		m.Use(reqHelperMiddleware)

--- a/flannel/build.sh
+++ b/flannel/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-commit=1d748d62859b74aa1fb441c14393845704f85c8b
+commit=9fa40e3fa014e5c2282edd872f769adbe46e8389
 dir=flannel-${commit}
 tmpdir=$(mktemp --directory)
 

--- a/flannel/runner.go
+++ b/flannel/runner.go
@@ -80,6 +80,7 @@ func main() {
 			flanneld,
 			"-discoverd-url=" + status.Discoverd.URL,
 			"-iface=" + os.Getenv("EXTERNAL_IP"),
+			"-http-port=" + os.Getenv("PORT"),
 			fmt.Sprintf("-notify-url=http://%s:1113/host/network", os.Getenv("EXTERNAL_IP")),
 		},
 		os.Environ(),

--- a/host/discoverd.go
+++ b/host/discoverd.go
@@ -71,7 +71,7 @@ func (d *DiscoverdManager) ConnectLocal(url string) error {
 	d.backend.SetDefaultEnv("DISCOVERD", url)
 
 	go func() {
-		if err := d.mux.Connect(disc, "flynn-logaggregator"); err != nil {
+		if err := d.mux.Connect(disc, "logaggregator"); err != nil {
 			shutdown.Fatal(err)
 		}
 	}()

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -477,7 +477,9 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 	}
 	for i, p := range job.Config.Ports {
 		if p.Proto != "tcp" && p.Proto != "udp" {
-			return fmt.Errorf("unknown port proto %q", p.Proto)
+			err := fmt.Errorf("unknown port proto %q", p.Proto)
+			g.Log(grohl.Data{"at": "alloc_port", "proto": p.Proto, "status": "error", "err": err})
+			return err
 		}
 
 		if p.Port == 0 {

--- a/logaggregator/client/client.go
+++ b/logaggregator/client/client.go
@@ -44,7 +44,7 @@ func New(uri string) (Client, error) {
 // NewClient creates a new Client pointing at uri with the specified http client.
 func NewWithHTTP(uri string, httpClient *http.Client) (Client, error) {
 	if uri == "" {
-		uri = "http://flynn-logaggregator.discoverd"
+		uri = "http://logaggregator.discoverd"
 	}
 	u, err := url.Parse(uri)
 	if err != nil {

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -55,7 +55,7 @@ func main() {
 		shutdown.Fatal(err)
 	}
 
-	hb, err := discoverd.AddServiceAndRegister("flynn-logaggregator", *logAddr)
+	hb, err := discoverd.AddServiceAndRegister("logaggregator", *logAddr)
 	if err != nil {
 		shutdown.Fatal(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -42,8 +42,12 @@ type Status struct {
 	Detail *json.RawMessage `json:"detail,omitempty"`
 }
 
-func New(code Code, detail interface{}) (Status, error) {
-	s := Status{Status: code}
+func New(healthy bool, detail interface{}) (Status, error) {
+	var s Status
+	s.Status = CodeHealthy
+	if !healthy {
+		s.Status = CodeUnhealthy
+	}
 	if detail != nil {
 		res, err := json.Marshal(detail)
 		if err != nil {

--- a/router/http.go
+++ b/router/http.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/flynn/flynn/discoverd/cache"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/random"
@@ -223,7 +224,7 @@ func (h *httpSyncHandler) Set(data *router.Route) error {
 		service = nil
 	}
 	if service == nil {
-		sc, err := NewDiscoverdServiceCache(h.l.discoverd.Service(r.Service))
+		sc, err := cache.New(h.l.discoverd.Service(r.Service))
 		if err != nil {
 			return err
 		}
@@ -379,7 +380,7 @@ type httpRoute struct {
 // A service definition: name, and set of backends.
 type httpService struct {
 	name string
-	sc   DiscoverdServiceCache
+	sc   cache.ServiceCache
 	refs int
 
 	rp *proxy.ReverseProxy

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/flynn/flynn/discoverd/cache"
 	"github.com/flynn/flynn/router/proxy"
 	"github.com/flynn/flynn/router/types"
 )
@@ -212,7 +213,7 @@ func (h *tcpSyncHandler) Set(data *router.Route) error {
 		service = nil
 	}
 	if service == nil {
-		sc, err := NewDiscoverdServiceCache(h.l.discoverd.Service(r.Service))
+		sc, err := cache.New(h.l.discoverd.Service(r.Service))
 		if err != nil {
 			return err
 		}
@@ -321,7 +322,7 @@ func (r *tcpRoute) Close() {
 
 type tcpService struct {
 	name string
-	sc   DiscoverdServiceCache
+	sc   cache.ServiceCache
 	refs int
 
 	rp *proxy.ReverseProxy

--- a/status/Dockerfile
+++ b/status/Dockerfile
@@ -1,0 +1,5 @@
+FROM flynn/busybox
+
+ADD ./bin/flynn-status /bin/flynn-status
+
+ENTRYPOINT ["/bin/flynn-status"]

--- a/status/Tupfile
+++ b/status/Tupfile
@@ -1,0 +1,3 @@
+include_rules
+: |> !go |> bin/flynn-status
+: bin/* |> !docker-bootstrapped |>

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/flynn/flynn/discoverd/cache"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/status"
+)
+
+func main() {
+	log.Fatal(http.ListenAndServe(":"+os.Getenv("PORT"), status.Handler(GetStatus)))
+}
+
+var httpClient = &http.Client{Timeout: 2 * time.Second}
+
+type ReqFn func() (*http.Request, error)
+
+type Service struct {
+	Name  string
+	ReqFn func() (*http.Request, error)
+}
+
+func (s Service) Status() status.Status {
+	req, err := s.ReqFn()
+	if err != nil {
+		return status.Unhealthy
+	}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return status.Unhealthy
+	}
+	defer res.Body.Close()
+
+	var data struct {
+		Data status.Status
+	}
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return status.Unhealthy
+	}
+	return data.Data
+}
+
+var services = []Service{
+	{Name: "blobstore"},
+	{
+		Name: "controller",
+		ReqFn: func() ReqFn {
+			instances, err := discoverd.GetInstances("controller", 1*time.Second)
+			if err != nil {
+				log.Fatalf("error discovering controller: %s", err)
+			}
+			key := instances[0].Meta["AUTH_KEY"]
+			fn := RandomReqFn("controller")
+			return func() (*http.Request, error) {
+				req, err := fn()
+				if err != nil {
+					return nil, err
+				}
+				req.SetBasicAuth("", key)
+				return req, nil
+			}
+		}(),
+	},
+	{Name: "controller-scheduler", ReqFn: LeaderReqFn("controller-scheduler", "")},
+	{Name: "controller-worker"},
+	{Name: "dashboard", ReqFn: RandomReqFn("dashboard-web")},
+	{Name: "discoverd"},
+	{Name: "flannel"},
+	{Name: "gitreceive", ReqFn: RandomReqFn("gitreceive-http")},
+	{Name: "logaggregator", ReqFn: LeaderReqFn("logaggregator", "80")},
+	{Name: "postgres", ReqFn: LeaderReqFn("postgres", "5433")},
+	{Name: "router", ReqFn: RandomReqFn("router-api")},
+}
+
+func RandomReqFn(name string) ReqFn {
+	sc, err := cache.New(discoverd.NewService(name))
+	if err != nil {
+		log.Fatalf("error creating %s cache: %s", name, err)
+	}
+	return func() (*http.Request, error) {
+		addrs := sc.Addrs()
+		if len(addrs) == 0 {
+			return nil, errors.New("no service instances")
+		}
+		return http.NewRequest("GET", fmt.Sprintf("http://%s%s", addrs[rand.Intn(len(addrs))], status.Path), nil)
+	}
+}
+
+func LeaderReqFn(name, port string) ReqFn {
+	events := make(chan *discoverd.Event)
+	if _, err := discoverd.NewService(name).Watch(events); err != nil {
+		log.Fatalf("error creating %s cache: %s", name, err)
+	}
+	var leader atomic.Value // addr string
+	leader.Store("")
+	go func() {
+		for e := range events {
+			if e.Kind != discoverd.EventKindLeader || e.Instance == nil {
+				continue
+			}
+			leader.Store(e.Instance.Addr)
+		}
+	}()
+	return func() (*http.Request, error) {
+		addr := leader.Load().(string)
+		if addr == "" {
+			return nil, errors.New("no leader")
+		}
+		if port != "" {
+			host, _, _ := net.SplitHostPort(addr)
+			addr = net.JoinHostPort(host, port)
+		}
+		return http.NewRequest("GET", fmt.Sprintf("http://%s%s", addr, status.Path), nil)
+	}
+}
+
+func init() {
+	for i, s := range services {
+		if s.ReqFn != nil {
+			continue
+		}
+		services[i].ReqFn = RandomReqFn(s.Name)
+	}
+}
+
+type ServiceStatus struct {
+	Name   string
+	Status status.Status
+}
+
+func GetStatus() status.Status {
+	results := make(chan ServiceStatus)
+	for _, s := range services {
+		go func(s Service) {
+			results <- ServiceStatus{s.Name, s.Status()}
+		}(s)
+	}
+
+	data := make(map[string]status.Status, len(services))
+	healthy := true
+	for i := 0; i < len(services); i++ {
+		res := <-results
+		data[res.Name] = res.Status
+		if res.Status.Status != status.CodeHealthy {
+			healthy = false
+		}
+	}
+
+	s, _ := status.New(healthy, data)
+	return s
+}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -41,7 +41,7 @@ func run() error {
 		return err
 	}
 
-	instances, err := discoverd.GetInstances("flynn-controller", 10*time.Second)
+	instances, err := discoverd.GetInstances("controller", 10*time.Second)
 	if err != nil {
 		log.Error("error looking up controller in service discovery", "err", err)
 		return err

--- a/util/release/version_template.json
+++ b/util/release/version_template.json
@@ -12,5 +12,6 @@
   "flynn/taffy": "$image_id[taffy]",
   "flynn/dashboard": "$image_id[dashboard]",
   "flynn/updater": "$image_id[updater]",
-  "flynn/logaggregator": "$image_id[logaggregator]"
+  "flynn/logaggregator": "$image_id[logaggregator]",
+  "flynn/status": "$image_id[status]"
 }


### PR DESCRIPTION
This adds a status service that is exposed via the router at `status.$CLUSTER_DOMAIN` and aggregates the health status endpoints of all of the Flynn services. Here's example output:

```json
{
  "data": {
    "status": "healthy",
    "detail": {
      "blobstore": {
        "status": "healthy"
      },
      "controller": {
        "status": "healthy"
      },
      "controller-scheduler": {
        "status": "healthy"
      },
      "controller-worker": {
        "status": "healthy"
      },
      "dashboard": {
        "status": "healthy"
      },
      "discoverd": {
        "status": "healthy"
      },
      "flannel": {
        "status": "healthy"
      },
      "gitreceive": {
        "status": "healthy"
      },
      "logaggregator": {
        "status": "healthy"
      },
      "postgres": {
        "status": "healthy"
      },
      "router": {
        "status": "healthy"
      }
    }
  }
}
```