### PR TITLE
release: Restore eu-central-1

### DIFF
--- a/installer/app/src/views/aws-region-picker.js.jsx
+++ b/installer/app/src/views/aws-region-picker.js.jsx
@@ -9,6 +9,7 @@ var AWSRegionPicker = React.createClass({
 					<option value="us-east-1">US East (N. Virginia)</option>
 					<option value="us-west-2">US West (Oregon)</option>
 					<option value="us-west-1">US West (N. California)</option>
+					<option value="eu-central-1">EU (Frankfurt)</option>
 					<option value="eu-west-1">EU (Ireland)</option>
 					<option value="ap-southeast-1">Asia Pacific (Singapore)</option>
 					<option value="ap-southeast-2">Asia Pacific (Sydney)</option>

--- a/script/release-vm-images
+++ b/script/release-vm-images
@@ -12,7 +12,7 @@
 #
 # - Install packer
 #   sudo apt-get install -y unzip
-#   wget -O /tmp/packer.zip https://dl.bintray.com/mitchellh/packer/packer_0.7.1_linux_amd64.zip
+#   wget -O /tmp/packer.zip https://dl.bintray.com/mitchellh/packer/packer_0.8.6_linux_amd64.zip
 #   sudo unzip -d /usr/local/bin /tmp/packer.zip
 #   rm /tmp/packer.zip
 #

--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -61,6 +61,7 @@
         "ap-northeast-1",
         "ap-southeast-1",
         "ap-southeast-2",
+        "eu-central-1",
         "eu-west-1",
         "sa-east-1",
         "us-west-1",


### PR DESCRIPTION
Now that Packer has migrated away from goamz v4 signatures are used and eu-central-1 can be supported.

Note: Requires packer version of 0.8.0 or greater.

Closes: #1758