### PR TITLE
script: Support installing explicit version

### DIFF
--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -30,7 +30,9 @@ Options:
   -c --config-dir=<dir>    config directory [default: /etc/flynn]
   -b --bin-dir=<dir>       binary directory [default: /usr/local/bin]
 
-Download container images and Flynn binaries from a TUF repository`)
+Download container images and Flynn binaries from a TUF repository.
+
+Set FLYNN_VERSION to download an explicit version.`)
 }
 
 func runDownload(args *docopt.Args) error {
@@ -60,10 +62,15 @@ func runDownload(args *docopt.Args) error {
 	}
 
 	configDir := args.String["--config-dir"]
-	version, err := getChannelVersion(configDir, client, log)
-	if err != nil {
-		return err
+
+	version := os.Getenv("FLYNN_VERSION")
+	if version == "" {
+		version, err = getChannelVersion(configDir, client, log)
+		if err != nil {
+			return err
+		}
 	}
+	log.Info(fmt.Sprintf("downloading components with version %s", version))
 
 	log.Info("downloading images")
 	if err := pinkerton.PullImagesWithClient(

--- a/script/install-flynn.tmpl
+++ b/script/install-flynn.tmpl
@@ -18,6 +18,7 @@ OPTIONS:
 
 VARIABLES:
   FLYNN_UPDATE_CHANNEL   The release channel to fetch updates from (either "nightly" or "stable") [default: stable]
+  FLYNN_VERSION          An explicit version to install (e.g. v20151104.1)
 USAGE
 }
 


### PR DESCRIPTION
I forgot to add this as part of closing #1100.

This means an explicit version can be installed like:

```bash
sudo FLYNN_VERSION="v20151104.1" bash < <(curl -fsSL https://dl.flynn.io/install-flynn)
```

/cc @temujin9 