### PR TITLE
installer: Use a separate EBS volume for data

### DIFF
--- a/installer/aws_cluster.go
+++ b/installer/aws_cluster.go
@@ -362,7 +362,7 @@ type stackTemplateData struct {
 
 func (c *AWSCluster) createStack() error {
 	c.base.SendLog("Generating start script")
-	startScript, discoveryToken, err := c.base.genStartScript(c.base.NumInstances)
+	startScript, discoveryToken, err := c.base.genStartScript(c.base.NumInstances, "/dev/xvdb")
 	if err != nil {
 		return err
 	}

--- a/installer/bare_cluster.go
+++ b/installer/bare_cluster.go
@@ -16,7 +16,7 @@ func (c *BareCluster) InstallFlynn() error {
 	c.Base.SendLog("Installing flynn")
 
 	var err error
-	c.startScript, c.Base.DiscoveryToken, err = c.Base.genStartScript(c.Base.NumInstances)
+	c.startScript, c.Base.DiscoveryToken, err = c.Base.genStartScript(c.Base.NumInstances, "")
 	if err != nil {
 		return err
 	}

--- a/installer/cluster.go
+++ b/installer/cluster.go
@@ -520,10 +520,10 @@ func (c *BaseCluster) genIPTablesConfigScript() (string, error) {
 	return buf.String(), err
 }
 
-func (c *BaseCluster) genStartScript(nodes int64) (string, string, error) {
-	var data struct {
-		DiscoveryToken string
-	}
+func (c *BaseCluster) genStartScript(nodes int64, dataDisk string) (string, string, error) {
+	data := struct {
+		DiscoveryToken, DataDisk string
+	}{DataDisk: dataDisk}
 	var err error
 	data.DiscoveryToken, err = discovery.NewToken()
 	if err != nil {
@@ -554,6 +554,10 @@ iptables -A FORWARD -i eth0 -j DROP
 
 var startScript = template.Must(template.New("start.sh").Parse(`
 #!/bin/sh
+
+{{if .DataDisk}}
+zpool create -f flynn-default {{.DataDisk}}
+{{end}}
 
 # wait for libvirt
 while ! [ -e /var/run/libvirt/libvirt-sock ]; do

--- a/installer/digital_ocean_cluster.go
+++ b/installer/digital_ocean_cluster.go
@@ -341,7 +341,7 @@ func (c *DigitalOceanCluster) configureDomain() error {
 func (c *DigitalOceanCluster) installFlynn() error {
 	c.base.SendLog("Installing flynn")
 
-	startScript, discoveryToken, err := c.base.genStartScript(c.base.NumInstances)
+	startScript, discoveryToken, err := c.base.genStartScript(c.base.NumInstances, "")
 	if err != nil {
 		return err
 	}

--- a/installer/stack_template.go
+++ b/installer/stack_template.go
@@ -25,9 +25,14 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
       "Default": "{{.DefaultInstanceType}}",
       "Description": "EC2 instance type"
     },
-    "VolumeSize": {
+    "BootVolumeSize": {
       "Type": "String",
-      "Description": "Size of instance volumes in GB",
+      "Description": "Size of boot volume in GB",
+      "Default": "50"
+    },
+    "DataVolumeSize": {
+      "Type": "String",
+      "Description": "Size of data volume in GB",
       "Default": "50"
     },
     "UserData": {
@@ -190,7 +195,14 @@ var stackTemplate = template.Must(template.New("stack_template.json").Parse(`
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": { "Ref" : "VolumeSize" },
+              "VolumeSize": { "Ref" : "BootVolumeSize" },
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/sdb",
+            "Ebs": {
+              "VolumeSize": { "Ref" : "DataVolumeSize" },
               "VolumeType": "gp2"
             }
           }


### PR DESCRIPTION
This avoids the initialization cost of EBS volumes provisioned from snapshots, which all boot volumes are. The initial `read(2)`/`write(2)` of a section of an EBS volume can take many seconds due to an underlying read from the snapshot in S3.

This was the cause of discoverd instance expiry, heartbeat writes were taking many seconds while the volume was initializing.

The solution also has the added benefit of not using a sparse file layered on top of ext4 for the ZFS pool.

Closes #2027
Closes #2060

/cc @temujin9