### PR TITLE
test: Fix controller restart test

### DIFF
--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -89,7 +89,7 @@ func (s *SchedulerSuite) TestControllerRestart(t *c.C) {
 			jobs = append(jobs, job)
 		}
 	}
-	t.Assert(jobs, c.HasLen, 2)
+	t.Assert(jobs, c.HasLen, formation.Processes["web"])
 	jobID := jobs[0].ID
 	hostID, _ := cluster.ExtractHostID(jobID)
 	t.Assert(hostID, c.Not(c.Equals), "")


### PR DESCRIPTION
The test assumed the controller formation would always have 2 processes.
This fixes the test by interrogating the current formation before initiating the restart process.

Closes #1668