### PR TITLE
Fix git cache directory permissions issues

### DIFF
--- a/gitreceived/gitreceived.go
+++ b/gitreceived/gitreceived.go
@@ -31,7 +31,7 @@ set -eo pipefail;
 git-archive-all() {
 	GIT_DIR="$(pwd)"
 	cd ..
-	git checkout --quiet $1
+	git checkout --force --quiet $1
 	git submodule --quiet update --init --recursive
 	tar --create --exclude-vcs .
 }
@@ -409,7 +409,7 @@ func uploadCache(tempDir, path string) error {
 
 	errCh := make(chan error)
 	go func() {
-		err := archiver.Tar(cachePath, tw)
+		err := archiver.Tar(cachePath, tw, func(n string) bool { return strings.Contains(n, ".git/") })
 		tw.Close()
 		w.Close()
 		errCh <- err

--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-func Tar(dir string, w *tar.Writer) error {
+func Tar(dir string, w *tar.Writer, filter func(string) bool) error {
 	if err := filepath.Walk(dir, func(path string, file os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -25,6 +25,9 @@ func Tar(dir string, w *tar.Writer) error {
 		fpath, err := filepath.Rel(dir, path)
 		if err != nil {
 			return err
+		}
+		if filter != nil && !filter(fpath) {
+			return nil
 		}
 		hdr := &tar.Header{
 			Name:    fpath,

--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -72,7 +72,7 @@ func Untar(dir string, r *tar.Reader) error {
 			}
 		case tar.TypeReg, tar.TypeRegA:
 			// if the files are out of order, the dir might not exist yet
-			if err := os.MkdirAll(filepath.Dir(filename), os.FileMode(header.Mode)); err != nil {
+			if err := os.MkdirAll(filepath.Dir(filename), os.FileMode(header.Mode|0111)); err != nil {
 				return err
 			}
 			writer, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))

--- a/test/apps/build-cache/bin/compile
+++ b/test/apps/build-cache/bin/compile
@@ -11,3 +11,6 @@ if [[ -n "${i}" ]]; then
 else
   echo 0 > "${file}"
 fi
+
+# Ensure there are no regressions for #1757, directories missing the +x bit
+mkdir $1/foo/bar || exit 1


### PR DESCRIPTION
The change in #1617 to checkout a git working directory instead of using `git-archiv`e caused a permissions handling bug that mangled permissions and omitted the +x flag from some directories when the working directory was restored from the repo cache.

This was fixed by stripping the (redundant) checked out working directory when creating the cache. A test was added to verify that the permissions bug does not return.

refs #1757