### PR TITLE
Revert "util/cedarish: Add postgres client libraries"

### DIFF
--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -43,7 +43,6 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.li
       openjdk-7-jre-headless \
       openssh-client \
       openssh-server \
-      postgresql-client-dev-9.3 \
       postgresql-server-dev-9.3 \
       python \
       python-dev \


### PR DESCRIPTION
Reverts flynn/flynn#1749

Something about this is broken, the package doesn't appear to exist.