### PR TITLE
blobstore: Migrate to pgx

### DIFF
--- a/blobstore/blobstore.go
+++ b/blobstore/blobstore.go
@@ -110,6 +110,7 @@ func main() {
 		if err != nil {
 			shutdown.Fatal(err)
 		}
+		db.Close() // not used once pgx is connected
 		storageDesc = "Postgres"
 	}
 

--- a/router/data_store.go
+++ b/router/data_store.go
@@ -10,7 +10,7 @@ import (
 	"github.com/flynn/flynn/router/types"
 )
 
-const UniqueConstraintViolation = "23505"
+const UniqueViolation = "23505"
 
 var ErrNotFound = errors.New("router: route not found")
 var ErrConflict = errors.New("router: duplicate route")
@@ -106,7 +106,7 @@ func (d *pgDataStore) Add(r *router.Route) (err error) {
 		).Scan(&r.ID, &r.CreatedAt, &r.UpdatedAt)
 	}
 	r.Type = d.routeType
-	if e, ok := err.(pgx.PgError); ok && e.Code == UniqueConstraintViolation {
+	if e, ok := err.(pgx.PgError); ok && e.Code == UniqueViolation {
 		err = ErrConflict
 	}
 	return err


### PR DESCRIPTION
Migrates the actual datapath of blobstore to pgx but retains logic tied to pkg/postgres for now for migrations etc.

Migration of pkg/postgres to follow.

Closes #988