### PR TITLE
all: Update Go to 1.4.3

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/flynn/flynn",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.4.3",
 	"Packages": [
 		"./..."
 	],
@@ -487,8 +487,8 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/gonative",
-			"Comment": "0.2.0-10-g9ba0b45",
-			"Rev": "9ba0b451d901155f5b1169162362a0b178ce4dc1"
+			"Comment": "0.2.0-12-g2013c28",
+			"Rev": "2013c28499ba031ea01f64e3daa556f35f694bb0"
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",

--- a/Godeps/_workspace/src/github.com/inconshreveable/gonative/gonative.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/gonative/gonative.go
@@ -64,10 +64,10 @@ func main() {
 			Name:  "build",
 			Usage: "build a go installation with native stdlib packages",
 			Flags: []cli.Flag{
-				cli.StringFlag{"version", "1.4.2", "version of Go to build", ""},
+				cli.StringFlag{"version", "1.4.3", "version of Go to build", ""},
 				cli.StringFlag{"src", "", "path to go source, empty string means to fetch from internet", ""},
 				cli.StringFlag{"target", "go", "target directory in which to build Go", ""},
-				cli.StringFlag{"platforms", "", "space separated list of platforms to build, default is darwin|linux|windows on 386|amd64", ""},
+				cli.StringFlag{"platforms", "", "space separated list of platforms to build, default is 'darwin_amd64 freebsd_amd64 linux_386 linux_amd64 windows_386 windows_amd64'", ""},
 			},
 			Action: buildCmd,
 		},

--- a/Godeps/_workspace/src/github.com/inconshreveable/gonative/platform.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/gonative/platform.go
@@ -18,16 +18,17 @@ var srcPlatform = Platform{"", ""}
 var defaultPlatforms = []Platform{
 	Platform{"linux", "386"},
 	Platform{"linux", "amd64"},
-	Platform{"darwin", "386"},
+	Platform{"freebsd", "amd64"},
 	Platform{"darwin", "amd64"},
 	Platform{"windows", "386"},
 	Platform{"windows", "amd64"},
 }
 
 const (
-	oldDistURL         = "https://go.googlecode.com/files/go%s.%s.tar.gz"
-	distURL            = "https://storage.googleapis.com/golang/go%s.%s.tar.gz"
-	lastOldDistVersion = "1.2.1"
+	oldDistURL           = "https://go.googlecode.com/files/go%s.%s.tar.gz"
+	distURL              = "https://storage.googleapis.com/golang/go%s.%s.tar.gz"
+	lastOldDistVersion   = "1.2.1"
+	lastOldDarwinVersion = "1.4.2"
 )
 
 type Platform struct {
@@ -98,7 +99,7 @@ func (p *Platform) distURL(version string) string {
 	distString := p.OS + "-" + p.Arch
 	// special cases
 	switch {
-	case p.OS == "darwin":
+	case p.OS == "darwin" && version <= lastOldDarwinVersion:
 		distString += "-osx10.8"
 	case p.OS == "" && p.Arch == "":
 		distString = "src"
@@ -137,6 +138,16 @@ func download(lg log15.Logger, rd io.Reader, name string, checksum string) (*os.
 }
 
 var checksums = map[string]string{
+	"https://storage.googleapis.com/golang/go1.4.3.src.tar.gz":                     "486db10dc571a55c8d795365070f66d343458c48",
+	"https://storage.googleapis.com/golang/go1.4.3.darwin-amd64.tar.gz":            "945666c36b42bf859d98775c4f02f807a5bdb6b0",
+	"https://storage.googleapis.com/golang/go1.4.3.darwin-amd64.pkg":               "3d91a21e3217370b80ca26e89a994e8199d583e7",
+	"https://storage.googleapis.com/golang/go1.4.3.freebsd-amd64.tar.gz":           "573217c097f78143ea7c54212445c31944750144",
+	"https://storage.googleapis.com/golang/go1.4.3.linux-386.tar.gz":               "405777725abe566989cdb436d2efeb2667be670f",
+	"https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz":             "332b64236d30a8805fc8dd8b3a269915b4c507fe",
+	"https://storage.googleapis.com/golang/go1.4.3.windows-386.zip":                "77ec9b61c1e1bf475463c62c36c395ba9d69aa9e",
+	"https://storage.googleapis.com/golang/go1.4.3.windows-386.msi":                "cad793895b258929ee796ef9ea77855626740ecd",
+	"https://storage.googleapis.com/golang/go1.4.3.windows-amd64.zip":              "821a6773adadd7409380addc4791771f2b057fa0",
+	"https://storage.googleapis.com/golang/go1.4.3.windows-amd64.msi":              "5e7c6cb012cbf09242b040b84b78b5e52d980337",
 	"https://storage.googleapis.com/golang/go1.4.2.src.tar.gz":                     "460caac03379f746c473814a65223397e9c9a2f6",
 	"https://storage.googleapis.com/golang/go1.4.2.darwin-386-osx10.6.tar.gz":      "fb3e6b30f4e1b1be47bbb98d79dd53da8dec24ec",
 	"https://storage.googleapis.com/golang/go1.4.2.darwin-386-osx10.8.tar.gz":      "65f5610fdb38febd869aeffbd426c83b650bb408",

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-integration:
 toolchain: util/_toolchain/go/bin/go
 
 util/_toolchain/go/bin/go: util/_toolchain/bin/gonative
-	cd util/_toolchain && rm -rf go && bin/gonative build -version=1.4.2 && ls | grep -v "^\(bin\|go\)$$" | xargs --no-run-if-empty rm -r
+	cd util/_toolchain && rm -rf go && bin/gonative build -version=1.4.3 && ls | grep -v "^\(bin\|go\)$$" | xargs --no-run-if-empty rm -r
 
 
 util/_toolchain/bin/gonative: Godeps/_workspace/src/github.com/inconshreveable/gonative/*.go

--- a/cli/Tupfile.lua
+++ b/cli/Tupfile.lua
@@ -23,8 +23,8 @@ tup.rule({"tuf.go.tmpl"},
          {"tuf.go"})
 
 vpkg = "github.com/flynn/flynn/pkg/version"
-for i, os in ipairs({"darwin", "linux", "windows"}) do
-  for j, arch in ipairs({"amd64", "386"}) do
+for os, arches in pairs({darwin = {"amd64"}, freebsd = {"amd64"}, linux = {"amd64", "386"}, windows = {"amd64", "386"}}) do
+  for j, arch in ipairs(arches) do
     tup.rule({"../installer/bindata.go", "tuf.go"},
              "^c go build %o^ GOOS="..os.." GOARCH="..arch.." CGO_ENABLED=0 ../util/_toolchain/go/bin/go build -installsuffix nocgo -o %o -ldflags=\"-X "..vpkg..".commit $GIT_COMMIT -X "..vpkg..".branch $GIT_BRANCH -X "..vpkg..".tag $GIT_TAG -X "..vpkg..".dirty $GIT_DIRTY\"",
              {string.format("bin/flynn-%s-%s", os, arch)})

--- a/script/export-components
+++ b/script/export-components
@@ -41,7 +41,7 @@ main() {
   tuf add
 
   local version=$("${ROOT}/cli/bin/flynn" version)
-  for f in ${ROOT}/cli/bin/flynn-{linux,darwin,windows}-{amd64,386}; do
+  for f in ${ROOT}/cli/bin/flynn-{linux-amd64,linux-386,darwin-amd64,freebsd-amd64,windows-amd64,windows-386}; do
     local name="$(basename "${f}").gz"
     gzip -9 --stdout "${f}" > "staged/targets/${name}"
     tuf add --custom="{\"version\": \"${version}\"}" "${name}"

--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -147,7 +147,7 @@ sed 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
 
 # install go
 curl -L j.mp/godeb | tar xz
-./godeb install 1.4.2
+./godeb install 1.4.3
 rm godeb
 
 # install go-tuf

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -211,7 +211,7 @@ install_go() {
   cd /tmp
   wget j.mp/godeb
   tar xvzf godeb
-  ./godeb install 1.4.2
+  ./godeb install 1.4.3
 }
 
 apt_cleanup() {


### PR DESCRIPTION
Also tweaked the CLI OS/architecture pairs to match the available builds:

- darwin 386 was removed
- freebsd amd64 was added