### PR TITLE
host: Add configurable tags, broadcast via service discovery

### DIFF
--- a/host/cli/tags.go
+++ b/host/cli/tags.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/cluster"
+)
+
+func init() {
+	Register("tags", runTags, `
+usage: flynn-host tags
+       flynn-host tags set <hostid> <var>=<val>...
+
+Manage flynn-host daemon tags.
+
+Commands:
+	With no arguments, shows a list of current tags.
+
+	set    sets value of one or more tags
+`)
+}
+
+func runTags(args *docopt.Args, client *cluster.Client) error {
+	if args.Bool["set"] {
+		return runTagsSet(args, client)
+	}
+	instances, err := client.HostInstances()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	listRec(w, "HOST", "TAGS")
+	for _, inst := range instances {
+		tags := make([]string, 0, len(inst.Meta))
+		for k, v := range inst.Meta {
+			if strings.HasPrefix(k, host.TagPrefix) {
+				tags = append(tags, fmt.Sprintf("%s=%s", strings.TrimPrefix(k, host.TagPrefix), v))
+			}
+		}
+		listRec(w, inst.Meta["id"], strings.Join(tags, " "))
+	}
+	return nil
+}
+
+func runTagsSet(args *docopt.Args, client *cluster.Client) error {
+	host, err := client.Host(args.String["<hostid>"])
+	if err != nil {
+		return err
+	}
+	pairs := args.All["<var>=<val>"].([]string)
+	tags := make(map[string]string, len(pairs))
+	for _, s := range pairs {
+		v := strings.SplitN(s, "=", 2)
+		if len(v) != 2 {
+			return fmt.Errorf("invalid tag format: %q", s)
+		}
+		tags[v[0]] = v[1]
+	}
+	return host.UpdateTags(tags)
+}

--- a/host/discoverd.go
+++ b/host/discoverd.go
@@ -114,7 +114,13 @@ func (d *DiscoverdManager) UpdateTags(tags map[string]string) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	for k, v := range tags {
-		d.inst.Meta[host.TagPrefix+k] = v
+		name := host.TagPrefix + k
+		// treat empty tags as ones to delete
+		if v == "" {
+			delete(d.inst.Meta, name)
+			continue
+		}
+		d.inst.Meta[name] = v
 	}
 	if d.hb == nil {
 		return nil

--- a/host/discoverd.go
+++ b/host/discoverd.go
@@ -116,5 +116,8 @@ func (d *DiscoverdManager) UpdateTags(tags map[string]string) error {
 	for k, v := range tags {
 		d.inst.Meta[host.TagPrefix+k] = v
 	}
+	if d.hb == nil {
+		return nil
+	}
 	return d.hb.SetMeta(d.inst.Meta)
 }

--- a/host/discoverd.go
+++ b/host/discoverd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/logmux"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/shutdown"
 )
 
@@ -21,7 +22,7 @@ func NewDiscoverdManager(backend Backend, mux *logmux.Mux, hostID, publishAddr s
 		},
 	}
 	for k, v := range tags {
-		d.inst.Meta["tag."+k] = v
+		d.inst.Meta[host.TagPrefix+k] = v
 	}
 	d.local.Store(false)
 	return d
@@ -107,4 +108,13 @@ func (d *DiscoverdManager) ConnectPeer(ips []string) error {
 		break
 	}
 	return err
+}
+
+func (d *DiscoverdManager) UpdateTags(tags map[string]string) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	for k, v := range tags {
+		d.inst.Meta[host.TagPrefix+k] = v
+	}
+	return d.hb.SetMeta(d.inst.Meta)
 }

--- a/host/discoverd.go
+++ b/host/discoverd.go
@@ -11,7 +11,7 @@ import (
 	"github.com/flynn/flynn/pkg/shutdown"
 )
 
