### PR TITLE
script: create local git tag in tag_release rather than in release-components

### DIFF
--- a/script/release-components
+++ b/script/release-components
@@ -119,7 +119,6 @@ main() {
 
   info "building flynn"
   git checkout --force --quiet $commit
-  git tag "v${version}"
 
   make release
 

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -179,6 +179,9 @@ tag_release() {
     --header "Authorization: token ${GITHUB_TOKEN}" \
     --data "{\"ref\":\"refs/tags/v${version}\",\"sha\":\"${commit}\"}" \
     "https://api.github.com/repos/flynn/flynn/git/refs"
+
+  # create the tag locally
+  git tag --force "v${version}" "${commit}"
 }
 
 main $@


### PR DESCRIPTION
We already create the tag in `release-flynn` so we shouldn't try retag it with the same tag here, it will fail.