### PR TITLE
Support running Flynn clusters on a single machine

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -12,7 +12,8 @@
     "action": "run-app",
     "release": {
       "env": {
-        "DISCOVERD": "none"
+        "DISCOVERD": "none",
+        "BACKEND": "{{ getenv \"FLANNEL_BACKEND\" }}"
       },
       "processes": {
         "app": {
@@ -288,7 +289,7 @@
       "processes": {
         "app": {
           "host_network": true,
-          "cmd": ["-httpaddr", ":80", "-httpsaddr", ":443", "-tcp-range-start", "3000", "-tcp-range-end", "3500"],
+          "cmd": ["-http-port", "80", "-https-port", "443", "-tcp-range-start", "3000", "-tcp-range-end", "3500"],
           "omni": true
         }
       }

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -108,7 +108,7 @@ func (m *Main) Run(args ...string) error {
 	} else if opt.WaitNetDNS {
 		go func() {
 			// Wait for the host network.
-			status, err := cluster.WaitForHostStatus(func(status *host.HostStatus) bool {
+			status, err := cluster.WaitForHostStatus(os.Getenv("EXTERNAL_IP"), func(status *host.HostStatus) bool {
 				return status.Network != nil && status.Network.Subnet != ""
 			})
 			if err != nil {

--- a/discoverd/start.sh
+++ b/discoverd/start.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
 
-exec /bin/discoverd -data-dir=/data -host="${EXTERNAL_IP}" -peers="${DISCOVERD_PEERS}" -raft-addr=":${PORT_0}" -http-addr=":${PORT_1}" -notify="http://127.0.0.1:1113/host/discoverd" -wait-net-dns=true
+exec /bin/discoverd \
+  -data-dir=/data \
+  -host="${EXTERNAL_IP}" \
+  -peers="${DISCOVERD_PEERS}" \
+  -raft-addr="${LISTEN_IP}:${PORT_0}" \
+  -http-addr="${LISTEN_IP}:${PORT_1}" \
+  -notify="http://${EXTERNAL_IP}:1113/host/discoverd" \
+  -wait-net-dns=true

--- a/flannel/runner.go
+++ b/flannel/runner.go
@@ -39,6 +39,9 @@ const serviceName = "flannel"
 func main() {
 	var config Config
 	config.Backend.Type = "vxlan"
+	if backend := os.Getenv("BACKEND"); backend != "" {
+		config.Backend.Type = backend
+	}
 	flag.StringVar(&config.Network, "network", "100.100.0.0/16", "container network")
 	flag.StringVar(&config.SubnetMin, "subnet-min", "", "container network min subnet")
 	flag.StringVar(&config.SubnetMax, "subnet-max", "", "container network max subnet")
@@ -48,7 +51,7 @@ func main() {
 	flag.Parse()
 
 	// wait for discoverd to come up
-	status, err := cluster.WaitForHostStatus(func(status *host.HostStatus) bool {
+	status, err := cluster.WaitForHostStatus(os.Getenv("EXTERNAL_IP"), func(status *host.HostStatus) bool {
 		return status.Discoverd != nil && status.Discoverd.URL != ""
 	})
 	if err != nil {

--- a/host/cli/cli.go
+++ b/host/cli/cli.go
@@ -28,8 +28,6 @@ func Register(cmd string, f interface{}, usage string) *command {
 	return c
 }
 
-var localAddr = "127.0.0.1:1113"
-
 var ErrInvalidCommand = errors.New("invalid command")
 
 func Run(name string, args []string) error {

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -61,10 +61,10 @@ func (c *Host) GetStatus() (*host.HostStatus, error) {
 	return &res, err
 }
 
-func WaitForHostStatus(desired func(*host.HostStatus) bool) (*host.HostStatus, error) {
+func WaitForHostStatus(hostIP string, desired func(*host.HostStatus) bool) (*host.HostStatus, error) {
 	const waitMax = time.Minute
 	const waitInterval = 500 * time.Millisecond
-	h := NewHost("", "http://127.0.0.1:1113", nil)
+	h := NewHost("", fmt.Sprintf("http://%s:1113", hostIP), nil)
 	timeout := time.After(waitMax)
 	for {
 		status, err := h.GetStatus()

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -9,99 +9,156 @@ usage() {
   cat <<USAGE >&2
 usage: $0 [options]
 
+Boot a Flynn cluster.
+
+Use the --size flag to boot a multi-node cluster, which will create a virtual
+network interface for each node and bind all host network services to that
+interface (i.e. flynn-host, discoverd, flannel and router)
+
 OPTIONS:
-  -h            Show this message
-  -b BACKEND    The job backend to use [default: `libvirt-lxc`]
-  -d DOMAIN     The default domain to use [default: `dev.localflynn.com`]
-  -i IP         The external IP address to bind to [default: the IP assigned to `eth0`]
-  -z            Don't destroy volumes
+  -h, --help               Show this message
+  -s, --size=SIZE          Cluster size [default: 1]
+  -d, --domain=DOMAIN      The default domain to use [default: `dev.localflynn.com`]
+  -z, --no-destroy-vols    Don't destroy volumes
 USAGE
 }
 
 main() {
-  local backend ip
-  local domain="${CLUSTER_DOMAIN}"
+  local size="1"
+  local domain="${CLUSTER_DOMAIN:="dev.localflynn.com"}"
   local destroy_vols=true
 
-  while getopts 'hb:d:i:z' opt; do
-    case $opt in
-      h)
+  while true; do
+    case "$1" in
+      -h | --help)
         usage
-        exit 1
+        exit 0
         ;;
-      b) backend=${OPTARG} ;;
-      d) domain=${OPTARG} ;;
-      i) ip=${OPTARG} ;;
-      z) destroy_vols=false ;;
-      ?)
-        usage
-        exit 1
+      -s | --size)
+        if [[ -z "$2" ]]; then
+          usage
+          exit 1
+        fi
+        size="$2"
+        shift 2
+        ;;
+      -d | --domain)
+        if [[ -z "$2" ]]; then
+          usage
+          exit 1
+        fi
+        domain="$2"
+        shift 2
+        ;;
+      -z | --no-destroy-vols)
+        destroy_vols=false
+        shift
+        ;;
+      *)
+        break
         ;;
     esac
   done
-  shift $((${OPTIND} - 1))
 
   if [[ $# -ne 0 ]]; then
     usage
     exit 1
   fi
 
-  backend=${backend:-"libvirt-lxc"}
-  domain="${domain:="dev.localflynn.com"}"
-  ip=${ip:-$(/sbin/ifconfig eth0 \
-    | grep -oP 'inet addr:\S+' \
-    | cut -d: -f2)}
-
-  export DISCOVERD="${ip}:1111"
   export CLUSTER_DOMAIN="${domain}"
 
   # kill flynn first
-  "${ROOT}/script/kill-flynn" -b "${backend}"
+  "${ROOT}/script/kill-flynn"
 
-  # delete the old state
-  sudo rm -f /tmp/flynn-host-state.bolt
-
-  if $destroy_vols; then
-    sudo "${ROOT}/host/bin/flynn-host" destroy-volumes --include-data
-  fi
-
-  case "${backend}" in
-    libvirt-lxc)
-      boot_libvirt_lxc $ip
-      ;;
-    *)
-      usage
-      exit 1
-      ;;
-  esac
-}
-
-boot_libvirt_lxc() {
-  local ip=$1
   local host_dir="${ROOT}/host"
   local bootstrap_dir="${ROOT}/bootstrap"
 
-  local log="/tmp/flynn-host-$(date +%Y-%m-%dT%H-%M-%S.%N).log"
-  ln -nfs "${log}" /tmp/flynn-host.log
-  info "starting flynn-host (libvirt-lxc backend)"
-  info "forwarding daemon output to ${log}"
+  local ips=()
+  if [[ "${size}" -eq "1" ]]; then
+    info "starting single node cluster"
+    local external_ip="$(ifconfig eth0 | grep -oP 'inet addr:\S+' | cut -d: -f2)"
+    start_flynn_host
+  else
+    info "starting ${size} node cluster"
+
+    # don't create unnecessary vxlan devices
+    export FLANNEL_BACKEND="alloc"
+
+    for index in $(seq 0 $((size - 1))); do
+      # An RFC 5737 TEST-NET-2 IP
+      local external_ip="198.51.100.$(($index + 1))"
+      local listen_ip="${external_ip}"
+
+      info "starting flynn-host using IP ${external_ip}"
+      sudo ifconfig "eth0:${index}" "${external_ip}"
+      start_flynn_host "${index}"
+    done
+  fi
+
+  info "bootstrapping Flynn"
+  export DISCOVERD="${ips[0]}:1111"
+  "${host_dir}/bin/flynn-host" \
+    bootstrap \
+    --min-hosts="${size}" \
+    --peer-ips="$(join "," ${ips[@]})" \
+    "${bootstrap_dir}/bin/manifest.json"
+}
+
+start_flynn_host() {
+  local index=$1
+
+  # if index is not set (i.e. a single node cluster), use non-namespaced names
+  if [[ -z "${index}" ]]; then
+    local id="host"
+    local state="/tmp/flynn-host-state.bolt"
+    local pidfile="/tmp/flynn-host.pid"
+    local bridge_name="flynnbr0"
+    local vol_path="/var/lib/flynn/volumes"
+    local log="/tmp/flynn-host-$(date +%Y-%m-%dT%H-%M-%S.%N).log"
+    ln -nfs "${log}" "/tmp/flynn-host.log"
+  else
+    local id="host${index}"
+    local state="/tmp/flynn-host-state-${index}.bolt"
+    local pidfile="/tmp/flynn-host-${index}.pid"
+    local bridge_name="flynnbr${index}"
+    local vol_path="/var/lib/flynn/volumes-${index}"
+    local log="/tmp/flynn-host-${index}-$(date +%Y-%m-%dT%H-%M-%S.%N).log"
+    ln -nfs "${log}" "/tmp/flynn-host-${index}.log"
+  fi
+
+  # delete the old state
+  sudo rm -f "${state}"
+
+  if $destroy_vols; then
+    sudo "${ROOT}/host/bin/flynn-host" destroy-volumes --volpath="${vol_path}" --include-data
+  fi
+
   sudo start-stop-daemon \
     --start \
     --background \
     --no-close \
+    --pidfile "${pidfile}" \
     --exec "${host_dir}/bin/flynn-host" \
     -- \
     daemon \
-    --external ${ip} \
+    --id "${id}" \
+    --external-ip "${external_ip}" \
+    --listen-ip "${listen_ip}" \
+    --bridge-name "${bridge_name}" \
     --force \
-    --backend libvirt-lxc \
-    --state /tmp/flynn-host-state.bolt \
+    --state "${state}" \
+    --volpath "${vol_path}" \
     --flynn-init "${host_dir}/bin/flynn-init" \
     --nsumount "${host_dir}/bin/flynn-nsumount" \
     &>"${log}"
 
-  info "bootstrapping Flynn"
-  "${host_dir}/bin/flynn-host" bootstrap "${bootstrap_dir}/bin/manifest.json"
+  ips+=("${external_ip}")
+}
+
+join() {
+  local IFS="$1"
+  shift
+  echo "$*"
 }
 
 main $@

--- a/script/kill-flynn
+++ b/script/kill-flynn
@@ -9,49 +9,24 @@ usage() {
   cat <<USAGE >&2
 usage: $0 [options]
 
+Kill running flynn-host daemons
+
 OPTIONS:
   -h            Show this message
-  -b BACKEND    The job backend to use [default: `libvirt-lxc`]
 USAGE
 }
 
 main() {
-  local backend
-
-  while getopts "hb:" opt; do
-    case $opt in
-      h)
-        usage
-        exit 1
-        ;;
-      b) backend=${OPTARG} ;;
-      ?)
-        usage
-        exit 1
-        ;;
-    esac
-  done
-  shift $((${OPTIND} - 1))
+  if [[ $1 = "-h" ]]; then
+    usage
+    exit 0
+  fi
 
   if [[ $# -ne 0 ]]; then
     usage
     exit 1
   fi
 
-  backend=${backend:-"libvirt-lxc"}
-
-  case "${backend}" in
-    libvirt-lxc)
-      kill_libvirt_lxc
-      ;;
-    *)
-      usage
-      exit 1
-      ;;
-  esac
-}
-
-kill_libvirt_lxc() {
   local flynn_host="${ROOT}/host/bin/flynn-host"
 
   info "killing running libvirt-lxc flynn-host, if any"

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -8,32 +8,52 @@ usage() {
   cat <<USAGE >&2
 usage: $0 [options]
 
+Boot a Flynn cluster and run integration tests.
+
 OPTIONS:
-  -h            Show this message
-  -f FILTER     Regular expression selecting which tests and/or suites to run
-  -s            Stream debug output
+  -h, --help               Show this message
+  -s, --size=SIZE          Cluster size [default: 1]
+  -f, --filter=FILTER      Regular expression selecting which tests and/or suites to run
+  -s, --stream             Stream debug output
 USAGE
 }
 
 main() {
+  local size="1"
   local filter
   local stream=false
 
-  while getopts 'hf:s' opt; do
-    case "${opt}" in
-      h)
+  while true; do
+    case "$1" in
+      -h | --help)
         usage
-        exit 1
+        exit 0
         ;;
-      f) filter="${OPTARG}" ;;
-      s) stream=true ;;
-      ?)
-        usage
-        exit 1
+      -s | --size)
+        if [[ -z "$2" ]]; then
+          usage
+          exit 1
+        fi
+        size="$2"
+        shift 2
+        ;;
+      -f | --filter)
+        if [[ -z "$2" ]]; then
+          usage
+          exit 1
+        fi
+        filter="$2"
+        shift 2
+        ;;
+      -s | --stream)
+        stream=true
+        shift
+        ;;
+      *)
+        break
         ;;
     esac
   done
