### PR TITLE
release: Restore eu-central-1

### DIFF
--- a/installer/app/src/views/aws-region-picker.js.jsx
+++ b/installer/app/src/views/aws-region-picker.js.jsx
@@ -9,6 +9,7 @@ var AWSRegionPicker = React.createClass({
 					<option value="us-east-1">US East (N. Virginia)</option>
 					<option value="us-west-2">US West (Oregon)</option>
 					<option value="us-west-1">US West (N. California)</option>
+					<option value="eu-central-1">EU (Frankfurt)</option>
 					<option value="eu-west-1">EU (Ireland)</option>
 					<option value="ap-southeast-1">Asia Pacific (Singapore)</option>
 					<option value="ap-southeast-2">Asia Pacific (Sydney)</option>

--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -61,6 +61,7 @@
         "ap-northeast-1",
         "ap-southeast-1",
         "ap-southeast-2",
+        "eu-central-1",
         "eu-west-1",
         "sa-east-1",
         "us-west-1",


### PR DESCRIPTION
This reverts commit 598838848a0647c6a8f14a41d06cf91b147f88ae.

This was disabled again on realizing that other tools in the release chain were still using `goamz`.
These have since been migrated to `aws-sdk-go` and as such eu-central-1 should now work fine.

Closes #1942 