### PR TITLE
appliance/postgresql: Add PGRouting extension to PostgreSQL appliance

### DIFF
--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update &&\
       postgresql-contrib-9.4 \
       postgresql-9.4-pgextwlist \
       postgresql-9.4-plv8 \
-      postgresql-9.4-postgis &&\
+      postgresql-9.4-postgis \
+      postgresql-9.4-pgrouting &&\
     apt-get clean &&\
     apt-get autoremove -y &&\
     echo "\set HISTFILE /dev/null" > /root/.psqlrc

--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -955,7 +955,7 @@ dynamic_shared_memory_type = '{{.SHMType}}'
 
 {{if .ExtWhitelist}}
 local_preload_libraries = 'pgextwlist'
-extwlist.extensions = 'btree_gin,btree_gist,chkpass,citext,cube,dblink,dict_int,earthdistance,fuzzystrmatch,hstore,intarray,isn,ltree,pg_prewarm,pg_stat_statements,pg_trgm,pgcrypto,pgrowlocks,pgstattuple,plpgsql,plv8,postgis,postgis_topology,postgres_fdw,tablefunc,unaccent,uuid-ossp'
+extwlist.extensions = 'btree_gin,btree_gist,chkpass,citext,cube,dblink,dict_int,earthdistance,fuzzystrmatch,hstore,intarray,isn,ltree,pg_prewarm,pg_stat_statements,pg_trgm,pgcrypto,pgrouting,pgrowlocks,pgstattuple,plpgsql,plv8,postgis,postgis_topology,postgres_fdw,tablefunc,unaccent,uuid-ossp'
 {{end}}
 `[1:]))
 

--- a/docs/content/postgres.html.md
+++ b/docs/content/postgres.html.md
@@ -119,6 +119,7 @@ This is a complete list of the extensions that are available:
 | pg\_stat\_statements | 1.2     | track execution statistics of all SQL statements executed           |
 | pg\_trgm             | 1.1     | text similarity measurement and index searching based on trigrams   |
 | pgcrypto             | 1.1     | cryptographic functions                                             |
+| pgrouting            | 2.0     | pgRouting Extension                                                 |
 | pgrowlocks           | 1.1     | show row-level locking information                                  |
 | pgstattuple          | 1.2     | show tuple-level statistics                                         |
 | plpgsql              | 1.0     | PL/pgSQL procedural language                                        |


### PR DESCRIPTION
This enables additional GIS workloads including importing and working with the Open Street Map dataset.