### PR TITLE
scheduler: Instead of directly assigning s.isLeader, use HandleLeaderChange to populate logs correctly

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -256,11 +256,11 @@ func (s *Scheduler) Run() error {
 		return err
 	}
 
-	var err error
-	s.isLeader, err = s.discoverd.Register()
+	isLeader, err := s.discoverd.Register()
 	if err != nil {
 		return err
 	}
+	s.HandleLeaderChange(isLeader)
 	leaderCh := s.discoverd.LeaderCh()
 
 	if err := s.streamFormationEvents(); err != nil {


### PR DESCRIPTION
Signed-off-by: John Zila <john@jzila.com>