### PR TITLE
controller: Create app_release event instead of app event when setting app release

### DIFF
--- a/controller/schema.go
+++ b/controller/schema.go
@@ -43,7 +43,7 @@ func migrateDB(db *sql.DB) error {
 		`CREATE UNIQUE INDEX ON apps (name) WHERE deleted_at IS NULL`,
 
 		`CREATE SEQUENCE event_ids`,
-		`CREATE TYPE event_type AS ENUM ('app_deletion', 'app', 'deployment', 'job', 'scale', 'release', 'artifact', 'provider', 'resource', 'resource_deletion', 'key', 'key_deletion', 'route', 'route_deletion')`,
+		`CREATE TYPE event_type AS ENUM ('app_deletion', 'app', 'app_release', 'deployment', 'job', 'scale', 'release', 'artifact', 'provider', 'resource', 'resource_deletion', 'key', 'key_deletion', 'route', 'route_deletion')`,
 		`CREATE TABLE events (
     event_id    bigint         PRIMARY KEY DEFAULT nextval('event_ids'),
     app_id      uuid           REFERENCES apps (app_id),

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -191,6 +191,7 @@ type EventType string
 const (
 	EventTypeApp              EventType = "app"
 	EventTypeAppDeletion      EventType = "app_deletion"
+	EventTypeAppRelease       EventType = "app_release"
 	EventTypeDeployment       EventType = "deployment"
 	EventTypeJob              EventType = "job"
 	EventTypeScale            EventType = "scale"


### PR DESCRIPTION
This makes watching for app releases much easier (i.e. not having to hold onto all release events until an app event containing the release id is received).

Dependency of #1768 