-  shift $((${OPTIND} - 1))
 
   if [[ $# -ne 0 ]]; then
     usage
@@ -46,7 +66,7 @@ main() {
   make
   popd >/dev/null
 
-  cluster_add=$("${ROOT}/script/bootstrap-flynn" &> >(tee /dev/stderr) | tail -3 | head -1)
+  cluster_add=$("${ROOT}/script/bootstrap-flynn" --size "${size}" &> >(tee /dev/stderr) | tail -3 | head -1)
 
   if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then
     echo Bootstrap failed >&2
@@ -74,6 +94,9 @@ main() {
   fi
   if $stream; then
     args+=("--stream")
+  fi
+  if [[ "${size}" -gt "1" ]]; then
+    args+=("--router-ip=198.51.100.1")
   fi
 
   bin/flynn-test ${args[@]}


### PR DESCRIPTION
This is made possible by creating virtual network interfaces for each node and binding all host network services (i.e. flynn-host, discoverd, flannel and router) to those interfaces. 

My main motivator here is being able to test updating a discoverd cluster on my local machine, but this is also pretty useful in general.

Boot a 5 node cluster:

```
$ script/bootstrap-flynn --size 5
```

or run integration tests against a 5 node cluster:

```
$ script/run-integration-tests --size 5
```

It works fine for me on an EC2 instance, but I would appreciate other people testing this out in their own environments.

/cc @titanous @jvatic @jzila @benbjohnson 