### PR TITLE
Add syslog structured data encoding/parsing

### DIFF
--- a/pkg/syslog/rfc5424/parser.go
+++ b/pkg/syslog/rfc5424/parser.go
@@ -97,7 +97,7 @@ func parsePriority(buf []byte, cursor *int, msg *Message) error {
 }
 
 func parseVersion(buf []byte, cursor *int, msg *Message) error {
-	if len(buf) < *cursor+1 {
+	if len(buf) < *cursor+2 {
 		return &ParseError{*cursor, "message ended before version was received"}
 	}
 	if buf[*cursor] != '1' || buf[*cursor+1] != ' ' {

--- a/pkg/syslog/rfc5424/parser.go
+++ b/pkg/syslog/rfc5424/parser.go
@@ -149,7 +149,7 @@ func parseStructuredData(buf []byte, cursor *int, msg *Message) error {
 	if len(buf) < *cursor {
 		return &ParseError{*cursor, "missing structured data field"}
 	}
-	if buf[*cursor] == '-' {
+	if c := buf[*cursor]; c == '-' {
 		if len(buf) > *cursor+1 && buf[*cursor+1] != ' ' {
 			return &ParseError{*cursor, "invalid structured data"}
 		}
@@ -158,8 +158,27 @@ func parseStructuredData(buf []byte, cursor *int, msg *Message) error {
 		}
 		*cursor++
 		return nil
+	} else if c != '[' {
+		return &ParseError{*cursor, "invalid structured data"}
 	}
-	return &ParseError{*cursor, "structured data is unsupported"}
+
+	// find the end of the field
+	end := *cursor
+	for {
+		end = indexByteAfter(buf, ']', end+1)
+		if end == -1 {
+			return &ParseError{*cursor, "invalid structured data"}
+		}
+		if buf[end-1] != '\\' {
+			if len(buf) < end+2 || buf[end+1] != ' ' {
+				return &ParseError{*cursor, "invalid structured data"}
+			}
+			break
+		}
+	}
+	msg.StructuredData = buf[*cursor : end+1]
+	*cursor = end + 2
+	return nil
 }
 
 func indexByteAfter(buf []byte, c byte, after int) int {

--- a/pkg/syslog/rfc5424/parser_test.go
+++ b/pkg/syslog/rfc5424/parser_test.go
@@ -83,14 +83,25 @@ func (s *S) TestParse(c *C) {
 				Msg:            []byte("message body"),
 			},
 		},
+
+		{
+			msg: "<0>1",
+		},
 	}
 
-	for _, test := range table {
+	for i, test := range table {
+		ctx := Commentf("i = %d", i)
 		msg, err := Parse([]byte(test.msg))
+		if test.want == nil {
+			if err == nil {
+				c.Error("expected error but didn't get one", ctx)
+			}
+			continue
+		}
 		if err != nil {
-			c.Error(err)
+			c.Error(err, ctx)
 		}
 
-		c.Assert(msg, DeepEquals, test.want)
+		c.Assert(msg, DeepEquals, test.want, ctx)
 	}
 }

--- a/pkg/syslog/rfc5424/parser_test.go
+++ b/pkg/syslog/rfc5424/parser_test.go
@@ -45,6 +45,44 @@ func (s *S) TestParse(c *C) {
 				Msg: []byte{},
 			},
 		},
+
+		// structured data
+		{
+			msg: fmt.Sprintf("<1>1 %s 3.4.5.6 APP-7 PID-8 FD9 [foo] message body", tss),
+			want: &Message{
+				Header: Header{
+					Facility:  0,
+					Severity:  1,
+					Version:   1,
+					Timestamp: ts,
+					Hostname:  []byte("3.4.5.6"),
+					AppName:   []byte("APP-7"),
+					ProcID:    []byte("PID-8"),
+					MsgID:     []byte("FD9"),
+				},
+				StructuredData: []byte("[foo]"),
+				Msg:            []byte("message body"),
+			},
+		},
+
+		// structured data with escaped brackets
+		{
+			msg: fmt.Sprintf(`<1>1 %s 3.4.5.6 APP-7 PID-8 FD9 [foo="bar\]\]\""] message body`, tss),
+			want: &Message{
+				Header: Header{
+					Facility:  0,
+					Severity:  1,
+					Version:   1,
+					Timestamp: ts,
+					Hostname:  []byte("3.4.5.6"),
+					AppName:   []byte("APP-7"),
+					ProcID:    []byte("PID-8"),
+					MsgID:     []byte("FD9"),
+				},
+				StructuredData: []byte(`[foo="bar\]\]\""]`),
+				Msg:            []byte("message body"),
+			},
+		},
 	}
 
 	for _, test := range table {

--- a/pkg/syslog/rfc5424/structured_data.go
+++ b/pkg/syslog/rfc5424/structured_data.go
@@ -1,0 +1,187 @@
+package rfc5424
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+type StructuredData struct {
+	ID     []byte
+	Params []StructuredDataParam
+}
+
+func (e StructuredData) Encode(w io.Writer) error {
+	if len(e.ID) == 0 {
+		return writeByte(w, '-')
+	}
+
+	writeByte(w, '[')
+	w.Write(e.ID)
+	writeByte(w, ' ')
+	for i, p := range e.Params {
+		p.Encode(w)
+		if i != len(e.Params)-1 {
+			writeByte(w, ' ')
+		}
+	}
+	return writeByte(w, ']')
+}
+
+func (s StructuredData) String() string {
+	res := fmt.Sprintf("[%s ", s.ID)
+	for i, e := range s.Params {
+		res += e.String()
+		if i != len(s.Params)-1 {
+			res += " "
+		}
+	}
+	res += "]"
+	return res
+}
+
+type StructuredDataParam struct {
+	Name  []byte
+	Value []byte
+}
+
+func (s StructuredDataParam) String() string {
+	return fmt.Sprintf("%s=%s", s.Name, s.Value)
+}
+
+func (s *StructuredDataParam) Encode(w io.Writer) error {
+	w.Write(s.Name)
+	writeByte(w, '=')
+	writeByte(w, '"')
+	for _, b := range s.Value {
+		if b == '"' || b == '\\' || b == ']' {
+			writeByte(w, '\\')
+		}
+		writeByte(w, b)
+	}
+	return writeByte(w, '"')
+}
+
+func writeByte(w io.Writer, b byte) error {
+	if bw, ok := w.(io.ByteWriter); ok {
+		return bw.WriteByte(b)
+	}
+	_, err := w.Write([]byte{b})
+	return err
+}
+
+func ParseStructuredData(buf []byte) (*StructuredData, error) {
+	if len(buf) == 1 && buf[0] == '-' {
+		return nil, nil
+	}
+	if len(buf) < 2 || buf[0] != '[' || buf[len(buf)-1] != ']' {
+		return nil, &ParseError{0, "invalid structured data"}
+	}
+
+	res := &StructuredData{
+		Params: make([]StructuredDataParam, 0, bytes.Count(buf, []byte{'='})),
+	}
+
+	cursor := 1
+	parseName := func(delimiters ...byte) ([]byte, error) {
+		var res []byte
+	outer:
+		for i, b := range buf[cursor:] {
+			for _, d := range delimiters {
+				if b == d {
+					res = buf[cursor : cursor+i]
+					cursor += i + 1
+					break outer
+				}
+			}
+			if b == ' ' || b == '=' || b == ']' || b == '"' {
+				return nil, &ParseError{cursor + i, fmt.Sprintf("unexpected %q parsing structured data name", b)}
+			}
+		}
+		if len(res) == 0 {
+			return nil, &ParseError{cursor, "invalid structured data name"}
+		}
+		return res, nil
+	}
+
+	var err error
+	res.ID, err = parseName(' ', ']')
+	if err != nil {
+		return nil, err
+	}
+
+	if len(buf) == cursor {
+		return res, nil
+	}
+
+outer:
+	for {
+		var d StructuredDataParam
+		d.Name, err = parseName('=')
+		if err != nil {
+			return nil, err
+		}
+		if len(buf) < cursor+3 {
+			return nil, &ParseError{cursor, "invalid structured data, expected value"}
+		}
+		if buf[cursor] != '"' {
+			return nil, &ParseError{cursor, "invalid structured data value, expected '\"'"}
+		}
+		cursor++
+
+		lastEscape := false
+		closed := false
+		var valBuf bytes.Buffer
+	value:
+		for _, b := range buf[cursor:] {
+			cursor++
+			switch b {
+			case '\\':
+				if !lastEscape {
+					lastEscape = true
+					continue
+				}
+			case ']':
+				if !lastEscape {
+					return nil, &ParseError{cursor, "invalid structured data, unexpected ']'"}
+				}
+			case '"':
+				if !lastEscape {
+					closed = true
+					break value
+				}
+			default:
+				if lastEscape {
+					valBuf.WriteByte('\\')
+				}
+			}
+			valBuf.WriteByte(b)
+			lastEscape = false
+		}
+		if !closed {
+			return nil, &ParseError{cursor, "unexpected end of structured data"}
+		}
+		d.Value = valBuf.Bytes()
+		res.Params = append(res.Params, d)
+
+		if len(buf) < cursor+1 {
+			return nil, &ParseError{cursor, "unexpected end of structured data, no closing ']'"}
+		}
+		switch buf[cursor] {
+		case ']':
+			if len(buf) > cursor+1 {
+				return nil, &ParseError{cursor, "unexpected end of structured data, "}
+			}
+			break outer
+		case ' ':
+			if len(buf) < cursor+5 || buf[cursor+1] == ']' {
+				return nil, &ParseError{cursor, "unexpected space"}
+			}
+		default:
+			return nil, &ParseError{cursor, fmt.Sprintf("unexpected structured data character %q", buf[cursor])}
+		}
+		cursor++
+	}
+
+	return res, nil
+}

--- a/pkg/syslog/rfc5424/structured_data_test.go
+++ b/pkg/syslog/rfc5424/structured_data_test.go
@@ -1,0 +1,186 @@
+package rfc5424
+
+import (
+	"bytes"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+func (s *S) TestStructuredData(c *C) {
+	table := []struct {
+		sd   *StructuredData
+		want string
+	}{
+		{
+			sd: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+				},
+			},
+			want: `[asdf foo="bar"]`,
+		},
+		{
+			sd: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte("baz"),
+					},
+				},
+			},
+			want: `[asdf foo="bar" bar="baz"]`,
+		},
+		{
+			sd: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\"az`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`baz]"\`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\\`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\a"`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte("baz"),
+					},
+				},
+			},
+			want: `[asdf foo="bar" bar="b\\\"az" bar="baz\]\"\\" bar="b\\\\" bar="b\\a\"" bar="baz"]`,
+		},
+	}
+
+	for _, test := range table {
+		buf := &bytes.Buffer{}
+		test.sd.Encode(buf)
+		c.Assert(buf.String(), Equals, test.want)
+	}
+}
+
+func (s *S) TestStructuredDataParser(c *C) {
+	table := []struct {
+		sd   string
+		want *StructuredData
+	}{
+		{
+			sd: `[asdf foo="bar"]`,
+			want: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+				},
+			},
+		},
+		{
+			sd: `[asdf foo="bar" bar="baz"]`,
+			want: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte("baz"),
+					},
+				},
+			},
+		},
+		{
+			sd: `[asdf foo="bar" bar="b\\\"az" bar="baz\]\"\\" bar="b\\\\" bar="b\a\"" bar="baz"]`,
+			want: &StructuredData{
+				ID: []byte("asdf"),
+				Params: []StructuredDataParam{
+					{
+						Name:  []byte("foo"),
+						Value: []byte("bar"),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\"az`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`baz]"\`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\\`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte(`b\a"`),
+					},
+					{
+						Name:  []byte("bar"),
+						Value: []byte("baz"),
+					},
+				},
+			},
+		},
+		{
+			sd: `[asdf]`,
+			want: &StructuredData{
+				ID:     []byte("asdf"),
+				Params: []StructuredDataParam{},
+			},
+		},
+		{sd: `[asdf  foo="bar" bar="baz"]`},
+		{sd: `[asdf= foo="bar" bar="baz"]`},
+		{sd: `[ foo="bar" bar="baz"]`},
+		{sd: `[foo="bar" bar="baz"]`},
+		{sd: `[asdf="foo" foo="bar" bar="baz"]`},
+		{sd: `[foo="bar" bar="baz" ]`},
+		{sd: `[foo="bar" bar="baz" ]`},
+		{sd: `[foo="bar"  bar="baz"]`},
+		{sd: `[foo="bar" b bar="baz"]`},
+		{sd: `[]`},
+		{sd: `[=]`},
+		{sd: `[`},
+		{sd: ``},
+		{sd: `[bar=`},
+		{sd: `[bar="asdf]`},
+		{sd: `[bar="asdf"] `},
+		{sd: `[bar "asdf"]`},
+		{sd: `[ bar="asdf"]`},
+	}
+
+	for i, test := range table {
+		info := Commentf("i = %d", i)
+		res, err := ParseStructuredData([]byte(test.sd))
+		if test.want == nil {
+			c.Assert(res, IsNil, Commentf("i = %d", i))
+			c.Assert(err, NotNil, Commentf("i = %d", i))
+			continue
+		}
+		c.Assert(err, IsNil, info)
+		c.Assert(res, DeepEquals, test.want, info)
+	}
+}


### PR DESCRIPTION
This is a prerequisite for work I'm doing on logaggregator replication. I also put in a fix for a bug that I found while fuzzing the main parser. Both parsers have been extensively fuzzed with go-fuzz.