### PR TITLE
WIP: Discoverd client improvements

### DIFF
--- a/discoverd/client/client.go
+++ b/discoverd/client/client.go
@@ -1,261 +1,112 @@
 package discoverd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
-	"time"
+	"sync"
 
-	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
-	hh "github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/stream"
 )
 
-type Service interface {
-	Leader() (*Instance, error)
-	Instances() ([]*Instance, error)
-	Addrs() ([]string, error)
-	Leaders(chan *Instance) (stream.Stream, error)
-	Watch(events chan *Event) (stream.Stream, error)
-	GetMeta() (*ServiceMeta, error)
-	SetMeta(*ServiceMeta) error
-	SetLeader(string) error
-}
-
 var ErrTimedOut = errors.New("discoverd: timed out waiting for instances")
 
-type Client struct {
-	c *httpclient.Client
+type Config struct {
+	Endpoints []string
 }
 
-func NewClient() *Client {
-	url := os.Getenv("DISCOVERD")
-	if url == "" {
-		url = "http://127.0.0.1:1111"
+type Client struct {
+	servers []*httpclient.Client
+	pinned  int
+	leader  int
+	mu      sync.RWMutex
+}
+
+func NewClientWithConfig(config Config) *Client {
+	client := Client{}
+	for _, e := range config.Endpoints {
+		client.servers = append(client.servers, client.httpClient(e))
 	}
-	return NewClientWithURL(url)
+	return &client
 }
 
 func NewClientWithURL(url string) *Client {
 	if !strings.HasPrefix(url, "http") {
 		url = "http://" + url
 	}
-	return &Client{
-		c: &httpclient.Client{
-			URL: url,
-			HTTP: &http.Client{
-				Transport:     &http.Transport{Dial: dialer.Retry.Dial},
-				CheckRedirect: redirectPreserveHeaders,
-			},
-		},
-	}
+	return NewClientWithConfig(Config{Endpoints: []string{url}})
 }
 
-func NewClientWithHTTP(url string, hc *http.Client) *Client {
-	if url == "" {
-		url = "http://127.0.0.1:1111"
-	}
-	return &Client{
-		c: &httpclient.Client{
-			URL:  url,
-			HTTP: hc,
-		},
-	}
+func NewClient() *Client {
+	return NewClientWithConfig(defaultConfig())
 }
 
-func redirectPreserveHeaders(req *http.Request, via []*http.Request) error {
-	if len(via) >= 10 {
-		return fmt.Errorf("too many redirects")
+func defaultConfig() Config {
+	urls := os.Getenv("DISCOVERD")
+	if urls == "" {
+		urls = "http://127.0.0.1:1111"
 	}
-	if len(via) == 0 {
-		return nil
-	}
-	for attr, val := range via[0].Header {
-		if _, ok := req.Header[attr]; !ok {
-			req.Header[attr] = val
+	return Config{Endpoints: strings.Split(urls, ",")}
+}
+
+func (c *Client) updateLeader(url string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, s := range c.servers {
+		if s.Host == url {
+			c.leader = i
 		}
 	}
+}
+
+func (c *Client) httpClient(url string) *httpclient.Client {
+	checkRedirect := func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("too many redirects")
+		}
+		if len(via) > 0 {
+			for attr, val := range via[0].Header {
+				if _, ok := req.Header[attr]; !ok {
+					req.Header[attr] = val
+				}
+			}
+		}
+		c.updateLeader(req.Host)
+		return nil
+	}
+	return &httpclient.Client{
+		URL: url,
+		HTTP: &http.Client{
+			CheckRedirect: checkRedirect,
+		},
+	}
+}
+
+func (c *Client) Send(method string, path string, in, out interface{}) error {
+	// Cluster logic goes here
 	return nil
 }
 
-func (c *Client) Ping() error {
-	return c.c.Get("/ping", nil)
+func (s *Client) Stream(method string, path string, in, out interface{}) (stream.Stream, error) {
+	return nil, nil
 }
 
-type LeaderType string
-
-const (
-	LeaderTypeManual LeaderType = "manual"
-	LeaderTypeOldest LeaderType = "oldest"
-)
-
-type ServiceConfig struct {
-	LeaderType LeaderType `json:"leader_type"`
+func (c *Client) Get(path string, out interface{}) error {
+	return c.Send("GET", path, nil, out)
 }
 
-func (c *Client) AddService(name string, conf *ServiceConfig) error {
-	if conf == nil {
-		conf = &ServiceConfig{}
-	}
-	if conf.LeaderType == "" {
-		conf.LeaderType = LeaderTypeOldest
-	}
-	return c.c.Put("/services/"+name, conf, nil)
+func (c *Client) Put(path string, in, out interface{}) error {
+	return c.Send("PUT", path, in, out)
 }
 
-func (c *Client) RemoveService(name string) error {
-	return c.c.Delete("/services/" + name)
+func (c *Client) Delete(path string) error {
+	return c.Send("DELETE", path, nil, nil)
 }
 
-func (c *Client) Service(name string) Service {
-	return newService(c, name)
-}
-
-func IsNotFound(err error) bool {
-	return hh.IsObjectNotFoundError(err)
-}
-
-func (c *Client) Instances(service string, timeout time.Duration) ([]*Instance, error) {
-	s := c.Service(service)
-	instances, err := s.Instances()
-	if len(instances) > 0 || err != nil && !IsNotFound(err) {
-		return instances, err
-	}
-
-	events := make(chan *Event)
-	stream, err := s.Watch(events)
-	if err != nil {
-		return nil, err
-	}
-	defer stream.Close()
-	// get any current instances
-outer:
-	for event := range events {
-		switch event.Kind {
-		case EventKindCurrent:
-			break outer
-		case EventKindUp:
-			instances = append(instances, event.Instance)
-		}
-	}
-	if len(instances) > 0 {
-		return instances, nil
-	}
-	// wait for an instance to come up
-	for {
-		select {
-		case event, ok := <-events:
-			if !ok {
-				return nil, stream.Err()
-			}
-			if event.Kind != EventKindUp {
-				continue
-			}
-			return []*Instance{event.Instance}, nil
-		case <-time.After(timeout):
-			return nil, ErrTimedOut
-		}
-	}
-}
-
-type service struct {
-	client *Client
-	name   string
-}
-
-func newService(client *Client, name string) Service {
-	return &service{
-		client: client,
-		name:   name,
-	}
-}
-
-func (s *service) Leader() (*Instance, error) {
-	res := &Instance{}
-	return res, s.client.c.Get(fmt.Sprintf("/services/%s/leader", s.name), res)
-}
-
-func (s *service) Instances() ([]*Instance, error) {
-	var res []*Instance
-	return res, s.client.c.Get(fmt.Sprintf("/services/%s/instances", s.name), &res)
-}
-
-func (s *service) Addrs() ([]string, error) {
-	instances, err := s.Instances()
-	if err != nil {
-		return nil, err
-	}
-	addrs := make([]string, len(instances))
-	for i, inst := range instances {
-		addrs[i] = inst.Addr
-	}
-	return addrs, nil
-}
-
-// Leaders sends leader events to the given channel (sending nil when there is
-// no leader, for example if there are no instances currently registered).
-func (s *service) Leaders(leaders chan *Instance) (stream.Stream, error) {
-	events := make(chan *Event)
-	eventStream, err := s.client.c.Stream("GET", fmt.Sprintf("/services/%s/leader", s.name), nil, events)
-	if err != nil {
-		return nil, err
-	}
-	stream := stream.New()
-	go func() {
-		defer func() {
-			eventStream.Close()
-			// wait for stream to close to prevent race with Err read
-			for range events {
-			}
-			if err := eventStream.Err(); err != nil {
-				stream.Error = err
-			}
-			close(leaders)
-		}()
-		for {
-			select {
-			case event, ok := <-events:
-				if !ok {
-					return
-				}
-				if event.Kind != EventKindLeader {
-					continue
-				}
-				select {
-				case leaders <- event.Instance:
-				case <-stream.StopCh:
-					return
-				}
-			case <-stream.StopCh:
-				return
-			}
-		}
-	}()
-	return stream, nil
-}
-
-type ServiceMeta struct {
-	Data json.RawMessage `json:"data"`
-
-	// When calling SetMeta, Index is checked against the current index and the
-	// set only succeeds if the index is the same. A zero index means the meta
-	// does not currently exist.
-	Index uint64 `json:"index"`
-}
-
-func (s *service) GetMeta() (*ServiceMeta, error) {
-	meta := &ServiceMeta{}
-	return meta, s.client.c.Get(fmt.Sprintf("/services/%s/meta", s.name), meta)
-}
-
-func (s *service) SetMeta(m *ServiceMeta) error {
-	return s.client.c.Put(fmt.Sprintf("/services/%s/meta", s.name), m, m)
-}
-
-func (s *service) SetLeader(id string) error {
-	return s.client.c.Put(fmt.Sprintf("/services/%s/leader", s.name), &Instance{ID: id}, nil)
+func (c *Client) Ping(url string) error {
+	// find appropriate server and send ping
+	return nil
 }

--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -115,7 +115,7 @@ func (h *heartbeater) SetMeta(meta map[string]string) error {
 	h.Lock()
 	defer h.Unlock()
 	h.inst.Meta = meta
-	return h.client().c.Put(fmt.Sprintf("/services/%s/instances/%s", h.service, h.inst.ID), h.inst, nil)
+	return h.client().Put(fmt.Sprintf("/services/%s/instances/%s", h.service, h.inst.ID), h.inst, nil)
 }
 
 func (h *heartbeater) Addr() string {
@@ -140,7 +140,7 @@ func (h *heartbeater) run(firstErr chan<- error) {
 	register := func() error {
 		h.Lock()
 		defer h.Unlock()
-		return h.client().c.Put(path, h.inst, nil)
+		return h.client().Put(path, h.inst, nil)
 	}
 
 	err := register()
@@ -159,7 +159,7 @@ func (h *heartbeater) run(firstErr chan<- error) {
 			}
 			timer.Reset(heartbeatInterval)
 		case <-h.stop:
-			h.client().c.Delete(path)
+			h.client().Delete(path)
 			close(h.done)
 			return
 		}

--- a/discoverd/client/service.go
+++ b/discoverd/client/service.go
@@ -1,0 +1,195 @@
+package discoverd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	hh "github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type Service interface {
+	Leader() (*Instance, error)
+	Instances() ([]*Instance, error)
+	Addrs() ([]string, error)
+	Leaders(chan *Instance) (stream.Stream, error)
+	Watch(events chan *Event) (stream.Stream, error)
+	GetMeta() (*ServiceMeta, error)
+	SetMeta(*ServiceMeta) error
+	SetLeader(string) error
+}
+
+type LeaderType string
+
+const (
+	LeaderTypeManual LeaderType = "manual"
+	LeaderTypeOldest LeaderType = "oldest"
+)
+
+type ServiceConfig struct {
+	LeaderType LeaderType `json:"leader_type"`
+}
+
+func (c *Client) AddService(name string, conf *ServiceConfig) error {
+	if conf == nil {
+		conf = &ServiceConfig{}
+	}
+	if conf.LeaderType == "" {
+		conf.LeaderType = LeaderTypeOldest
+	}
+	return c.Put("/services/"+name, conf, nil)
+}
+
+func (c *Client) RemoveService(name string) error {
+	return c.Delete("/services/" + name)
+}
+
+func (c *Client) Service(name string) Service {
+	return newService(c, name)
+}
+
+func IsNotFound(err error) bool {
+	return hh.IsObjectNotFoundError(err)
+}
+
+func (c *Client) Instances(service string, timeout time.Duration) ([]*Instance, error) {
+	s := c.Service(service)
+	instances, err := s.Instances()
+	if len(instances) > 0 || err != nil && !IsNotFound(err) {
+		return instances, err
+	}
+
+	events := make(chan *Event)
+	stream, err := s.Watch(events)
+	if err != nil {
+		return nil, err
+	}
+	defer stream.Close()
+	// get any current instances
+outer:
+	for event := range events {
+		switch event.Kind {
+		case EventKindCurrent:
+			break outer
+		case EventKindUp:
+			instances = append(instances, event.Instance)
+		}
+	}
+	if len(instances) > 0 {
+		return instances, nil
+	}
+	// wait for an instance to come up
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return nil, stream.Err()
+			}
+			if event.Kind != EventKindUp {
+				continue
+			}
+			return []*Instance{event.Instance}, nil
+		case <-time.After(timeout):
+			return nil, ErrTimedOut
+		}
+	}
+}
+
+type service struct {
+	client *Client
+	name   string
+}
+
+func newService(client *Client, name string) Service {
+	return &service{
+		client: client,
+		name:   name,
+	}
+}
+
+func (s *service) Leader() (*Instance, error) {
+	res := &Instance{}
+	return res, s.client.Get(fmt.Sprintf("/services/%s/leader", s.name), res)
+}
+
+func (s *service) Instances() ([]*Instance, error) {
+	var res []*Instance
+	return res, s.client.Get(fmt.Sprintf("/services/%s/instances", s.name), &res)
+}
+
+func (s *service) Addrs() ([]string, error) {
+	instances, err := s.Instances()
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]string, len(instances))
+	for i, inst := range instances {
+		addrs[i] = inst.Addr
+	}
+	return addrs, nil
+}
+
+// Leaders sends leader events to the given channel (sending nil when there is
+// no leader, for example if there are no instances currently registered).
+func (s *service) Leaders(leaders chan *Instance) (stream.Stream, error) {
+	events := make(chan *Event)
+	eventStream, err := s.client.Stream("GET", fmt.Sprintf("/services/%s/leader", s.name), nil, events)
+	if err != nil {
+		return nil, err
+	}
+	stream := stream.New()
+	go func() {
+		defer func() {
+			eventStream.Close()
+			// wait for stream to close to prevent race with Err read
+			for range events {
+			}
+			if err := eventStream.Err(); err != nil {
+				stream.Error = err
+			}
+			close(leaders)
+		}()
+		for {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				if event.Kind != EventKindLeader {
+					continue
+				}
+				select {
+				case leaders <- event.Instance:
+				case <-stream.StopCh:
+					return
+				}
+			case <-stream.StopCh:
+				return
+			}
+		}
+	}()
+	return stream, nil
+}
+
+type ServiceMeta struct {
+	Data json.RawMessage `json:"data"`
+
+	// When calling SetMeta, Index is checked against the current index and the
+	// set only succeeds if the index is the same. A zero index means the meta
+	// does not currently exist.
+	Index uint64 `json:"index"`
+}
+
+func (s *service) GetMeta() (*ServiceMeta, error) {
+	meta := &ServiceMeta{}
+	return meta, s.client.Get(fmt.Sprintf("/services/%s/meta", s.name), meta)
+}
+
+func (s *service) SetMeta(m *ServiceMeta) error {
+	return s.client.Put(fmt.Sprintf("/services/%s/meta", s.name), m, m)
+}
+
+func (s *service) SetLeader(id string) error {
+	return s.client.Put(fmt.Sprintf("/services/%s/leader", s.name), &Instance{ID: id}, nil)
+}

--- a/discoverd/client/watch.go
+++ b/discoverd/client/watch.go
@@ -103,7 +103,7 @@ func (s *service) Watch(ch chan *Event) (stream.Stream, error) {
 	watch := NewWatch()
 	connect := func() error {
 		events = make(chan *Event)
-		stream, err := s.client.c.Stream("GET", fmt.Sprintf("/services/%s", s.name), nil, events)
+		stream, err := s.client.Stream("GET", fmt.Sprintf("/services/%s", s.name), nil, events)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Allows the discoverd client to connect to multiple peers and retry if the first peer is unavailable.

It will retry each server for up to a second every 100ms before moving to the next server.
It's possible to make this much better with a background goroutine to keep track of which servers are up so that requests always have low latency if there is a server available.

The main motivation for this is to allow `flynn-host` and `flynn-postgres` to not experience noticeable interuptions during `discoverd` deployments/updates but it should provide additional robustness in the face of network errors etc.

TODO
- [ ] Populate `DISCOVERD_PEERS` default environment variable with all of the peer URLs
- [ ] Sort the peer list so that the local server is prefered
- [x] Keep track of the current leader and direct writes there to avoid proxying