### PR TITLE
logaggregator: Use retry dialer in client

### DIFF
--- a/logaggregator/client/client.go
+++ b/logaggregator/client/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/logaggregator/utils"
+	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
 )
 
@@ -34,7 +35,8 @@ func newClient(url string, http *http.Client) *Client {
 
 // NewClient creates a new Client pointing at uri.
 func New(uri string) (*Client, error) {
-	return NewWithHTTP(uri, http.DefaultClient)
+	httpClient := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
+	return NewWithHTTP(uri, httpClient)
 }
 
 // NewClient creates a new Client pointing at uri with the specified http client.


### PR DESCRIPTION
This prevents errors like the on in CI build https://ci.flynn.io/builds/20151115010657-73c9f645 where the test got a connection refused as it was connecting to a logaggregator which just went down (but whose address was still being returned by discoverd).