### PR TITLE
slugrunner: Retry downloading slugs

### DIFF
--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -9,7 +9,7 @@ mkdir -p "${HOME}"
 if [[ -n $(ls -A "${HOME}") ]]; then
   true
 elif ! [[ -z "${SLUG_URL}" ]]; then
-  curl -s -L --noproxy "discoverd"  "${SLUG_URL}" | tar -xzC "${HOME}"
+  curl --silent --location --noproxy "discoverd" --retry 5 --show-error "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL
 else
   cat | tar -xzC "${HOME}"


### PR DESCRIPTION
This prevents slugrunner jobs failing immediately if started when the blobstore is temporarily unavailable (e.g. when resurrecting the cluster and the job starts before the blobstore).

Tested manually by scaling the blobstore down to zero, scaling my app up, scaling the blobstore back up after 10s and seeing that my job started ok (albeit delayed by 10s).

Fixes #1428.