### PR TITLE
receiver,slugbuilder: Allow specifying SSH private key for buildpacks

### DIFF
--- a/receiver/flynn-receive.go
+++ b/receiver/flynn-receive.go
@@ -79,6 +79,11 @@ func main() {
 	if buildpackURL, ok := prevRelease.Env["BUILDPACK_URL"]; ok {
 		cmd.Env["BUILDPACK_URL"] = buildpackURL
 	}
+	for _, k := range []string{"SSH_CLIENT_KEY", "SSH_CLIENT_HOSTS"} {
+		if v := os.Getenv(k); v != "" {
+			cmd.Env[k] = v
+		}
+	}
 
 	if err := cmd.Run(); err != nil {
 		log.Fatalln("Build failed:", err)

--- a/receiver/start.sh
+++ b/receiver/start.sh
@@ -1,3 +1,23 @@
-#!/bin/sh
+#!/bin/bash
+
+if [[ -z "${HOME}" ]] || [[ "${HOME}" == "/" ]] ; then
+  export HOME=/root
+fi
+
+# If there is a SSH private key available in the environment, save it so that it can be used
+if [[ -n "${SSH_CLIENT_KEY}" ]]; then
+  mkdir -p ${HOME}/.ssh
+  file="${HOME}/.ssh/id_rsa"
+  echo "${SSH_CLIENT_KEY}" > ${file}
+  chmod 600 ${file}
+fi
+
+# If there is a list of known SSH hosts available in the environment, save it so that it can be used
+if [[ -n "${SSH_CLIENT_HOSTS}" ]]; then
+  mkdir -p ${HOME}/.ssh
+  file="${HOME}/.ssh/known_hosts"
+  echo "${SSH_CLIENT_HOSTS}" > ${file}
+  chmod 600 ${file}
+fi
 
 exec /bin/gitreceived --auth-checker /bin/flynn-key-check --receiver /bin/flynn-receiver --cache-key-hook /bin/flynn-cache-key

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -57,6 +57,28 @@ curl() {
   $(which curl) --silent --retry 3 $@
 }
 
+if [[ -z "${HOME}" ]] || [[ "${HOME}" == "/" ]] ; then
+  export HOME=/root
+fi
+
+# If there is a SSH private key available in the environment, save it so that it can be used
+if [[ -n "${SSH_CLIENT_KEY}" ]]; then
+  mkdir -p ${HOME}/.ssh
+  file="${HOME}/.ssh/id_rsa"
+  echo "${SSH_CLIENT_KEY}" > ${file}
+  chmod 600 ${file}
+  unset SSH_CLIENT_KEY
+fi
+
+# If there is a list of known SSH hosts available in the environment, save it so that it can be used
+if [[ -n "${SSH_CLIENT_HOSTS}" ]]; then
+  mkdir -p ${HOME}/.ssh
+  file="${HOME}/.ssh/known_hosts"
+  echo "${SSH_CLIENT_HOSTS}" > ${file}
+  chmod 600 ${file}
+  unset SSH_CLIENT_HOSTS
+fi
+
 cd ${app_dir}
 
 ## Load source from STDIN

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"time"
 
@@ -20,6 +23,39 @@ var _ = c.ConcurrentSuite(&GitDeploySuite{})
 
 func (s *GitDeploySuite) SetUpSuite(t *c.C) {
 	t.Assert(flynn(t, "/", "key", "add", s.sshKeys(t).Pub), Succeeds)
+
+	// Unencrypted SSH private key for the flynn-test GitHub account, used in TestPrivateSSHKeyClone.
+	// Omits header/footer to avoid any GitHub auto-revoke key crawlers
+	sshKey := `MIIEpAIBAAKCAQEA2UnQ/17TfzQRt4HInuP1SYz/tSNaCGO3NDIPLydVu8mmxuKT
+zlJtH3pz3uWpMEKdZtSjV+QngJL8OFzanQVZtRBJjF2m+cywHJoZA5KsplMon+R+
+QmVqu92WlcRdkcft1F1CLoTXTmHHfvuhOkG6GgJONNLP9Z14EsQ7MbBh5guafWOX
+kdGFajyd+T2aj27yIkK44WjWqiLjxRIAtgOJrmd/3H0w3E+O1cgNrA2gkFEUhvR1
+OHz8SmugYva0VZWKvxZ6muZvn26L1tajYsCntCRR3/a74cAnVFAXjqSatL6YTbSH
+sdtE91kEC73/U4SL3OFdDiCrAvXpJ480C2/GQQIDAQABAoIBAHNQNVYRIPS00WIt
+wiZwm8/4wAuFQ1aIdMWCe4Ruv5T1I0kRHZe1Lqwx9CQqhWtTLu1Pk5AlSMF3P9s5
+i9sg58arahzP5rlS43OKZBP9Vxq9ryWLwWXDJK2mny/EElQ3YgP9qg29+fVi9thw
++dNM5lK/PnnSFwMmGn77HN712D6Yl3CCJJjsAunTfPzR9hyEqX5YvUB5eq/TNhXe
+sqrKcGORIoNfv7WohlFSkTAXIvoMxmFWXg8piZ9/b1W4NwvO4wup3ZSErIk0AQ97
+HtyXJIXgtj6pLkPqvPXPGvS3quYAddNxvGIdvge7w5LHnrxOzdqbeDAVmJLVwVlv
+oo+7aQECgYEA8ZliUuA8q86SWE0N+JZUqbTvE6VzyWG0/u0BJYDkH7yHkbpFOIEy
+KTw048WOZLQ6/wPwL8Hb090Cas/6pmRFMgCedarzXc9fvGEwW95em7jA4AyOVBMC
+KIAmaYkm6LcUFeyR6ektZeCkT0MNoi4irjBC3/hMRyZu+6RL4jXxHLkCgYEA5j13
+2nkbV99GtRRjyGB7uMkrhMere2MekANXEm4dW+LZFZUda4YCqdzfjDfBTxsuyGqi
+DnvI7bZFzIQPiiEzvL2Mpiy7JqxmPLGmwzxDp3z75T5vOrGs4g9IQ7yDjp5WPzjz
+KCJJHn8Qt9tNZb5h0hBM+NWLT0c1XxtTIVFfgckCgYAfNpTYZjYQcFDB7bqXWjy3
+7DNTE3YhF2l94fra8IsIep/9ONaGlVJ4t1mR780Uv6A7oDOgx+fxuET+rb4RTzUN
+X70ZMKvee9M/kELiK5mHftgUWirtO8N0nhHYYqrPOA/1QSoc0U5XMi2oO96ADHvY
+i02oh/i63IFMK47OO+/ZqQKBgQCY8bY/Y/nc+o4O1hee0TD+xGvrTXRFh8eSpRVf
+QdSw6FWKt76OYbw9OGMr0xHPyd/e9K7obiRAfLeLLyLfgETNGSFodghwnU9g/CYq
+RUsv5J+0XjAnTkXo+Xvouz6tK9NhNiSYwYXPA1uItt6IOtriXz+ygLCFHml+3zju
+xg5quQKBgQCEL95Di6WD+155gEG2NtqeAOWhgxqAbGjFjfpV+pVBksBCrWOHcBJp
+QAvAdwDIZpqRWWMcLS7zSDrzn3ZscuHCMxSOe40HbrVdDUee24/I4YQ+R8EcuzcA
+3IV9ai+Bxs6PvklhXmarYxJl62LzPLyv0XFscGRes/2yIIxNfNzFug==`
+
+	t.Assert(flynn(t, "/", "-a", "gitreceive", "env", "set",
+		"SSH_CLIENT_HOSTS=github.com,192.30.252.131 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
+		fmt.Sprintf("SSH_CLIENT_KEY=-----BEGIN RSA PRIVATE KEY-----\n%s\n-----END RSA PRIVATE KEY-----\n", sshKey)),
+		Succeeds)
 }
 
 var Attempts = attempt.Strategy{
@@ -195,8 +231,26 @@ func (s *GitDeploySuite) TestRunQuoting(t *c.C) {
 func (s *GitDeploySuite) TestGitSubmodules(t *c.C) {
 	r := s.newGitRepo(t, "empty")
 	t.Assert(r.git("submodule", "add", "https://github.com/flynn-examples/go-flynn-example.git"), Succeeds)
-	t.Assert(r.git("commit", "-m", "Add Submodule"), Succeeds)
+
+	// use a private SSH URL to test ssh client key
+	gmPath := filepath.Join(r.dir, ".gitmodules")
+	gm, err := ioutil.ReadFile(gmPath)
+	t.Assert(err, c.IsNil)
+	gm = bytes.Replace(gm, []byte("https://github.com/"), []byte("git@github.com:"), 1)
+	err = ioutil.WriteFile(gmPath, gm, os.ModePerm)
+	t.Assert(err, c.IsNil)
+
+	t.Assert(r.git("commit", "-am", "Add Submodule"), Succeeds)
 	t.Assert(r.flynn("create"), Succeeds)
 	t.Assert(r.git("push", "flynn", "master"), Succeeds)
 	t.Assert(r.flynn("run", "ls", "go-flynn-example"), SuccessfulOutputContains, "main.go")
+}
+
+func (s *GitDeploySuite) TestPrivateSSHKeyClone(t *c.C) {
+	r := s.newGitRepo(t, "empty-release")
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.flynn("env", "set", "BUILDPACK_URL=git@github.com:kr/heroku-buildpack-inline.git"), Succeeds)
+
+	push := r.git("push", "flynn", "master")
+	t.Assert(push, Succeeds)
 }


### PR DESCRIPTION
This allows the use of an SSH private key specified in the gitreceive environment as `SSH_CLIENT_KEY` and `known_hosts` entries in `SSH_CLIENT_HOSTS`.

This key and hosts will be used for SSH client operations performed by slugbuilder, including cloning buildpacks.

Closes #1662

@temujin9 Please give this a try and let me know if it meets your needs.