### PR TITLE
Fixes #1887 - Hanging DigitalOcean installer

### DIFF
--- a/installer/cluster.go
+++ b/installer/cluster.go
@@ -538,6 +538,7 @@ func (c *BaseCluster) genStartScript(nodes int64) (string, string, error) {
 }
 
 var iptablesConfigScript = template.Must(template.New("iptables.sh").Parse(`
+export DEBIAN_FRONTEND=noninteractive
 apt-get install -y iptables-persistent
 {{ range $i, $ip := .InstanceIPs }}
 iptables -A FORWARD -s {{$ip}} -j ACCEPT


### PR DESCRIPTION
Added this export, per suggestion [here](https://github.com/flynn/flynn/issues/1887#issuecomment-140901222). Tried it out locally and was able to complete an install on DigitalOcean with this change.