### PR TITLE
bootstrap: Check if ports are available prior to bootstrap

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -5,6 +5,16 @@
     "vars": ["CLUSTER_DOMAIN"]
   },
   {
+    "id": "resource-check",
+    "action": "resource-check",
+    "ports": [
+      { "port": 80 },
+      { "port": 443 },
+      { "port": 5002 },
+      { "port": 1111 }
+    ]
+  },
+  {
     "id": "flannel",
     "app": {
       "name": "flannel"

--- a/bootstrap/resource_check_action.go
+++ b/bootstrap/resource_check_action.go
@@ -1,0 +1,53 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/httphelper"
+)
+
+type ResourceCheckAction struct {
+	Ports []host.Port
+}
+
+func init() {
+	Register("resource-check", &ResourceCheckAction{})
+}
+
+func (a *ResourceCheckAction) Run(s *State) error {
+	conflicts := make(map[*cluster.Host][]host.Port)
+	for _, h := range s.Hosts {
+		req := host.ResourceCheck{Ports: a.Ports}
+		if err := h.ResourceCheck(req); err != nil {
+			if j, ok := err.(httphelper.JSONError); ok {
+				var resp host.ResourceCheck
+				if err := json.Unmarshal(j.Detail, &resp); err != nil {
+					return err
+				}
+				conflicts[h] = resp.Ports
+			} else {
+				return err
+			}
+		}
+	}
+	if len(conflicts) > 0 {
+		conflictMsg := "conflicts detected!\n\nThe following hosts have conflicting services listening on ports Flynn is configured to use:\n"
+		for host, ports := range conflicts {
+			hostIP, _, err := net.SplitHostPort(host.Addr())
+			if err != nil {
+				return err
+			}
+			conflictMsg += hostIP + ": "
+			for _, port := range ports {
+				conflictMsg += fmt.Sprintf("%s:%d ", port.Proto, port.Port)
+			}
+		}
+		conflictMsg += "\n\nAfter you correct the above errors re-run bootstrap to continue setting up Flynn."
+		return fmt.Errorf(conflictMsg)
+	}
+	return nil
+}

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -286,3 +286,7 @@ const (
 	JobEventStop   string = "stop"
 	JobEventError  string = "error"
 )
+
+type ResourceCheck struct {
+	Ports []Port `json"ports,omitempty"`
+}

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -171,3 +171,7 @@ func (c *Host) PullImages(repository, driver, root string, tufDB io.Reader, ch c
 	path := fmt.Sprintf("/host/pull-images?repository=%s&driver=%s&root=%s", repository, driver, root)
 	return c.c.StreamWithHeader("POST", path, header, tufDB, ch)
 }
+
+func (c *Host) ResourceCheck(request host.ResourceCheck) error {
+	return c.c.Post("/host/resource-check", request, nil)
+}


### PR DESCRIPTION
This introduces a stage into bootstrap that runs ahead of starting any services to try ascertain if there are any resources in-use that might cause the bootstrap to fail. Currently this only checks that required ports are available.

Example output when `tcp:1111` is in use on a bootstrap target:
```
00:28:39.479409 check online-hosts
00:28:40.496625 require-env require-env
00:28:40.498279 resource-check resource-check
00:28:40.499529 resource-check resource-check error: conflicts detected!

The following hosts have conflicting services listening on ports Flynn is configured to use:
10.0.2.15: tcp:1111

After you correct the above errors re-run bootstrap to continue setting up Flynn.
```

Closes #1824 