### PR TITLE
discoverd/server: Bump raft apply timeout to 30 seconds

### DIFF
--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -811,7 +811,7 @@ func (s *Store) raftApply(typ byte, cmd []byte) (uint64, error) {
 	buf := append([]byte{typ}, cmd...)
 
 	// Apply to raft and receive an ApplyFuture back.
-	f := s.raft.Apply(buf, 5*time.Second)
+	f := s.raft.Apply(buf, 30*time.Second)
 	if err := f.Error(); err == raft.ErrNotLeader {
 		return 0, ErrNotLeader // hide underlying implementation error
 	} else if err != nil {


### PR DESCRIPTION
The current timeout of five seconds is clearly not high enough, as users are hitting it in the wild in otherwise normal situations.

30 seconds is the timeout that Consul, the primary user of the raft package uses.

Closes #1899 

/cc @benbjohnson
