### PR TITLE
boostrap: When checking status in bootstrap, retry if unhealthy

### DIFF
--- a/bootstrap/status_check_action.go
+++ b/bootstrap/status_check_action.go
@@ -55,6 +55,11 @@ func (a *StatusCheckAction) Run(s *State) error {
 		}
 		if res.StatusCode == 200 {
 			s.StepData[a.ID] = &LogMessage{Msg: "all services healthy"}
+		} else if time.Now().Sub(start) < waitMax {
+			// if services are unhealthy wait out the wait period
+			// before reporting them as unhealthy to the user
+			time.Sleep(waitInterval)
+			continue
 		} else {
 			var status StatusResponse
 			err = json.NewDecoder(res.Body).Decode(&status)


### PR DESCRIPTION
The status check was racing with the dashboard starting up and reporting it unhealthy falsely.
By retrying until the max wait period is reached we avoid reporting false positives to the user.