### PR TITLE
controller: Add App.DeployTimeout

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -213,7 +213,8 @@
     "app": {
       "name": "controller",
       "meta": {"flynn-system-app": "true"},
-      "strategy": "one-by-one"
+      "strategy": "one-by-one",
+      "deploy_timeout": 120
     }
   },
   {
@@ -223,7 +224,8 @@
     "app": {
       "name": "postgres",
       "meta": {"flynn-system-app": "true"},
-      "strategy": "postgres"
+      "strategy": "postgres",
+      "deploy_timeout": 120
     }
   },
   {

--- a/cli/release.go
+++ b/cli/release.go
@@ -18,7 +18,7 @@ func init() {
 	register("release", runRelease, `
 usage: flynn release [-q|--quiet]
        flynn release add [-t <type>] [-f <file>] <uri>
-       flynn release show [<id>]
+       flynn release show [--json] [<id>]
 
 Manage app releases.
 
@@ -26,6 +26,7 @@ Options:
 	-q, --quiet        only print release IDs
 	-t <type>          type of the release. Currently only 'docker' is supported. [default: docker]
 	-f, --file=<file>  release configuration file
+	--json             print release configuration in JSON format
 
 Commands:
 	With no arguments, shows a list of releases associated with the app.
@@ -121,6 +122,9 @@ func runReleaseShow(args *docopt.Args, client *controller.Client) error {
 	}
 	if err != nil {
 		return err
+	}
+	if args.Bool["--json"] {
+		return json.NewEncoder(os.Stdout).Encode(release)
 	}
 	var artifactDesc string
 	if release.ArtifactID != "" {

--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -178,11 +178,12 @@ func (c *controllerAPI) CreateDeployment(ctx context.Context, w http.ResponseWri
 	}
 
 	deployment := &ct.Deployment{
-		AppID:        app.ID,
-		NewReleaseID: release.ID,
-		Strategy:     app.Strategy,
-		OldReleaseID: oldRelease.ID,
-		Processes:    oldFormation.Processes,
+		AppID:         app.ID,
+		NewReleaseID:  release.ID,
+		Strategy:      app.Strategy,
+		OldReleaseID:  oldRelease.ID,
+		Processes:     oldFormation.Processes,
+		DeployTimeout: app.DeployTimeout,
 	}
 
 	if err := schema.Validate(deployment); err != nil {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -181,5 +181,10 @@ $$ LANGUAGE plpgsql`,
     CONSTRAINT que_jobs_pkey PRIMARY KEY (queue, priority, run_at, job_id))`,
 		`COMMENT ON TABLE que_jobs IS '3'`,
 	)
+	m.Add(3,
+		`ALTER TABLE apps ADD COLUMN deploy_timeout integer NOT NULL DEFAULT 30`,
+		`UPDATE apps SET deploy_timeout = 120 WHERE name = 'controller'`,
+		`UPDATE apps SET deploy_timeout = 120 WHERE name = 'postgres'`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -80,22 +80,22 @@ const (
 	pingQuery = `SELECT 1`
 	// apps
 	appListQuery = `
-SELECT app_id, name, meta, strategy, release_id, created_at, updated_at
+SELECT app_id, name, meta, strategy, release_id, deploy_timeout, created_at, updated_at
 FROM apps WHERE deleted_at IS NULL ORDER BY created_at DESC`
 	appSelectByNameQuery = `
-SELECT app_id, name, meta, strategy, release_id, created_at, updated_at
+SELECT app_id, name, meta, strategy, release_id, deploy_timeout, created_at, updated_at
 FROM apps WHERE deleted_at IS NULL AND name = $1`
 	appSelectByNameForUpdateQuery = `
-SELECT app_id, name, meta, strategy, release_id, created_at, updated_at
+SELECT app_id, name, meta, strategy, release_id, deploy_timeout, created_at, updated_at
 FROM apps WHERE deleted_at IS NULL AND name = $1 FOR UPDATE`
 	appSelectByNameOrIDQuery = `
-SELECT app_id, name, meta, strategy, release_id, created_at, updated_at
+SELECT app_id, name, meta, strategy, release_id, deploy_timeout, created_at, updated_at
 FROM apps WHERE deleted_at IS NULL AND (app_id = $1 OR name = $2) LIMIT 1`
 	appSelectByNameOrIDForUpdateQuery = `
-SELECT app_id, name, meta, strategy, release_id, created_at, updated_at
+SELECT app_id, name, meta, strategy, release_id, deploy_timeout, created_at, updated_at
 FROM apps WHERE deleted_at IS NULL AND (app_id = $1 OR name = $2) LIMIT 1 FOR UPDATE`
 	appInsertQuery = `
-INSERT INTO apps (app_id, name, meta, strategy) VALUES ($1, $2, $3, $4) RETURNING created_at, updated_at`
+INSERT INTO apps (app_id, name, meta, strategy, deploy_timeout) VALUES ($1, $2, $3, $4, $5) RETURNING created_at, updated_at`
 	appUpdateStrategyQuery = `
 UPDATE apps SET strategy = $2, updated_at = now() WHERE app_id = $1`
 	appUpdateMetaQuery = `

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -23,13 +23,14 @@ type ExpandedFormation struct {
 }
 
 type App struct {
-	ID        string            `json:"id,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Meta      map[string]string `json:"meta,omitempty"`
-	Strategy  string            `json:"strategy,omitempty"`
-	ReleaseID string            `json:"release,omitempty"`
-	CreatedAt *time.Time        `json:"created_at,omitempty"`
-	UpdatedAt *time.Time        `json:"updated_at,omitempty"`
+	ID            string            `json:"id,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Meta          map[string]string `json:"meta,omitempty"`
+	Strategy      string            `json:"strategy,omitempty"`
+	ReleaseID     string            `json:"release,omitempty"`
+	DeployTimeout int32             `json:"deploy_timeout,omitempty"`
+	CreatedAt     *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt     *time.Time        `json:"updated_at,omitempty"`
 }
 
 func (a *App) System() bool {
@@ -129,16 +130,19 @@ type NewJob struct {
 	Resources  resource.Resources `json:"resources,omitempty"`
 }
 
+const DefaultDeployTimeout = 30 // seconds
+
 type Deployment struct {
-	ID           string         `json:"id,omitempty"`
-	AppID        string         `json:"app,omitempty"`
-	OldReleaseID string         `json:"old_release,omitempty"`
-	NewReleaseID string         `json:"new_release,omitempty"`
-	Strategy     string         `json:"strategy,omitempty"`
-	Status       string         `json:"status,omitempty"`
-	Processes    map[string]int `json:"processes,omitempty"`
-	CreatedAt    *time.Time     `json:"created_at,omitempty"`
-	FinishedAt   *time.Time     `json:"finished_at,omitempty"`
+	ID            string         `json:"id,omitempty"`
+	AppID         string         `json:"app,omitempty"`
+	OldReleaseID  string         `json:"old_release,omitempty"`
+	NewReleaseID  string         `json:"new_release,omitempty"`
+	Strategy      string         `json:"strategy,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	Processes     map[string]int `json:"processes,omitempty"`
+	DeployTimeout int32          `json:"deploy_timeout,omitempty"`
+	CreatedAt     *time.Time     `json:"created_at,omitempty"`
+	FinishedAt    *time.Time     `json:"finished_at,omitempty"`
 }
 
 type DeployID struct {

--- a/schema/controller/app.json
+++ b/schema/controller/app.json
@@ -38,6 +38,9 @@
     "release": {
       "$ref": "/schema/controller/common#/definitions/id"
     },
+    "deploy_timeout": {
+      "$ref": "/schema/controller/common#/definitions/deploy_timeout"
+    },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"
     },

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -54,6 +54,10 @@
     "resources": {
       "description": "resource request and limits",
       "type": "object"
+    },
+    "deploy_timeout": {
+      "description": "deployment timeout (default 30s)",
+      "type": "integer"
     }
   }
 }

