### PR TITLE
gitreceive/receiver: Set service on process type for zero-downtime deploy

### DIFF
--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -154,11 +154,12 @@ Options:
 		proc := prevRelease.Processes[t]
 		proc.Cmd = []string{"start", t}
 		if t == "web" || strings.HasSuffix(t, "-web") {
+			proc.Service = app.Name + "-" + t
 			proc.Ports = []ct.Port{{
 				Port:  8080,
 				Proto: "tcp",
 				Service: &host.Service{
-					Name:   app.Name + "-" + t,
+					Name:   proc.Service,
 					Create: true,
 					Check:  &host.HealthCheck{Type: "tcp"},
 				},

--- a/test/test_taffy_deploy.go
+++ b/test/test_taffy_deploy.go
@@ -70,10 +70,10 @@ func (s *TaffyDeploySuite) TestDeploys(t *c.C) {
 
 	github := map[string]string{
 		"user":      "flynn-examples",
-		"repo":      "go-flynn-example",
+		"repo":      "nodejs-flynn-example",
 		"branch":    "master",
-		"rev":       "a2ac6b059e1359d0e974636935fda8995de02b16",
-		"clone_url": "https://github.com/flynn-examples/go-flynn-example.git",
+		"rev":       "5e177fec38fbde7d0a03e9e8dccf8757c68caa11",
+		"clone_url": "https://github.com/flynn-examples/nodejs-flynn-example.git",
 	}
 
 	// initial deploy
@@ -109,7 +109,7 @@ func (s *TaffyDeploySuite) TestDeploys(t *c.C) {
 
 	// second deploy
 
-	github["rev"] = "2bc7e016b1b4aae89396c898583763c5781e031a"
+	github["rev"] = "4231f8871da2b9fd73a5402753df3dfc5609d7b7"
 
 	release, err = client.GetAppRelease(app.ID)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
When the service is specified, it is used by the deployer to ensure that old jobs are not terminated until the new ones are registered in discoverd.