### PR TITLE
worker: Always scale old formations down after deployment

### DIFF
--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -57,17 +57,18 @@ func (d *DeployJob) deployAllAtOnce() error {
 			expected[typ] = map[string]int{"down": existing}
 		}
 	}
-	if expected.Count() > 0 {
-		log := log.New("release_id", d.OldReleaseID)
-		log.Info("scaling old formation to zero")
-		if err := d.client.PutFormation(&ct.Formation{
-			AppID:     d.AppID,
-			ReleaseID: d.OldReleaseID,
-		}); err != nil {
-			log.Error("error scaling old formation to zero", "err", err)
-			return err
-		}
 
+	log = log.New("release_id", d.OldReleaseID)
+	log.Info("scaling old formation to zero")
+	if err := d.client.PutFormation(&ct.Formation{
+		AppID:     d.AppID,
+		ReleaseID: d.OldReleaseID,
+	}); err != nil {
+		log.Error("error scaling old formation to zero", "err", err)
+		return err
+	}
+
+	if expected.Count() > 0 {
 		log.Info("waiting for job events", "expected", expected)
 		if err := d.waitForJobEvents(d.OldReleaseID, expected, log); err != nil {
 			log.Error("error waiting for job events", "err", err)

--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -92,14 +92,14 @@ func (d *DeployJob) deployOneByOne() error {
 	for typ, count := range oldScale {
 		diff[typ] = map[string]int{"down": count}
 	}
+	if err := d.client.PutFormation(&ct.Formation{
+		AppID:     d.AppID,
+		ReleaseID: d.OldReleaseID,
+	}); err != nil {
+		log.Error("error scaling old formation down to zero", "err", err)
+		return err
+	}
 	if diff.Count() > 0 {
-		if err := d.client.PutFormation(&ct.Formation{
-			AppID:     d.AppID,
-			ReleaseID: d.OldReleaseID,
-		}); err != nil {
-			log.Error("error scaling old formation down to zero", "err", err)
-			return err
-		}
 		log.Info(fmt.Sprintf("waiting for %d job down event(s)", diff.Count()))
 		if err := d.waitForJobEvents(d.OldReleaseID, diff, log); err != nil {
 			log.Error("error waiting for job down events", "err", err)


### PR DESCRIPTION
The deployer previously only scaled the old formation down if there were running jobs for the old release, so if the jobs were crashed at the time, the formation would stay scaled up and the jobs would be restarted.