### PR TITLE
router: Report conflict on duplicate route

### DIFF
--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -383,6 +383,11 @@ func (s *CLISuite) TestRoute(t *c.C) {
 	routeID := strings.TrimSpace(newRoute.Output)
 	assertRouteContains(routeID, true)
 
+	// duplicate http route
+	dupRoute := app.flynn("route", "add", "http", "--sticky", route)
+	t.Assert(dupRoute, c.Not(Succeeds))
+	t.Assert(dupRoute.Output, c.Equals, "conflict: Duplicate route\n")
+
 	// ensure sticky flag is set
 	routes, err := s.controllerClient(t).RouteList(app.name)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
If the router receives a request to add a duplicate route it will now respond with a 409 Conflict.

The resultant error on the command line now looks like this:

```
$ flynn route add http example.com
conflict: Duplicate route
$ echo $?
1
```

Closes #708 