### PR TITLE
scheduler: Simplify main loop select

### DIFF
--- a/controller/Tupfile
+++ b/controller/Tupfile
@@ -1,6 +1,6 @@
 include_rules
 : |> !go |> bin/flynn-controller
-: |> !go ./scheduler |> bin/flynn-scheduler
+: |> !go ./scheduler-v2 |> bin/flynn-scheduler
 : |> !go ./worker |> bin/flynn-worker
 : foreach $(ROOT)/schema/*.json |> !cp |> bin/jsonschema/%g.json
 : foreach $(ROOT)/schema/controller/*.json |> !cp |> bin/jsonschema/controller/%g.json

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -112,7 +112,7 @@ func main() {
 
 	handler := appHandler(handlerConfig{
 		db:      db,
-		cc:      clusterClientWrapper{cluster.NewClient()},
+		cc:      utils.ClusterClientWrapper(cluster.NewClient()),
 		lc:      lc,
 		rc:      rc,
 		pgxpool: pgxpool,

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -186,7 +186,7 @@ func streamRouterEvents(rc routerc.Client, db *postgres.DB, doneCh chan struct{}
 
 type handlerConfig struct {
 	db      *postgres.DB
-	cc      clusterClient
+	cc      utils.ClusterClient
 	lc      logaggc.Client
 	rc      routerc.Client
 	pgxpool *pgx.ConnPool
@@ -337,7 +337,7 @@ type controllerAPI struct {
 	resourceRepo   *ResourceRepo
 	deploymentRepo *DeploymentRepo
 	eventRepo      *EventRepo
-	clusterClient  clusterClient
+	clusterClient  utils.ClusterClient
 	logaggc        logaggc.Client
 	routerc        routerc.Client
 	que            *que.Client

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
+	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -142,9 +143,9 @@ func (c clusterClientWrapper) Hosts() ([]utils.HostClient, error) {
 	return res, nil
 }
 
-func (c clusterClientWrapper) StreamHosts(ch chan utils.HostClient) (stream.Stream, error) {
-	hostChan := make(chan *cluster.Host)
-	stream, err := c.Client.StreamHosts(hostChan)
+func (c clusterClientWrapper) StreamHostEvents(ch chan *discoverd.Event) (stream.Stream, error) {
+	hostChan := make(chan *discoverd.Event)
+	stream, err := c.Client.StreamHostEvents(hostChan)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (c clusterClientWrapper) StreamHosts(ch chan utils.HostClient) (stream.Stre
 }
 
 type clusterStream struct {
-	ch           chan utils.HostClient
+	ch           chan *discoverd.Event
 	parentStream stream.Stream
 }
 

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -242,6 +242,9 @@ func (c *controllerAPI) KillJob(ctx context.Context, w http.ResponseWriter, req 
 	}
 
 	if err = client.StopJob(jobID); err != nil {
+		if _, ok := err.(ct.NotFoundError); ok {
+			err = ErrNotFound
+		}
 		respondWithError(w, err)
 		return
 	}

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -141,11 +141,6 @@ func (c clusterClientWrapper) Hosts() ([]utils.HostClient, error) {
 	return res, nil
 }
 
-type clusterClient interface {
-	Host(string) (utils.HostClient, error)
-	Hosts() ([]utils.HostClient, error)
-}
-
 func (c *controllerAPI) connectHost(ctx context.Context) (utils.HostClient, string, error) {
 	params, _ := ctxhelper.ParamsFromContext(ctx)
 	jobID := params.ByName("jobs_id")

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	controller "github.com/flynn/flynn/controller/client"
 	tu "github.com/flynn/flynn/controller/testutils"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
@@ -95,7 +96,7 @@ func (s *S) TestKillJob(c *C) {
 	s.cc.AddHost(hc)
 
 	err := s.c.DeleteJob(app.ID, jobID)
-	c.Assert(err, ErrorMatches, "controller: resource not found")
+	c.Assert(err, Equals, controller.ErrNotFound)
 	c.Assert(hc.IsStopped(jobID), Equals, true)
 }
 

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -125,25 +125,29 @@ func (s *S) TestRunJobDetached(c *C) {
 	c.Assert(res.Type, Equals, "")
 	c.Assert(res.Cmd, DeepEquals, cmd)
 
-	job := host.Jobs[0]
-	c.Assert(res.ID, Equals, job.ID)
-	c.Assert(job.Metadata, DeepEquals, map[string]string{
-		"flynn-controller.app":      app.ID,
-		"flynn-controller.app_name": app.Name,
-		"flynn-controller.release":  release.ID,
-		"foo": "baz",
-	})
-	c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
-	c.Assert(job.Config.Env, DeepEquals, map[string]string{
-		"FLYNN_APP_ID":       app.ID,
-		"FLYNN_RELEASE_ID":   release.ID,
-		"FLYNN_PROCESS_TYPE": "",
-		"FLYNN_JOB_ID":       job.ID,
-		"FOO":                "baz",
-		"JOB":                "true",
-		"RELEASE":            "true",
-	})
-	c.Assert(job.Config.Stdin, Equals, false)
+	jobs, err := host.ListJobs()
+	c.Assert(err, IsNil)
+	for _, j := range jobs {
+		job := j.Job
+		c.Assert(res.ID, Equals, job.ID)
+		c.Assert(job.Metadata, DeepEquals, map[string]string{
+			"flynn-controller.app":      app.ID,
+			"flynn-controller.app_name": app.Name,
+			"flynn-controller.release":  release.ID,
+			"foo": "baz",
+		})
+		c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
+		c.Assert(job.Config.Env, DeepEquals, map[string]string{
+			"FLYNN_APP_ID":       app.ID,
+			"FLYNN_RELEASE_ID":   release.ID,
+			"FLYNN_PROCESS_TYPE": "",
+			"FLYNN_JOB_ID":       job.ID,
+			"FOO":                "baz",
+			"JOB":                "true",
+			"RELEASE":            "true",
+		})
+		c.Assert(job.Config.Stdin, Equals, false)
+	}
 }
 
 func (s *S) TestRunJobAttached(c *C) {
@@ -204,23 +208,27 @@ func (s *S) TestRunJobAttached(c *C) {
 	c.Assert(string(stdout), Equals, "test out")
 	rwc.Close()
 
-	job := hc.Jobs[0]
-	c.Assert(job.ID, Equals, jobID)
-	c.Assert(job.Metadata, DeepEquals, map[string]string{
-		"flynn-controller.app":      app.ID,
-		"flynn-controller.app_name": app.Name,
-		"flynn-controller.release":  release.ID,
-		"foo": "baz",
-	})
-	c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
-	c.Assert(job.Config.Env, DeepEquals, map[string]string{
-		"FLYNN_APP_ID":       app.ID,
-		"FLYNN_RELEASE_ID":   release.ID,
-		"FLYNN_PROCESS_TYPE": "",
-		"FLYNN_JOB_ID":       job.ID,
-		"FOO":                "baz",
-		"JOB":                "true",
-		"RELEASE":            "true",
-	})
-	c.Assert(job.Config.Stdin, Equals, true)
+	jobs, err := hc.ListJobs()
+	c.Assert(err, IsNil)
+	for _, j := range jobs {
+		job := j.Job
+		c.Assert(job.ID, Equals, jobID)
+		c.Assert(job.Metadata, DeepEquals, map[string]string{
+			"flynn-controller.app":      app.ID,
+			"flynn-controller.app_name": app.Name,
+			"flynn-controller.release":  release.ID,
+			"foo": "baz",
+		})
+		c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
+		c.Assert(job.Config.Env, DeepEquals, map[string]string{
+			"FLYNN_APP_ID":       app.ID,
+			"FLYNN_RELEASE_ID":   release.ID,
+			"FLYNN_PROCESS_TYPE": "",
+			"FLYNN_JOB_ID":       job.ID,
+			"FOO":                "baz",
+			"JOB":                "true",
+			"RELEASE":            "true",
+		})
+		c.Assert(job.Config.Stdin, Equals, true)
+	}
 }

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -94,7 +94,8 @@ func (s *S) TestKillJob(c *C) {
 	hc := tu.NewFakeHostClient(hostID)
 	s.cc.AddHost(hc)
 
-	c.Assert(s.c.DeleteJob(app.ID, jobID), IsNil)
+	err := s.c.DeleteJob(app.ID, jobID)
+	c.Assert(err, ErrorMatches, "controller: resource not found")
 	c.Assert(hc.IsStopped(jobID), Equals, true)
 }
 

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -167,7 +167,7 @@ func (fc pendingJobs) GetHostJobCounts(key utils.FormationKey, typ string) map[s
 	return counts
 }
 
-func (fc pendingJobs) hasPendingJobs(j *Job) bool {
+func (fc pendingJobs) HasStarts(j *Job) bool {
 	if j == nil || j.Formation == nil {
 		return false
 	}
@@ -178,19 +178,5 @@ func (fc pendingJobs) hasPendingJobs(j *Job) bool {
 	if _, ok := fc[key][j.Type]; !ok {
 		return false
 	}
-	return true
-}
-
-func (fc pendingJobs) HasStarts(j *Job) bool {
-	if fc.hasPendingJobs(j) {
-		return fc[j.Formation.key()][j.Type][j.HostID] > 0
-	}
-	return false
-}
-
-func (fc pendingJobs) HasStops(j *Job) bool {
-	if fc.hasPendingJobs(j) {
-		return fc[j.Formation.key()][j.Type][j.HostID] < 0
-	}
-	return false
+	return fc[j.Formation.key()][j.Type][j.HostID] > 0
 }

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -54,10 +54,16 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 
 type formationJobs map[utils.FormationKey]map[string][]*Job
 
-func NewFormationJobs(jobs map[string]*Job) formationJobs {
+func NewFormationJobs(jobs map[string]*Job, requests map[*JobRequest]struct{}) formationJobs {
 	fj := make(formationJobs)
 	for _, job := range jobs {
 		fj.AddJob(job)
+	}
+
+	for req := range requests {
+		if req.RequestType == JobRequestTypeUp {
+			fj.AddJob(req.Job)
+		}
 	}
 	return fj
 }

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -39,11 +39,17 @@ func (f *Formation) key() utils.FormationKey {
 func (f *Formation) Update(procs map[string]int) map[string]int {
 	diff := make(map[string]int)
 	for typ, requested := range procs {
+		if typ == "" {
+			continue
+		}
 		current := f.Processes[typ]
 		diff[typ] = requested - current
 	}
 
 	for typ, current := range f.Processes {
+		if typ == "" {
+			continue
+		}
 		if _, ok := procs[typ]; !ok {
 			diff[typ] = -current
 		}
@@ -140,8 +146,9 @@ func (fc pendingJobs) GetProcesses(key utils.FormationKey) map[string]int {
 	procs := make(map[string]int)
 	for typ, hosts := range fc[key] {
 		for _, numJobs := range hosts {
-			if numJobs != 0 {
-				procs[typ] += numJobs
+			procs[typ] += numJobs
+			if procs[typ] == 0 {
+				delete(procs, typ)
 			}
 		}
 	}

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -52,17 +52,9 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 	return diff
 }
 
-type formationCounts map[utils.FormationKey]map[string]int
+type formationJobs map[utils.FormationKey]map[string]int
 
-func NewFormationCounts(fs Formations) formationCounts {
-	fc := make(formationCounts)
-	for fKey := range fs {
-		fc[fKey] = make(map[string]int)
-	}
-	return fc
-}
-
-func (fc formationCounts) AddJob(j *Job) {
+func (fc formationJobs) AddJob(j *Job) {
 	key := j.Formation.key()
 	f, ok := fc[key]
 	if !ok {

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -51,3 +51,23 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 	f.Processes = procs
 	return diff
 }
+
+type formationCounts map[utils.FormationKey]map[string]int
+
+func NewFormationCounts(fs Formations) formationCounts {
+	fc := make(formationCounts)
+	for fKey := range fs {
+		fc[fKey] = make(map[string]int)
+	}
+	return fc
+}
+
+func (fc formationCounts) AddJob(j *Job) {
+	key := j.Formation.key()
+	f, ok := fc[key]
+	if !ok {
+		fc[key] = make(map[string]int)
+		f = fc[key]
+	}
+	f[j.Type]++
+}

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/utils"
+	"github.com/flynn/flynn/host/types"
+)
+
+type Formations struct {
+	formations map[utils.FormationKey]*Formation
+}
+
+func newFormations() *Formations {
+	return &Formations{
+		formations: make(map[utils.FormationKey]*Formation),
+	}
+}
+
+func (fs *Formations) Get(appID, releaseID string) *Formation {
+	if form, ok := fs.formations[utils.FormationKey{AppID: appID, ReleaseID: releaseID}]; ok {
+		return form
+	}
+	return nil
+}
+
+func (fs *Formations) Add(f *Formation) *Formation {
+	if existing, ok := fs.formations[f.key()]; ok {
+		return existing
+	}
+	fs.formations[f.key()] = f
+	return f
+}
+
+func (fs *Formations) RectifyAll() error {
+	for _, f := range fs.formations {
+		err := f.Rectify()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type Formation struct {
+	*ct.ExpandedFormation
+
+	jobs jobTypeMap
+	s    *Scheduler
+}
+
+func NewFormation(s *Scheduler, ef *ct.ExpandedFormation) *Formation {
+	return &Formation{
+		ExpandedFormation: ef,
+		jobs:              make(jobTypeMap),
+		s:                 s,
+	}
+}
+
+func (f *Formation) key() utils.FormationKey {
+	return utils.FormationKey{f.App.ID, f.Release.ID}
+}
+
+func (f *Formation) GetJobsForType(typ string) map[jobKey]*Job {
+	return f.jobs[typ]
+}
+
+func (f *Formation) SetFormation(ef *ct.ExpandedFormation) {
+	f.ExpandedFormation = ef
+}
+
+func (f *Formation) Rectify() error {
+	log := f.s.log.New("fn", "rectify")
+	log.Info("rectifying formation", "app.id", f.App.ID, "release.id", f.Release.ID)
+
+	for t, expected := range f.Processes {
+		actual := len(f.jobs[t])
+		diff := expected - actual
+		if diff > 0 {
+			f.sendJobRequest(JobRequestTypeUp, diff, t, "", "")
+		} else if diff < 0 {
+			f.sendJobRequest(JobRequestTypeDown, -diff, t, "", "")
+		}
+	}
+
+	// remove extraneous process types
+	for t, jobs := range f.jobs {
+		// ignore jobs that don't have a type
+		if t == "" {
+			continue
+		}
+
+		if _, exists := f.Processes[t]; !exists {
+			f.sendJobRequest(JobRequestTypeDown, len(jobs), t, "", "")
+		}
+	}
+	return nil
+}
+
+func (f *Formation) sendJobRequest(requestType JobRequestType, numJobs int, typ string, hostID, jobID string) {
+	for i := 0; i < numJobs; i++ {
+		f.s.jobRequests <- NewJobRequest(requestType, typ, f.App.ID, f.Release.ID, hostID, jobID)
+	}
+}
+
+func (f *Formation) handleJobRequest(req *JobRequest) (err error) {
+	log := f.s.log.New("fn", "handleJobRequest")
+	defer func() {
+		if err != nil {
+			log.Error("error handling job request", "error", err)
+		}
+	}()
+
+	switch req.RequestType {
+	case JobRequestTypeUp:
+		_, err = f.startJob(req)
+	case JobRequestTypeDown:
+		err = f.stopJob(req)
+	default:
+		return fmt.Errorf("Unknown job request type")
+	}
+	return err
+}
+
+func (f *Formation) startJob(req *JobRequest) (job *Job, err error) {
+	log := f.s.log.New("fn", "startJob")
+	defer func() {
+		if err != nil {
+			log.Error("error starting job", "error", err)
+		} else {
+			log.Info("started job", "host.id", job.HostID, "job.type", job.JobType, "job.id", job.JobID)
+		}
+		f.s.sendEvent(NewEvent(EventTypeJobStart, err, job))
+	}()
+	h, err := f.findBestHost(req.JobType, req.HostID)
+	if err != nil {
+		return nil, err
+	}
+
+	hostJob := f.configureJob(req.JobType, h.ID())
+
+	// Provision a data volume on the host if needed.
+	if f.Release.Processes[req.JobType].Data {
+		if err := utils.ProvisionVolume(h, hostJob); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := h.AddJob(hostJob); err != nil {
+		return nil, err
+	}
+	job, err = f.s.AddJob(
+		NewJob(req.JobType, f.App.ID, f.Release.ID, h.ID(), hostJob.ID),
+		f.App.Name,
+		utils.JobMetaFromMetadata(hostJob.Metadata),
+	)
+	return job, err
+}
+
+func (f *Formation) stopJob(req *JobRequest) (err error) {
+	log := f.s.log.New("fn", "stopJob")
+	defer func() {
+		if err != nil {
+			log.Error("error stopping job", "error", err)
+		}
+		f.s.sendEvent(NewEvent(EventTypeJobStop, err, nil))
+	}()
+	h, err := f.s.Host(req.HostID)
+	if err != nil {
+		return err
+	}
+
+	if err := h.StopJob(req.JobID); err != nil {
+		return err
+	}
+	f.s.RemoveJob(req.JobID)
+	return nil
+}
+
+func (f *Formation) configureJob(typ, hostID string) *host.Job {
+	return utils.JobConfig(&ct.ExpandedFormation{
+		App:      &ct.App{ID: f.App.ID, Name: f.App.Name},
+		Release:  f.Release,
+		Artifact: f.Artifact,
+	}, typ, hostID)
+}
+
+func (f *Formation) findBestHost(typ, hostID string) (utils.HostClient, error) {
+	hosts, err := f.s.Hosts()
+	if err != nil {
+		return nil, err
+	}
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("scheduler: no online hosts")
+	}
+
+	if hostID == "" {
+		hostMap := f.getHostMap(typ)
+		var minCount int = math.MaxInt32
+		for _, host := range hosts {
+			jobCount := hostMap[host.ID()]
+			if jobCount < minCount {
+				minCount = jobCount
+				hostID = host.ID()
+			}
+		}
+	}
+	if hostID == "" {
+		return nil, fmt.Errorf("no host found")
+	}
+	h, err := f.s.Host(hostID)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+func (f *Formation) getHostMap(typ string) map[string]int {
+	hostMap := make(map[string]int)
+	for _, j := range f.jobs[typ] {
+		hostMap[j.HostID]++
+	}
+	return hostMap
+}
+
+func (f *Formation) jobType(job *host.Job) string {
+	if job.Metadata["flynn-controller.app"] != f.App.ID ||
+		job.Metadata["flynn-controller.release"] != f.Release.ID {
+		return ""
+	}
+	return job.Metadata["flynn-controller.type"]
+}

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -52,14 +52,23 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 	return diff
 }
 
-type formationProcesses map[utils.FormationKey]map[string]int
+type formationJobs map[utils.FormationKey]map[string][]*Job
 
-func (fc formationProcesses) AddJob(j *Job) {
+func (fc formationJobs) AddJob(j *Job) {
 	key := j.Formation.key()
-	f, ok := fc[key]
+	_, ok := fc[key]
 	if !ok {
-		fc[key] = make(map[string]int)
-		f = fc[key]
+		fc[key] = make(map[string][]*Job)
 	}
-	f[j.Type]++
+	fc[key][j.Type] = append(fc[key][j.Type], j)
+}
+
+func (fc formationJobs) GetProcesses(key utils.FormationKey) map[string]int {
+	procs := make(map[string]int)
+
+	for typ, jobs := range fc[key] {
+		procs[typ] = len(jobs)
+	}
+
+	return procs
 }

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -54,6 +54,14 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 
 type formationJobs map[utils.FormationKey]map[string][]*Job
 
+func NewFormationJobs(jobs map[string]*Job) formationJobs {
+	fj := make(formationJobs)
+	for _, job := range jobs {
+		fj.AddJob(job)
+	}
+	return fj
+}
+
 func (fc formationJobs) AddJob(j *Job) {
 	key := j.Formation.key()
 	_, ok := fc[key]

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -1,234 +1,53 @@
 package main
 
 import (
-	"fmt"
-	"math"
-
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
-	"github.com/flynn/flynn/host/types"
 )
 
-type Formations struct {
-	formations map[utils.FormationKey]*Formation
-}
+type Formations map[utils.FormationKey]*Formation
 
-func newFormations() *Formations {
-	return &Formations{
-		formations: make(map[utils.FormationKey]*Formation),
-	}
-}
-
-func (fs *Formations) Get(appID, releaseID string) *Formation {
-	if form, ok := fs.formations[utils.FormationKey{AppID: appID, ReleaseID: releaseID}]; ok {
+func (fs Formations) Get(appID, releaseID string) *Formation {
+	if form, ok := fs[utils.FormationKey{AppID: appID, ReleaseID: releaseID}]; ok {
 		return form
 	}
 	return nil
 }
 
-func (fs *Formations) Add(f *Formation) *Formation {
-	if existing, ok := fs.formations[f.key()]; ok {
+func (fs Formations) Add(f *Formation) *Formation {
+	if existing, ok := fs[f.key()]; ok {
 		return existing
 	}
-	fs.formations[f.key()] = f
+	fs[f.key()] = f
 	return f
-}
-
-func (fs *Formations) RectifyAll() error {
-	for _, f := range fs.formations {
-		err := f.Rectify()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 type Formation struct {
 	*ct.ExpandedFormation
-
-	jobs jobTypeMap
-	s    *Scheduler
 }
 
-func NewFormation(s *Scheduler, ef *ct.ExpandedFormation) *Formation {
-	return &Formation{
-		ExpandedFormation: ef,
-		jobs:              make(jobTypeMap),
-		s:                 s,
-	}
+func NewFormation(ef *ct.ExpandedFormation) *Formation {
+	return &Formation{ef}
 }
 
 func (f *Formation) key() utils.FormationKey {
 	return utils.FormationKey{f.App.ID, f.Release.ID}
 }
 
-func (f *Formation) GetJobsForType(typ string) map[jobKey]*Job {
-	return f.jobs[typ]
-}
+// Update stores the new processes and returns the diff from the previous
+// processes.
+func (f *Formation) Update(procs map[string]int) map[string]int {
+	diff := make(map[string]int)
+	for typ, requested := range procs {
+		current := f.Processes[typ]
+		diff[typ] = requested - current
+	}
 
-func (f *Formation) SetFormation(ef *ct.ExpandedFormation) {
-	f.ExpandedFormation = ef
-}
-
-func (f *Formation) Rectify() error {
-	log := f.s.log.New("fn", "rectify")
-	log.Info("rectifying formation", "app.id", f.App.ID, "release.id", f.Release.ID)
-
-	for t, expected := range f.Processes {
-		actual := len(f.jobs[t])
-		diff := expected - actual
-		if diff > 0 {
-			f.sendJobRequest(JobRequestTypeUp, diff, t, "", "")
-		} else if diff < 0 {
-			f.sendJobRequest(JobRequestTypeDown, -diff, t, "", "")
+	for typ, current := range f.Processes {
+		if _, ok := procs[typ]; !ok {
+			diff[typ] = -current
 		}
 	}
-
-	// remove extraneous process types
-	for t, jobs := range f.jobs {
-		// ignore jobs that don't have a type
-		if t == "" {
-			continue
-		}
-
-		if _, exists := f.Processes[t]; !exists {
-			f.sendJobRequest(JobRequestTypeDown, len(jobs), t, "", "")
-		}
-	}
-	return nil
-}
-
-func (f *Formation) sendJobRequest(requestType JobRequestType, numJobs int, typ string, hostID, jobID string) {
-	for i := 0; i < numJobs; i++ {
-		f.s.jobRequests <- NewJobRequest(requestType, typ, f.App.ID, f.Release.ID, hostID, jobID)
-	}
-}
-
-func (f *Formation) handleJobRequest(req *JobRequest) (err error) {
-	log := f.s.log.New("fn", "handleJobRequest")
-	defer func() {
-		if err != nil {
-			log.Error("error handling job request", "error", err)
-		}
-	}()
-
-	switch req.RequestType {
-	case JobRequestTypeUp:
-		_, err = f.startJob(req)
-	case JobRequestTypeDown:
-		err = f.stopJob(req)
-	default:
-		return fmt.Errorf("Unknown job request type")
-	}
-	return err
-}
-
-func (f *Formation) startJob(req *JobRequest) (job *Job, err error) {
-	log := f.s.log.New("fn", "startJob")
-	defer func() {
-		if err != nil {
-			log.Error("error starting job", "error", err)
-		} else {
-			log.Info("started job", "host.id", job.HostID, "job.type", job.JobType, "job.id", job.JobID)
-		}
-		f.s.sendEvent(NewEvent(EventTypeJobStart, err, job))
-	}()
-	h, err := f.findBestHost(req.JobType, req.HostID)
-	if err != nil {
-		return nil, err
-	}
-
-	hostJob := f.configureJob(req.JobType, h.ID())
-
-	// Provision a data volume on the host if needed.
-	if f.Release.Processes[req.JobType].Data {
-		if err := utils.ProvisionVolume(h, hostJob); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := h.AddJob(hostJob); err != nil {
-		return nil, err
-	}
-	job, err = f.s.AddJob(
-		NewJob(req.JobType, f.App.ID, f.Release.ID, h.ID(), hostJob.ID),
-		f.App.Name,
-		utils.JobMetaFromMetadata(hostJob.Metadata),
-	)
-	return job, err
-}
-
-func (f *Formation) stopJob(req *JobRequest) (err error) {
-	log := f.s.log.New("fn", "stopJob")
-	defer func() {
-		if err != nil {
-			log.Error("error stopping job", "error", err)
-		}
-		f.s.sendEvent(NewEvent(EventTypeJobStop, err, nil))
-	}()
-	h, err := f.s.Host(req.HostID)
-	if err != nil {
-		return err
-	}
-
-	if err := h.StopJob(req.JobID); err != nil {
-		return err
-	}
-	f.s.RemoveJob(req.JobID)
-	return nil
-}
-
-func (f *Formation) configureJob(typ, hostID string) *host.Job {
-	return utils.JobConfig(&ct.ExpandedFormation{
-		App:      &ct.App{ID: f.App.ID, Name: f.App.Name},
-		Release:  f.Release,
-		Artifact: f.Artifact,
-	}, typ, hostID)
-}
-
-func (f *Formation) findBestHost(typ, hostID string) (utils.HostClient, error) {
-	hosts, err := f.s.Hosts()
-	if err != nil {
-		return nil, err
-	}
-	if len(hosts) == 0 {
-		return nil, fmt.Errorf("scheduler: no online hosts")
-	}
-
-	if hostID == "" {
-		hostMap := f.getHostMap(typ)
-		var minCount int = math.MaxInt32
-		for _, host := range hosts {
-			jobCount := hostMap[host.ID()]
-			if jobCount < minCount {
-				minCount = jobCount
-				hostID = host.ID()
-			}
-		}
-	}
-	if hostID == "" {
-		return nil, fmt.Errorf("no host found")
-	}
-	h, err := f.s.Host(hostID)
-	if err != nil {
-		return nil, err
-	}
-	return h, nil
-}
-
-func (f *Formation) getHostMap(typ string) map[string]int {
-	hostMap := make(map[string]int)
-	for _, j := range f.jobs[typ] {
-		hostMap[j.HostID]++
-	}
-	return hostMap
-}
-
-func (f *Formation) jobType(job *host.Job) string {
-	if job.Metadata["flynn-controller.app"] != f.App.ID ||
-		job.Metadata["flynn-controller.release"] != f.Release.ID {
-		return ""
-	}
-	return job.Metadata["flynn-controller.type"]
+	f.Processes = procs
+	return diff
 }

--- a/controller/scheduler-v2/formation.go
+++ b/controller/scheduler-v2/formation.go
@@ -52,9 +52,9 @@ func (f *Formation) Update(procs map[string]int) map[string]int {
 	return diff
 }
 
-type formationJobs map[utils.FormationKey]map[string]int
+type formationProcesses map[utils.FormationKey]map[string]int
 
-func (fc formationJobs) AddJob(j *Job) {
+func (fc formationProcesses) AddJob(j *Job) {
 	key := j.Formation.key()
 	f, ok := fc[key]
 	if !ok {

--- a/controller/scheduler-v2/formation_test.go
+++ b/controller/scheduler-v2/formation_test.go
@@ -118,7 +118,6 @@ func (*TestSuite) TestPendingJobs(c *C) {
 	procs = pj.GetProcesses(key)
 	c.Assert(procs["web"], Equals, 2)
 	c.Assert(pj.HasStarts(j), Equals, true)
-	c.Assert(pj.HasStops(j), Equals, false)
 	hostJobs = pj.GetHostJobCounts(key, "web")
 	c.Assert(hostJobs, DeepEquals, map[string]int{"": 1, "host-1": 1, "host-2": -1, "host-3": 1})
 	pj.RemoveJob(j)
@@ -129,7 +128,6 @@ func (*TestSuite) TestPendingJobs(c *C) {
 	c.Assert(hostJobs, DeepEquals, map[string]int{"": 1, "host-1": 1, "host-2": -1, "host-3": 0})
 	pj.RemoveJob(j)
 	c.Assert(pj.HasStarts(j), Equals, false)
-	c.Assert(pj.HasStops(j), Equals, true)
 	j.HostID = ""
 	c.Assert(pj.HasStarts(j), Equals, true)
 	hostJobs = pj.GetHostJobCounts(key, "web")

--- a/controller/scheduler-v2/formation_test.go
+++ b/controller/scheduler-v2/formation_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+func (TestSuite) TestFormationUpdate(c *C) {
+	type test struct {
+		desc      string
+		initial   map[string]int
+		requested map[string]int
+		diff      map[string]int
+	}
+	for _, t := range []test{
+		{
+			desc:      "+1 web proc",
+			initial:   map[string]int{"web": 1},
+			requested: map[string]int{"web": 2},
+			diff:      map[string]int{"web": 1},
+		},
+		{
+			desc:      "+3 web proc",
+			initial:   map[string]int{"web": 1},
+			requested: map[string]int{"web": 4},
+			diff:      map[string]int{"web": 3},
+		},
+		{
+			desc:      "-1 web proc",
+			initial:   map[string]int{"web": 2},
+			requested: map[string]int{"web": 1},
+			diff:      map[string]int{"web": -1},
+		},
+		{
+			desc:      "-3 web proc",
+			initial:   map[string]int{"web": 4},
+			requested: map[string]int{"web": 1},
+			diff:      map[string]int{"web": -3},
+		},
+		{
+			desc:      "no change",
+			initial:   map[string]int{"web": 1},
+			requested: map[string]int{"web": 1},
+			diff:      map[string]int{"web": 0},
+		},
+		{
+			desc:      "missing type",
+			initial:   map[string]int{"web": 1, "worker": 1},
+			requested: map[string]int{"web": 1},
+			diff:      map[string]int{"web": 0, "worker": -1},
+		},
+		{
+			desc:      "nil request",
+			initial:   map[string]int{"web": 1, "worker": 1},
+			requested: nil,
+			diff:      map[string]int{"web": -1, "worker": -1},
+		},
+		{
+			desc:      "multiple type changes",
+			initial:   map[string]int{"web": 3, "worker": 1},
+			requested: map[string]int{"web": 1, "clock": 2},
+			diff:      map[string]int{"web": -2, "worker": -1, "clock": 2},
+		},
+	} {
+		formation := NewFormation(&ct.ExpandedFormation{Processes: t.initial})
+		diff := formation.Update(t.requested)
+		c.Assert(diff, DeepEquals, t.diff, Commentf(t.desc))
+		c.Assert(formation.Processes, DeepEquals, t.requested, Commentf(t.desc))
+	}
+}

--- a/controller/scheduler-v2/formation_test.go
+++ b/controller/scheduler-v2/formation_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	. "github.com/flynn/flynn/controller/testutils"
 	ct "github.com/flynn/flynn/controller/types"
-	utils "github.com/flynn/flynn/controller/utils"
+	"github.com/flynn/flynn/controller/utils"
 )
 
 func (TestSuite) TestFormationUpdate(c *C) {
@@ -112,7 +112,9 @@ func (*TestSuite) TestPendingJobs(c *C) {
 	c.Assert(procs["web"], Equals, 1)
 	hostJobs = pj1.GetHostJobCounts(key, "web")
 	c.Assert(hostJobs, DeepEquals, map[string]int{"host-1": 1})
-	pj := NewPendingJobs(jobs, MergePendingJobs(pj1, pj2))
+	pj := NewPendingJobs(jobs)
+	pj.Update(pj1)
+	pj.Update(pj2)
 	procs = pj.GetProcesses(key)
 	c.Assert(procs["web"], Equals, 2)
 	c.Assert(pj.HasStarts(j), Equals, true)

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -65,9 +65,3 @@ func controllerJobFromSchedulerJob(job *Job, state string, metadata map[string]s
 		Meta:      metadata,
 	}
 }
-
-type jobsByStartTime []*Job
-
-func (a jobsByStartTime) Len() int           { return len(a) }
-func (a jobsByStartTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a jobsByStartTime) Less(i, j int) bool { return a[i].startedAt.Before(a[j].startedAt) }

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"sync"
 	"time"
 
 	ct "github.com/flynn/flynn/controller/types"
@@ -21,7 +20,7 @@ type JobRequest struct {
 
 func NewJobRequest(f *Formation, requestType JobRequestType, typ, hostID, jobID string) *JobRequest {
 	return &JobRequest{
-		Job:         NewJob(f, typ, hostID, jobID, time.Time{}),
+		Job:         NewJob(f, typ, hostID, jobID, time.Now()),
 		RequestType: requestType,
 	}
 }
@@ -40,8 +39,6 @@ type Job struct {
 	Formation *Formation
 
 	restarts  int
-	timer     *time.Timer
-	timerMtx  sync.Mutex
 	startedAt time.Time
 }
 

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -65,3 +65,9 @@ func controllerJobFromSchedulerJob(job *Job, state string, metadata map[string]s
 		Meta:      metadata,
 	}
 }
+
+type jobsByStartTime []*Job
+
+func (a jobsByStartTime) Len() int           { return len(a) }
+func (a jobsByStartTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a jobsByStartTime) Less(i, j int) bool { return a[i].startedAt.Before(a[j].startedAt) }

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -38,7 +38,7 @@ type Job struct {
 
 	Formation *Formation
 
-	restarts  int
+	restarts  uint
 	startedAt time.Time
 }
 

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -3,6 +3,8 @@ package main
 import (
 	"sync"
 	"time"
+
+	ct "github.com/flynn/flynn/controller/types"
 )
 
 type JobRequestType string
@@ -51,5 +53,17 @@ func NewJob(f *Formation, typ, hostID, id string) *Job {
 		HostID:    hostID,
 		JobID:     id,
 		Formation: f,
+	}
+}
+
+// TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host
+func controllerJobFromSchedulerJob(job *Job, state string, metadata map[string]string) *ct.Job {
+	return &ct.Job{
+		ID:        job.JobID,
+		AppID:     job.AppID,
+		ReleaseID: job.ReleaseID,
+		Type:      job.Type,
+		State:     state,
+		Meta:      metadata,
 	}
 }

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -21,7 +21,7 @@ type JobRequest struct {
 
 func NewJobRequest(f *Formation, requestType JobRequestType, typ, hostID, jobID string) *JobRequest {
 	return &JobRequest{
-		Job:         NewJob(f, typ, hostID, jobID),
+		Job:         NewJob(f, typ, hostID, jobID, time.Time{}),
 		RequestType: requestType,
 	}
 }
@@ -45,7 +45,7 @@ type Job struct {
 	startedAt time.Time
 }
 
-func NewJob(f *Formation, typ, hostID, id string) *Job {
+func NewJob(f *Formation, typ, hostID, id string, startedAt time.Time) *Job {
 	return &Job{
 		Type:      typ,
 		AppID:     f.App.ID,
@@ -53,6 +53,7 @@ func NewJob(f *Formation, typ, hostID, id string) *Job {
 		HostID:    hostID,
 		JobID:     id,
 		Formation: f,
+		startedAt: startedAt,
 	}
 }
 

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+type jobKey struct {
+	hostID, jobID string
+}
+
+type JobRequestType string
+
+const (
+	JobRequestTypeUp   JobRequestType = "up"
+	JobRequestTypeDown JobRequestType = "down"
+)
+
+type JobSpec struct {
+	JobType   string
+	AppID     string
+	ReleaseID string
+}
+
+func NewJobSpec(typ, appID, releaseID string) *JobSpec {
+	return &JobSpec{
+		JobType:   typ,
+		AppID:     appID,
+		ReleaseID: releaseID,
+	}
+}
+
+type HostJobSpec struct {
+	*JobSpec
+	HostID string
+}
+
+func NewHostJobSpec(typ, appID, releaseID, hostID string) *HostJobSpec {
+	return &HostJobSpec{
+		JobSpec: NewJobSpec(typ, appID, releaseID),
+		HostID:  hostID,
+	}
+}
+
+type JobRequest struct {
+	*Job
+	RequestType JobRequestType
+}
+
+func NewJobRequest(requestType JobRequestType, typ, appID, releaseID, hostID, jobID string) *JobRequest {
+	return &JobRequest{
+		Job:         NewJob(typ, appID, releaseID, hostID, jobID),
+		RequestType: requestType,
+	}
+}
+
+type Job struct {
+	*HostJobSpec
+	JobID string
+
+	restarts  int
+	timer     *time.Timer
+	timerMtx  sync.Mutex
+	startedAt time.Time
+}
+
+func NewJob(typ, appID, releaseID, hostID, id string) *Job {
+	return &Job{
+		HostJobSpec: NewHostJobSpec(typ, appID, releaseID, hostID),
+		JobID:       id,
+	}
+}
+
+type jobTypeMap map[string]map[jobKey]*Job
+
+func (m jobTypeMap) Add(job *Job) *Job {
+	jobs, ok := m[job.JobType]
+	if !ok {
+		jobs = make(map[jobKey]*Job)
+		m[job.JobType] = jobs
+	}
+	jobs[jobKey{job.HostID, job.JobID}] = job
+	return job
+}
+
+func (m jobTypeMap) Remove(job *Job) {
+	if jobs, ok := m[job.JobType]; ok {
+		j := jobs[jobKey{job.HostID, job.JobID}]
+		// cancel job restarts
+		j.timerMtx.Lock()
+		if j.timer != nil {
+			j.timer.Stop()
+			j.timer = nil
+		}
+		j.timerMtx.Unlock()
+		delete(jobs, jobKey{job.HostID, job.JobID})
+	}
+}
+
+func (m jobTypeMap) Get(typ, host, id string) *Job {
+	return m[typ][jobKey{host, id}]
+}

--- a/controller/scheduler-v2/job.go
+++ b/controller/scheduler-v2/job.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-type jobKey struct {
-	hostID, jobID string
-}
-
 type JobRequestType string
 
 const (
@@ -16,47 +12,30 @@ const (
 	JobRequestTypeDown JobRequestType = "down"
 )
 
-type JobSpec struct {
-	JobType   string
-	AppID     string
-	ReleaseID string
-}
-
-func NewJobSpec(typ, appID, releaseID string) *JobSpec {
-	return &JobSpec{
-		JobType:   typ,
-		AppID:     appID,
-		ReleaseID: releaseID,
-	}
-}
-
-type HostJobSpec struct {
-	*JobSpec
-	HostID string
-}
-
-func NewHostJobSpec(typ, appID, releaseID, hostID string) *HostJobSpec {
-	return &HostJobSpec{
-		JobSpec: NewJobSpec(typ, appID, releaseID),
-		HostID:  hostID,
-	}
-}
-
 type JobRequest struct {
 	*Job
 	RequestType JobRequestType
 }
 
-func NewJobRequest(requestType JobRequestType, typ, appID, releaseID, hostID, jobID string) *JobRequest {
+func NewJobRequest(f *Formation, requestType JobRequestType, typ, hostID, jobID string) *JobRequest {
 	return &JobRequest{
-		Job:         NewJob(typ, appID, releaseID, hostID, jobID),
+		Job:         NewJob(f, typ, hostID, jobID),
 		RequestType: requestType,
 	}
 }
 
+func (r *JobRequest) needsVolume() bool {
+	return r.Job.Formation.Release.Processes[r.Type].Data
+}
+
 type Job struct {
-	*HostJobSpec
-	JobID string
+	Type      string
+	AppID     string
+	ReleaseID string
+	HostID    string
+	JobID     string
+
+	Formation *Formation
 
 	restarts  int
 	timer     *time.Timer
@@ -64,39 +43,13 @@ type Job struct {
 	startedAt time.Time
 }
 
-func NewJob(typ, appID, releaseID, hostID, id string) *Job {
+func NewJob(f *Formation, typ, hostID, id string) *Job {
 	return &Job{
-		HostJobSpec: NewHostJobSpec(typ, appID, releaseID, hostID),
-		JobID:       id,
+		Type:      typ,
+		AppID:     f.App.ID,
+		ReleaseID: f.Release.ID,
+		HostID:    hostID,
+		JobID:     id,
+		Formation: f,
 	}
-}
-
-type jobTypeMap map[string]map[jobKey]*Job
-
-func (m jobTypeMap) Add(job *Job) *Job {
-	jobs, ok := m[job.JobType]
-	if !ok {
-		jobs = make(map[jobKey]*Job)
-		m[job.JobType] = jobs
-	}
-	jobs[jobKey{job.HostID, job.JobID}] = job
-	return job
-}
-
-func (m jobTypeMap) Remove(job *Job) {
-	if jobs, ok := m[job.JobType]; ok {
-		j := jobs[jobKey{job.HostID, job.JobID}]
-		// cancel job restarts
-		j.timerMtx.Lock()
-		if j.timer != nil {
-			j.timer.Stop()
-			j.timer = nil
-		}
-		j.timerMtx.Unlock()
-		delete(jobs, jobKey{job.HostID, job.JobID})
-	}
-}
-
-func (m jobTypeMap) Get(typ, host, id string) *Job {
-	return m[typ][jobKey{host, id}]
 }

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/host/types"
+)
+
+type Host interface {
+	ID() string
+	ListJobs() (map[string]host.ActiveJob, error)
+}
+
+type Cluster interface {
+	ListHosts() ([]Host, error)
+}
+
+type Scheduler struct {
+	cluster Cluster
+	log     log15.Logger
+
+	jobs    map[string]*host.ActiveJob
+	jobsMtx sync.RWMutex
+
+	listeners map[chan *Event]struct{}
+	listenMtx sync.RWMutex
+
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+func NewScheduler(cluster Cluster) *Scheduler {
+	return &Scheduler{
+		cluster:   cluster,
+		log:       log15.New("component", "scheduler"),
+		jobs:      make(map[string]*host.ActiveJob),
+		listeners: make(map[chan *Event]struct{}),
+		stop:      make(chan struct{}),
+	}
+}
+
+func (s *Scheduler) Run() error {
+	log := s.log.New("fn", "Run")
+	log.Info("starting scheduler loop")
+	defer log.Info("exiting scheduler loop")
+
+	for {
+		// check if we should stop first
+		select {
+		case <-s.stop:
+			return nil
+		default:
+		}
+
+		log.Info("starting cluster sync")
+		if err := s.Sync(); err != nil {
+			log.Error("error performing cluster sync", "err", err)
+			continue
+		}
+		log.Info("finished cluster sync")
+
+		// TODO: watch events
+		select {
+		case <-s.stop:
+			return nil
+		case <-time.After(time.Second):
+		}
+	}
+	return nil
+}
+
+func (s *Scheduler) Sync() error {
+	log := s.log.New("fn", "Sync")
+
+	defer s.sendEvent(&Event{Type: EventTypeClusterSync})
+
+	log.Info("getting host list")
+	hosts, err := s.cluster.ListHosts()
+	if err != nil {
+		log.Error("error getting host list", "err", err)
+		return err
+	}
+	log.Info(fmt.Sprintf("got %d hosts", len(hosts)))
+
+	s.jobsMtx.Lock()
+	defer s.jobsMtx.Unlock()
+	for _, h := range hosts {
+		log = log.New("host_id", h.ID())
+		log.Info("getting jobs list")
+		var jobs map[string]host.ActiveJob
+		jobs, err = h.ListJobs()
+		if err != nil {
+			log.Error("error getting jobs list", "err", err)
+			continue
+		}
+		log.Info(fmt.Sprintf("got %d jobs", len(jobs)))
+		for id, job := range jobs {
+			log.Info(fmt.Sprintf("adding job with ID %q", id))
+			s.jobs[id] = &job
+		}
+	}
+	return err
+}
+
+func (s *Scheduler) Stop() error {
+	s.log.Info("stopping scheduler loop", "fn", "Stop")
+	s.stopOnce.Do(func() { close(s.stop) })
+	return nil
+}
+
+func (s *Scheduler) GetJob(id string) *host.ActiveJob {
+	s.jobsMtx.RLock()
+	defer s.jobsMtx.RUnlock()
+	return s.jobs[id]
+}
+
+func (s *Scheduler) Subscribe(events chan *Event) *Stream {
+	s.log.Info("adding subscriber", "fn", "Subscribe")
+	s.listenMtx.Lock()
+	defer s.listenMtx.Unlock()
+	s.listeners[events] = struct{}{}
+	return &Stream{s, events}
+}
+
+func (s *Scheduler) Unsubscribe(events chan *Event) {
+	s.log.Info("removing subscriber", "fn", "Unsubscribe")
+	s.listenMtx.Lock()
+	defer s.listenMtx.Unlock()
+	delete(s.listeners, events)
+}
+
+type Stream struct {
+	s      *Scheduler
+	events chan *Event
+}
+
+func (s *Stream) Close() error {
+	s.s.Unsubscribe(s.events)
+	return nil
+}
+
+func (s *Scheduler) sendEvent(event *Event) {
+	s.listenMtx.RLock()
+	defer s.listenMtx.RUnlock()
+	s.log.Info(fmt.Sprintf("sending %q event to %d listeners", event.Type, len(s.listeners)))
+	for ch := range s.listeners {
+		// TODO: handle slow listeners
+		ch <- event
+	}
+}
+
+type Event struct {
+	Type EventType
+}
+
+type EventType string
+
+const (
+	EventTypeClusterSync EventType = "cluster-sync"
+)

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"sort"
 	"sync"
 	"time"
 
@@ -39,8 +38,8 @@ type Scheduler struct {
 	formations    Formations
 	hostStreams   map[string]stream.Stream
 	jobs          map[string]*Job
+	stoppedJobs   map[string]*Job
 	pendingStarts pendingJobs
-	pendingStops  pendingJobs
 
 	jobEvents chan *host.Event
 
@@ -67,8 +66,8 @@ func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient) *Sched
 		backoffPeriod:    getBackoffPeriod(),
 		hostStreams:      make(map[string]stream.Stream),
 		jobs:             make(map[string]*Job),
+		stoppedJobs:      make(map[string]*Job),
 		pendingStarts:    make(pendingJobs),
-		pendingStops:     make(pendingJobs),
 		formations:       make(Formations),
 		jobEvents:        make(chan *host.Event, eventBufferSize),
 		listeners:        make(map[chan Event]struct{}),
@@ -290,22 +289,21 @@ func (s *Scheduler) Rectify() {
 
 	pending := NewPendingJobs(s.jobs)
 	pending.Update(s.pendingStarts)
-	pending.Update(s.pendingStops)
 
 	for key := range pending {
-		log = log.New("app.id", key.AppID, "release.id", key.ReleaseID)
-		log.Info("rectifying formation")
+		formationLog := log.New("app.id", key.AppID, "release.id", key.ReleaseID)
+		formationLog.Info("rectifying formation")
 		formation, ok := s.formations[key]
 		if !ok {
-			log.Info("unknown formation, getting from the controller")
+			formationLog.Info("unknown formation, getting from the controller")
 			cf, err := s.GetFormation(key.AppID, key.ReleaseID)
 			if err != nil {
-				log.Error("error getting formation", "err", err)
+				formationLog.Error("error getting formation", "err", err)
 				continue
 			}
 			formation, err = s.updateFormation(cf)
 			if err != nil {
-				log.Error("error updating formation", "err", err)
+				formationLog.Error("error updating formation", "err", err)
 				continue
 			}
 		}
@@ -314,13 +312,13 @@ func (s *Scheduler) Rectify() {
 		actual := pending.GetProcesses(key)
 
 		if len(actual) == 0 && len(expected) == 0 || reflect.DeepEqual(actual, expected) {
-			log.Info("formation in correct state")
+			formationLog.Info("formation in correct state", "expected", expected, "actual", actual)
 			continue
 		}
 		// TODO: make this formation.Diff(actual)?
 		formation.Processes = actual
 		diff := formation.Update(expected)
-		log.Info("formation in incorrect state", "expected", expected, "actual", actual, "diff", diff)
+		formationLog.Info("formation in incorrect state", "expected", expected, "actual", actual, "diff", diff)
 		s.sendDiffRequests(formation, diff)
 	}
 
@@ -339,7 +337,13 @@ func (s *Scheduler) HandleFormationChange(ef *ct.ExpandedFormation) {
 		s.sendEvent(NewEvent(EventTypeFormationChange, err, nil))
 	}()
 
-	log := logger.New("fn", "HandleFormationChange", "app.id", ef.App.ID, "release.id", ef.Release.ID)
+	log := logger.New("fn", "HandleFormationChange")
+	if ef.App != nil {
+		log = log.New("app.id", ef.App.ID)
+	}
+	if ef.Release != nil {
+		log = log.New("release.id", ef.Release.ID)
+	}
 	log.Info("handling formation change")
 	_, err = s.changeFormation(ef)
 	if err != nil {
@@ -354,8 +358,6 @@ func (s *Scheduler) HandleFormationChange(ef *ct.ExpandedFormation) {
 
 func (s *Scheduler) HandleJobRequest(req *JobRequest) {
 	log := logger.New("fn", "HandleJobRequest", "req.id", req.JobID, "req.type", req.RequestType)
-
-	// Ensure that we've cleared this request from pendingJobs
 
 	if !s.isLeader {
 		log.Warn("ignoring job request as not service leader")
@@ -373,9 +375,10 @@ func (s *Scheduler) HandleJobRequest(req *JobRequest) {
 	log.Info("handling job request")
 	switch req.RequestType {
 	case JobRequestTypeUp:
+		// startJob sets the HostID on the request if successful
+		s.pendingStarts.RemoveJob(req.Job)
 		err = s.startJob(req)
-	case JobRequestTypeDown:
-		err = s.stopJob(req)
+		s.pendingStarts.AddJob(req.Job)
 	default:
 		err = fmt.Errorf("unknown job request type: %s", req.RequestType)
 	}
@@ -391,13 +394,13 @@ func (s *Scheduler) RunPutJobs() {
 			log.Info("stopping job persistence loop")
 			return
 		}
-		log = log.New("job.id", job.ID, "job.state", job.State)
-		log.Info("persisting job")
+		jobLog := log.New("job.id", job.ID, "job.state", job.State)
+		jobLog.Info("persisting job")
 		err := strategy.Run(func() error {
 			return s.PutJob(job)
 		})
 		if err != nil {
-			log.Error("error persisting job", "err", err)
+			jobLog.Error("error persisting job", "err", err)
 		}
 	}
 }
@@ -426,15 +429,16 @@ func (s *Scheduler) sendDiffRequests(f *Formation, diff map[string]int) {
 			log.Info(fmt.Sprintf("requesting %d new job(s) of type %s", n, typ))
 			for i := 0; i < n; i++ {
 				req := NewJobRequest(f, JobRequestTypeUp, typ, "", "")
+				s.startJob(req)
+				// startJob sets the HostID on the request if successful,
+				// otherwise the HostID will be blank
 				s.pendingStarts.AddJob(req.Job)
-				s.jobRequests <- req
 			}
 		} else if n < 0 {
 			log.Info(fmt.Sprintf("requesting removal of %d job(s) of type %s", -n, typ))
 			for i := 0; i < -n; i++ {
 				req := NewJobRequest(f, JobRequestTypeDown, typ, "", "")
-				s.pendingStops.RemoveJob(req.Job)
-				s.jobRequests <- req
+				s.stopJob(req)
 			}
 		}
 	}
@@ -497,6 +501,8 @@ func (s *Scheduler) unfollowHost(id string) {
 func (s *Scheduler) HandleHostEvent(e *discoverd.Event) {
 	log := logger.New("fn", "HandleHostEvent")
 
+	// Sometimes events are missing e.Instance or e.Instance.Meta,
+	// in which case we can get a panic by not checking it first
 	if e == nil || e.Instance == nil || e.Instance.Meta == nil {
 		log.Error(fmt.Sprintf("ignoring invalid host event: %+v", e))
 		return
@@ -544,7 +550,7 @@ func (s *Scheduler) HandleJobEvent(e *host.Event) {
 	case host.JobEventStart:
 		s.sendEvent(NewEvent(EventTypeJobStart, err, job))
 	case host.JobEventStop:
-		s.sendEvent(NewEvent(EventTypeJobStop, err, nil))
+		s.sendEvent(NewEvent(EventTypeJobStop, err, job))
 	}
 
 	if err == nil {
@@ -568,22 +574,24 @@ func (s *Scheduler) handleActiveJob(activeJob *host.ActiveJob) (*Job, error) {
 
 	j, ok := s.jobs[job.ID]
 	if !ok {
-		log.Info("job is new, looking up formation")
-		f := s.formations.Get(appID, releaseID)
-		if f == nil {
-			log.Info("job is from new formation, getting formation from controller")
-			cf, err := s.GetFormation(appID, releaseID)
-			if err != nil {
-				log.Error("error getting formation", "err", err)
-				return nil, err
+		if j, ok = s.stoppedJobs[job.ID]; !ok {
+			log.Info("job is new, looking up formation")
+			f := s.formations.Get(appID, releaseID)
+			if f == nil {
+				log.Info("job is from new formation, getting formation from controller")
+				cf, err := s.GetFormation(appID, releaseID)
+				if err != nil {
+					log.Error("error getting formation", "err", err)
+					return nil, err
+				}
+				f, err = s.updateFormation(cf)
+				if err != nil {
+					log.Error("error updating formation", "err", err)
+					return nil, err
+				}
 			}
-			f, err = s.updateFormation(cf)
-			if err != nil {
-				log.Error("error updating formation", "err", err)
-				return nil, err
-			}
+			j = NewJob(f, jobType, activeJob.HostID, job.ID, activeJob.StartedAt)
 		}
-		j = NewJob(f, jobType, activeJob.HostID, job.ID, activeJob.StartedAt)
 	}
 	s.SaveJob(j, appName, activeJob.Status, utils.JobMetaFromMetadata(job.Metadata))
 	return j, nil
@@ -629,7 +637,6 @@ func (s *Scheduler) startJob(req *JobRequest) (err error) {
 	log.Info("starting job")
 	defer func() {
 		if err != nil {
-			s.pendingStarts.RemoveJob(req.Job)
 			s.scheduleJobRequest(req)
 			log.Error("error starting job", "err", err)
 		}
@@ -658,9 +665,7 @@ func (s *Scheduler) startJob(req *JobRequest) (err error) {
 		log.Error("error requesting host to add job", "err", err)
 		return err
 	}
-	s.pendingStarts.RemoveJob(req.Job)
 	req.HostID = host.ID()
-	s.pendingStarts.AddJob(req.Job)
 	return nil
 }
 
@@ -675,27 +680,19 @@ func (s *Scheduler) stopJob(req *JobRequest) (err error) {
 
 	var job *Job
 	if req.JobID == "" {
-		// TODO this is a terrible solution. We need to actually store the jobs that are pending stops.
-		// Proposed solution: create s.stopped and use that to track stopped jobs. Treat a job as stopped
-		// as soon as the request is executed.
-		log.Info("no job ID, stopping most recent job")
 		formationKey := utils.FormationKey{AppID: req.AppID, ReleaseID: req.ReleaseID}
 		formJobs := NewFormationJobs(s.jobs)
-		formJob := formJobs[formationKey]
-		typJobs := jobsByStartTime(formJob[req.Type])
+		typJobs := formJobs[formationKey][req.Type]
 		if len(typJobs) == 0 {
 			e := fmt.Sprintf("no %s jobs running", req.Type)
 			log.Error(e)
 			return errors.New(e)
 		}
-		sort.Sort(typJobs)
-
-		// TODO: log what is happening here
-		typProcs := -s.pendingStops[formationKey][req.Type][""]
-		if typProcs > 0 && typProcs <= len(typJobs) {
-			job = typJobs[typProcs-1]
-		} else {
-			return fmt.Errorf("Unable to stop the job; there are more stops pending than there are jobs. Job count: %v, pending stops: %v", len(typJobs), typProcs)
+		job = typJobs[0]
+		for _, j := range typJobs {
+			if j.startedAt.After(job.startedAt) {
+				job = j
+			}
 		}
 	} else {
 		var ok bool
@@ -720,9 +717,8 @@ func (s *Scheduler) stopJob(req *JobRequest) (err error) {
 		log.Error("error requesting host to stop job", "err", err)
 		return err
 	}
-	s.pendingStops.AddJob(req.Job)
-	req.HostID = host.ID()
-	s.pendingStops.RemoveJob(req.Job)
+	s.stoppedJobs[job.JobID] = job
+	delete(s.jobs, job.JobID)
 	return nil
 }
 
@@ -751,7 +747,6 @@ func (s *Scheduler) findBestHost(formation *Formation, typ, hostID string) (util
 
 	pending := NewPendingJobs(s.jobs)
 	pending.Update(s.pendingStarts)
-	pending.Update(s.pendingStops)
 	counts := pending.GetHostJobCounts(formation.key(), typ)
 	var minCount int = math.MaxInt32
 	for _, host := range hosts {
@@ -819,14 +814,19 @@ func (s *Scheduler) SaveJob(job *Job, appName string, status host.JobStatus, met
 		s.handleJobStart(job)
 		controllerState = "up"
 	default:
-		s.handleJobStop(job)
+		delete(s.jobs, job.JobID)
+		delete(s.stoppedJobs, job.JobID)
 	}
 	s.putJobs <- controllerJobFromSchedulerJob(job, controllerState, metadata)
 	return job, nil
 }
 
 func (s *Scheduler) Jobs() map[string]*Job {
-	return s.jobs
+	jobs := make(map[string]*Job)
+	for id, j := range s.jobs {
+		jobs[id] = j
+	}
+	return jobs
 }
 
 func (s *Scheduler) expandOmni(ef *ct.ExpandedFormation) {
@@ -841,9 +841,7 @@ func (s *Scheduler) expandOmni(ef *ct.ExpandedFormation) {
 
 func (s *Scheduler) scheduleJobRequest(req *JobRequest) {
 	backoff := s.getBackoffDuration(req.restarts)
-	req.startedAt = time.Now()
 	req.restarts += 1
-	s.pendingStarts.AddJob(req.Job)
 	time.AfterFunc(backoff, func() {
 		s.jobRequests <- req
 	})
@@ -870,16 +868,6 @@ func (s *Scheduler) handleJobStart(job *Job) {
 		s.pendingStarts.RemoveJob(job)
 	}
 	s.jobs[job.JobID] = job
-}
-
-func (s *Scheduler) handleJobStop(job *Job) {
-	log := logger.New("fn", "handleJobStop", "job.id", job.JobID)
-	log.Info("removing job from in-memory state")
-	_, ok := s.jobs[job.JobID]
-	if s.isLeader && ok && s.pendingStops.HasStops(job) {
-		s.pendingStops.AddJob(job)
-	}
-	delete(s.jobs, job.JobID)
 }
 
 func (s *Scheduler) handleLeaderStream(leaders chan *discoverd.Instance, selfAddr string) {
@@ -1006,7 +994,7 @@ func (de *DefaultEvent) Type() EventType {
 	return de.typ
 }
 
-type JobStartEvent struct {
+type JobEvent struct {
 	Event
 	Job *Job
 }
@@ -1023,9 +1011,11 @@ type JobRequestEvent struct {
 
 func NewEvent(typ EventType, err error, data interface{}) Event {
 	switch typ {
+	case EventTypeJobStop:
+		fallthrough
 	case EventTypeJobStart:
 		job, _ := data.(*Job)
-		return &JobStartEvent{Event: &DefaultEvent{err: err, typ: typ}, Job: job}
+		return &JobEvent{Event: &DefaultEvent{err: err, typ: typ}, Job: job}
 	case EventTypeJobRequest:
 		req, _ := data.(*JobRequest)
 		return &JobRequestEvent{Event: &DefaultEvent{err: err, typ: typ}, Request: req}

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -442,32 +442,9 @@ func (s *Scheduler) changeFormation(ef *ct.ExpandedFormation) *Formation {
 }
 
 func (s *Scheduler) updateFormation(controllerFormation *ct.Formation) (*Formation, error) {
-	log := s.log.New("fn", "updateFormation")
-
-	appID := controllerFormation.AppID
-	releaseID := controllerFormation.ReleaseID
-
-	localFormation := s.formations.Get(appID, releaseID)
-
-	var ef *ct.ExpandedFormation
-	var err error
-
-	if localFormation != nil {
-		log.Info("Updating formation", "app.id", appID, "release.id", releaseID, "formation.processes", controllerFormation.Processes)
-		ef = &ct.ExpandedFormation{
-			App:       localFormation.App,
-			Release:   localFormation.Release,
-			Artifact:  localFormation.Artifact,
-			Processes: controllerFormation.Processes,
-			UpdatedAt: time.Now(),
-		}
-	} else {
-		log.Info("Creating new formation", "app.id", appID, "release.id", releaseID, "formation.processes", controllerFormation.Processes)
-		ef, err = utils.ExpandedFormationFromFormation(s, controllerFormation)
-		if err != nil {
-			return nil, err
-		}
-		ef.UpdatedAt = time.Now()
+	ef, err := utils.ExpandedFormationFromFormation(s, controllerFormation)
+	if err != nil {
+		return nil, err
 	}
 	return s.changeFormation(ef), nil
 }

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -357,7 +357,7 @@ func (s *Scheduler) followHost(h utils.HostClient) error {
 			return fmt.Errorf("Error following host with id %q", h.ID())
 		}
 	} else {
-		return fmt.Errorf("Unable to stream from host with id %q", h.ID())
+		return fmt.Errorf("Already following host with id %q", h.ID())
 	}
 	return nil
 }

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -46,12 +46,12 @@ type Scheduler struct {
 	listeners map[chan Event]struct{}
 	listenMtx sync.RWMutex
 
-	stop     chan interface{}
+	stop     chan struct{}
 	stopOnce sync.Once
 
-	rectifyJobs     chan interface{}
-	syncJobs        chan interface{}
-	syncFormations  chan interface{}
+	rectifyJobs     chan struct{}
+	syncJobs        chan struct{}
+	syncFormations  chan struct{}
 	hostChange      chan *discoverd.Event
 	formationChange chan *ct.ExpandedFormation
 	jobRequests     chan *JobRequest
@@ -72,10 +72,10 @@ func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient) *Sched
 		formations:       make(Formations),
 		hostEvents:       make(chan *host.Event, eventBufferSize),
 		listeners:        make(map[chan Event]struct{}),
-		stop:             make(chan interface{}),
-		rectifyJobs:      make(chan interface{}, 1),
-		syncJobs:         make(chan interface{}, 1),
-		syncFormations:   make(chan interface{}, 1),
+		stop:             make(chan struct{}),
+		rectifyJobs:      make(chan struct{}, 1),
+		syncJobs:         make(chan struct{}, 1),
+		syncFormations:   make(chan struct{}, 1),
 		formationChange:  make(chan *ct.ExpandedFormation, eventBufferSize),
 		hostChange:       make(chan *discoverd.Event, eventBufferSize),
 		jobRequests:      make(chan *JobRequest, eventBufferSize),
@@ -781,7 +781,7 @@ func (s *Scheduler) startHTTPServer(port string) {
 	}
 }
 
-func tickChannel(ch chan interface{}, d time.Duration) {
+func tickChannel(ch chan struct{}, d time.Duration) {
 	ticker := time.Tick(d)
 
 	go func() {
@@ -791,7 +791,7 @@ func tickChannel(ch chan interface{}, d time.Duration) {
 	}()
 }
 
-func triggerChan(ch chan interface{}) {
+func triggerChan(ch chan struct{}) {
 	select {
 	case ch <- struct{}{}:
 	default:

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -282,7 +282,7 @@ func (s *Scheduler) RectifyJobs() (err error) {
 		schedulerProcs := schedulerFormation.Processes
 		clusterProcs := fj.GetProcesses(fKey)
 
-		if eq := reflect.DeepEqual(clusterProcs, schedulerProcs); !eq {
+		if eq := reflect.DeepEqual(clusterProcs, schedulerProcs); (len(clusterProcs) != 0 || len(schedulerProcs) != 0) && !eq {
 			log.Debug("Updating processes", "formation.processes", schedulerProcs, "cluster.processes", clusterProcs)
 			schedulerFormation.Processes = clusterProcs
 

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -10,11 +10,14 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/attempt"
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/stream"
 )
 
@@ -79,7 +82,16 @@ func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient) *Sched
 }
 
 func main() {
-	return
+	clusterClient := utils.ClusterClientWrapper(cluster.NewClient())
+	controllerClient, err := controller.NewClient("", os.Getenv("AUTH_KEY"))
+	if err != nil {
+		shutdown.Fatal(err)
+	}
+	s := NewScheduler(clusterClient, controllerClient)
+	if err := s.Run(); err != nil {
+		shutdown.Fatal(err)
+	}
+	shutdown.Exit()
 }
 
 func (s *Scheduler) Run() error {

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -877,8 +877,12 @@ func (s *Scheduler) getHosts() ([]utils.HostClient, error) {
 
 	// Ensure that we're only following hosts that we can discover
 	knownHosts := make(map[string]struct{})
-	for id := range s.hostStreams {
-		knownHosts[id] = struct{}{}
+	for id, hostStream := range s.hostStreams {
+		if hostStream.Err() == nil {
+			knownHosts[id] = struct{}{}
+		} else {
+			s.unfollowHost(id)
+		}
 	}
 	for _, h := range hosts {
 		delete(knownHosts, h.ID())

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -12,6 +12,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/stream"
 )
 
 const eventBufferSize int = 1000
@@ -473,7 +474,7 @@ func (s *Scheduler) Stop() error {
 	return nil
 }
 
-func (s *Scheduler) Subscribe(events chan Event) *Stream {
+func (s *Scheduler) Subscribe(events chan Event) stream.Stream {
 	s.log.Info("adding subscriber", "fn", "Subscribe")
 	s.listenMtx.Lock()
 	defer s.listenMtx.Unlock()
@@ -542,6 +543,10 @@ type Stream struct {
 
 func (s *Stream) Close() error {
 	s.s.Unsubscribe(s.events)
+	return nil
+}
+
+func (s *Stream) Err() error {
 	return nil
 }
 

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -211,12 +211,14 @@ func (s *Scheduler) FormationChange(ef *ct.ExpandedFormation) (err error) {
 	}()
 
 	f := s.formations.Get(ef.App.ID, ef.Release.ID)
+	var diff map[string]int
 	if f == nil {
 		log.Info("creating new formation")
 		f = s.formations.Add(NewFormation(ef))
+		diff = f.Processes
+	} else {
+		diff = f.Update(ef.Processes)
 	}
-	// TODO: Update won't work for new formations!
-	diff := f.Update(ef.Processes)
 	for typ, n := range diff {
 		if n > 0 {
 			for i := 0; i < n; i++ {

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -417,6 +417,7 @@ func (s *Scheduler) startJob(req *JobRequest) (err error) {
 
 	host, err := s.findBestHost(req.Type, req.HostID)
 	if err != nil {
+		s.jobRequests <- req
 		return err
 	}
 
@@ -469,6 +470,8 @@ func (s *Scheduler) stopJob(req *JobRequest) (err error) {
 	}
 	host, err := s.Host(job.HostID)
 	if err != nil {
+		req.JobID = job.JobID
+		s.jobRequests <- req
 		return err
 	}
 	if err := host.StopJob(job.JobID); err != nil {

--- a/controller/scheduler-v2/scheduler.go
+++ b/controller/scheduler-v2/scheduler.go
@@ -6,40 +6,53 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/host/types"
 )
 
-type Host interface {
-	ID() string
-	ListJobs() (map[string]host.ActiveJob, error)
-}
-
-type Cluster interface {
-	ListHosts() ([]Host, error)
-}
+const eventBufferSize int = 1000
 
 type Scheduler struct {
-	cluster Cluster
-	log     log15.Logger
+	utils.ControllerClient
+	utils.ClusterClient
+	log        log15.Logger
+	formations *Formations
 
-	jobs    map[string]*host.ActiveJob
-	jobsMtx sync.RWMutex
+	jobs map[string]*Job
 
-	listeners map[chan *Event]struct{}
+	listeners map[chan Event]struct{}
 	listenMtx sync.RWMutex
 
 	stop     chan struct{}
 	stopOnce sync.Once
+
+	formationChange chan *ct.ExpandedFormation
+	jobRequests     chan *JobRequest
+
+	validJobStatuses map[host.JobStatus]bool
 }
 
-func NewScheduler(cluster Cluster) *Scheduler {
+func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient) *Scheduler {
 	return &Scheduler{
-		cluster:   cluster,
-		log:       log15.New("component", "scheduler"),
-		jobs:      make(map[string]*host.ActiveJob),
-		listeners: make(map[chan *Event]struct{}),
-		stop:      make(chan struct{}),
+		ControllerClient: cc,
+		ClusterClient:    cluster,
+		log:              log15.New("component", "scheduler"),
+		jobs:             make(map[string]*Job),
+		listeners:        make(map[chan Event]struct{}),
+		stop:             make(chan struct{}),
+		formations:       newFormations(),
+		formationChange:  make(chan *ct.ExpandedFormation, 1),
+		jobRequests:      make(chan *JobRequest, eventBufferSize),
+		validJobStatuses: map[host.JobStatus]bool{
+			host.StatusStarting: true,
+			host.StatusRunning:  true,
+		},
 	}
+}
+
+func main() {
+	return
 }
 
 func (s *Scheduler) Run() error {
@@ -48,10 +61,13 @@ func (s *Scheduler) Run() error {
 	defer log.Info("exiting scheduler loop")
 
 	for {
-		// check if we should stop first
+		// first, check if we should stop or process pending job events
 		select {
 		case <-s.stop:
 			return nil
+		case req := <-s.jobRequests:
+			s.HandleJobRequest(req)
+			continue
 		default:
 		}
 
@@ -60,49 +76,148 @@ func (s *Scheduler) Run() error {
 			log.Error("error performing cluster sync", "err", err)
 			continue
 		}
-		log.Info("finished cluster sync")
 
-		// TODO: watch events
+		log.Info("starting watching events")
 		select {
 		case <-s.stop:
 			return nil
+		case fc := <-s.formationChange:
+			if err := s.FormationChange(fc); err != nil {
+				log.Error("error performing formation change", "err", err)
+				continue
+			}
 		case <-time.After(time.Second):
 		}
 	}
 	return nil
 }
 
-func (s *Scheduler) Sync() error {
+func (s *Scheduler) Sync() (err error) {
 	log := s.log.New("fn", "Sync")
 
-	defer s.sendEvent(&Event{Type: EventTypeClusterSync})
+	defer func() {
+		s.sendEvent(NewEvent(EventTypeClusterSync, err, nil))
+	}()
 
 	log.Info("getting host list")
-	hosts, err := s.cluster.ListHosts()
+	hosts, err := s.Hosts()
 	if err != nil {
 		log.Error("error getting host list", "err", err)
 		return err
 	}
 	log.Info(fmt.Sprintf("got %d hosts", len(hosts)))
 
-	s.jobsMtx.Lock()
-	defer s.jobsMtx.Unlock()
 	for _, h := range hosts {
 		log = log.New("host_id", h.ID())
 		log.Info("getting jobs list")
-		var jobs map[string]host.ActiveJob
-		jobs, err = h.ListJobs()
+		activeJobs, err := h.ListJobs()
 		if err != nil {
 			log.Error("error getting jobs list", "err", err)
 			continue
 		}
-		log.Info(fmt.Sprintf("got %d jobs", len(jobs)))
-		for id, job := range jobs {
-			log.Info(fmt.Sprintf("adding job with ID %q", id))
-			s.jobs[id] = &job
+		log.Info("active jobs", "count", len(activeJobs))
+		for _, activeJob := range activeJobs {
+			if s.validJobStatuses[activeJob.Status] {
+				job := activeJob.Job
+				appID := job.Metadata["flynn-controller.app"]
+				appName := job.Metadata["flynn-controller.app_name"]
+				releaseID := job.Metadata["flynn-controller.release"]
+				jobType := job.Metadata["flynn-controller.type"]
+				log.Info("adding job", "host.id", h.ID(), "job.id", job.ID, "app.id", appID, "release.id", releaseID, "type", jobType)
+
+				if appID == "" || releaseID == "" {
+					continue
+				}
+				if _, ok := s.jobs[job.ID]; ok {
+					continue
+				}
+
+				s.AddJob(NewJob(jobType, appID, releaseID, h.ID(), job.ID), appName, utils.JobMetaFromMetadata(job.Metadata))
+			}
 		}
 	}
+	if err != nil {
+		return err
+	}
+	err = s.formations.RectifyAll()
 	return err
+}
+
+func (s *Scheduler) getFormation(appID, appName, releaseID string) (*Formation, error) {
+	log := s.log.New("fn", "getFormation")
+
+	artifacts := make(map[string]*ct.Artifact)
+	releases := make(map[string]*ct.Release)
+
+	f := s.formations.Get(appID, releaseID)
+	if f == nil {
+		release := releases[releaseID]
+		var err error
+		if release == nil {
+			release, err = s.GetRelease(releaseID)
+			if err != nil {
+				log.Error("at", "getRelease", "status", "error", "err", err)
+				return nil, err
+			}
+			releases[release.ID] = release
+		}
+
+		artifact := artifacts[release.ArtifactID]
+		if artifact == nil {
+			artifact, err := s.GetArtifact(release.ArtifactID)
+			if err != nil {
+				log.Error("at", "getArtifact", "status", "error", "err", err)
+				return nil, err
+			}
+			artifacts[artifact.ID] = artifact
+		}
+
+		formation, err := s.GetFormation(appID, releaseID)
+		if err != nil {
+			log.Error("at", "getFormation", "status", "error", "err", err)
+			return nil, err
+		}
+
+		f = NewFormation(s, &ct.ExpandedFormation{
+			App:       &ct.App{ID: appID, Name: appName},
+			Release:   release,
+			Artifact:  artifact,
+			Processes: formation.Processes,
+		})
+		log.Info("at", "addFormation")
+		f = s.formations.Add(f)
+	}
+	if f == nil {
+		return nil, fmt.Errorf("no formation found")
+	}
+	return f, nil
+}
+
+func (s *Scheduler) FormationChange(ef *ct.ExpandedFormation) (err error) {
+	log := s.log.New("fn", "FormationChange")
+
+	defer func() {
+		if err != nil {
+			log.Error("error in FormationChange", "err", err)
+		}
+		s.sendEvent(NewEvent(EventTypeFormationChange, err, nil))
+	}()
+
+	f := s.formations.Get(ef.App.ID, ef.Release.ID)
+	if f != nil {
+		f.SetFormation(ef)
+	} else {
+		log.Info("creating new formation")
+		f = NewFormation(s, ef)
+		s.formations.Add(f)
+	}
+	return f.Rectify()
+}
+
+func (s *Scheduler) HandleJobRequest(req *JobRequest) error {
+	f := s.formations.Get(req.AppID, req.ReleaseID)
+	f.handleJobRequest(req)
+	return nil
 }
 
 func (s *Scheduler) Stop() error {
@@ -111,13 +226,7 @@ func (s *Scheduler) Stop() error {
 	return nil
 }
 
-func (s *Scheduler) GetJob(id string) *host.ActiveJob {
-	s.jobsMtx.RLock()
-	defer s.jobsMtx.RUnlock()
-	return s.jobs[id]
-}
-
-func (s *Scheduler) Subscribe(events chan *Event) *Stream {
+func (s *Scheduler) Subscribe(events chan Event) *Stream {
 	s.log.Info("adding subscriber", "fn", "Subscribe")
 	s.listenMtx.Lock()
 	defer s.listenMtx.Unlock()
@@ -125,16 +234,38 @@ func (s *Scheduler) Subscribe(events chan *Event) *Stream {
 	return &Stream{s, events}
 }
 
-func (s *Scheduler) Unsubscribe(events chan *Event) {
+func (s *Scheduler) Unsubscribe(events chan Event) {
 	s.log.Info("removing subscriber", "fn", "Unsubscribe")
 	s.listenMtx.Lock()
 	defer s.listenMtx.Unlock()
 	delete(s.listeners, events)
 }
 
+func (s *Scheduler) AddJob(job *Job, appName string, metadata map[string]string) (*Job, error) {
+	f, err := s.getFormation(job.AppID, appName, job.ReleaseID)
+	if err != nil {
+		return nil, err
+	}
+	job = f.jobs.Add(job)
+	s.jobs[job.JobID] = job
+	s.PutJob(controllerJobFromSchedulerJob(job, "up", metadata))
+	return job, nil
+}
+
+func (s *Scheduler) RemoveJob(jobID string) {
+	job, ok := s.jobs[jobID]
+	if !ok {
+		return
+	}
+	f := s.formations.Get(job.AppID, job.ReleaseID)
+	f.jobs.Remove(job)
+	s.PutJob(controllerJobFromSchedulerJob(job, "down", make(map[string]string)))
+	delete(s.jobs, jobID)
+}
+
 type Stream struct {
 	s      *Scheduler
-	events chan *Event
+	events chan Event
 }
 
 func (s *Stream) Close() error {
@@ -142,22 +273,70 @@ func (s *Stream) Close() error {
 	return nil
 }
 
-func (s *Scheduler) sendEvent(event *Event) {
+func (s *Scheduler) sendEvent(event Event) {
 	s.listenMtx.RLock()
 	defer s.listenMtx.RUnlock()
-	s.log.Info(fmt.Sprintf("sending %q event to %d listeners", event.Type, len(s.listeners)))
+	s.log.Info("sending event to listeners", "event.type", event.Type(), "listeners.count", len(s.listeners))
 	for ch := range s.listeners {
 		// TODO: handle slow listeners
 		ch <- event
 	}
 }
 
-type Event struct {
-	Type EventType
+type Event interface {
+	Type() EventType
+	Err() error
 }
 
 type EventType string
 
 const (
-	EventTypeClusterSync EventType = "cluster-sync"
+	EventTypeDefault         EventType = "default"
+	EventTypeClusterSync     EventType = "cluster-sync"
+	EventTypeFormationChange EventType = "formation-change"
+	EventTypeJobStart        EventType = "start-job"
+	EventTypeJobStop         EventType = "stop-job"
 )
+
+type DefaultEvent struct {
+	err error
+	typ EventType
+}
+
+func (de *DefaultEvent) Err() error {
+	return de.err
+}
+
+func (de *DefaultEvent) Type() EventType {
+	return de.typ
+}
+
+type JobStartEvent struct {
+	Event
+	Job *Job
+}
+
+func NewEvent(typ EventType, err error, data interface{}) Event {
+	switch typ {
+	case EventTypeJobStart:
+		job, ok := data.(*Job)
+		if !ok {
+			job = nil
+		}
+		return &JobStartEvent{Event: &DefaultEvent{err: err, typ: typ}, Job: job}
+	default:
+		return &DefaultEvent{err: err, typ: typ}
+	}
+}
+
+// TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host
+func controllerJobFromSchedulerJob(job *Job, state string, metadata map[string]string) *ct.Job {
+	return &ct.Job{
+		ID:        job.JobID,
+		AppID:     job.AppID,
+		ReleaseID: job.ReleaseID,
+		Type:      job.JobType,
+		State:     state,
+		Meta:      metadata,
+	}
+}

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	"github.com/flynn/flynn/host/types"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+type FakeCluster struct {
+	hosts []Host
+}
+
+func (f *FakeCluster) ListHosts() ([]Host, error) {
+	return f.hosts, nil
+}
+
+type FakeHost struct {
+	id   string
+	jobs map[string]host.ActiveJob
+}
+
+func (f *FakeHost) ID() string {
+	return f.id
+}
+
+func (f *FakeHost) ListJobs() (map[string]host.ActiveJob, error) {
+	return f.jobs, nil
+}
+
+func (TestSuite) TestInitialClusterSync(c *C) {
+	jobID := "job-1"
+	host := &FakeHost{id: "host-1", jobs: map[string]host.ActiveJob{
+		jobID: {Job: &host.Job{ID: jobID}},
+	}}
+	cluster := &FakeCluster{hosts: []Host{host}}
+
+	s := NewScheduler(cluster)
+	events := make(chan *Event)
+	stream := s.Subscribe(events)
+	defer stream.Close()
+	go s.Run()
+	defer s.Stop()
+
+	// wait for a cluster sync event
+loop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				c.Fatal("unexpected close of scheduler event stream")
+			}
+			if event.Type == EventTypeClusterSync {
+				break loop
+			}
+		case <-time.After(time.Second):
+			c.Fatal("timed out waiting for cluster sync event")
+		}
+	}
+
+	// check the scheduler has the job
+	job := s.GetJob(jobID)
+	c.Assert(job, NotNil)
+	c.Assert(job.Job.ID, Equals, jobID)
+}
+
+func (TestSuite) TestFormationChange(c *C) {
+}

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -304,7 +304,7 @@ func (ts *TestSuite) TestMultipleHosts(c *C) {
 	artifact := &ct.Artifact{ID: "test-artifact-2"}
 	processes := map[string]int{testJobType: 1}
 	release := NewReleaseOmni("test-release-2", artifact, processes, true)
-	s.log.Info("Add the formation to the controller. Wait for formation change.")
+	s.log.Info("Add the formation to the controller. Wait for formation change and start for jobs on both hosts.")
 	s.CreateApp(app)
 	s.CreateArtifact(artifact)
 	s.CreateRelease(release)

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -256,6 +256,10 @@ func (ts *TestSuite) TestRectify(c *C) {
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	_, err = waitForEvent(events, EventTypeFormationChange)
 	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeRectify)
+	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeJobStart)
+	c.Assert(err, IsNil)
 	jobs = s.Jobs()
 	c.Assert(jobs, HasLen, 2)
 }

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -361,9 +361,6 @@ func (ts *TestSuite) TestMultipleHosts(c *C) {
 	c.Assert(len(hostJobs), Equals, 1)
 }
 
-func (ts *TestSuite) TestRemovingHost(c *C) {
-}
-
 func checkJobStartEvent(c *C, e Event) *Job {
 	event, ok := e.(*JobStartEvent)
 	c.Assert(ok, Equals, true)

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -144,7 +144,7 @@ func (ts *TestSuite) TestFormationChange(c *C) {
 
 	// Test scaling up an existing formation
 	s.log.Info("Test scaling up an existing formation. Wait for formation change and job start")
-	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: map[string]int{"web": 2}})
+	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: map[string]int{"web": 4}})
 	_, err = waitForEvent(events, EventTypeFormationChange)
 	c.Assert(err, IsNil)
 	e, err := waitForEvent(events, EventTypeJobStart)
@@ -153,13 +153,21 @@ func (ts *TestSuite) TestFormationChange(c *C) {
 	c.Assert(job.Type, Equals, testJobType)
 	c.Assert(job.AppID, Equals, app.ID)
 	c.Assert(job.ReleaseID, Equals, testReleaseID)
+	_, err = waitForEvent(events, EventTypeJobStart)
+	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeJobStart)
+	c.Assert(err, IsNil)
 	jobs := s.Jobs()
-	c.Assert(jobs, HasLen, 2)
+	c.Assert(jobs, HasLen, 4)
 
 	// Test scaling down an existing formation
 	s.log.Info("Test scaling down an existing formation. Wait for formation change and job stop")
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: map[string]int{"web": 1}})
 	_, err = waitForEvent(events, EventTypeFormationChange)
+	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeJobStop)
+	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeJobStop)
 	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeJobStop)
 	c.Assert(err, IsNil)

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -39,8 +39,10 @@ func createTestScheduler() *Scheduler {
 	cc.CreateArtifact(artifact)
 	cc.CreateRelease(release)
 	cc.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
+	s := NewScheduler(cluster, cc)
+	s.SetLeader(true)
 
-	return NewScheduler(cluster, cc)
+	return s
 }
 
 func waitForEvent(events chan Event, typ EventType) (Event, error) {

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -96,16 +96,16 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 func (ts *TestSuite) TestFormationChange(c *C) {
 	app := &ct.App{ID: random.UUID(), Name: "test-formation-change"}
 	s := createTestScheduler(app.ID, map[string]int{"web": 1})
-	release, err := s.GetRelease(testReleaseID)
-	c.Assert(err, IsNil)
-	artifact, err := s.GetArtifact(release.ArtifactID)
-	c.Assert(err, IsNil)
-
 	events := make(chan Event, 1)
 	stream := s.Subscribe(events)
 	defer stream.Close()
 	go s.Run()
 	defer s.Stop()
+
+	release, err := s.GetRelease(testReleaseID)
+	c.Assert(err, IsNil)
+	artifact, err := s.GetArtifact(release.ArtifactID)
+	c.Assert(err, IsNil)
 
 	s.formationChange <- &ct.ExpandedFormation{
 		App:       app,

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -18,19 +18,24 @@ type TestSuite struct{}
 
 var _ = Suite(&TestSuite{})
 
+const (
+	testHostID    = "host-1"
+	testReleaseID = "release-1"
+)
+
 func createTestScheduler(appID string, processes map[string]int) *Scheduler {
 	artifact := &ct.Artifact{ID: "artifact-1"}
-	release := NewRelease("release-1", artifact, processes)
-	h := NewFakeHostClient("host-1")
-	for k, c := range processes {
-		for i := 0; i < c; i++ {
+	release := NewRelease(testReleaseID, artifact, processes)
+	h := NewFakeHostClient(testHostID)
+	for typ, count := range processes {
+		for i := 0; i < count; i++ {
 			jobID := random.UUID()
 			h.AddJob(&host.Job{
 				ID: jobID,
 				Metadata: map[string]string{
 					"flynn-controller.app":     appID,
 					"flynn-controller.release": release.ID,
-					"flynn-controller.type":    k,
+					"flynn-controller.type":    typ,
 				},
 				Artifact: host.Artifact{
 					Type: artifact.Type,
@@ -46,21 +51,21 @@ func createTestScheduler(appID string, processes map[string]int) *Scheduler {
 	return NewScheduler(cluster, cc)
 }
 
-func waitForEventType(events chan Event, etype EventType) (Event, error) {
+func waitForEvent(events chan Event, typ EventType) (Event, error) {
 	for {
 		select {
 		case event, ok := <-events:
 			if !ok {
 				return nil, fmt.Errorf("unexpected close of scheduler event stream")
 			}
-			if event.Type() == etype {
-				if event.Err() != nil {
-					return nil, fmt.Errorf("Error occurred occurred while processing event of type %q. Error: %v", etype, event.Err())
-				}
+			if err := event.Err(); err != nil {
+				return nil, fmt.Errorf("unexpected event error: %s", err)
+			}
+			if event.Type() == typ {
 				return event, nil
 			}
 		case <-time.After(time.Second):
-			return nil, fmt.Errorf("timed out waiting for cluster sync event")
+			return nil, fmt.Errorf("timed out waiting for %s event", typ)
 		}
 	}
 }
@@ -75,25 +80,26 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 	defer s.Stop()
 
 	// wait for a cluster sync event
-	_, err := waitForEventType(events, EventTypeClusterSync)
-	fatalIfError(c, err)
+	_, err := waitForEvent(events, EventTypeClusterSync)
+	c.Assert(err, IsNil)
 
 	// check the scheduler has the job
-	formation, err := s.getFormation("testApp", "testApp", "release-1")
-	jobs := formation.GetJobsForType("web")
-	c.Assert(err, IsNil)
-	c.Assert(jobs, NotNil)
-	for _, j := range jobs {
-		c.Assert(j.HostID, Equals, "host-1")
+	jobs := s.Jobs()
+	c.Assert(jobs, HasLen, 1)
+	for _, job := range jobs {
+		c.Assert(job.Type, Equals, "web")
+		c.Assert(job.HostID, Equals, testHostID)
+		c.Assert(job.AppID, Equals, "testApp")
 	}
-	c.Assert(len(jobs), Equals, 1)
 }
 
 func (ts *TestSuite) TestFormationChange(c *C) {
-	s := createTestScheduler("testApp", map[string]int{"web": 1})
-	release, _ := s.GetRelease("release-1")
-	artifact, _ := s.GetArtifact(release.ArtifactID)
-	s.log.Info("Testing formation change")
+	app := &ct.App{ID: random.UUID(), Name: "test-formation-change"}
+	s := createTestScheduler(app.ID, map[string]int{"web": 1})
+	release, err := s.GetRelease(testReleaseID)
+	c.Assert(err, IsNil)
+	artifact, err := s.GetArtifact(release.ArtifactID)
+	c.Assert(err, IsNil)
 
 	events := make(chan Event, 1)
 	stream := s.Subscribe(events)
@@ -101,33 +107,22 @@ func (ts *TestSuite) TestFormationChange(c *C) {
 	go s.Run()
 	defer s.Stop()
 
-	// wait for a cluster sync event
-	_, err := waitForEventType(events, EventTypeClusterSync)
-	fatalIfError(c, err)
-
 	s.formationChange <- &ct.ExpandedFormation{
-		App: &ct.App{
-			Name: "test-formation-change",
-			ID:   "test-formation-change",
-		},
+		App:       app,
 		Release:   release,
 		Artifact:  artifact,
 		Processes: map[string]int{"web": 2},
 	}
 
-	_, err = waitForEventType(events, EventTypeFormationChange)
-	fatalIfError(c, err)
-	e, err := waitForEventType(events, EventTypeJobStart)
-	fatalIfError(c, err)
-	je, ok := e.(*JobStartEvent)
+	_, err = waitForEvent(events, EventTypeFormationChange)
+	c.Assert(err, IsNil)
+	e, err := waitForEvent(events, EventTypeJobStart)
+	c.Assert(err, IsNil)
+	event, ok := e.(*JobStartEvent)
 	c.Assert(ok, Equals, true)
-	c.Assert(je.Job, NotNil)
-
-	s.stop <- struct{}{}
-}
-
-func fatalIfError(c *C, err error) {
-	if err != nil {
-		c.Fatal(err.Error())
-	}
+	c.Assert(event.Job, NotNil)
+	job := event.Job
+	c.Assert(job.Type, Equals, "web")
+	c.Assert(job.AppID, Equals, app.ID)
+	c.Assert(job.ReleaseID, Equals, testReleaseID)
 }

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -72,9 +72,7 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 	go s.Run()
 
 	// wait for a cluster sync event
-	_, err := waitForEvent(events, EventTypeClusterSync)
-	c.Assert(err, IsNil)
-	_, err = waitForEvent(events, EventTypeRectifyJobs)
+	_, err := waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
 	e, err := waitForEvent(events, EventTypeJobStart)
 	c.Assert(err, IsNil)
@@ -192,10 +190,7 @@ func (ts *TestSuite) TestRectifyJobs(c *C) {
 	request := NewJobRequest(form, JobRequestTypeUp, testJobType, "", "")
 	config := jobConfig(request, testHostID)
 	host.AddJob(config)
-	s.jobSync <- struct{}{}
 
-	_, err = waitForEvent(events, EventTypeClusterSync)
-	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeJobStop)
@@ -218,14 +213,10 @@ func (ts *TestSuite) TestRectifyJobs(c *C) {
 	s.CreateApp(app)
 	s.CreateArtifact(artifact)
 	s.CreateRelease(release)
-	s.jobSync <- struct{}{}
 
-	_, err = waitForEvent(events, EventTypeClusterSync)
-	c.Assert(err, Not(IsNil))
 	_, err = waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
-	s.jobSync <- struct{}{}
 	_, err = waitForEvent(events, EventTypeClusterSync)
 	c.Assert(err, IsNil)
 

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -72,11 +72,7 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 	go s.Run()
 
 	// wait for a cluster sync event
-	_, err := waitForEvent(events, EventTypeFormationSync)
-	c.Assert(err, IsNil)
-	_, err = waitForEvent(events, EventTypeFormationChange)
-	c.Assert(err, IsNil)
-	_, err = waitForEvent(events, EventTypeClusterSync)
+	_, err := waitForEvent(events, EventTypeClusterSync)
 	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
@@ -188,8 +184,6 @@ func (ts *TestSuite) TestRectifyJobs(c *C) {
 	// wait for the formation to cascade to the scheduler
 	_, err := waitForEvent(events, EventTypeFormationSync)
 	c.Assert(err, IsNil)
-	_, err = waitForEvent(events, EventTypeFormationChange)
-	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
 
@@ -228,15 +222,11 @@ func (ts *TestSuite) TestRectifyJobs(c *C) {
 
 	_, err = waitForEvent(events, EventTypeClusterSync)
 	c.Assert(err, Not(IsNil))
-	_, err = waitForEvent(events, EventTypeFormationSync)
-	c.Assert(err, IsNil)
-	_, err = waitForEvent(events, EventTypeFormationChange)
-	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeRectifyJobs)
 	c.Assert(err, IsNil)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
-	s.formationSync <- struct{}{}
-	_, err = waitForEvent(events, EventTypeFormationSync)
+	s.jobSync <- struct{}{}
+	_, err = waitForEvent(events, EventTypeClusterSync)
 	c.Assert(err, IsNil)
 
 }

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	. "github.com/flynn/flynn/controller/testutils"
+	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/random"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -14,62 +18,116 @@ type TestSuite struct{}
 
 var _ = Suite(&TestSuite{})
 
-type FakeCluster struct {
-	hosts []Host
+func createTestScheduler(appID string, processes map[string]int) *Scheduler {
+	artifact := &ct.Artifact{ID: "artifact-1"}
+	release := NewRelease("release-1", artifact, processes)
+	h := NewFakeHostClient("host-1")
+	for k, c := range processes {
+		for i := 0; i < c; i++ {
+			jobID := random.UUID()
+			h.AddJob(&host.Job{
+				ID: jobID,
+				Metadata: map[string]string{
+					"flynn-controller.app":     appID,
+					"flynn-controller.release": release.ID,
+					"flynn-controller.type":    k,
+				},
+				Artifact: host.Artifact{
+					Type: artifact.Type,
+					URI:  artifact.URI,
+				},
+			})
+		}
+	}
+	cluster := NewFakeCluster()
+	cluster.SetHosts(map[string]*FakeHostClient{h.ID(): h})
+	cc := NewFakeControllerClient(appID, release, artifact, processes)
+
+	return NewScheduler(cluster, cc)
 }
 
-func (f *FakeCluster) ListHosts() ([]Host, error) {
-	return f.hosts, nil
+func waitForEventType(events chan Event, etype EventType) (Event, error) {
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return nil, fmt.Errorf("unexpected close of scheduler event stream")
+			}
+			if event.Type() == etype {
+				if event.Err() != nil {
+					return nil, fmt.Errorf("Error occurred occurred while processing event of type %q. Error: %v", etype, event.Err())
+				}
+				return event, nil
+			}
+		case <-time.After(time.Second):
+			return nil, fmt.Errorf("timed out waiting for cluster sync event")
+		}
+	}
 }
 
-type FakeHost struct {
-	id   string
-	jobs map[string]host.ActiveJob
-}
+func (ts *TestSuite) TestInitialClusterSync(c *C) {
+	s := createTestScheduler("testApp", map[string]int{"web": 1})
 
-func (f *FakeHost) ID() string {
-	return f.id
-}
-
-func (f *FakeHost) ListJobs() (map[string]host.ActiveJob, error) {
-	return f.jobs, nil
-}
-
-func (TestSuite) TestInitialClusterSync(c *C) {
-	jobID := "job-1"
-	host := &FakeHost{id: "host-1", jobs: map[string]host.ActiveJob{
-		jobID: {Job: &host.Job{ID: jobID}},
-	}}
-	cluster := &FakeCluster{hosts: []Host{host}}
-
-	s := NewScheduler(cluster)
-	events := make(chan *Event)
+	events := make(chan Event)
 	stream := s.Subscribe(events)
 	defer stream.Close()
 	go s.Run()
 	defer s.Stop()
 
 	// wait for a cluster sync event
-loop:
-	for {
-		select {
-		case event, ok := <-events:
-			if !ok {
-				c.Fatal("unexpected close of scheduler event stream")
-			}
-			if event.Type == EventTypeClusterSync {
-				break loop
-			}
-		case <-time.After(time.Second):
-			c.Fatal("timed out waiting for cluster sync event")
-		}
-	}
+	_, err := waitForEventType(events, EventTypeClusterSync)
+	fatalIfError(c, err)
 
 	// check the scheduler has the job
-	job := s.GetJob(jobID)
-	c.Assert(job, NotNil)
-	c.Assert(job.Job.ID, Equals, jobID)
+	formation, err := s.getFormation("testApp", "testApp", "release-1")
+	jobs := formation.GetJobsForType("web")
+	c.Assert(err, IsNil)
+	c.Assert(jobs, NotNil)
+	for _, j := range jobs {
+		c.Assert(j.HostID, Equals, "host-1")
+	}
+	c.Assert(len(jobs), Equals, 1)
 }
 
-func (TestSuite) TestFormationChange(c *C) {
+func (ts *TestSuite) TestFormationChange(c *C) {
+	s := createTestScheduler("testApp", map[string]int{"web": 1})
+	release, _ := s.GetRelease("release-1")
+	artifact, _ := s.GetArtifact(release.ArtifactID)
+	s.log.Info("Testing formation change")
+
+	events := make(chan Event, 1)
+	stream := s.Subscribe(events)
+	defer stream.Close()
+	go s.Run()
+	defer s.Stop()
+
+	// wait for a cluster sync event
+	_, err := waitForEventType(events, EventTypeClusterSync)
+	fatalIfError(c, err)
+
+	s.formationChange <- &ct.ExpandedFormation{
+		App: &ct.App{
+			Name: "test-formation-change",
+			ID:   "test-formation-change",
+		},
+		Release:   release,
+		Artifact:  artifact,
+		Processes: map[string]int{"web": 2},
+	}
+
+	_, err = waitForEventType(events, EventTypeFormationChange)
+	fatalIfError(c, err)
+	e, err := waitForEventType(events, EventTypeJobStart)
+	fatalIfError(c, err)
+	je, ok := e.(*JobStartEvent)
+	c.Assert(ok, Equals, true)
+	c.Assert(je.Job, NotNil)
+
+	s.stop <- struct{}{}
+}
+
+func fatalIfError(c *C, err error) {
+	if err != nil {
+		c.Fatal(err.Error())
+	}
 }

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -72,12 +72,15 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 	go s.Run()
 
 	// wait for a cluster sync event
-	_, err := waitForEvent(events, EventTypeClusterSync)
+	_, err := waitForEvent(events, EventTypeFormationSync)
 	c.Assert(err, IsNil)
-
-	// Ensure that the scheduler initializes the formation correctly and starts its jobs
+	_, err = waitForEvent(events, EventTypeFormationChange)
+	c.Assert(err, IsNil)
 	e, err := waitForEvent(events, EventTypeJobStart)
 	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeClusterSync)
+	c.Assert(err, IsNil)
+
 	event, ok := e.(*JobStartEvent)
 	c.Assert(ok, Equals, true)
 	c.Assert(event.Job, NotNil)

--- a/controller/scheduler-v2/scheduler_test.go
+++ b/controller/scheduler-v2/scheduler_test.go
@@ -80,6 +80,8 @@ func (ts *TestSuite) TestInitialClusterSync(c *C) {
 	c.Assert(err, IsNil)
 	_, err = waitForEvent(events, EventTypeClusterSync)
 	c.Assert(err, IsNil)
+	_, err = waitForEvent(events, EventTypeRectifyJobs)
+	c.Assert(err, IsNil)
 
 	event, ok := e.(*JobStartEvent)
 	c.Assert(ok, Equals, true)

--- a/controller/testutils/fake_cluster.go
+++ b/controller/testutils/fake_cluster.go
@@ -61,7 +61,10 @@ func (c *FakeCluster) Host(id string) (utils.HostClient, error) {
 func (c *FakeCluster) SetHosts(h map[string]*FakeHostClient) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-	c.hosts = h
+	c.hosts = make(map[string]*FakeHostClient)
+	for id, h := range h {
+		c.hosts[id] = h
+	}
 }
 
 func (c *FakeCluster) AddHost(h *FakeHostClient) {

--- a/controller/testutils/fake_cluster.go
+++ b/controller/testutils/fake_cluster.go
@@ -45,6 +45,7 @@ func (c *FakeCluster) StreamHostEvents(ch chan *discoverd.Event) (stream.Stream,
 	for id := range c.hosts {
 		ch <- createDiscoverdEvent(id, discoverd.EventKindUp)
 	}
+	ch <- createDiscoverdEvent("", discoverd.EventKindCurrent)
 
 	return &ClusterStream{cluster: c, ch: ch}, nil
 }

--- a/controller/testutils/fake_cluster.go
+++ b/controller/testutils/fake_cluster.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/flynn/flynn/controller/utils"
@@ -50,7 +51,11 @@ func (c *FakeCluster) StreamHosts(ch chan utils.HostClient) (stream.Stream, erro
 func (c *FakeCluster) Host(id string) (utils.HostClient, error) {
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
-	return c.hosts[id], nil
+	host, ok := c.hosts[id]
+	if !ok {
+		return nil, fmt.Errorf("Host with id %q not found", id)
+	}
+	return host, nil
 }
 
 func (c *FakeCluster) SetHosts(h map[string]*FakeHostClient) {

--- a/controller/testutils/fake_cluster.go
+++ b/controller/testutils/fake_cluster.go
@@ -37,6 +37,10 @@ func (c *FakeCluster) StreamHosts(ch chan utils.HostClient) (stream.Stream, erro
 	}
 	c.hostChannels[ch] = struct{}{}
 
+	for _, h := range c.hosts {
+		ch <- h
+	}
+
 	return &ClusterStream{cluster: c, ch: ch}, nil
 }
 
@@ -57,6 +61,10 @@ func (c *FakeCluster) AddHost(h *FakeHostClient) {
 	defer c.mtx.Unlock()
 	h.cluster = c
 	c.hosts[h.ID()] = h
+
+	for ch := range c.hostChannels {
+		ch <- h
+	}
 }
 
 type ClusterStream struct {

--- a/controller/testutils/fake_cluster.go
+++ b/controller/testutils/fake_cluster.go
@@ -9,7 +9,10 @@ import (
 )
 
 func NewFakeCluster() *FakeCluster {
-	return &FakeCluster{hosts: make(map[string]*FakeHostClient)}
+	return &FakeCluster{
+		hosts:        make(map[string]*FakeHostClient),
+		hostChannels: make(map[chan utils.HostClient]struct{}),
+	}
 }
 
 type FakeCluster struct {

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -84,7 +84,7 @@ func (c *FakeControllerClient) PutFormation(formation *ct.Formation) error {
 	releases[formation.ReleaseID] = formation
 
 	for ch := range c.formationStreams {
-		ef, err := utils.ExpandedFormationFromFormation(c, formation)
+		ef, err := utils.ExpandFormation(c, formation)
 		if err == nil {
 			ch <- ef
 		}
@@ -119,7 +119,7 @@ func (c *FakeControllerClient) StreamFormations(since *time.Time, ch chan<- *ct.
 
 	for _, releases := range c.formations {
 		for _, f := range releases {
-			ef, err := utils.ExpandedFormationFromFormation(c, f)
+			ef, err := utils.ExpandFormation(c, f)
 			if err == nil {
 				ch <- ef
 			}

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -138,9 +138,16 @@ func (c *FakeControllerClient) PutJob(job *ct.Job) error {
 }
 
 func NewRelease(id string, artifact *ct.Artifact, processes map[string]int) *ct.Release {
+	return NewReleaseOmni(id, artifact, processes, false)
+}
+
+func NewReleaseOmni(id string, artifact *ct.Artifact, processes map[string]int, omni bool) *ct.Release {
 	processTypes := make(map[string]ct.ProcessType, len(processes))
 	for t := range processes {
-		processTypes[t] = ct.ProcessType{Cmd: []string{"start", t}}
+		processTypes[t] = ct.ProcessType{
+			Cmd:  []string{"start", t},
+			Omni: omni,
+		}
 	}
 
 	return &ct.Release{

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -1,0 +1,64 @@
+package testutils
+
+import (
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/utils"
+)
+
+type FakeControllerClient struct {
+	releases   map[string]*ct.Release
+	artifacts  map[string]*ct.Artifact
+	formations map[utils.FormationKey]*ct.Formation
+	jobs       map[string]*ct.Job
+}
+
+func NewFakeControllerClient(appID string, release *ct.Release, artifact *ct.Artifact, processes map[string]int) *FakeControllerClient {
+	return &FakeControllerClient{
+		releases:  map[string]*ct.Release{release.ID: release},
+		artifacts: map[string]*ct.Artifact{artifact.ID: artifact},
+		formations: map[utils.FormationKey]*ct.Formation{
+			utils.NewFormationKey(appID, release.ID): {AppID: appID, ReleaseID: release.ID, Processes: processes},
+		},
+		jobs: make(map[string]*ct.Job),
+	}
+}
+
+func (c *FakeControllerClient) GetRelease(releaseID string) (*ct.Release, error) {
+	if release, ok := c.releases[releaseID]; ok {
+		return release, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *FakeControllerClient) GetArtifact(artifactID string) (*ct.Artifact, error) {
+	if artifact, ok := c.artifacts[artifactID]; ok {
+		return artifact, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *FakeControllerClient) GetFormation(appID, releaseID string) (*ct.Formation, error) {
+	if formation, ok := c.formations[utils.NewFormationKey(appID, releaseID)]; ok {
+		return formation, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *FakeControllerClient) PutJob(job *ct.Job) error {
+	c.jobs[job.ID] = job
+	return nil
+}
+
+func NewRelease(id string, artifact *ct.Artifact, processes map[string]int) *ct.Release {
+	processTypes := make(map[string]ct.ProcessType, len(processes))
+	for t := range processes {
+		processTypes[t] = ct.ProcessType{Cmd: []string{"start", t}}
+	}
+
+	return &ct.Release{
+		ID:         id,
+		ArtifactID: artifact.ID,
+		Processes:  processTypes,
+	}
+}

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -3,22 +3,30 @@ package testutils
 import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
-	"github.com/flynn/flynn/controller/utils"
 )
 
 type FakeControllerClient struct {
 	releases   map[string]*ct.Release
 	artifacts  map[string]*ct.Artifact
-	formations map[utils.FormationKey]*ct.Formation
+	formations map[string]map[string]*ct.Formation
 	jobs       map[string]*ct.Job
+	apps       []*ct.App
 }
 
 func NewFakeControllerClient(appID string, release *ct.Release, artifact *ct.Artifact, processes map[string]int) *FakeControllerClient {
 	return &FakeControllerClient{
 		releases:  map[string]*ct.Release{release.ID: release},
 		artifacts: map[string]*ct.Artifact{artifact.ID: artifact},
-		formations: map[utils.FormationKey]*ct.Formation{
-			utils.NewFormationKey(appID, release.ID): {AppID: appID, ReleaseID: release.ID, Processes: processes},
+		formations: map[string]map[string]*ct.Formation{
+			appID: {
+				release.ID: {AppID: appID, ReleaseID: release.ID, Processes: processes},
+			},
+		},
+		apps: []*ct.App{
+			{
+				ID:   appID,
+				Name: appID,
+			},
 		},
 		jobs: make(map[string]*ct.Job),
 	}
@@ -39,8 +47,25 @@ func (c *FakeControllerClient) GetArtifact(artifactID string) (*ct.Artifact, err
 }
 
 func (c *FakeControllerClient) GetFormation(appID, releaseID string) (*ct.Formation, error) {
-	if formation, ok := c.formations[utils.NewFormationKey(appID, releaseID)]; ok {
-		return formation, nil
+	if releases, ok := c.formations[appID]; ok {
+		if formation, ok := releases[releaseID]; ok {
+			return formation, nil
+		}
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *FakeControllerClient) AppList() ([]*ct.App, error) {
+	return c.apps, nil
+}
+
+func (c *FakeControllerClient) FormationList(appID string) ([]*ct.Formation, error) {
+	if releases, ok := c.formations[appID]; ok {
+		formations := make([]*ct.Formation, 0, len(releases))
+		for _, f := range releases {
+			formations = append(formations, f)
+		}
+		return formations, nil
 	}
 	return nil, controller.ErrNotFound
 }

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
@@ -43,7 +44,7 @@ func (c *FakeHostClient) ListJobs() (map[string]host.ActiveJob, error) {
 }
 
 func (c *FakeHostClient) AddJob(job *host.Job) error {
-	c.Jobs[job.ID] = host.ActiveJob{Job: job, HostID: c.hostID}
+	c.Jobs[job.ID] = host.ActiveJob{Job: job, HostID: c.hostID, StartedAt: time.Now()}
 	return nil
 }
 
@@ -57,6 +58,7 @@ func (c *FakeHostClient) GetJob(id string) (*host.ActiveJob, error) {
 
 func (c *FakeHostClient) StopJob(id string) error {
 	c.stopped[id] = true
+	delete(c.Jobs, id)
 	return nil
 }
 

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -102,6 +102,18 @@ func (c *FakeHostClient) stop(id string) error {
 	return nil
 }
 
+func (c *FakeHostClient) CrashJob(id string) error {
+	c.stopped[id] = true
+	job, ok := c.Jobs[id]
+	if ok {
+		job.Status = host.StatusCrashed
+		c.Jobs[id] = job
+		return c.stop(id)
+	} else {
+		return ct.NotFoundError{Resource: id}
+	}
+}
+
 func (c *FakeHostClient) IsStopped(id string) bool {
 	return c.stopped[id]
 }

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -135,7 +135,7 @@ func (c *FakeHostClient) CreateVolume(providerID string) (*volume.Info, error) {
 	return volume, nil
 }
 
-func (c *FakeHostClient) StreamEvents(id string, ch chan<- *host.Event) (stream.Stream, error) {
+func (c *FakeHostClient) StreamEvents(id string, ch chan *host.Event) (stream.Stream, error) {
 	if _, ok := c.eventChannels[ch]; ok {
 		return nil, errors.New("Already streaming that channel")
 	}

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -79,12 +80,12 @@ func (c *FakeHostClient) StopJob(id string) error {
 		case host.StatusRunning:
 			job.Status = host.StatusDone
 		default:
-			return fmt.Errorf("host: job %q is already stopped", id)
+			return nil
 		}
 		c.Jobs[id] = job
 		return c.stop(id)
 	} else {
-		return fmt.Errorf("Job with id %q does not exist", id)
+		return ct.NotFoundError{Resource: id}
 	}
 }
 

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -1,8 +1,12 @@
 package testutils
 
 import (
+	"fmt"
+
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/random"
 )
 
 func NewFakeHostClient(hostID string) *FakeHostClient {
@@ -10,6 +14,8 @@ func NewFakeHostClient(hostID string) *FakeHostClient {
 		hostID:  hostID,
 		stopped: make(map[string]bool),
 		attach:  make(map[string]attachFunc),
+		volumes: make(map[string]*volume.Info),
+		Jobs:    make(map[string]host.ActiveJob),
 	}
 }
 
@@ -17,8 +23,9 @@ type FakeHostClient struct {
 	hostID  string
 	stopped map[string]bool
 	attach  map[string]attachFunc
-	Jobs    []*host.Job
+	Jobs    map[string]host.ActiveJob
 	cluster *FakeCluster
+	volumes map[string]*volume.Info
 }
 
 func (c *FakeHostClient) ID() string { return c.hostID }
@@ -31,9 +38,21 @@ func (c *FakeHostClient) Attach(req *host.AttachReq, wait bool) (cluster.AttachC
 	return f(req, wait)
 }
 
+func (c *FakeHostClient) ListJobs() (map[string]host.ActiveJob, error) {
+	return c.Jobs, nil
+}
+
 func (c *FakeHostClient) AddJob(job *host.Job) error {
-	c.Jobs = append(c.Jobs, job)
+	c.Jobs[job.ID] = host.ActiveJob{Job: job, HostID: c.hostID}
 	return nil
+}
+
+func (c *FakeHostClient) GetJob(id string) (*host.ActiveJob, error) {
+	job, ok := c.Jobs[id]
+	if !ok {
+		return nil, fmt.Errorf("unable to find job with ID %q", id)
+	}
+	return &job, nil
 }
 
 func (c *FakeHostClient) StopJob(id string) error {
@@ -53,6 +72,13 @@ func (c *FakeHostClient) SetAttach(id string, ac cluster.AttachClient) {
 
 func (c *FakeHostClient) SetAttachFunc(id string, f attachFunc) {
 	c.attach[id] = f
+}
+
+func (c *FakeHostClient) CreateVolume(providerID string) (*volume.Info, error) {
+	id := random.UUID()
+	volume := &volume.Info{ID: id}
+	c.volumes[id] = volume
+	return volume, nil
 }
 
 type attachFunc func(req *host.AttachReq, wait bool) (cluster.AttachClient, error)

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -92,6 +92,14 @@ func (c *FakeHostClient) StreamEvents(id string, ch chan<- *host.Event) (stream.
 	}
 	c.eventChannels[ch] = struct{}{}
 
+	for _, j := range c.Jobs {
+		ch <- &host.Event{
+			Event: host.JobEventStart,
+			JobID: j.Job.ID,
+			Job:   &j,
+		}
+	}
+
 	return &HostStream{host: c, ch: ch}, nil
 }
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -180,6 +180,14 @@ func (v ValidationError) Error() string {
 	return fmt.Sprintf("validation error: %s %s", v.Field, v.Message)
 }
 
+type NotFoundError struct {
+	Resource string `json:"field"`
+}
+
+func (n NotFoundError) Error() string {
+	return fmt.Sprintf("resource not found: %s", n.Resource)
+}
+
 type LogOpts struct {
 	Follow      bool
 	JobID       string

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -110,11 +110,16 @@ func ExpandedFormationFromFormation(c ControllerClient, f *ct.Formation) (*ct.Ex
 		return nil, fmt.Errorf("Error getting artifact. Error: %v", err)
 	}
 
+	procs := make(map[string]int)
+	for typ, count := range f.Processes {
+		procs[typ] = count
+	}
+
 	ef := &ct.ExpandedFormation{
 		App:       app,
 		Release:   release,
 		Artifact:  artifact,
-		Processes: f.Processes,
+		Processes: procs,
 		UpdatedAt: time.Now(),
 	}
 	if f.UpdatedAt != nil {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -165,6 +165,34 @@ type ControllerClient interface {
 	PutJob(*ct.Job) error
 }
 
+func ClusterClientWrapper(c *cluster.Client) clusterClientWrapper {
+	return clusterClientWrapper{c}
+}
+
+type clusterClientWrapper struct {
+	*cluster.Client
+}
+
+func (c clusterClientWrapper) Host(id string) (HostClient, error) {
+	return c.Client.Host(id)
+}
+
+func (c clusterClientWrapper) Hosts() ([]HostClient, error) {
+	hosts, err := c.Client.Hosts()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]HostClient, len(hosts))
+	for i, h := range hosts {
+		res[i] = h
+	}
+	return res, nil
+}
+
+func (c clusterClientWrapper) StreamHostEvents(ch chan *discoverd.Event) (stream.Stream, error) {
+	return c.Client.StreamHostEvents(ch)
+}
+
 var AppNamePattern = regexp.MustCompile(`^[a-z\d]+(-[a-z\d]+)*$`)
 
 func ParseBasicAuth(h http.Header) (username, password string, err error) {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -140,13 +141,13 @@ type HostClient interface {
 	Attach(*host.AttachReq, bool) (cluster.AttachClient, error)
 	StopJob(string) error
 	ListJobs() (map[string]host.ActiveJob, error)
-	StreamEvents(id string, ch chan<- *host.Event) (stream.Stream, error)
+	StreamEvents(id string, ch chan *host.Event) (stream.Stream, error)
 }
 
 type ClusterClient interface {
 	Host(string) (HostClient, error)
 	Hosts() ([]HostClient, error)
-	StreamHosts(chan HostClient) (stream.Stream, error)
+	StreamHostEvents(chan *discoverd.Event) (stream.Stream, error)
 }
 
 type ControllerClient interface {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -95,20 +95,20 @@ func NewFormationKey(appID, releaseID string) FormationKey {
 	return FormationKey{AppID: appID, ReleaseID: releaseID}
 }
 
-func ExpandedFormationFromFormation(c ControllerClient, f *ct.Formation) (*ct.ExpandedFormation, error) {
+func ExpandFormation(c ControllerClient, f *ct.Formation) (*ct.ExpandedFormation, error) {
 	app, err := c.GetApp(f.AppID)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting app. Error: %v", err)
+		return nil, fmt.Errorf("error getting app: %s", err)
 	}
 
 	release, err := c.GetRelease(f.ReleaseID)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting release. Error: %v", err)
+		return nil, fmt.Errorf("error getting release: %s", err)
 	}
 
 	artifact, err := c.GetArtifact(release.ArtifactID)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting artifact. Error: %v", err)
+		return nil, fmt.Errorf("error getting artifact: %s", err)
 	}
 
 	procs := make(map[string]int)

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -112,9 +112,14 @@ type ClusterClient interface {
 }
 
 type ControllerClient interface {
+	GetApp(appID string) (*ct.App, error)
 	GetRelease(releaseID string) (*ct.Release, error)
 	GetArtifact(artifactID string) (*ct.Artifact, error)
 	GetFormation(appID, releaseID string) (*ct.Formation, error)
+	CreateApp(app *ct.App) error
+	CreateRelease(release *ct.Release) error
+	CreateArtifact(artifact *ct.Artifact) error
+	PutFormation(formation *ct.Formation) error
 	AppList() ([]*ct.App, error)
 	FormationList(appID string) ([]*ct.Formation, error)
 	PutJob(*ct.Job) error

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
@@ -123,6 +124,7 @@ type ControllerClient interface {
 	CreateRelease(release *ct.Release) error
 	CreateArtifact(artifact *ct.Artifact) error
 	PutFormation(formation *ct.Formation) error
+	StreamFormations(since time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	AppList() ([]*ct.App, error)
 	FormationList(appID string) ([]*ct.Formation, error)
 	PutJob(*ct.Job) error

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -94,6 +94,35 @@ func NewFormationKey(appID, releaseID string) FormationKey {
 	return FormationKey{AppID: appID, ReleaseID: releaseID}
 }
 
+func ExpandedFormationFromFormation(c ControllerClient, f *ct.Formation) (*ct.ExpandedFormation, error) {
+	app, err := c.GetApp(f.AppID)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting app. Error: %v", err)
+	}
+
+	release, err := c.GetRelease(f.ReleaseID)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting release. Error: %v", err)
+	}
+
+	artifact, err := c.GetArtifact(release.ArtifactID)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting artifact. Error: %v", err)
+	}
+
+	ef := &ct.ExpandedFormation{
+		App:       app,
+		Release:   release,
+		Artifact:  artifact,
+		Processes: f.Processes,
+		UpdatedAt: time.Now(),
+	}
+	if f.UpdatedAt != nil {
+		ef.UpdatedAt = *f.UpdatedAt
+	}
+	return ef, nil
+}
+
 type VolumeCreator interface {
 	CreateVolume(string) (*volume.Info, error)
 }

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -124,7 +124,7 @@ type ControllerClient interface {
 	CreateRelease(release *ct.Release) error
 	CreateArtifact(artifact *ct.Artifact) error
 	PutFormation(formation *ct.Formation) error
-	StreamFormations(since time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)
+	StreamFormations(since *time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	AppList() ([]*ct.App, error)
 	FormationList(appID string) ([]*ct.Formation, error)
 	PutJob(*ct.Job) error

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -10,6 +10,7 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
 )
 
@@ -59,7 +60,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
 	return job
 }
 
-func ProvisionVolume(h *cluster.Host, job *host.Job) error {
+func ProvisionVolume(h VolumeCreator, job *host.Job) error {
 	vol, err := h.CreateVolume("default")
 	if err != nil {
 		return err
@@ -72,11 +73,49 @@ func ProvisionVolume(h *cluster.Host, job *host.Job) error {
 	return nil
 }
 
+func JobMetaFromMetadata(metadata map[string]string) map[string]string {
+	jobMeta := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if strings.HasPrefix(k, "flynn-controller.") {
+			continue
+		}
+		jobMeta[k] = v
+	}
+	return jobMeta
+}
+
+type FormationKey struct {
+	AppID, ReleaseID string
+}
+
+func NewFormationKey(appID, releaseID string) FormationKey {
+	return FormationKey{AppID: appID, ReleaseID: releaseID}
+}
+
+type VolumeCreator interface {
+	CreateVolume(string) (*volume.Info, error)
+}
+
 type HostClient interface {
+	VolumeCreator
 	ID() string
 	AddJob(*host.Job) error
+	GetJob(id string) (*host.ActiveJob, error)
 	Attach(*host.AttachReq, bool) (cluster.AttachClient, error)
 	StopJob(string) error
+	ListJobs() (map[string]host.ActiveJob, error)
+}
+
+type ClusterClient interface {
+	Host(string) (HostClient, error)
+	Hosts() ([]HostClient, error)
+}
+
+type ControllerClient interface {
+	GetRelease(releaseID string) (*ct.Release, error)
+	GetArtifact(artifactID string) (*ct.Artifact, error)
+	GetFormation(appID, releaseID string) (*ct.Formation, error)
+	PutJob(*ct.Job) error
 }
 
 var AppNamePattern = regexp.MustCompile(`^[a-z\d]+(-[a-z\d]+)*$`)

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/stream"
 )
 
 func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
@@ -104,11 +105,13 @@ type HostClient interface {
 	Attach(*host.AttachReq, bool) (cluster.AttachClient, error)
 	StopJob(string) error
 	ListJobs() (map[string]host.ActiveJob, error)
+	StreamEvents(id string, ch chan<- *host.Event) (stream.Stream, error)
 }
 
 type ClusterClient interface {
 	Host(string) (HostClient, error)
 	Hosts() ([]HostClient, error)
+	StreamHosts(chan HostClient) (stream.Stream, error)
 }
 
 type ControllerClient interface {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -115,6 +115,8 @@ type ControllerClient interface {
 	GetRelease(releaseID string) (*ct.Release, error)
 	GetArtifact(artifactID string) (*ct.Artifact, error)
 	GetFormation(appID, releaseID string) (*ct.Formation, error)
+	AppList() ([]*ct.App, error)
+	FormationList(appID string) ([]*ct.Formation, error)
 	PutJob(*ct.Job) error
 }
 

--- a/host/state.go
+++ b/host/state.go
@@ -275,7 +275,7 @@ func (s *State) AddJob(j *host.Job, ip net.IP) {
 		job.InternalIP = ip.String()
 	}
 	s.jobs[j.ID] = job
-	s.sendEvent(job, "create")
+	s.sendEvent(job, host.JobEventCreate)
 	s.persist(j.ID)
 }
 
@@ -350,7 +350,7 @@ func (s *State) SetStatusRunning(jobID string) {
 
 	job.StartedAt = time.Now().UTC()
 	job.Status = host.StatusRunning
-	s.sendEvent(job, "start")
+	s.sendEvent(job, host.JobEventStart)
 	s.persist(jobID)
 }
 
@@ -386,7 +386,7 @@ func (s *State) setStatusDone(job *host.ActiveJob, exitStatus int) {
 	} else {
 		job.Status = host.StatusCrashed
 	}
-	s.sendEvent(job, "stop")
+	s.sendEvent(job, host.JobEventStop)
 	s.persist(job.Job.ID)
 }
 
@@ -402,7 +402,7 @@ func (s *State) SetStatusFailed(jobID string, err error) {
 	job.EndedAt = time.Now().UTC()
 	errStr := err.Error()
 	job.Error = &errStr
-	s.sendEvent(job, "error")
+	s.sendEvent(job, host.JobEventError)
 	s.persist(jobID)
 	go s.WaitAttach(jobID)
 }

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -279,3 +279,10 @@ type HostStatus struct {
 	Discoverd *DiscoverdConfig `json:"discoverd,omitempty"`
 	Network   *NetworkConfig   `json:"network,omitempty"`
 }
+
+const (
+	JobEventCreate string = "create"
+	JobEventStart  string = "start"
+	JobEventStop   string = "stop"
+	JobEventError  string = "error"
+)


### PR DESCRIPTION
There doesn't seem to be a reason to prioritise certain channels, and this removes the need for a sleep in the loop, as it will block on all channels if there is nothing to do.

/cc @jzila 