### PR TITLE
bootstrap: Report service status details in bootstrap

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -510,8 +510,8 @@
     "url": "tcp://gitreceive.discoverd"
   },
   {
-    "id": "status-wait",
-    "action": "wait",
+    "id": "status-check",
+    "action": "status-check",
     "url": "http://status-web.discoverd"
   },
   {

--- a/bootstrap/status_check_action.go
+++ b/bootstrap/status_check_action.go
@@ -1,0 +1,81 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type StatusCheckAction struct {
+	ID     string `json:"id"`
+	URL    string `json:"url"`
+	Output string `json:"output"`
+}
+
+type StatusResponse struct {
+	Data StatusData `json:"data"`
+}
+
+type StatusData struct {
+	Status string                  `json:"status"`
+	Detail map[string]StatusDetail `json:"detail"`
+}
+
+type StatusDetail struct {
+	Status string `json:"status"`
+}
+
+func init() {
+	Register("status-check", &StatusCheckAction{})
+}
+
+func (a *StatusCheckAction) Run(s *State) error {
+	const waitMax = time.Minute
+	const waitInterval = 500 * time.Millisecond
+
+	u, err := url.Parse(interpolate(s, a.URL))
+	if err != nil {
+		return err
+	}
+	lookupDiscoverdURLHost(u, waitMax)
+
+	start := time.Now()
+	for {
+		req, err := http.NewRequest("GET", u.String(), nil)
+		if err != nil {
+			return err
+		}
+		req.Header = make(http.Header)
+		req.Header.Set("Accept", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			goto fail
+		}
+		if res.StatusCode == 200 {
+			s.StepData[a.ID] = &LogMessage{Msg: "all services healthy"}
+		} else {
+			var status StatusResponse
+			err = json.NewDecoder(res.Body).Decode(&status)
+			if err != nil {
+				goto fail
+			}
+			res.Body.Close()
+			msg := "unhealthy services detected!\n\nThe following services are reporting unhealthy, this likely indicates a problem with your deployment:\n"
+			for svc, s := range status.Data.Detail {
+				if s.Status != "healthy" {
+					msg += "\t" + svc + "\n"
+				}
+			}
+			msg += "\n"
+			s.StepData[a.ID] = &LogMessage{Msg: msg}
+		}
+		return nil
+	fail:
+		if time.Now().Sub(start) >= waitMax {
+			return fmt.Errorf("bootstrap: timed out waiting for %s, last response %s", a.URL, err)
+		}
+		time.Sleep(waitInterval)
+	}
+}


### PR DESCRIPTION
This introduces another step into the bootstrap process that queries the status app to ascertain the health of the cluster before completing the bootstrap.

Example output with a single unhealthy service:
```
19:17:35.309024 wait status-wait
19:17:38.062046 status-check status-check
19:18:08.068476 status-check status-check unhealthy services detected!

The following services are reporting unhealthy, this likely indicates a problem with your deployment:
	dashboard

19:18:08.068492 log log-complete
19:18:08.068593 log log-complete

Flynn bootstrapping complete. Install the Flynn CLI (see https://flynn.io/docs/cli for instructions) and paste the line below into a terminal window:

flynn cluster add -p AnKjz+VOD1ndlsUKhGjc/JiiQ4QfsNVQu9Gjg4Cduf0= default dev.localflynn.com 339cb492858821690bf4d297540f2ce3

The built-in dashboard can be accessed at http://dashboard.dev.localflynn.com and your login token is 53303cfc65d00f8085ba08ec75e0b140
```

Closes  #1825