### PR TITLE
bootstrap: Set PG* env vars on postgres release

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -88,6 +88,10 @@
     "action": "run-app",
     "release": {
       "env": {
+        "FLYNN_POSTGRES": "postgres",
+        "PGDATABASE": "postgres",
+        "PGHOST": "leader.postgres.discoverd",
+        "PGUSER": "flynn",
         "PGPASSWORD": "{{ (index .StepData \"pg-password\").Data }}"
       },
       "processes": {


### PR DESCRIPTION
Allows usage of the `flynn pg` tools with the default `postgres` database.