### PR TITLE
host: Add signal command

### DIFF
--- a/host/cli/signal.go
+++ b/host/cli/signal.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/pkg/cluster"
+)
+
+func init() {
+	Register("signal", runSignal, `
+usage: flynn-host signal ID SIGNAL
+
+Signal a job`)
+}
+
+func runSignal(args *docopt.Args, client *cluster.Client) error {
+	id := args.String["ID"]
+	sig, err := strconv.Atoi(args.String["SIGNAL"])
+	if err != nil {
+		fmt.Println("invalid value for SIGNAL")
+		return err
+	}
+	hostID, err := cluster.ExtractHostID(id)
+	if err != nil {
+		fmt.Println("could not parse", id)
+		return err
+	}
+	hostClient, err := client.Host(hostID)
+	if err != nil {
+		fmt.Println("could not connect to host", hostID)
+		return err
+	}
+	if err := hostClient.SignalJob(id, sig); err != nil {
+		fmt.Println("could not signal job", id)
+		return err
+	}
+	fmt.Printf("sent signal %d to %s successfully\n", sig, id)
+	return nil
+}

--- a/host/host.go
+++ b/host/host.go
@@ -70,6 +70,7 @@ Commands:
   log                        Get the logs of a job
   ps                         List jobs
   stop                       Stop running jobs
+  signal                     Signal a job
   destroy-volumes            Destroys the local volume database
   collect-debug-info         Collect debug information into an anonymous gist or tarball
   version                    Show current version


### PR DESCRIPTION
Adds a `signal` command to `flynn-host` for signalling jobs.

Could potentially add a mapping from string => int signals to allow usage of any of SIGQUIT, QUIT or 3 as the SIGNAL argument.