### PR TITLE
Add raft log cache

### DIFF
--- a/discoverd/server/store_test.go
+++ b/discoverd/server/store_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -573,6 +574,23 @@ func TestStore_Subscribe_NoBlock(t *testing.T) {
 	}
 
 	// Ensure that program does not hang.
+}
+
+func BenchmarkStore_AddInstance(b *testing.B) {
+	s := MustOpenStore()
+	defer s.Close()
+	if err := s.AddService("service0", nil); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	// Continually heartbeat 10 instances.
+	const instanceN = 10
+	for i := 0; i < b.N; i++ {
+		if err := s.AddInstance("service0", &discoverd.Instance{ID: fmt.Sprintf("inst%d", i%instanceN)}); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // Store represents a test wrapper for server.Store.


### PR DESCRIPTION
This commit wraps the log store in a raft.LogCache to improve I/O performance.

Benchmark tests with the log cache show about a 33% improvement in throughput on my local SSD, however, more importantly, the disk I/O seems to be much more consistent. With the log cache, it was consistently writing about 70MB/sec and without the log cache it would write anywhere from 8-50MB/sec The performance improvement should be more significant on spinning disk.

Signed-off-by: Ben Johnson <benbjohnson@yahoo.com>