### PR TITLE
test/runner: Increase timeout for integration tests to 25m

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -305,7 +305,7 @@ cmd="bin/flynn-test \
   --router-ip {{ .Cluster.RouterIP }} \
   --debug"
 
-timeout --signal=QUIT --kill-after=10 20m $cmd
+timeout --signal=QUIT --kill-after=10 25m $cmd
 `[1:]))
 
 func formatDuration(d time.Duration) string {


### PR DESCRIPTION
The margin for tests taking a little longer is getting pretty thin with some new tests that take longer (domain migration, discoverd deployment etc) the timeout needs to be increased a bit to cover this.
It may be possible to speed the tests up by increasing concurrency also.