### PR TITLE
Make more Procfile process types routable via HTTP

### DIFF
--- a/docs/content/index.html.md
+++ b/docs/content/index.html.md
@@ -177,9 +177,9 @@ Listening on 55007
 
 ## Routes
 
-On creation, applications get a default route which is a subdomain of the default
-route domain (e.g. `example.demo.localflynn.com`). If you want to use a different
-domain, you will need to add another route.
+On creation, the application's `web` process gets a default HTTP route which is a
+subdomain of the default route domain (e.g. `example.demo.localflynn.com`). If
+you want to use a different domain, you will need to add another route.
 
 Let's say you have a domain `example.com` which is pointed at your Flynn cluster
 (e.g. it is a `CNAME` for `example.demo.localflynn.com`).
@@ -209,6 +209,15 @@ Hello from Flynn on port 55007 from container cf834b6db8bb4514a34372c8b0020b1e
 
 You could now modify your application to respond differently based on the HTTP Host
 header (which here could be either `example.demo.localflynn.com` or `example.com`).
+
+HTTP routes can only be made for the default `web` process and processes that end in
+`-web`. For example, given a process type named `api-web`, you can create a route for
+it with:
+
+```
+$ flynn route add http -s example-api-web api.example.com
+http/9cfb5f1b-b174-476c-b869-71f1e03ef4b
+```
 
 ## Multiple Processes
 

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -153,12 +153,12 @@ Options:
 	for _, t := range types {
 		proc := prevRelease.Processes[t]
 		proc.Cmd = []string{"start", t}
-		if t == "web" {
+		if t == "web" || strings.HasSuffix(t, "-web") {
 			proc.Ports = []ct.Port{{
 				Port:  8080,
 				Proto: "tcp",
 				Service: &host.Service{
-					Name:   app.Name + "-web",
+					Name:   app.Name + "-" + t,
 					Create: true,
 					Check:  &host.HealthCheck{Type: "tcp"},
 				},

--- a/test/README.md
+++ b/test/README.md
@@ -29,7 +29,7 @@ Run the `flynn cluster add` command from the bootstrap output to add the cluster
 ```text
 flynn cluster add ...
 cd ~/go/src/github.com/flynn/flynn/test
-bin/flynn-test --flynnrc ~/.flynnrc --cli `pwd`/../cli/cli
+bin/flynn-test --flynnrc ~/.flynnrc --cli `pwd`/../cli/bin/flynn
 ```
 
 ## Auto booting clusters

--- a/test/apps/http/Procfile
+++ b/test/apps/http/Procfile
@@ -1,1 +1,2 @@
 web: http
+another-web: http

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -329,10 +329,18 @@ func (s *ControllerSuite) TestAppDeleteCleanup(t *c.C) {
 	_, err := s.discoverdClient(t).Instances(service, 10*time.Second)
 	t.Assert(err, c.IsNil)
 
+	t.Assert(r.flynn("scale", "another-web=1"), Succeeds)
+	_, err = s.discoverdClient(t).Instances(app+"-another-web", 10*time.Second)
+	t.Assert(err, c.IsNil)
+
 	// create some routes
-	routes := []string{"foo.example.com", "bar.example.com"}
+	routes := []string{"foo.example.com", "bar.example.com", "another.example.com"}
 	for _, route := range routes {
-		t.Assert(r.flynn("route", "add", "http", route), Succeeds)
+		if route == "another.example.com" {
+			t.Assert(r.flynn("route", "add", "http", "-s", app+"-another-web", route), Succeeds)
+		} else {
+			t.Assert(r.flynn("route", "add", "http", route), Succeeds)
+		}
 	}
 	routeList, err := client.RouteList(app)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
Very new to Flynn, so correct me if there are other ways of doing this.

The problem I'm trying to solve is that I have multiple processes in my app that I want to accessible via the web. Specifically, I have an API, JS frontend and admin UI all running as individual processes in my Procfile, but I can only have one of them routed with `flynn route add http`.

How would it be to extend the "web" process type behaviour to also include process types ending in "-web"?