### PR TITLE
Revert "release: Restore eu-central-1"

### DIFF
--- a/installer/app/src/views/aws-region-picker.js.jsx
+++ b/installer/app/src/views/aws-region-picker.js.jsx
@@ -9,7 +9,6 @@ var AWSRegionPicker = React.createClass({
 					<option value="us-east-1">US East (N. Virginia)</option>
 					<option value="us-west-2">US West (Oregon)</option>
 					<option value="us-west-1">US West (N. California)</option>
-					<option value="eu-central-1">EU (Frankfurt)</option>
 					<option value="eu-west-1">EU (Ireland)</option>
 					<option value="ap-southeast-1">Asia Pacific (Singapore)</option>
 					<option value="ap-southeast-2">Asia Pacific (Sydney)</option>

--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -61,7 +61,6 @@
         "ap-northeast-1",
         "ap-southeast-1",
         "ap-southeast-2",
-        "eu-central-1",
         "eu-west-1",
         "sa-east-1",
         "us-west-1",


### PR DESCRIPTION
Reverts flynn/flynn#1759

Revert this temporarily until `flynn-release` is fixed to handle publishing ec2 manifests to the eu-central-1 region.