--- a/schema/controller/deployment.json
+++ b/schema/controller/deployment.json
@@ -36,6 +36,9 @@
         "type": "integer"
       }
     },
+    "deploy_timeout": {
+      "$ref": "/schema/controller/common#/definitions/deploy_timeout"
+    },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"
     },

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -482,7 +482,7 @@ loop:
 			case "failed":
 				t.Fatal("the deployment failed")
 			}
-		case <-time.After(2 * time.Minute):
+		case <-time.After(time.Duration(app.DeployTimeout) * time.Second):
 			t.Fatal("timed out waiting for the deploy to complete")
 		}
 	}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -16,8 +16,6 @@ import (
 	"github.com/flynn/flynn/updater/types"
 )
 
-const defaultTimeout = 30 * time.Second
-
 var slugbuilderURI, slugrunnerURI string
 
 // use a flag to determine whether to use a TTY log formatter because actually
@@ -82,11 +80,7 @@ func run() error {
 			log.Error("error getting app", "err", err)
 			return err
 		}
-		timeout := defaultTimeout
-		if name == "postgres" {
-			timeout = 2 * time.Minute
-		}
-		if err := deployApp(client, app, uris[name], log, timeout); err != nil {
+		if err := deployApp(client, app, uris[name], log); err != nil {
 			if e, ok := err.(errDeploySkipped); ok {
 				log.Info("skipped deploy of system app", "reason", e.reason)
 				continue
@@ -108,7 +102,7 @@ func run() error {
 		}
 		log := log.New("name", app.Name)
 		log.Info("starting deploy of app to update slugrunner")
-		if err := deployApp(client, app, slugrunnerURI, log, defaultTimeout); err != nil {
+		if err := deployApp(client, app, slugrunnerURI, log); err != nil {
 			if e, ok := err.(errDeploySkipped); ok {
 				log.Info("skipped deploy of app", "reason", e.reason)
 				continue
@@ -128,7 +122,7 @@ func (e errDeploySkipped) Error() string {
 	return e.reason
 }
 
-func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Logger, timeout time.Duration) error {
+func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Logger) error {
 	release, err := client.GetAppRelease(app.ID)
 	if err != nil {
 		log.Error("error getting release", "err", err)
@@ -171,7 +165,7 @@ func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Log
 		log.Error("error creating new release", "err", err)
 		return err
 	}
-	if err := client.DeployAppReleaseWithTimeout(app.ID, release.ID, timeout); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID); err != nil {
 		log.Error("error deploying app", "err", err)
 		return err
 	}


### PR DESCRIPTION
Both the controller and postgres can take longer than the default 30s to deploy, and so we have some custom timeouts spread amongst the code, but the default timeout is used in cases like `flynn -a controller env set`, so is susceptible to timeouts.

I have added `App.DeployTimeout` which is the timeout in seconds, and added `Deployment.DeployTimeout` which is copied from the app so the client knows what the timeout is when creating a deployment without also looking up the app.

I have also made the schema change as a new migration now that we have a stable release :smile: