### PR TITLE
Stopped jobs now get saved to the controller

### DIFF
--- a/controller/scheduler/formation.go
+++ b/controller/scheduler/formation.go
@@ -38,6 +38,15 @@ func (p Processes) Equals(other Processes) bool {
 	return true
 }
 
+func (p Processes) IsEmpty() bool {
+	for _, count := range p {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 type Formation struct {
 	*ct.ExpandedFormation
 }

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -17,6 +17,7 @@ const (
 	JobRequestTypeDown JobRequestType = "down"
 	JobStateStarting   JobState       = "starting"
 	JobStateRunning    JobState       = "running"
+	JobStateStopping   JobState       = "stopping"
 	JobStateStopped    JobState       = "stopped"
 	JobStateCrashed    JobState       = "crashed"
 	JobStateRequesting JobState       = "requesting"
@@ -83,7 +84,7 @@ func (j *Job) Clone() *Job {
 
 //
 func (j *Job) IsStopped() bool {
-	return j.state == JobStateStopped
+	return j.state == JobStateStopping || j.state == JobStateStopped
 }
 
 func (j *Job) IsRunning() bool {

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -823,7 +823,7 @@ func (s *Scheduler) stopJob(req *JobRequest) (err error) {
 			return errors.New(e)
 		}
 	}
-	s.jobs.SetState(job.JobID, JobStateStopped)
+	s.jobs.SetState(job.JobID, JobStateStopping)
 	if job.HostID != "" {
 		log.Info("getting host client", "host.id", job.HostID)
 		host, err := s.Host(job.HostID)


### PR DESCRIPTION
Added job state to represent jobs that are stopping but not yet stopped, to ensure they get saved to the controller

Signed-off-by: John Zila <john@jzila.com>