### PR TITLE
util/packer: Normalize apt sources across releases

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -7,6 +7,23 @@ export DEBIAN_FRONTEND=noninteractive
 # cron can run apt/dpkg commands that will disrupt our tasks
 service cron stop
 
+# setup system apt sources
+cat << EOF > /etc/apt/sources.list
+deb http://archive.ubuntu.com/ubuntu trusty main universe
+deb-src http://archive.ubuntu.com/ubuntu trusty main universe
+deb http://archive.ubuntu.com/ubuntu trusty-updates main universe
+deb-src http://archive.ubuntu.com/ubuntu trusty-updates main universe
+deb http://security.ubuntu.com/ubuntu trusty-security main universe
+deb-src http://security.ubuntu.com/ubuntu trusty-security main universe
+EOF
+
+# ensure cloud-init doesn't overwrite our apt sources
+if [[ -f /etc/cloud/cloud.cfg ]]; then
+  grep -q '^apt_preserve_sources_list:' /etc/cloud/cloud.cfg &&
+  sed -i 's/^apt_preserve_sources_list.*/apt_preserve_sources_list: true/' /etc/cloud/cloud.cfg ||
+  echo 'apt_preserve_sources_list: true' >> /etc/cloud/cloud.cfg
+fi
+
 apt-get update
 
 if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then


### PR DESCRIPTION
The Ubuntu cloud mirrors seem to be finicky.
Switching to achive.ubuntu.com brings the EC2 image inline with the Virtualbox and VMware images.

Closes #1829 