### PR TITLE
bootstrap: Allow passing pre-generated TLS details in env vars

### DIFF
--- a/bootstrap/gen_tls_cert_action.go
+++ b/bootstrap/gen_tls_cert_action.go
@@ -1,6 +1,9 @@
 package bootstrap
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 
 	"github.com/flynn/flynn/pkg/certgen"
@@ -9,6 +12,10 @@ import (
 type GenTLSCertAction struct {
 	ID    string   `json:"id"`
 	Hosts []string `json:"hosts"`
+
+	CACert     string `json:"ca_cert"`
+	Cert       string `json:"cert"`
+	PrivateKey string `json:"key"`
 }
 
 func init() {
@@ -30,6 +37,21 @@ func (c *TLSCert) String() string {
 func (a *GenTLSCertAction) Run(s *State) (err error) {
 	data := &TLSCert{}
 	s.StepData[a.ID] = data
+
+	a.CACert = interpolate(s, a.CACert)
+	a.Cert = interpolate(s, a.Cert)
+	a.PrivateKey = interpolate(s, a.PrivateKey)
+	if a.CACert != "" && a.Cert != "" && a.PrivateKey != "" {
+		data.CACert = a.CACert
+		data.Cert = a.Cert
+		data.PrivateKey = a.PrivateKey
+
+		// calculate cert pin
+		b, _ := pem.Decode([]byte(data.Cert))
+		sha := sha256.Sum256(b.Bytes)
+		data.Pin = base64.StdEncoding.EncodeToString(sha[:])
+		return nil
+	}
 
 	for i, h := range a.Hosts {
 		a.Hosts[i] = interpolate(s, h)

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -138,7 +138,10 @@
   {
     "id": "controller-cert",
     "action": "gen-tls-cert",
-    "hosts": ["{{ getenv \"CLUSTER_DOMAIN\" }}", "*.{{ getenv \"CLUSTER_DOMAIN\" }}"]
+    "hosts": ["{{ getenv \"CLUSTER_DOMAIN\" }}", "*.{{ getenv \"CLUSTER_DOMAIN\" }}"],
+    "ca_cert": "{{ getenv \"TLS_CA\" }}",
+    "cert": "{{ getenv \"TLS_CERT\" }}",
+    "key": "{{ getenv \"TLS_KEY\" }}"
   },
   {
     "id": "controller",


### PR DESCRIPTION
This allows a cluster to be bootstrapped using a previous cluster's certificates, so a cluster can be seamlessly replaced without breaking clients.

Closes #1039 

/cc @temujin9