### PR TITLE
gitreceive/receiver: Drop process type from slugbuilder job meta

### DIFF
--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -95,7 +95,6 @@ Options:
 		"flynn-controller.app":      app.ID,
 		"flynn-controller.app_name": app.Name,
 		"flynn-controller.release":  prevRelease.ID,
-		"flynn-controller.type":     "slugbuilder",
 	}
 	if len(prevRelease.Env) > 0 {
 		stdin, err := cmd.StdinPipe()

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -117,6 +117,14 @@ func (s *GitDeploySuite) TestStaticBuildpack(t *c.C) {
 	s.runBuildpackTestWithResponsePattern(t, "static-flynn-example", nil, `Hello, Flynn!`)
 }
 
+func (s *GitDeploySuite) TestPushTwice(t *c.C) {
+	r := s.newGitRepo(t, "https://github.com/flynn-examples/nodejs-flynn-example")
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.git("push", "flynn", "master"), Succeeds)
+	t.Assert(r.git("commit", "-m", "second", "--allow-empty"), Succeeds)
+	t.Assert(r.git("push", "flynn", "master"), Succeeds)
+}
+
 func (s *GitDeploySuite) runBuildpackTest(t *c.C, name string, resources []string) {
 	s.runBuildpackTestWithResponsePattern(t, name, resources, `Hello from Flynn on port \d+`)
 }


### PR DESCRIPTION
When the type is in the job meta, the new scheduler kills some slugbuilder jobs while they are running.

Closes #1929
Closes #1934