### PR TITLE
Full cluster backup/restore

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -85,7 +85,7 @@ func (a *RunAppAction) Run(s *State) error {
 		if err != nil {
 			return err
 		}
-		lookupDiscoverdURLHost(u, time.Second)
+		lookupDiscoverdURLHost(s, u, time.Second)
 		res, err := resource.Provision(u.String(), nil)
 		if err != nil {
 			return err

--- a/bootstrap/status_check_action.go
+++ b/bootstrap/status_check_action.go
@@ -39,7 +39,7 @@ func (a *StatusCheckAction) Run(s *State) error {
 	if err != nil {
 		return err
 	}
-	lookupDiscoverdURLHost(u, waitMax)
+	lookupDiscoverdURLHost(s, u, waitMax)
 
 	start := time.Now()
 	for {

--- a/bootstrap/wait_action.go
+++ b/bootstrap/wait_action.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/flynn/flynn/discoverd/client"
 )
 
 type WaitAction struct {
@@ -34,7 +32,7 @@ func (a *WaitAction) Run(s *State) error {
 	if err != nil {
 		return err
 	}
-	lookupDiscoverdURLHost(u, waitMax)
+	lookupDiscoverdURLHost(s, u, waitMax)
 
 	start := time.Now()
 	for {
@@ -78,9 +76,13 @@ func (a *WaitAction) Run(s *State) error {
 	}
 }
 
-func lookupDiscoverdURLHost(u *url.URL, timeout time.Duration) error {
+func lookupDiscoverdURLHost(s *State, u *url.URL, timeout time.Duration) error {
 	if strings.HasSuffix(u.Host, ".discoverd") {
-		instances, err := discoverd.GetInstances(strings.Split(u.Host, ".")[0], timeout)
+		d, err := s.DiscoverdClient()
+		if err != nil {
+			return err
+		}
+		instances, err := d.Instances(strings.Split(u.Host, ".")[0], timeout)
 		if err != nil {
 			return err
 		}

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -24,21 +24,34 @@ usage: flynn cluster
        flynn cluster default [<cluster-name>]
        flynn cluster migrate-domain <domain>
 
-Manage clusters in the ~/.flynnrc configuration file.
+Manage Flynn clusters.
 
-Options:
-	-f, --force               force add cluster
-	-d, --default             set as default cluster
-	-g, --git-host=<githost>  git host (legacy SSH only)
-	--git-url=<giturl>        git URL
-	-p, --tls-pin=<tlspin>    SHA256 of the cluster's TLS cert (useful if it is self-signed)
 
 Commands:
-	With no arguments, shows a list of clusters.
+    With no arguments, shows a list of configured clusters.
 
-	add      adds a cluster to the ~/.flynnrc configuration file
-	remove   removes a cluster from the ~/.flynnrc configuration file
-	default  set or print the default cluster
+    add
+        Adds <cluster-name> to the ~/.flynnrc configuration file.
+
+        options:
+            -f, --force               force add cluster
+            -d, --default             set as default cluster
+            -g, --git-host=<githost>  git host (legacy SSH only)
+            --git-url=<giturl>        git URL
+            -p, --tls-pin=<tlspin>    SHA256 of the cluster's TLS cert
+
+    remove
+        Removes <cluster-name> from the ~/.flynnrc configuration file.
+
+    default
+        With no arguments, prints the default cluster. With <cluster-name>, sets
+        the default cluster.
+
+    migrate-domain
+        Migrates the cluster's base domain from the current one to <domain>.
+
+        New certificates will be generated for the controller/dashboard and new
+        routes will be added with the pattern <app-name>.<domain> for each app.
 
 Examples:
 

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cheggaaa/pb"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	cfg "github.com/flynn/flynn/cli/config"
 	"github.com/flynn/flynn/controller/client"
@@ -23,6 +26,7 @@ usage: flynn cluster
        flynn cluster remove <cluster-name>
        flynn cluster default [<cluster-name>]
        flynn cluster migrate-domain <domain>
+       flynn cluster backup [--file <file>]
 
 Manage Flynn clusters.
 
@@ -53,6 +57,15 @@ Commands:
         New certificates will be generated for the controller/dashboard and new
         routes will be added with the pattern <app-name>.<domain> for each app.
 
+    backup
+        Takes a backup of the cluster.
+
+        The backup may be restored while creating a new cluster with
+        'flynn-host bootstrap --from-backup'.
+
+        options:
+            --file=<backup-file>  file to write backup to (defaults to stdout)
+
 Examples:
 
 	$ flynn cluster add -p KGCENkp53YF5OvOKkZIry71+czFRkSw2ZdMszZ/0ljs= default dev.localflynn.com e09dc5301d72be755a3d666f617c4600
@@ -78,6 +91,8 @@ func runCluster(args *docopt.Args) error {
 		return runClusterDefault(args)
 	} else if args.Bool["migrate-domain"] {
 		return runClusterMigrateDomain(args)
+	} else if args.Bool["backup"] {
+		return runClusterBackup(args)
 	}
 
 	w := tabWriter()
@@ -280,4 +295,89 @@ func runClusterMigrateDomain(args *docopt.Args) error {
 			return errors.New("timed out waiting for domain migration to complete")
 		}
 	}
+}
+
+func runClusterBackup(args *docopt.Args) error {
+	client, err := getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	var bar *pb.ProgressBar
+	if term.IsTerminal(os.Stderr.Fd()) {
+		bar = pb.New(0)
+		bar.SetUnits(pb.U_BYTES)
+		bar.ShowBar = false
+		bar.ShowSpeed = true
+		bar.Output = os.Stderr
+		bar.Start()
+	}
+
+	var dest io.Writer = os.Stdout
+	if filename := args.String["--file"]; filename != "" {
+		f, err := os.Create(filename)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		dest = f
+	}
+
+	fmt.Fprintln(os.Stderr, "Creating cluster backup...")
+
+	tw := NewTarWriter("flynn-backup-"+time.Now().UTC().Format("2006-01-02_150405"), dest)
+	defer tw.Close()
+
+	// get app and release details for key apps
+	data := make(map[string]*ct.ExpandedFormation, 4)
+	for _, name := range []string{"postgres", "discoverd", "flannel", "controller"} {
+		app, err := client.GetApp(name)
+		if err != nil {
+			return fmt.Errorf("error getting %s app details: %s", name, err)
+		}
+		release, err := client.GetAppRelease(app.ID)
+		if err != nil {
+			return fmt.Errorf("error getting %s app release: %s", name, err)
+		}
+		formation, err := client.GetFormation(app.ID, release.ID)
+		if err != nil {
+			return fmt.Errorf("error getting %s app formation: %s", name, err)
+		}
+		artifact, err := client.GetArtifact(release.ArtifactID)
+		if err != nil {
+			return fmt.Errorf("error getting %s app artifact: %s", name, err)
+		}
+		data[name] = &ct.ExpandedFormation{
+			App:       app,
+			Release:   release,
+			Artifact:  artifact,
+			Processes: formation.Processes,
+		}
+	}
+	if err := tw.WriteJSON("flynn.json", data); err != nil {
+		return err
+	}
+
+	config := &runConfig{
+		App:        "postgres",
+		Release:    data["postgres"].Release.ID,
+		Entrypoint: []string{"sh"},
+		Args:       []string{"-c", "pg_dumpall --clean --if-exists | gzip -9"},
+		Env: map[string]string{
+			"PGHOST":     "leader.postgres.discoverd",
+			"PGUSER":     "flynn",
+			"PGPASSWORD": data["postgres"].Release.Env["PGPASSWORD"],
+		},
+		DisableLog: true,
+	}
+	if err := tw.WriteCommandOutput(client, "postgres.sql.gz", config, bar); err != nil {
+		return fmt.Errorf("error dumping database: %s", err)
+	}
+
+	if bar != nil {
+		bar.Finish()
+	}
+	fmt.Fprintln(os.Stderr, "Backup complete.")
+
+	return nil
 }

--- a/cli/pg.go
+++ b/cli/pg.go
@@ -122,9 +122,13 @@ func runPgDump(args *docopt.Args, client *controller.Client, config *runConfig) 
 	return pgDump(client, config)
 }
 
-func pgDump(client *controller.Client, config *runConfig) error {
+func configPgDump(config *runConfig) {
 	config.Entrypoint = []string{"pg_dump"}
 	config.Args = []string{"--format=custom", "--no-owner", "--no-acl"}
+}
+
+func pgDump(client *controller.Client, config *runConfig) error {
+	configPgDump(config)
 	return runJob(client, *config)
 }
 

--- a/cli/tar_writer.go
+++ b/cli/tar_writer.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"syscall"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/cheggaaa/pb"
+	"github.com/flynn/flynn/controller/client"
+)
+
+type TarWriter struct {
+	*tar.Writer
+	uid  int
+	name string
+}
+
+func NewTarWriter(name string, w io.Writer) *TarWriter {
+	return &TarWriter{
+		Writer: tar.NewWriter(w),
+		uid:    syscall.Getuid(),
+		name:   name,
+	}
+}
+
+func (t *TarWriter) WriteHeader(name string, length int) error {
+	return t.Writer.WriteHeader(&tar.Header{
+		Name:     path.Join(t.name, name),
+		Mode:     0644,
+		Size:     int64(length),
+		ModTime:  time.Now(),
+		Typeflag: tar.TypeReg,
+		Uid:      t.uid,
+		Gid:      t.uid,
+	})
+}
+
+func (t *TarWriter) WriteJSON(name string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := t.WriteHeader(name, len(data)+1); err != nil {
+		return err
+	}
+	if _, err := t.Write(data); err != nil {
+		return err
+	}
+	_, err = t.Write([]byte("\n"))
+	return err
+}
+
+func (t *TarWriter) WriteCommandOutput(client *controller.Client, name string, config *runConfig, bar *pb.ProgressBar) error {
+	f, err := ioutil.TempFile("", name)
+	if err != nil {
+		return fmt.Errorf("error creating temp file: %s", err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+	config.Stdout = f
+	config.Exit = false
+
+	if bar != nil {
+		config.Stdout = io.MultiWriter(config.Stdout, bar)
+	}
+	if err := runJob(client, *config); err != nil {
+		return fmt.Errorf("error running export: %s", err)
+	}
+
+	length, err := f.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return fmt.Errorf("error getting size: %s", err)
+	}
+	if err := t.WriteHeader(name, int(length)); err != nil {
+		return fmt.Errorf("error writing header: %s", err)
+	}
+	if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+		return fmt.Errorf("error seeking: %s", err)
+	}
+	if _, err := io.Copy(t, f); err != nil {
+		return fmt.Errorf("error exporting: %s", err)
+	}
+	return nil
+}

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -1077,10 +1077,7 @@ func (l *LibvirtLXCBackend) Attach(req *AttachRequest) (err error) {
 		if w == nil {
 			continue
 		}
-		if _, err := w.Write(msg.Msg); err != nil {
-			return nil
-		}
-		if _, err := w.Write([]byte{'\n'}); err != nil {
+		if _, err := w.Write(append(msg.Msg, '\n')); err != nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
`flynn cluster backup` saves a full-cluster backup to a local tar file. The backup consists of expanded app details for the discoverd, flannel, postgres, and controller apps and a SQL dump of all databases in the postgres cluster.

`flynn-host bootstrap --from-backup` bootstraps a cluster and restores a backup. First the discoverd, flannel, and postgres apps are started on the cluster, then the SQL is restored along with some extra commands that update the artifact URLs to the latest ones from the bootstrap manifest.

After the data is restored, the controller/scheduler is started and the scheduler handles starting the rest of the Flynn and user apps.

Refs #1244

/cc @temujin9
