### PR TITLE
Update discoverd

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -32,7 +32,8 @@
           "data": true,
           "resurrect": true,
           "host_network": true,
-          "omni": true
+          "omni": true,
+          "service": "discoverd"
         }
       }
     },
@@ -245,7 +246,8 @@
     "app": {
       "name": "discoverd",
       "meta": {"flynn-system-app": "true"},
-      "strategy": "one-by-one"
+      "strategy": "discoverd-meta",
+      "deploy_timeout": 120
     }
   },
   {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -210,5 +210,8 @@ $$ LANGUAGE plpgsql`,
 	m.Add(5,
 		`ALTER TABLE deployments ADD COLUMN deploy_timeout integer NOT NULL DEFAULT 30`,
 	)
+	m.Add(6,
+		`INSERT INTO deployment_strategies (name) VALUES ('discoverd-meta')`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/worker/deployment/context.go
+++ b/controller/worker/deployment/context.go
@@ -98,6 +98,7 @@ func (c *context) HandleDeployment(job *que.Job) (e error) {
 		Deployment:      deployment,
 		client:          c.client,
 		deployEvents:    events,
+		serviceNames:    make(map[string]string),
 		serviceEvents:   make(chan *discoverd.Event),
 		useJobEvents:    make(map[string]struct{}),
 		logger:          c.logger,

--- a/controller/worker/deployment/discoverd_meta.go
+++ b/controller/worker/deployment/discoverd_meta.go
@@ -1,0 +1,50 @@
+package deployment
+
+import (
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	dd "github.com/flynn/flynn/discoverd/deployment"
+)
+
+// deployDiscoverMeta does a one-by-one deployment but uses discoverd.Deployment
+// to wait for appropriate service metadata before stopping old jobs.
+func (d *DeployJob) deployDiscoverdMeta() (err error) {
+	log := d.logger.New("fn", "deployDiscoverdMeta")
+	log.Info("starting discoverd-meta deployment")
+
+	defer func() {
+		if err != nil {
+			// TODO: support rolling back
+			err = ErrSkipRollback{err.Error()}
+		}
+	}()
+
+	discDeploys := make(map[string]*dd.Deployment)
+
+	for typ, serviceName := range d.serviceNames {
+		discDeploy, err := dd.NewDeployment(serviceName)
+		if err != nil {
+			return err
+		}
+		discDeploys[typ] = discDeploy
+		if err := discDeploy.Reset(); err != nil {
+			return err
+		}
+		defer discDeploy.Close()
+	}
+
+	return d.deployOneByOneWithWaitFn(func(releaseID string, expected jobEvents, log log15.Logger) error {
+		for typ, events := range expected {
+			if count, ok := events["up"]; ok && count > 0 {
+				if discDeploy, ok := discDeploys[typ]; ok {
+					if err := discDeploy.Wait(count, 120, log); err != nil {
+						return err
+					}
+					// clear up events for this type so we can safely
+					// process job down events if needed
+					expected[typ]["up"] = 0
+				}
+			}
+		}
+		return d.waitForJobEvents(releaseID, expected, log)
+	})
+}

--- a/discoverd/client/client.go
+++ b/discoverd/client/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	dt "github.com/flynn/flynn/discoverd/types"
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
 	hh "github.com/flynn/flynn/pkg/httphelper"
@@ -160,6 +161,10 @@ outer:
 			return nil, ErrTimedOut
 		}
 	}
+}
+
+func (c *Client) Shutdown() (res dt.ShutdownInfo, err error) {
+	return res, c.c.Post("/shutdown", nil, &res)
 }
 
 type service struct {

--- a/discoverd/deployment/deployment.go
+++ b/discoverd/deployment/deployment.go
@@ -1,0 +1,194 @@
+package deployment
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/attempt"
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type DeploymentState string
+
+const (
+	DeploymentStatePerforming DeploymentState = "performing"
+	DeploymentStateDone       DeploymentState = "done"
+)
+
+func NewDeployment(service string) (*Deployment, error) {
+	s := discoverd.NewService(service)
+	events := make(chan *discoverd.Event)
+	stream, err := s.Watch(events)
+	if err != nil {
+		return nil, err
+	}
+	return &Deployment{s, events, stream}, nil
+}
+
+// Deployment is a wrapper around service metadata for marking jobs as either
+// performing a deployment or done deploying
+type Deployment struct {
+	service discoverd.Service
+	events  chan *discoverd.Event
+	stream  stream.Stream
+}
+
+// MarkPerforming marks the given address as performing in the service metadata,
+// ensuring there is only one address marked as performing at any given time
+// (waiting for a ServiceMeta event and retrying if there is already an
+// address performing).
+func (d *Deployment) MarkPerforming(addr string, timeout int) error {
+outer:
+	for {
+		meta, err := d.service.GetMeta()
+		if err != nil {
+			return err
+		}
+
+		states, err := d.decode(meta)
+		if err != nil {
+			return err
+		}
+
+		performing := ""
+		for a, state := range states {
+			if a == addr {
+				// already marked as performing, nothing to do
+				return nil
+			}
+
+			if state == DeploymentStatePerforming {
+				performing = a
+				break
+			}
+		}
+
+		// if another address is performing, wait for a ServiceMeta
+		// event then try again
+		if performing != "" {
+			for {
+				select {
+				case event, ok := <-d.events:
+					if !ok {
+						return fmt.Errorf("service stream closed unexpectedly: %s", d.stream.Err())
+					}
+					if event.Kind == discoverd.EventKindServiceMeta {
+						continue outer
+					}
+				case <-time.After(time.Duration(timeout) * time.Second):
+					return fmt.Errorf("timed out waiting for %s to finish performing", performing)
+				}
+			}
+		}
+
+		// no performing addresses, attempt to mark addr
+		states[addr] = DeploymentStatePerforming
+
+		data, err := json.Marshal(states)
+		if err != nil {
+			return err
+		}
+		meta.Data = data
+
+		if err := d.service.SetMeta(meta); err == nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+var attempts = attempt.Strategy{
+	Delay: 100 * time.Millisecond,
+	Total: 30 * time.Second,
+}
+
+// MarkDone marks the addr as done in the service metadata
+func (d *Deployment) MarkDone(addr string) error {
+	return attempts.Run(func() error {
+		meta, err := d.service.GetMeta()
+		if err != nil {
+			return err
+		}
+
+		states, err := d.decode(meta)
+		if err != nil {
+			return err
+		}
+
+		states[addr] = DeploymentStateDone
+
+		return d.set(meta, states)
+	})
+}
+
+// Wait waits for an expected number of "done" addresses in the service metadata
+func (d *Deployment) Wait(expected int, timeout int, log log15.Logger) error {
+	for {
+		actual := 0
+		select {
+		case event, ok := <-d.events:
+			if !ok {
+				return fmt.Errorf("service stream closed unexpectedly: %s", d.stream.Err())
+			}
+			if event.Kind == discoverd.EventKindServiceMeta {
+				states, err := d.decode(event.ServiceMeta)
+				if err != nil {
+					return err
+				}
+				log.Info("got service meta event", "states", states)
+				actual = 0
+				for _, state := range states {
+					if state == DeploymentStateDone {
+						actual++
+					}
+				}
+				if actual == expected {
+					return nil
+				}
+			}
+		case <-time.After(time.Duration(timeout) * time.Second):
+			return fmt.Errorf("timed out waiting for discoverd deployment (expected=%d actual=%d)", expected, actual)
+		}
+	}
+}
+
+// Reset sets the service metadata to null
+func (d *Deployment) Reset() error {
+	return attempts.Run(func() error {
+		if err := d.set(&discoverd.ServiceMeta{}, nil); err == nil {
+			return nil
+		}
+		meta, err := d.service.GetMeta()
+		if err != nil {
+			return err
+		}
+		return d.set(meta, nil)
+	})
+}
+
+func (d *Deployment) Close() error {
+	return d.stream.Close()
+}
+
+func (d *Deployment) decode(meta *discoverd.ServiceMeta) (map[string]DeploymentState, error) {
+	var states map[string]DeploymentState
+	if err := json.Unmarshal(meta.Data, &states); err != nil {
+		return nil, err
+	}
+	if states == nil {
+		states = make(map[string]DeploymentState)
+	}
+	return states, nil
+}
+
+func (d *Deployment) set(meta *discoverd.ServiceMeta, states map[string]DeploymentState) error {
+	data, err := json.Marshal(states)
+	if err != nil {
+		return err
+	}
+	meta.Data = data
+	return d.service.SetMeta(meta)
+}

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -43,11 +43,12 @@ func main() {
 
 // Main represents the main program execution.
 type Main struct {
-	mu        sync.Mutex
-	status    host.DiscoverdConfig
-	store     *server.Store
-	dnsServer *server.DNSServer
-	ln        net.Listener
+	mu         sync.Mutex
+	status     host.DiscoverdConfig
+	store      *server.Store
+	dnsServer  *server.DNSServer
+	httpServer *http.Server
+	ln         net.Listener
 
 	logger *log.Logger
 
@@ -172,6 +173,10 @@ func (m *Main) Run(args ...string) error {
 
 // Close shuts down all open servers.
 func (m *Main) Close() error {
+	if m.httpServer != nil {
+		// Disable keep alives so that persistent connections will close
+		m.httpServer.SetKeepAlivesEnabled(false)
+	}
 	if m.store != nil {
 		m.store.Close()
 		m.store = nil
@@ -258,15 +263,16 @@ func (m *Main) openDNSServer(addr string, recursors, peers []string) error {
 func (m *Main) openHTTPServer(ln net.Listener, peers []string) error {
 	// If we have no store then simply start a proxy handler.
 	if m.store == nil {
-		go http.Serve(ln, &server.ProxyHandler{Peers: peers})
+		m.httpServer = &http.Server{Handler: &server.ProxyHandler{Peers: peers}}
+		go m.httpServer.Serve(ln)
 		return nil
 	}
 
 	// Otherwise initialize and start handler.
 	h := server.NewHandler()
 	h.Store = m.store
-	go http.Serve(ln, h)
-
+	m.httpServer = &http.Server{Handler: h}
+	go m.httpServer.Serve(ln)
 	return nil
 }
 

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -16,7 +16,9 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/discoverd/client"
+	dd "github.com/flynn/flynn/discoverd/deployment"
 	"github.com/flynn/flynn/discoverd/server"
+	dt "github.com/flynn/flynn/discoverd/types"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/shutdown"
@@ -77,6 +79,64 @@ func (m *Main) Run(args ...string) error {
 		return err
 	}
 
+	// Set up advertised address and default peer set.
+	advertiseAddr := MergeHostPort(opt.Host, opt.Addr)
+	if len(opt.Peers) == 0 {
+		opt.Peers = []string{advertiseAddr}
+	}
+
+	// Create a slice of peers with their HTTP address set instead.
+	httpPeers, err := SetPortSlice(opt.Peers, opt.Addr)
+	if err != nil {
+		return fmt.Errorf("set port slice: %s", err)
+	}
+
+	// if there is a discoverd process already running on this
+	// address perform a deployment by starting a proxy DNS server
+	// and shutting down the old discoverd job
+	var deploy *dd.Deployment
+	var shutdownInfo dt.ShutdownInfo
+
+	target := fmt.Sprintf("http://%s:1111", opt.Host)
+	m.logger.Println("checking for existing discoverd process at", target)
+	if err := discoverd.NewClientWithHTTP(target, &http.Client{}).Ping(); err == nil {
+		m.logger.Println("discoverd responding at", target, "taking over")
+
+		// update DISCOVERD environment variable so that the default
+		// discoverd client connects to the instance we intend to replace.
+		os.Setenv("DISCOVERD", target)
+		discoverd.DefaultClient = discoverd.NewClient()
+
+		deploy, err = dd.NewDeployment("discoverd")
+		if err != nil {
+			return err
+		}
+		m.logger.Println("Created deployment")
+		if err := deploy.MarkPerforming(advertiseAddr, 60); err != nil {
+			return err
+		}
+		m.logger.Println("marked", advertiseAddr, "as performing in deployent")
+		addr, resolvers := waitHostDNSConfig()
+		if opt.DNSAddr != "" {
+			addr = opt.DNSAddr
+		}
+		if len(opt.Recursors) > 0 {
+			resolvers = opt.Recursors
+		}
+		m.logger.Println("starting proxy DNS server")
+		if err := m.openDNSServer(addr, resolvers, httpPeers); err != nil {
+			return fmt.Errorf("Failed to start DNS server: %s", err)
+		}
+		m.logger.Printf("discoverd listening for DNS on %s", addr)
+
+		shutdownInfo, err = discoverd.NewClientWithURL(target).Shutdown()
+		if err != nil {
+			return err
+		}
+	} else {
+		m.logger.Println("failed to contact existing discoverd server, starting up without takeover")
+	}
+
 	// Open listener.
 	ln, err := net.Listen("tcp4", opt.Addr)
 	if err != nil {
@@ -86,12 +146,6 @@ func (m *Main) Run(args ...string) error {
 
 	// Multiplex listener to store and http api.
 	storeLn, httpLn := server.Mux(ln)
-
-	// Set up advertised address and default peer set.
-	advertiseAddr := MergeHostPort(opt.Host, opt.Addr)
-	if len(opt.Peers) == 0 {
-		opt.Peers = []string{advertiseAddr}
-	}
 
 	// Open store if we are not proxying.
 	if err := m.openStore(opt.DataDir, storeLn, advertiseAddr, opt.Peers); err != nil {
@@ -103,37 +157,33 @@ func (m *Main) Run(args ...string) error {
 		fmt.Fprintln(m.Stderr, "advertised address not in peer set, joining as proxy")
 	}
 
-	// Create a slice of peers with their HTTP address set instead.
-	httpPeers, err := SetPortSlice(opt.Peers, opt.Addr)
-	if err != nil {
-		return fmt.Errorf("set port slice: %s", err)
+	// Wait for the store to catchup before switching to local store if we are doing a deployment
+	if m.store != nil && shutdownInfo.LastIndex > 0 {
+		for m.store.LastIndex() < shutdownInfo.LastIndex {
+			m.logger.Println("Waiting for store to catchup, current:", m.store.LastIndex(), "target:", shutdownInfo.LastIndex)
+			time.Sleep(100 * time.Millisecond)
+		}
 	}
 
-	// If we have a DNS address, start a DNS server right away, otherwise
-	// wait for the host network to come up and then start a DNS server.
-	if opt.DNSAddr != "" {
+	// If we already started the DNS server as part of a deployment above,
+	// and we have an initialized store, just switch from the proxy store
+	// to the initialized store.
+	//
+	// Else if we have a DNS address, start a DNS server right away.
+	//
+	// Otherwise wait for the host network to come up and then start a DNS
+	// server.
+	if m.dnsServer != nil && m.store != nil {
+		m.dnsServer.SetStore(m.store)
+	} else if opt.DNSAddr != "" {
 		if err := m.openDNSServer(opt.DNSAddr, opt.Recursors, httpPeers); err != nil {
 			return fmt.Errorf("Failed to start DNS server: %s", err)
 		}
 		m.logger.Printf("discoverd listening for DNS on %s", opt.DNSAddr)
 	} else if opt.WaitNetDNS {
 		go func() {
-			// Wait for the host network.
-			status, err := cluster.WaitForHostStatus(os.Getenv("EXTERNAL_IP"), func(status *host.HostStatus) bool {
-				return status.Network != nil && status.Network.Subnet != ""
-			})
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// Parse network subnet to determine bind address.
-			ip, _, err := net.ParseCIDR(status.Network.Subnet)
-			if err != nil {
-				log.Fatal(err)
-			}
-			addr := net.JoinHostPort(ip.String(), "53")
-
-			if err := m.openDNSServer(addr, status.Network.Resolvers, httpPeers); err != nil {
+			addr, resolvers := waitHostDNSConfig()
+			if err := m.openDNSServer(addr, resolvers, httpPeers); err != nil {
 				log.Fatalf("Failed to start DNS server: %s", err)
 			}
 			m.logger.Printf("discoverd listening for DNS on %s", addr)
@@ -147,6 +197,13 @@ func (m *Main) Run(args ...string) error {
 
 	if err := m.openHTTPServer(httpLn, opt.Peers); err != nil {
 		return fmt.Errorf("Failed to start HTTP server: %s", err)
+	}
+
+	if deploy != nil {
+		if err := deploy.MarkDone(advertiseAddr); err != nil {
+			return err
+		}
+		m.logger.Println("marked", advertiseAddr, "as done in deployment")
 	}
 
 	// Notify user that the servers are listening.
@@ -171,25 +228,43 @@ func (m *Main) Run(args ...string) error {
 	return nil
 }
 
+func waitHostDNSConfig() (addr string, resolvers []string) {
+	// Wait for the host network.
+	status, err := cluster.WaitForHostStatus(os.Getenv("EXTERNAL_IP"), func(status *host.HostStatus) bool {
+		return status.Network != nil && status.Network.Subnet != ""
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Parse network subnet to determine bind address.
+	ip, _, err := net.ParseCIDR(status.Network.Subnet)
+	if err != nil {
+		log.Fatal(err)
+	}
+	addr = net.JoinHostPort(ip.String(), "53")
+	return addr, status.Network.Resolvers
+}
+
 // Close shuts down all open servers.
-func (m *Main) Close() error {
+func (m *Main) Close() (info dt.ShutdownInfo, err error) {
 	if m.httpServer != nil {
 		// Disable keep alives so that persistent connections will close
 		m.httpServer.SetKeepAlivesEnabled(false)
-	}
-	if m.store != nil {
-		m.store.Close()
-		m.store = nil
 	}
 	if m.dnsServer != nil {
 		m.dnsServer.Close()
 		m.dnsServer = nil
 	}
+	if m.store != nil {
+		info.LastIndex, err = m.store.Close()
+		m.store = nil
+	}
 	if m.ln != nil {
 		m.ln.Close()
 		m.ln = nil
 	}
-	return nil
+	return info, err
 }
 
 // openStore initializes and opens the store.
@@ -246,9 +321,9 @@ func (m *Main) openDNSServer(addr string, recursors, peers []string) error {
 
 	// If store is available then attach it. Otherwise use a proxy.
 	if m.store != nil {
-		s.Store = m.store
+		s.SetStore(m.store)
 	} else {
-		s.Store = &server.ProxyStore{Peers: peers}
+		s.SetStore(&server.ProxyStore{Peers: peers})
 	}
 
 	if err := s.ListenAndServe(); err != nil {
@@ -270,6 +345,7 @@ func (m *Main) openHTTPServer(ln net.Listener, peers []string) error {
 
 	// Otherwise initialize and start handler.
 	h := server.NewHandler()
+	h.Main = m
 	h.Store = m.store
 	m.httpServer = &http.Server{Handler: h}
 	go m.httpServer.Serve(ln)

--- a/discoverd/server/dns_test.go
+++ b/discoverd/server/dns_test.go
@@ -24,7 +24,7 @@ var _ = Suite(&DNSSuite{})
 
 func (s *DNSSuite) SetUpTest(c *C) {
 	s.srv = s.newServer(c, []string{"8.8.8.8", "8.8.4.4"})
-	s.srv.Store = &s.store
+	s.srv.SetStore(&s.store)
 	s.store.InstancesFn = func(service string) ([]*discoverd.Instance, error) { return nil, nil }
 	s.store.ServiceLeaderFn = func(service string) (*discoverd.Instance, error) { return nil, nil }
 }
@@ -33,9 +33,9 @@ func (s *DNSSuite) newServer(c *C, recursors []string) *DNSServer {
 	srv := &DNSServer{
 		UDPAddr:   "127.0.0.1:0",
 		TCPAddr:   "127.0.0.1:0",
-		Store:     &s.store,
 		Recursors: recursors,
 	}
+	srv.SetStore(&s.store)
 	c.Assert(srv.ListenAndServe(), IsNil)
 	return srv
 }

--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -217,6 +217,11 @@ func (s *Store) Close() error {
 	close(s.closing)
 	s.wg.Wait()
 
+	for _, l := range s.subscribers {
+		for el := l.Front(); el != nil; el = el.Next() {
+			el.Value.(*subscription).Close()
+		}
+	}
 	if s.raft != nil {
 		s.raft.Shutdown()
 		s.raft = nil

--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -223,7 +223,7 @@ func (s *Store) Close() error {
 		}
 	}
 	if s.raft != nil {
-		s.raft.Shutdown()
+		s.raft.Shutdown().Error()
 		s.raft = nil
 	}
 	if s.transport != nil {

--- a/discoverd/server/store_test.go
+++ b/discoverd/server/store_test.go
@@ -673,7 +673,8 @@ func MustOpenStore() *Store {
 // Close closes the store and removes its path.
 func (s *Store) Close() error {
 	defer os.RemoveAll(s.Path())
-	return s.Store.Close()
+	_, err := s.Store.Close()
+	return err
 }
 
 // MustWaitForLeader blocks until a leader is established. Panic on timeout.

--- a/discoverd/types/types.go
+++ b/discoverd/types/types.go
@@ -1,0 +1,5 @@
+package types
+
+type ShutdownInfo struct {
+	LastIndex uint64 `json:"last_index"`
+}

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -35,7 +35,7 @@
     },
     "strategy": {
       "type": "string",
-      "enum": ["all-at-once", "one-by-one", "postgres"]
+      "enum": ["all-at-once", "one-by-one", "postgres", "discoverd-meta"]
     },
     "meta": {
       "description": "client-specified metadata",

--- a/test/test_z_discoverd.go
+++ b/test/test_z_discoverd.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"time"
+
+	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+// Prefix the suite with "Z" so that it runs after all other tests
+type ZDiscoverdSuite struct {
+	Helper
+}
+
+var _ = c.Suite(&ZDiscoverdSuite{})
+
+func (s *ZDiscoverdSuite) TestDeploy(t *c.C) {
+	client := s.controllerClient(t)
+	app, err := client.GetApp("discoverd")
+	t.Assert(err, c.IsNil)
+	release, err := client.GetAppRelease(app.ID)
+	t.Assert(err, c.IsNil)
+	release.ID = ""
+	t.Assert(client.CreateRelease(release), c.IsNil)
+	deployment, err := client.CreateDeployment(app.ID, release.ID)
+	t.Assert(err, c.IsNil)
+
+	events := make(chan *ct.DeploymentEvent)
+	stream, err := client.StreamDeployment(deployment, events)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+loop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("unexpected close of deployment event stream")
+			}
+			if event.Status == "complete" {
+				debugf(t, "got deployment event: %s", event.Status)
+				break loop
+			}
+			if event.Status == "failed" {
+				t.Fatal("the deployment failed")
+			}
+			debugf(t, "got deployment event: %s %s", event.JobType, event.JobState)
+		case <-time.After(time.Duration(app.DeployTimeout) * time.Second):
+			t.Fatal("timed out waiting for deployment event")
+		}
+	}
+}


### PR DESCRIPTION
This patchset implements an in-place update of the discoverd service.

The process is as follows:

1. A discoverd deployment is triggered
2. The controller then creates a "deployment context" that describes the state of the discoverd deployment in the discoverd service metadata. This is implemented as a re-usable deployment strategy called "discoverd-meta"
3. The controller worker will then scale the formation up, as discoverd is an omnipresent job this means it will spawn new jobs on every node in the cluster.
4. These jobs will upon starting up check to see if there is already a discoverd process listening on the HTTP address they intend to bind to, if so they will connect to it.
5. They will then attempt to mark themselves as "performing" in the deployment context, ensuring only one node is marked performing at a time. This is safe because discoverd service metadata is linear.
6. Once it successfully marks itself as performing it will start it's DNS server in proxy mode (using SO_REUSEPORT) and issue a shutdown command to the process it's replacing, acquiring that processes current log position in the process.
7. It will block on the other node shutting down before starting it's Raft store and will wait until it's atleast caught up to the position that the process it replaced was before it starts the HTTP listener.
8. Once reaching this point the process will mark itself as "done" in the deployment context.
9. The controller worker watches the discoverd service meta event stream and when all nodes are marked "done" it will proceed to scaling down the formation and terminating the now dormant old jobs.
10. Deployment complete.
