### PR TITLE
test: Fix setting dashboard domain

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -554,7 +554,7 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	if err != nil {
 		return fmt.Errorf("could not detect router ip: %s", err)
 	}
-	if err = setLocalDNS([]string{c.ClusterDomain, c.ControllerDomain(), c.GitDomain(), fmt.Sprintf("dashboard.%s", c.ClusterDomain)}, leader.Host()); err != nil {
+	if err = setLocalDNS([]string{c.ClusterDomain, c.ControllerDomain(), c.GitDomain()}, leader.Host()); err != nil {
 		return fmt.Errorf("could not set cluster DNS entries: %s", err)
 	}
 	c.RouterIP = leader.Host()

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
@@ -554,20 +553,8 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	if err != nil {
 		return fmt.Errorf("could not detect router ip: %s", err)
 	}
-	if err = setLocalDNS([]string{c.ClusterDomain, c.ControllerDomain(), c.GitDomain()}, leader.Host()); err != nil {
-		return fmt.Errorf("could not set cluster DNS entries: %s", err)
-	}
 	c.RouterIP = leader.Host()
 	return nil
-}
-
-func setLocalDNS(domains []string, ip string) error {
-	command := fmt.Sprintf(
-		`grep -q "^%[1]s" /etc/hosts && sed "s/^%[1]s.*/%[1]s %s/" -i /etc/hosts || echo %[1]s %s >> /etc/hosts`,
-		ip, strings.Join(domains, " "),
-	)
-	cmd := exec.Command("bash", "-c", command)
-	return cmd.Run()
 }
 
 func lookupUser(name string) (int, int, error) {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -267,7 +267,7 @@ var testRunScript = template.Must(template.New("test-run").Parse(`
 #!/bin/bash
 set -e -x -o pipefail
 
-echo {{ .Cluster.RouterIP }} {{ .Cluster.ClusterDomain }} {{ .Cluster.ControllerDomain }} {{ .Cluster.GitDomain }} | sudo tee -a /etc/hosts
+echo {{ .Cluster.RouterIP }} {{ .Cluster.ClusterDomain }} {{ .Cluster.ControllerDomain }} {{ .Cluster.GitDomain }} dashboard.{{ .Cluster.ClusterDomain }} | sudo tee -a /etc/hosts
 
 # Wait for the Flynn bridge interface to show up so we can use it as the
 # nameserver to resolve discoverd domains


### PR DESCRIPTION
Where it was being set previously was ineffective. I have added the domain in the correct place (just before running the test binary) and removed the ineffective `setLocalDNS`.

/cc @jvatic 