### PR TITLE
controller: Fix app lookup when streaming events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -331,13 +331,6 @@ func (c *controllerAPI) getApp(ctx context.Context) *ct.App {
 	return ctx.Value("app").(*ct.App)
 }
 
-func (c *controllerAPI) maybeGetApp(ctx context.Context) *ct.App {
-	if app, ok := ctx.Value("app").(*ct.App); ok {
-		return app
-	}
-	return nil
-}
-
 func (c *controllerAPI) getRelease(ctx context.Context) (*ct.Release, error) {
 	params, _ := ctxhelper.ParamsFromContext(ctx)
 	data, err := c.releaseRepo.Get(params.ByName("releases_id"))

--- a/controller/events.go
+++ b/controller/events.go
@@ -111,7 +111,16 @@ func (c *controllerAPI) Events(ctx context.Context, w http.ResponseWriter, req *
 	if err := c.maybeStartEventListener(); err != nil {
 		respondWithError(w, err)
 	}
-	if err := streamEvents(ctx, w, req, c.eventListener, c.maybeGetApp(ctx), c.eventRepo); err != nil {
+	var app *ct.App
+	if appID := req.FormValue("app_id"); appID != "" {
+		data, err := c.appRepo.Get(appID)
+		if err != nil {
+			respondWithError(w, err)
+			return
+		}
+		app = data.(*ct.App)
+	}
+	if err := streamEvents(ctx, w, req, c.eventListener, app, c.eventRepo); err != nil {
 		respondWithError(w, err)
 	}
 }


### PR DESCRIPTION
The Events handler is not wrapped in appLookup, so there will never be an app in the context.

The appID is also passed as a query string rather than a param, so we can't use appLookup.