### PR TITLE
cli: Allow selecting port for TCP routes

### DIFF
--- a/cli/route.go
+++ b/cli/route.go
@@ -18,7 +18,7 @@ func init() {
 	register("route", runRoute, `
 usage: flynn route
        flynn route add http [-s <service>] [-c <tls-cert> -k <tls-key>] [--sticky] <domain>
-       flynn route add tcp [-s <service>]
+       flynn route add tcp [-s <service>] [-p <port>]
        flynn route remove <id>
 
 Manage routes for application.
@@ -28,6 +28,7 @@ Options:
 	-c, --tls-cert=<tls-cert>  path to PEM encoded certificate for TLS, - for stdin (http only)
 	-k, --tls-key=<tls-key>    path to PEM encoded private key for TLS, - for stdin (http only)
 	--sticky                   enable cookie-based sticky routing (http only)
+	-p, --port=<port>          port to accept traffic on (tcp only)
 
 Commands:
 	With no arguments, shows a list of routes.
@@ -93,7 +94,16 @@ func runRouteAddTCP(args *docopt.Args, client *controller.Client) error {
 		service = mustApp() + "-web"
 	}
 
-	hr := &router.TCPRoute{Service: service}
+	port := 0
+	if args.String["--port"] != "" {
+		p, err := strconv.Atoi(args.String["--port"])
+		if err != nil {
+			return err
+		}
+		port = p
+	}
+
+	hr := &router.TCPRoute{Service: service, Port: port}
 	r := hr.ToRoute()
 	if err := client.CreateRoute(mustApp(), r); err != nil {
 		return err

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -406,6 +406,13 @@ func (s *CLISuite) TestRoute(t *c.C) {
 	routeID = strings.Split(tcpRoute.Output, " ")[0]
 	assertRouteContains(routeID, true)
 
+	// flynn route add tcp --port
+	portRoute := app.flynn("route", "add", "tcp", "--port", "9999")
+	t.Assert(portRoute, Succeeds)
+	routeID = strings.Split(portRoute.Output, " ")[0]
+	port := strings.Split(portRoute.Output, " ")[4]
+	t.Assert(port, c.Equals, "9999\n")
+
 	// flynn route remove
 	t.Assert(app.flynn("route", "remove", routeID), Succeeds)
 	assertRouteContains(routeID, false)


### PR DESCRIPTION
Allows users to specify the port they wish to allocate.
If the port is take it will return a duplicate route error.

Closes #1524