### PR TITLE
controller,cli,test: Use Job in place of JobEvent

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -132,8 +132,8 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 	}
 
 	start := time.Now()
-	err = watcher.WaitFor(expected, scaleTimeout, func(e *ct.JobEvent) error {
-		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), e.Type, e.JobID, e.State)
+	err = watcher.WaitFor(expected, scaleTimeout, func(e *ct.Job) error {
+		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), e.Type, e.ID, e.State)
 		return nil
 	})
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -34,12 +34,12 @@ type Client struct {
 }
 
 type JobWatcher struct {
-	events    chan *ct.JobEvent
+	events    chan *ct.Job
 	stream    stream.Stream
 	releaseID string
 }
 
-func newJobWatcher(events chan *ct.JobEvent, stream stream.Stream, releaseID string) *JobWatcher {
+func newJobWatcher(events chan *ct.Job, stream stream.Stream, releaseID string) *JobWatcher {
 	w := &JobWatcher{
 		events:    events,
 		stream:    stream,
@@ -67,7 +67,7 @@ func jobEventsEqual(expected, actual ct.JobEvents) bool {
 	return true
 }
 
-func (w *JobWatcher) WaitFor(expected ct.JobEvents, timeout time.Duration, callback func(*ct.JobEvent) error) error {
+func (w *JobWatcher) WaitFor(expected ct.JobEvents, timeout time.Duration, callback func(*ct.Job) error) error {
 	actual := make(ct.JobEvents)
 	for {
 		select {
@@ -493,7 +493,7 @@ outer:
 }
 
 // StreamJobEvents streams job events to the output channel.
-func (c *Client) StreamJobEvents(appID string, output chan *ct.JobEvent) (stream.Stream, error) {
+func (c *Client) StreamJobEvents(appID string, output chan *ct.Job) (stream.Stream, error) {
 	appEvents := make(chan *ct.Event)
 	go convertEvents(appEvents, output)
 	return c.StreamEvents(StreamEventsOptions{
@@ -503,7 +503,7 @@ func (c *Client) StreamJobEvents(appID string, output chan *ct.JobEvent) (stream
 }
 
 func (c *Client) WatchJobEvents(appID, releaseID string) (*JobWatcher, error) {
-	events := make(chan *ct.JobEvent)
+	events := make(chan *ct.Job)
 	stream, err := c.StreamJobEvents(appID, events)
 	if err != nil {
 		return nil, err

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -57,16 +57,10 @@ func (s *S) TestEvents(c *C) {
 				if !ok {
 					c.Fatalf("unexpected close of event stream: %s", sub.Err)
 				}
-				var jobEvent ct.JobEvent
+				var jobEvent ct.Job
 				c.Assert(json.Unmarshal(e.Data, &jobEvent), IsNil)
 				job := expected[index]
-				c.Assert(jobEvent, DeepEquals, ct.JobEvent{
-					JobID:     job.ID,
-					AppID:     job.AppID,
-					ReleaseID: job.ReleaseID,
-					Type:      job.Type,
-					State:     job.State,
-				})
+				c.Assert(jobEvent, DeepEquals, *job)
 				index += 1
 				if index == len(expected) {
 					return

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -76,19 +76,12 @@ func (r *JobRepo) Add(job *ct.Job) error {
 	}
 
 	// create a job event, ignoring possible duplications
-	e := ct.JobEvent{
-		JobID:     job.ID,
-		AppID:     job.AppID,
-		ReleaseID: job.ReleaseID,
-		Type:      job.Type,
-		State:     job.State,
-	}
-	uniqueID := strings.Join([]string{e.JobID, e.State}, "|")
-	data, err := json.Marshal(e)
+	uniqueID := strings.Join([]string{job.ID, job.State}, "|")
+	data, err := json.Marshal(job)
 	if err != nil {
 		return err
 	}
-	err = r.db.Exec("INSERT INTO events (app_id, object_id, unique_id, object_type, data) VALUES ($1, $2, $3, $4, $5)", e.AppID, e.JobID, uniqueID, string(ct.EventTypeJob), data)
+	err = r.db.Exec("INSERT INTO events (app_id, object_id, unique_id, object_type, data) VALUES ($1, $2, $3, $4, $5)", job.AppID, job.ID, uniqueID, string(ct.EventTypeJob), data)
 	if postgres.IsUniquenessError(err, "") {
 		return nil
 	}

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -95,15 +95,7 @@ type Job struct {
 	UpdatedAt *time.Time        `json:"updated_at,omitempty"`
 }
 
-type JobEvent struct {
-	JobID     string `json:"job_id,omitempty"`
-	AppID     string `json:"app,omitempty"`
-	ReleaseID string `json:"release,omitempty"`
-	Type      string `json:"type,omitempty"`
-	State     string `json:"state,omitempty"`
-}
-
-func (e *JobEvent) IsDown() bool {
+func (e *Job) IsDown() bool {
 	return e.State == "failed" || e.State == "crashed" || e.State == "down"
 }
 

--- a/controller/worker/deployment/postgres.go
+++ b/controller/worker/deployment/postgres.go
@@ -223,7 +223,7 @@ loop:
 			if !ok {
 				return loggedErr("unexpected close of job event stream")
 			}
-			log.Info("got job event", "job_id", event.JobID, "type", event.Type, "state", event.State)
+			log.Info("got job event", "job_id", event.ID, "type", event.Type, "state", event.State)
 			if event.State == "down" && event.Type == "postgres" && event.ReleaseID == d.OldReleaseID {
 				actual++
 				if actual == d.Processes["postgres"] {

--- a/receiver/flynn-receive.go
+++ b/receiver/flynn-receive.go
@@ -156,7 +156,7 @@ func main() {
 		}
 		fmt.Println("=====> Waiting for web job to start...")
 
-		err = watcher.WaitFor(ct.JobEvents{"web": {"up": 1}}, scaleTimeout, func(e *ct.JobEvent) error {
+		err = watcher.WaitFor(ct.JobEvents{"web": {"up": 1}}, scaleTimeout, func(e *ct.Job) error {
 			switch e.State {
 			case "up":
 				fmt.Println("=====> Default web formation scaled to 1")

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -67,8 +67,8 @@ func (a *cliTestApp) flynnCmd(args ...string) *exec.Cmd {
 
 func (a *cliTestApp) waitFor(events ct.JobEvents) string {
 	var id string
-	idSetter := func(e *ct.JobEvent) error {
-		id = e.JobID
+	idSetter := func(e *ct.Job) error {
+		id = e.ID
 		return nil
 	}
 
@@ -210,14 +210,14 @@ func (s *CLISuite) TestScale(t *c.C) {
 	defer app.cleanup()
 
 	assertEventOutput := func(scale *CmdResult, events ct.JobEvents) {
-		var actual []*ct.JobEvent
-		f := func(e *ct.JobEvent) error {
+		var actual []*ct.Job
+		f := func(e *ct.Job) error {
 			actual = append(actual, e)
 			return nil
 		}
 		t.Assert(app.watcher.WaitFor(events, scaleTimeout, f), c.IsNil)
 		for _, e := range actual {
-			t.Assert(scale, OutputContains, fmt.Sprintf("==> %s %s %s", e.Type, e.JobID, e.State))
+			t.Assert(scale, OutputContains, fmt.Sprintf("==> %s %s %s", e.Type, e.ID, e.State))
 		}
 	}
 

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -228,8 +228,8 @@ func (s *ControllerSuite) TestResourceLimitsReleaseJob(t *c.C) {
 		Processes: map[string]int{"resources": 1},
 	}), c.IsNil)
 	var jobID string
-	err = watcher.WaitFor(ct.JobEvents{"resources": {"up": 1, "down": 1}}, scaleTimeout, func(e *ct.JobEvent) error {
-		jobID = e.JobID
+	err = watcher.WaitFor(ct.JobEvents{"resources": {"up": 1, "down": 1}}, scaleTimeout, func(e *ct.Job) error {
+		jobID = e.ID
 		return nil
 	})
 	t.Assert(err, c.IsNil)
@@ -444,7 +444,7 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 	app2, release2 := s.createApp(t)
 
 	// stream events for app1
-	events := make(chan *ct.JobEvent)
+	events := make(chan *ct.Job)
 	stream, err := client.StreamJobEvents(app1.ID, events)
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
@@ -467,7 +467,7 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 	t.Assert(watcher.WaitFor(
 		ct.JobEvents{"": {"up": 1, "down": 1}},
 		10*time.Second,
-		func(e *ct.JobEvent) error {
+		func(e *ct.Job) error {
 			debugf(t, "got %s job event for app2", e.State)
 			return nil
 		},

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -139,7 +139,7 @@ func (s *PostgresSuite) testDeploy(t *c.C, d *pgDeploy) {
 	discStream, err := s.discoverdClient(t).Service(d.name).Watch(discEvents)
 	t.Assert(err, c.IsNil)
 	defer discStream.Close()
-	jobEvents := make(chan *ct.JobEvent)
+	jobEvents := make(chan *ct.Job)
 	jobStream, err := client.StreamJobEvents(d.name, jobEvents)
 	t.Assert(err, c.IsNil)
 	defer jobStream.Close()
@@ -213,7 +213,7 @@ func (s *PostgresSuite) testDeploy(t *c.C, d *pgDeploy) {
 			if !ok {
 				t.Fatalf("job event stream closed: %s", jobStream.Err())
 			}
-			debugf(t, "got job event: %s %s %s", e.Type, e.JobID, e.State)
+			debugf(t, "got job event: %s %s %s", e.Type, e.ID, e.State)
 			if e.Type == "web" && e.State == "up" {
 				webJobs++
 			}

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -281,8 +281,8 @@ func (s *SchedulerSuite) TestJobRestartBackoffPolicy(t *c.C) {
 		Processes: map[string]int{"printer": 1},
 	}), c.IsNil)
 	var id string
-	var assignId = func(e *ct.JobEvent) error {
-		id = e.JobID
+	var assignId = func(e *ct.Job) error {
+		id = e.ID
 		return nil
 	}
 	err = watcher.WaitFor(ct.JobEvents{"printer": {"up": 1}}, scaleTimeout, assignId)


### PR DESCRIPTION
This makes the events endpoint more useful for apps such as the dashboard which need job meta for identification (e.g. in the case of taffy jobs).

Dependency of #1768 