### PR TITLE
util/packer: Wait 60s before running provisioning scripts on EC2

### DIFF
--- a/util/packer/ubuntu-14.04/template.json
+++ b/util/packer/ubuntu-14.04/template.json
@@ -73,7 +73,13 @@
       "ssh_username": "ubuntu"
     }
   ],
+  "_comment": "Sleep provisioner for amazon-ebs is an attempt to fix gh#1829",
   "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["sleep 60"],
+      "only": ["amazon-ebs"]
+    },
     {
       "type": "shell",
       "scripts": [


### PR DESCRIPTION
The idea here is to try workaround the race that is causing the apt failures.
If it doesn't help will probably revert it but if it does I will try track down the actual root cause properly (it's just proven elusive).