### PR TITLE
Install squid-deb-proxy during 'vagrant up' and try to use it in ever…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,6 +97,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sudo curl -sLo "/usr/local/bin/jq" "http://stedolan.github.io/jq/download/linux64/jq"
     sudo chmod +x "/usr/local/bin/jq"
 
+    # Install and configure squid-deb-proxy to speedup builds by caching deb packages
+    sudo apt-get update
+    sudo apt-get -y install squid-deb-proxy squid-deb-proxy-client
+    sudo sh -c 'echo "10.0.0.0/8\n172.16.0.0/12\n192.168.0.0/16" > /etc/squid-deb-proxy/allowed-networks-src.acl.d/20-private'
+    sudo sh -c 'echo "deb.nodesource.com\napt.postgresql.org\nppa.launchpad.net" > /etc/squid-deb-proxy/mirror-dstdomain.acl.d/20-flynndepsources'
+    sudo service squid-deb-proxy restart
+
     # For controller tests
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'

--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -2,9 +2,12 @@ FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update &&\
-    apt-get dist-upgrade -y &&\
-    apt-get -qy --fix-missing --force-yes install language-pack-en &&\
+# Try to use the Hosts squid-deb-proxy and fall back if it's unreachable
+RUN (echo 'Acquire { Retries "0"; HTTP { Proxy "http://172.17.42.1:8000"; }; };' > /etc/apt/apt.conf.d/10_docker_hostproxy && apt-get update -qq 2>&1 | grep -q 'Unable to connect to 172.17.42.1:8000' && rm /etc/apt/apt.conf.d/10_docker_hostproxy) || true &&\
+    apt-get update &&\
+    apt-get dist-upgrade -y
+
+RUN apt-get -qy --fix-missing --force-yes install language-pack-en &&\
     update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 &&\
     dpkg-reconfigure locales &&\
     apt-get -y install curl sudo &&\
@@ -21,6 +24,7 @@ RUN apt-get update &&\
       postgresql-9.4-pgrouting &&\
     apt-get clean &&\
     apt-get autoremove -y &&\
+    rm /etc/apt/apt.conf.d/10_docker_hostproxy || true &&\
     echo "\set HISTFILE /dev/null" > /root/.psqlrc
 
 ADD bin/flynn-postgres /bin/flynn-postgres

--- a/gitreceive/Dockerfile
+++ b/gitreceive/Dockerfile
@@ -1,6 +1,15 @@
 FROM ubuntu-debootstrap:14.04
 
-RUN apt-get update && apt-get -qy install git && apt-get clean
+ENV DEBIAN_FRONTEND noninteractive
+
+# Try to use the Hosts squid-deb-proxy and fall back if it's unreachable
+RUN (echo 'Acquire { Retries "0"; HTTP { Proxy "http://172.17.42.1:8000"; }; };' > /etc/apt/apt.conf.d/10_docker_hostproxy && apt-get update -qq 2>&1 | grep -q 'Unable to connect to 172.17.42.1:8000' && rm /etc/apt/apt.conf.d/10_docker_hostproxy) || true &&\
+    apt-get update &&\
+    apt-get dist-upgrade -y
+
+RUN apt-get -qy install git && apt-get clean &&\
+    rm /etc/apt/apt.conf.d/10_docker_hostproxy || true
+
 ADD start.sh /bin/start-flynn-receiver
 ADD flynn-receiver /bin/flynn-receiver
 ADD gitreceived /bin/gitreceived

--- a/taffy/Dockerfile
+++ b/taffy/Dockerfile
@@ -1,6 +1,14 @@
 FROM ubuntu-debootstrap:14.04
 
-RUN apt-get update && apt-get -qy install git && apt-get clean
+ENV DEBIAN_FRONTEND noninteractive
+
+# Try to use the Hosts squid-deb-proxy and fall back if it's unreachable
+RUN (echo 'Acquire { Retries "0"; HTTP { Proxy "http://172.17.42.1:8000"; }; };' > /etc/apt/apt.conf.d/10_docker_hostproxy && apt-get update -qq 2>&1 | grep -q 'Unable to connect to 172.17.42.1:8000' && rm /etc/apt/apt.conf.d/10_docker_hostproxy) || true &&\
+    apt-get update &&\
+    apt-get dist-upgrade -y
+
+RUN apt-get apt-get -qy install git && apt-get clean &&\
+    rm /etc/apt/apt.conf.d/10_docker_hostproxy || true
 
 ADD bin/taffy /bin/taffy
 ADD bin/flynn-receiver /bin/flynn-receiver

--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -1,15 +1,18 @@
 FROM ubuntu-debootstrap:14.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Derived from https://github.com/heroku/stack-images/blob/master/Dockerfile
+
+# Try to use the Hosts squid-deb-proxy and fall back if it's unreachable
+RUN (echo 'Acquire { Retries "0"; HTTP { Proxy "http://172.17.42.1:8000"; }; };' > /etc/apt/apt.conf.d/10_docker_hostproxy && apt-get update -qq 2>&1 | grep -q 'Unable to connect to 172.17.42.1:8000' && rm /etc/apt/apt.conf.d/10_docker_hostproxy) || true &&\
+    apt-get update &&\
+    apt-get dist-upgrade -y
 
 RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.list &&\
     echo 'deb http://archive.ubuntu.com/ubuntu trusty-security main' >>/etc/apt/sources.list &&\
     echo 'deb http://archive.ubuntu.com/ubuntu trusty-updates main' >>/etc/apt/sources.list &&\
     echo 'deb http://archive.ubuntu.com/ubuntu trusty universe' >>/etc/apt/sources.list &&\
-
-    apt-get update &&\
-    apt-get dist-upgrade -y &&\
-
     apt-get install -y --force-yes \
       autoconf \
       bind9-host \
@@ -56,5 +59,6 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.li
       zip \
       zlib1g-dev \
       pigz &&\
+      rm /etc/apt/apt.conf.d/10_docker_hostproxy || true &&\
 
     rm /etc/ssh/ssh_host_*


### PR DESCRIPTION
…y Debian based Dockerfile. Silently falls back to not using the proxy if it's unreachable.

A proposal for #2042 

Things to consider:
 * Caching won't work if the gateway is not the default 172.17.42.1 for the containers
 * I only whitelisted the currently used apt sources, new ones need to be added when needed

