### PR TITLE
script: Clear apt lists to ensure clean slate

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -24,6 +24,9 @@ if [[ -f /etc/cloud/cloud.cfg ]]; then
   echo 'apt_preserve_sources_list: true' >> /etc/cloud/cloud.cfg
 fi
 
+# clear apt lists
+rm -rf /var/lib/apt/lists/*
+
 apt-get update
 
 if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then


### PR DESCRIPTION
The idea here is that the failures we are seeing indicate that the trusty release is either untrusted or not correctly downloaded, by clearing the existing state we eliminate some sources of uncertainty.
It's unlikely this will fix the problem but it makes it easier to reason about what could be wrong.