### PR TITLE
util/release: Deference device names when updating EC2 manifest

### DIFF
--- a/util/release/amis.go
+++ b/util/release/amis.go
@@ -38,7 +38,7 @@ func amis(args *docopt.Args) {
 
 		var snapshotID string
 		for _, mapping := range image.BlockDeviceMappings {
-			if mapping.DeviceName == image.RootDeviceName {
+			if *mapping.DeviceName == *image.RootDeviceName {
 				snapshotID = *mapping.EBS.SnapshotID
 			}
 		}


### PR DESCRIPTION
Fixes a bug introduced by switching to `aws-sdk-go` inadvertently.