-func NewDiscoverdManager(backend Backend, mux *logmux.Mux, hostID, publishAddr string) *DiscoverdManager {
+func NewDiscoverdManager(backend Backend, mux *logmux.Mux, hostID, publishAddr string, tags map[string]string) *DiscoverdManager {
 	d := &DiscoverdManager{
 		backend: backend,
 		mux:     mux,
@@ -19,6 +19,9 @@ func NewDiscoverdManager(backend Backend, mux *logmux.Mux, hostID, publishAddr s
 			Addr: publishAddr,
 			Meta: map[string]string{"id": hostID},
 		},
+	}
+	for k, v := range tags {
+		d.inst.Meta["tag."+k] = v
 	}
 	d.local.Store(false)
 	return d

--- a/host/host.go
+++ b/host/host.go
@@ -260,9 +260,14 @@ func runDaemon(args *docopt.Args) {
 	discoverdManager := NewDiscoverdManager(backend, mux, hostID, publishAddr, tags)
 	publishURL := "http://" + publishAddr
 	host := &Host{
-		id:      hostID,
-		url:     publishURL,
-		status:  &host.HostStatus{ID: hostID, PID: os.Getpid(), URL: publishURL},
+		id:  hostID,
+		url: publishURL,
+		status: &host.HostStatus{
+			ID:   hostID,
+			PID:  os.Getpid(),
+			URL:  publishURL,
+			Tags: tags,
+		},
 		state:   state,
 		backend: backend,
 		vman:    vman,
@@ -280,6 +285,8 @@ func runDaemon(args *docopt.Args) {
 		pid := os.Getpid()
 		log.Info("setting status PID", "pid", pid)
 		host.status.PID = pid
+		// keep the same tags as the parent
+		discoverdManager.UpdateTags(host.status.Tags)
 	}
 
 	log.Info("creating HTTP listener")

--- a/host/host.go
+++ b/host/host.go
@@ -260,14 +260,14 @@ func runDaemon(args *docopt.Args) {
 	discoverdManager := NewDiscoverdManager(backend, mux, hostID, publishAddr, tags)
 	publishURL := "http://" + publishAddr
 	host := &Host{
-		id:               hostID,
-		url:              publishURL,
-		status:           &host.HostStatus{ID: hostID, PID: os.Getpid(), URL: publishURL},
-		state:            state,
-		backend:          backend,
-		vman:             vman,
-		connectDiscoverd: discoverdManager.ConnectLocal,
-		log:              logger.New("host.id", hostID),
+		id:      hostID,
+		url:     publishURL,
+		status:  &host.HostStatus{ID: hostID, PID: os.Getpid(), URL: publishURL},
+		state:   state,
+		backend: backend,
+		vman:    vman,
+		discMan: discoverdManager,
+		log:     logger.New("host.id", hostID),
 	}
 
 	// restore the host status if set in the environment
@@ -383,7 +383,7 @@ func runDaemon(args *docopt.Args) {
 	}
 	if config := host.status.Discoverd; config != nil && config.URL != "" {
 		log.Info("connecting to service discovery", "url", config.URL)
-		if err := host.connectDiscoverd(config.URL); err != nil {
+		if err := discoverdManager.ConnectLocal(config.URL); err != nil {
 			log.Error("error connecting to service discovery", "err", err)
 			shutdown.Fatal(err)
 		}

--- a/host/host.go
+++ b/host/host.go
@@ -457,10 +457,11 @@ func parseTagArgs(args string) map[string]string {
 	tags := make(map[string]string)
 	for _, s := range strings.Split(args, ",") {
 		keyVal := strings.SplitN(s, "=", 2)
-		if len(keyVal) != 2 {
-			continue
+		if len(keyVal) == 1 && keyVal[0] != "" {
+			tags[keyVal[0]] = "true"
+		} else if len(keyVal) == 2 {
+			tags[keyVal[0]] = keyVal[1]
 		}
-		tags[keyVal[0]] = keyVal[1]
 	}
 	return tags
 }

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -14,11 +14,11 @@ func (S) TestParseTagArgs(c *C) {
 		},
 		{
 			args:     "foo",
-			expected: map[string]string{},
+			expected: map[string]string{"foo": "true"},
 		},
 		{
 			args:     "foo,",
-			expected: map[string]string{},
+			expected: map[string]string{"foo": "true"},
 		},
 		{
 			args:     "foo=",
@@ -35,6 +35,10 @@ func (S) TestParseTagArgs(c *C) {
 		{
 			args:     "foo=bar=baz",
 			expected: map[string]string{"foo": "bar=baz"},
+		},
+		{
+			args:     "foo=bar,baz",
+			expected: map[string]string{"foo": "bar", "baz": "true"},
 		},
 		{
 			args:     "foo=bar,baz=",

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -1,0 +1,55 @@
+package main
+
+import . "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+
+func (S) TestParseTagArgs(c *C) {
+	type test struct {
+		args     string
+		expected map[string]string
+	}
+	for _, t := range []*test{
+		{
+			args:     "",
+			expected: map[string]string{},
+		},
+		{
+			args:     "foo",
+			expected: map[string]string{},
+		},
+		{
+			args:     "foo,",
+			expected: map[string]string{},
+		},
+		{
+			args:     "foo=",
+			expected: map[string]string{"foo": ""},
+		},
+		{
+			args:     "foo=bar",
+			expected: map[string]string{"foo": "bar"},
+		},
+		{
+			args:     "foo=bar,",
+			expected: map[string]string{"foo": "bar"},
+		},
+		{
+			args:     "foo=bar=baz",
+			expected: map[string]string{"foo": "bar=baz"},
+		},
+		{
+			args:     "foo=bar,baz=",
+			expected: map[string]string{"foo": "bar", "baz": ""},
+		},
+		{
+			args:     "foo=bar,baz=,",
+			expected: map[string]string{"foo": "bar", "baz": ""},
+		},
+		{
+			args:     "foo=bar,baz=qux",
+			expected: map[string]string{"foo": "bar", "baz": "qux"},
+		},
+	} {
+		actual := parseTagArgs(t.args)
+		c.Assert(actual, DeepEquals, t.expected, Commentf("parsing %q", t.args))
+	}
+}

--- a/host/http.go
+++ b/host/http.go
@@ -365,11 +365,21 @@ func (h *jobAPI) UpdateTags(w http.ResponseWriter, r *http.Request, _ httprouter
 		httphelper.Error(w, err)
 		return
 	}
-	if err := h.host.discMan.UpdateTags(tags); err != nil {
+	if err := h.host.UpdateTags(tags); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
 	w.WriteHeader(200)
+}
+
+func (h *Host) UpdateTags(tags map[string]string) error {
+	h.statusMtx.RLock()
+	defer h.statusMtx.RUnlock()
+	if err := h.discMan.UpdateTags(tags); err != nil {
+		return err
+	}
+	h.status.Tags = tags
+	return nil
 }
 
 func checkPort(port host.Port) bool {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -277,11 +277,12 @@ type DiscoverdConfig struct {
 }
 
 type HostStatus struct {
-	ID        string           `json:"id"`
-	PID       int              `json:"pid"`
-	URL       string           `json:"url"`
-	Discoverd *DiscoverdConfig `json:"discoverd,omitempty"`
-	Network   *NetworkConfig   `json:"network,omitempty"`
+	ID        string            `json:"id"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	PID       int               `json:"pid"`
+	URL       string            `json:"url"`
+	Discoverd *DiscoverdConfig  `json:"discoverd,omitempty"`
+	Network   *NetworkConfig    `json:"network,omitempty"`
 }
 
 const (

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -7,6 +7,9 @@ import (
 	"github.com/flynn/flynn/host/resource"
 )
 
+// TagPrefix is the prefix added to tags in discoverd instance metadata
+const TagPrefix = "tag:"
+
 type Job struct {
 	ID string `json:"id,omitempty"`
 

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -76,6 +76,11 @@ func (c *Client) Hosts() ([]*Host, error) {
 	return hosts, nil
 }
 
+// HostInstances returns a list of discoverd instances for hosts in the cluster.
+func (c *Client) HostInstances() ([]*discoverd.Instance, error) {
+	return c.s.Instances()
+}
+
 func (c *Client) StreamHostEvents(ch chan *discoverd.Event) (stream.Stream, error) {
 	return c.s.Watch(ch)
 }

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -197,3 +197,7 @@ func (c *Host) Update(name string, args ...string) (pid int, err error) {
 	cmd := &host.Command{Path: name, Args: args}
 	return cmd.PID, c.c.Post("/host/update", cmd, cmd)
 }
+
+func (c *Host) UpdateTags(tags map[string]string) error {
+	return c.c.Post("/host/tags", tags, nil)
+}

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -389,3 +389,49 @@ func (s *HostSuite) TestUpdate(t *c.C) {
 	t.Assert(status.ID, c.Equals, id)
 	t.Assert(status.PID, c.Equals, pid)
 }
+
+func (s *HostSuite) TestUpdateTags(t *c.C) {
+	events := make(chan *discoverd.Event)
+	stream, err := s.discoverdClient(t).Service("flynn-host").Watch(events)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+	nextEvent := func() *discoverd.Event {
+		select {
+		case e, ok := <-events:
+			if !ok {
+				t.Fatal("unexpected close of discoverd stream")
+			}
+			return e
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for discoverd event")
+		}
+		return nil
+	}
+
+	var client *cluster.Host
+	for {
+		e := nextEvent()
+		if e.Kind == discoverd.EventKindUp && client == nil {
+			client = cluster.NewHost(e.Instance.Meta["id"], e.Instance.Addr, nil)
+		}
+		if e.Kind == discoverd.EventKindCurrent {
+			break
+		}
+	}
+	if client == nil {
+		t.Fatal("did not initialize flynn-host client")
+	}
+
+	t.Assert(client.UpdateTags(map[string]string{"foo": "bar"}), c.IsNil)
+
+	var meta map[string]string
+	for {
+		e := nextEvent()
+		if e.Kind == discoverd.EventKindUpdate && e.Instance.Meta["id"] == client.ID() {
+			meta = e.Instance.Meta
+			break
+		}
+	}
+	t.Assert(meta["tag:foo"], c.Equals, "bar")
+}

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -434,4 +434,18 @@ func (s *HostSuite) TestUpdateTags(t *c.C) {
 		}
 	}
 	t.Assert(meta["tag:foo"], c.Equals, "bar")
+
+	// setting to empty string should delete the tag
+	t.Assert(client.UpdateTags(map[string]string{"foo": ""}), c.IsNil)
+
+	for {
+		e := nextEvent()
+		if e.Kind == discoverd.EventKindUpdate && e.Instance.Meta["id"] == client.ID() {
+			meta = e.Instance.Meta
+			break
+		}
+	}
+	if _, ok := meta["tag:foo"]; ok {
+		t.Fatal("expected tag to be deleted but is still present")
+	}
 }


### PR DESCRIPTION
This is a prerequisite for implementing tag based constraints in the scheduler (i.e. run a job only on hosts tagged with `role=db`).

Tags can be set in a number of ways:

* Via the `--tags` flag when starting `flynn-host daemon`
* Via the host API (`POST /host/tags`)
* Via the CLI (`flynn-host tags set <hostid> key=val...`)

The tags are set in service discovery instance metadata so that they can be easily seen by services which already watch the `flynn-host` service (e.g. the scheduler), and the keys are prefixed with `tag:` so it is clear which metadata should be interpreted as tags.