### PR TITLE
Makefile: Fix git tag determination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GIT_COMMIT=`git rev-parse --short HEAD`
 GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-GIT_TAG=`git describe --tags --exact-match --match "v*" 2>/dev/null || echo "none"`
+# NOTE: the `git tag` command is filtered through `grep .` so it returns non-zero when empty
+GIT_TAG=`git tag --list "v*" --sort "v:refname" --points-at HEAD 2>/dev/null | tail -n 1 | grep . || echo "none"`
 GIT_DIRTY=`test -n "$(git status --porcelain)" && echo true || echo false`
 
 all: toolchain


### PR DESCRIPTION
Using `git describe --exact-match` was just returning the first tag seen
for a commit. From `git help describe`:

    If an exact match is found, its name will be output and searching
    will stop.

So at the current master which is tagged with both v20151113.0 and
v20151114.0, GIT_TAG was being set to v20151113.0, whereas we want it to
be the latest value of v20151114.0:

    $ git tag --points-at master
    v20151113.0
    v20151114.0
    $ git describe --tags --exact-match --match "v*"
    v20151113.0

Using `git tag --sort | tail -n1` fixes this:

    $ git tag --list "v*" --sort "v:refname" --points-at HEAD | tail -n1
    v20151114.0