### PR TITLE
Scheduler Updates

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -108,7 +108,7 @@ func (a *RunAppAction) Run(s *State) error {
 		}
 		for i := 0; i < count; i++ {
 			host := hosts[i%len(hosts)]
-			config := utils.JobConfig(a.ExpandedFormation, typ, host.ID())
+			config := utils.JobConfig(a.ExpandedFormation, typ, host.ID(), "")
 			hostresource.SetDefaults(&config.Resources)
 			if a.ExpandedFormation.Release.Processes[typ].Data {
 				if err := utils.ProvisionVolume(host, config); err != nil {

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -371,6 +371,13 @@ func (c *Client) GetFormation(appID, releaseID string) (*ct.Formation, error) {
 	return formation, c.Get(fmt.Sprintf("/apps/%s/formations/%s", appID, releaseID), formation)
 }
 
+// GetExpandedFormation returns expanded details for the specified formation
+// under app and release.
+func (c *Client) GetExpandedFormation(appID, releaseID string) (*ct.ExpandedFormation, error) {
+	formation := &ct.ExpandedFormation{}
+	return formation, c.Get(fmt.Sprintf("/apps/%s/formations/%s?expand=true", appID, releaseID), formation)
+}
+
 // FormationList returns a list of all formations under appID.
 func (c *Client) FormationList(appID string) ([]*ct.Formation, error) {
 	var formations []*ct.Formation

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -377,6 +377,13 @@ func (c *Client) FormationList(appID string) ([]*ct.Formation, error) {
 	return formations, c.Get(fmt.Sprintf("/apps/%s/formations", appID), &formations)
 }
 
+// FormationListActive returns a list of all active formations (i.e. formations
+// whose process count is greater than zero).
+func (c *Client) FormationListActive() ([]*ct.ExpandedFormation, error) {
+	var formations []*ct.ExpandedFormation
+	return formations, c.Get("/formations?active=true", &formations)
+}
+
 // DeleteFormation deletes the formation matching appID and releaseID.
 func (c *Client) DeleteFormation(appID, releaseID string) error {
 	return c.Delete(fmt.Sprintf("/apps/%s/formations/%s", appID, releaseID), nil)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -265,6 +265,7 @@ func (s *S) TestCreateFormation(c *C) {
 		// Now edit the formation to have valid process types. Should succeed.
 		in.Processes = map[string]int{"web": 1}
 		out := s.createTestFormation(c, in)
+		defer s.deleteTestFormation(out)
 		c.Assert(out.AppID, Equals, app.ID)
 		c.Assert(out.ReleaseID, Equals, release.ID)
 		c.Assert(out.Processes["web"], Equals, 1)
@@ -287,6 +288,10 @@ func (s *S) TestCreateFormation(c *C) {
 func (s *S) createTestFormation(c *C, formation *ct.Formation) *ct.Formation {
 	c.Assert(s.c.PutFormation(formation), IsNil)
 	return formation
+}
+
+func (s *S) deleteTestFormation(formation *ct.Formation) {
+	s.c.DeleteFormation(formation.AppID, formation.ReleaseID)
 }
 
 func (s *S) TestDeleteFormation(c *C) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -280,6 +280,13 @@ func (s *S) TestCreateFormation(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(gotFormation, DeepEquals, out)
 
+		expanded, err := s.c.GetExpandedFormation(appID, release.ID)
+		c.Assert(err, IsNil)
+		c.Assert(expanded.App.ID, Equals, app.ID)
+		c.Assert(expanded.Release.ID, Equals, release.ID)
+		c.Assert(expanded.Artifact.ID, Equals, release.ArtifactID)
+		c.Assert(expanded.Processes, DeepEquals, out.Processes)
+
 		_, err = s.c.GetFormation(appID, release.ID+"fail")
 		c.Assert(err, Equals, controller.ErrNotFound)
 	}

--- a/controller/deployment_test.go
+++ b/controller/deployment_test.go
@@ -19,6 +19,7 @@ func (s *S) TestCreateDeployment(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"web": 1},
 	}), IsNil)
+	defer s.c.DeleteFormation(app.ID, release.ID)
 
 	// deploying an initial release should no-op
 	d, err := s.c.CreateDeployment(app.ID, release.ID)
@@ -53,6 +54,7 @@ func (s *S) TestStreamDeployment(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"web": 1},
 	}), IsNil)
+	defer s.c.DeleteFormation(app.ID, release.ID)
 	c.Assert(s.c.SetAppRelease(app.ID, release.ID), IsNil)
 
 	newRelease := s.createTestRelease(c, &ct.Release{})
@@ -97,6 +99,7 @@ func (s *S) TestGetDeployment(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"web": 1},
 	}), IsNil)
+	defer s.c.DeleteFormation(app.ID, release.ID)
 
 	// deploy initial release
 	d, err := s.c.CreateDeployment(app.ID, release.ID)
@@ -130,6 +133,7 @@ func (s *S) TestDeploymentList(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"web": 1},
 	}), IsNil)
+	defer s.c.DeleteFormation(app.ID, release.ID)
 
 	// deploy initial release
 	initial, err := s.c.CreateDeployment(app.ID, release.ID)

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -225,6 +225,7 @@ func (s *S) TestStreamFormationEvents(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"foo": 1},
 	})
+	defer s.deleteTestFormation(formation)
 
 	select {
 	case e, ok := <-events:
@@ -247,6 +248,7 @@ func (s *S) TestStreamFormationEvents(c *C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"foo": 2},
 	})
+	defer s.deleteTestFormation(nextFormation)
 
 	select {
 	case e, ok := <-events:

--- a/controller/formation_test.go
+++ b/controller/formation_test.go
@@ -38,6 +38,7 @@ func (s *S) TestFormationStreaming(c *C) {
 		AppID:     app.ID,
 		Processes: map[string]int{"foo": 1},
 	})
+	defer s.deleteTestFormation(formation)
 
 	var out *ct.ExpandedFormation
 	select {
@@ -63,4 +64,55 @@ func (s *S) TestFormationStreaming(c *C) {
 	c.Assert(out.Release, DeepEquals, release)
 	c.Assert(out.App, DeepEquals, app)
 	c.Assert(out.Processes, IsNil)
+}
+
+func (s *S) TestFormationListActive(c *C) {
+	app1 := s.createTestApp(c, &ct.App{})
+	app2 := s.createTestApp(c, &ct.App{})
+	artifact := s.createTestArtifact(c, &ct.Artifact{})
+
+	createFormation := func(app *ct.App, procs map[string]int) *ct.ExpandedFormation {
+		release := &ct.Release{
+			ArtifactID: artifact.ID,
+			Processes:  make(map[string]ct.ProcessType, len(procs)),
+		}
+		for typ := range procs {
+			release.Processes[typ] = ct.ProcessType{}
+		}
+		s.createTestRelease(c, release)
+		s.createTestFormation(c, &ct.Formation{
+			AppID:     app.ID,
+			ReleaseID: release.ID,
+			Processes: procs,
+		})
+		return &ct.ExpandedFormation{
+			App:       app,
+			Release:   release,
+			Artifact:  artifact,
+			Processes: procs,
+		}
+	}
+
+	formations := []*ct.ExpandedFormation{
+		createFormation(app1, map[string]int{"web": 0}),
+		createFormation(app1, map[string]int{"web": 1}),
+		createFormation(app2, map[string]int{"web": 0, "worker": 0}),
+		createFormation(app2, map[string]int{"web": 0, "worker": 1}),
+		createFormation(app2, map[string]int{"web": 1, "worker": 2}),
+	}
+
+	list, err := s.c.FormationListActive()
+	c.Assert(err, IsNil)
+	c.Assert(list, HasLen, 3)
+
+	// check that we only get the formations with a non-zero process count,
+	// most recently updated first
+	expected := []*ct.ExpandedFormation{formations[4], formations[3], formations[1]}
+	for i, f := range expected {
+		actual := list[i]
+		c.Assert(actual.App.ID, Equals, f.App.ID)
+		c.Assert(actual.Release.ID, Equals, f.Release.ID)
+		c.Assert(actual.Artifact.ID, Equals, f.Artifact.ID)
+		c.Assert(actual.Processes, DeepEquals, f.Processes)
+	}
 }

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -217,7 +217,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 	}
 	client := hosts[random.Math.Intn(len(hosts))]
 
-	id := cluster.GenerateJobID(client.ID())
+	id := cluster.GenerateJobID(client.ID(), "")
 	app := c.getApp(ctx)
 	env := make(map[string]string, len(release.Env)+len(newJob.Env)+4)
 	env["FLYNN_APP_ID"] = app.ID

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -91,7 +91,7 @@ func (l *fakeLog) Write([]byte) (int, error) {
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
 	hostID := fakeHostID()
-	jobID := cluster.GenerateJobID(hostID)
+	jobID := cluster.GenerateJobID(hostID, "")
 	hc := tu.NewFakeHostClient(hostID)
 	s.cc.AddHost(hc)
 

--- a/controller/scheduler/formation.go
+++ b/controller/scheduler/formation.go
@@ -85,12 +85,3 @@ func (f *Formation) Update(procs Processes) Processes {
 	f.Processes = procs
 	return diff
 }
-
-func (f *Formation) IsEmpty() bool {
-	for _, count := range f.Processes {
-		if count > 0 {
-			return false
-		}
-	}
-	return true
-}

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -20,15 +20,6 @@ const (
 	JobStateNew       JobState = "new"
 )
 
-type JobRequest struct {
-	Job      *Job
-	attempts uint
-}
-
-func NewJobRequest(f *Formation, typ, hostID, internalID string) *JobRequest {
-	return &JobRequest{Job: NewJob(f, f.App.ID, f.Release.ID, typ, hostID, internalID)}
-}
-
 type Job struct {
 	// InternalID is used to track jobs in-memory and is added to the
 	// cluster job's metadata (with key "flynn-controller.scheduler_id").

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"time"
 
 	ct "github.com/flynn/flynn/controller/types"
@@ -85,6 +84,14 @@ func (j *Job) IsInFormation(key utils.FormationKey) bool {
 	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key
 }
 
+func (j *Job) SetState(state JobState) {
+	j.state = state
+}
+
+func (j *Job) HasState(state JobState) bool {
+	return j.state == state
+}
+
 type Jobs map[string]*Job
 
 func (js Jobs) GetStoppableJobs(key utils.FormationKey, typ string) []*Job {
@@ -120,19 +127,6 @@ func (js Jobs) GetProcesses(key utils.FormationKey) Processes {
 
 func (js Jobs) AddJob(j *Job) {
 	js[j.InternalID] = j
-}
-
-func (js Jobs) IsJobInState(id string, state JobState) bool {
-	j, ok := js[id]
-	return ok && j.state == state
-}
-
-func (js Jobs) SetState(id string, state JobState) error {
-	if j, ok := js[id]; ok {
-		j.state = state
-		return nil
-	}
-	return errors.New("job not found")
 }
 
 // TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -8,18 +8,38 @@ import (
 	"github.com/flynn/flynn/host/types"
 )
 
+// JobState is a job's in-memory state
 type JobState string
 
 const (
-	JobStateStarting  JobState = "starting"
-	JobStateRunning   JobState = "running"
-	JobStateStopping  JobState = "stopping"
-	JobStateStopped   JobState = "stopped"
-	JobStateCrashed   JobState = "crashed"
+	// JobStateStarting is a job's state when it has started in the cluster
+	// (i.e. a host.StatusStarting event has been received)
+	JobStateStarting JobState = "starting"
+
+	// JobStateRunning is a job's state when it is running in the cluster
+	// (i.e. a host.StatusRunning event has been received)
+	JobStateRunning JobState = "running"
+
+	// JobStateStopping is a job's state when a request has been made to
+	// stop the job in the cluster
+	JobStateStopping JobState = "stopping"
+
+	// JobStateStopped is a job's state when it has stopped in the cluster
+	// (i.e. either a host.StatusDone, host.StatusCrashed or
+	// host.StatusFailed event has been received)
+	JobStateStopped JobState = "stopped"
+
+	// JobStateScheduled is a job's state when it is scheduled to start in
+	// the future (because it's in the process of being restarted)
 	JobStateScheduled JobState = "scheduled"
-	JobStateNew       JobState = "new"
+
+	// JobStateNew is a job's state when it has been created in-memory (in
+	// response to a formation change) and is in the process of being
+	// started in the cluster
+	JobStateNew JobState = "new"
 )
 
+// Job is an in-memory representation of a cluster job
 type Job struct {
 	// InternalID is used to track jobs in-memory and is added to the
 	// cluster job's metadata (with key "flynn-controller.scheduler_id").
@@ -32,35 +52,64 @@ type Job struct {
 	Type      string
 	AppID     string
 	ReleaseID string
-	HostID    string
-	JobID     string
 
+	// HostID is the ID of the host the job has been placed on, and is set
+	// when a StartJob goroutine makes a placement request to the scheduler
+	// loop
+	HostID string
+
+	// JobID is the ID of the cluster job that this in-memory job
+	// represents, and is set either by a StartJob goroutine when it makes
+	// a placement request to the scheduler loop, or when an event is
+	// received for a yet unknown job (e.g. one started by the controller)
+	JobID string
+
+	// Formation is the formation this job belongs to
 	Formation *Formation
 
-	restarts  uint
+	// restarts is the number of times this job has been restarted and is
+	// used to calculate the amount of time to wait before restarting the
+	// job again when it stops (see scheduler.restartJob)
+	restarts uint
+
+	// restartTimer is a timer set when scheduling a job to start in the
+	// future
+	restartTimer *time.Timer
+
+	// startedAt is the time the job started in the cluster, assigned
+	// whenever a host event is received for the job, and is used to sort
+	// jobs when deciding which job to stop when a formation is scaled down
 	startedAt time.Time
-	state     JobState
+
+	// state is the job's current in-memory state and should only be
+	// referenced from within the main scheduler loop
+	state JobState
+
+	// metadata is the cluster job's metadata, assigned whenever a host
+	// event is received for the job, and is used when persisting the job
+	// to the controller
+	metadata map[string]string
 }
 
-func NewJob(f *Formation, appID, releaseID, typ, hostID, internalID string) *Job {
-	return &Job{
-		InternalID: internalID,
-		Type:       typ,
-		AppID:      appID,
-		ReleaseID:  releaseID,
-		HostID:     hostID,
-		Formation:  f,
-		startedAt:  time.Now(),
-		state:      JobStateNew,
-	}
-}
-
+// needsVolume indicates whether a volume should be provisioned in the cluster
+// for the job, determined from the corresponding process type in the release
 func (j *Job) needsVolume() bool {
 	return j.Formation.Release.Processes[j.Type].Data
 }
 
+// HasTypeFromRelease indicates whether the job has a type which is present
+// in the release
+func (j *Job) HasTypeFromRelease() bool {
+	for typ := range j.Formation.Release.Processes {
+		if j.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
 func (j *Job) IsStopped() bool {
-	return j.state == JobStateStopping || j.state == JobStateStopped || j.state == JobStateCrashed
+	return j.state == JobStateStopping || j.state == JobStateStopped
 }
 
 func (j *Job) IsRunning() bool {
@@ -72,35 +121,26 @@ func (j *Job) IsSchedulable() bool {
 }
 
 func (j *Job) IsInFormation(key utils.FormationKey) bool {
-	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key
-}
-
-func (j *Job) SetState(state JobState) {
-	j.state = state
-}
-
-func (j *Job) HasState(state JobState) bool {
-	return j.state == state
+	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key && j.HasTypeFromRelease()
 }
 
 type Jobs map[string]*Job
 
-func (js Jobs) GetStoppableJobs(key utils.FormationKey, typ string) []*Job {
-	formTypeJobs := make([]*Job, 0, len(js))
-	for _, j := range js {
-		if j.IsInFormation(key) && j.IsRunning() && j.Type == typ {
-			formTypeJobs = append(formTypeJobs, j)
+func (j Jobs) WithFormationAndType(f *Formation, typ string) []*Job {
+	jobs := make([]*Job, 0, len(j))
+	for _, job := range j {
+		if job.Formation == f && job.Type == typ {
+			jobs = append(jobs, job)
 		}
 	}
-	return formTypeJobs
+	return jobs
 }
 
-func (js Jobs) GetHostJobCounts(key utils.FormationKey, typ string) map[string]int {
+func (j Jobs) GetHostJobCounts(key utils.FormationKey, typ string) map[string]int {
 	counts := make(map[string]int)
-
-	for _, j := range js {
-		if j.IsInFormation(key) && j.Type == typ && !j.HasState(JobStateScheduled) {
-			counts[j.HostID]++
+	for _, job := range j {
+		if job.IsInFormation(key) && job.Type == typ && job.state != JobStateScheduled {
+			counts[job.HostID]++
 		}
 	}
 	return counts
@@ -116,19 +156,19 @@ func (js Jobs) GetProcesses(key utils.FormationKey) Processes {
 	return procs
 }
 
-func (js Jobs) AddJob(j *Job) {
+func (js Jobs) Add(j *Job) {
 	js[j.InternalID] = j
 }
 
 // TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host
-func controllerJobFromSchedulerJob(job *Job, state string, metadata map[string]string) *ct.Job {
+func controllerJobFromSchedulerJob(job *Job, state string) *ct.Job {
 	return &ct.Job{
 		ID:        job.JobID,
 		AppID:     job.AppID,
 		ReleaseID: job.ReleaseID,
 		Type:      job.Type,
 		State:     state,
-		Meta:      metadata,
+		Meta:      utils.JobMetaFromMetadata(job.metadata),
 	}
 }
 

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -9,32 +9,25 @@ import (
 	"github.com/flynn/flynn/host/types"
 )
 
-type JobRequestType string
 type JobState string
 
 const (
-	JobRequestTypeUp   JobRequestType = "up"
-	JobRequestTypeDown JobRequestType = "down"
-	JobStateStarting   JobState       = "starting"
-	JobStateRunning    JobState       = "running"
-	JobStateStopping   JobState       = "stopping"
-	JobStateStopped    JobState       = "stopped"
-	JobStateCrashed    JobState       = "crashed"
-	JobStateRequesting JobState       = "requesting"
-	JobStateNew        JobState       = "new"
+	JobStateStarting   JobState = "starting"
+	JobStateRunning    JobState = "running"
+	JobStateStopping   JobState = "stopping"
+	JobStateStopped    JobState = "stopped"
+	JobStateCrashed    JobState = "crashed"
+	JobStateRequesting JobState = "requesting"
+	JobStateNew        JobState = "new"
 )
 
 type JobRequest struct {
 	*Job
-	RequestType JobRequestType
-	attempts    uint
+	attempts uint
 }
 
-func NewJobRequest(f *Formation, requestType JobRequestType, typ, hostID, jobID string) *JobRequest {
-	return &JobRequest{
-		Job:         NewJob(f, f.App.ID, f.Release.ID, typ, hostID, jobID),
-		RequestType: requestType,
-	}
+func NewJobRequest(f *Formation, typ, hostID, jobID string) *JobRequest {
+	return &JobRequest{Job: NewJob(f, f.App.ID, f.Release.ID, typ, hostID, jobID)}
 }
 
 func (r *JobRequest) needsVolume() bool {
@@ -43,9 +36,8 @@ func (r *JobRequest) needsVolume() bool {
 
 func (r *JobRequest) Clone() *JobRequest {
 	return &JobRequest{
-		Job:         r.Job.Clone(),
-		RequestType: r.RequestType,
-		attempts:    r.attempts,
+		Job:      r.Job.Clone(),
+		attempts: r.attempts,
 	}
 }
 

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -41,13 +41,13 @@ const (
 
 // Job is an in-memory representation of a cluster job
 type Job struct {
-	// InternalID is used to track jobs in-memory and is added to the
-	// cluster job's metadata (with key "flynn-controller.scheduler_id").
+	// ID is used to track jobs in-memory and is the UUID part of the
+	// cluster job's ID.
 	//
-	// It is distinct from the cluster job's ID due to the fact that a
-	// cluster job only has an ID once a host has been picked to run the
-	// job on, and we need to track it before that happens.
-	InternalID string
+	// We only use the UUID part due to the fact that a cluster job only
+	// has a HostID once a host has been picked to run the job on, and we
+	// need to track it before that happens.
+	ID string
 
 	Type      string
 	AppID     string
@@ -157,7 +157,7 @@ func (js Jobs) GetProcesses(key utils.FormationKey) Processes {
 }
 
 func (js Jobs) Add(j *Job) {
-	js[j.InternalID] = j
+	js[j.ID] = j
 }
 
 // TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -739,15 +739,12 @@ func (s *Scheduler) handleActiveJob(activeJob *host.ActiveJob) (*Job, error) {
 		f := s.formations.Get(appID, releaseID)
 		if f == nil {
 			log.Info("job is from new formation, getting formation from controller")
-			var cf *ct.Formation
-			cf, err = s.GetFormation(appID, releaseID)
+			var ef *ct.ExpandedFormation
+			ef, err = s.GetExpandedFormation(appID, releaseID)
 			if err != nil {
 				log.Error("error getting formation", "err", err)
 			} else {
-				f, err = s.handleControllerFormation(cf)
-				if err != nil {
-					log.Error("error updating formation", "err", err)
-				}
+				f = s.handleFormation(ef)
 			}
 		}
 		job.Formation = f
@@ -792,14 +789,6 @@ func (s *Scheduler) triggerRectify(key utils.FormationKey) {
 	case s.rectify <- struct{}{}:
 	default:
 	}
-}
-
-func (s *Scheduler) handleControllerFormation(f *ct.Formation) (*Formation, error) {
-	ef, err := utils.ExpandFormation(s, f)
-	if err != nil {
-		return nil, err
-	}
-	return s.handleFormation(ef), nil
 }
 
 func (s *Scheduler) startJob(req *JobRequest) (err error) {

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -883,7 +883,12 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 					s.formationlessJobs[key] = jobs
 				}
 				jobs[job.InternalID] = job
-				log.Error("error looking up formation for job", "err", err)
+
+				// only log an error if the state changed (so we don't
+				// keep logging it in periodic SyncJobs calls)
+				if job.state != previousState {
+					log.Error("error looking up formation for job", "err", err)
+				}
 				return
 			}
 			formation = s.handleFormation(ef)

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -263,7 +263,7 @@ func (TestSuite) TestRectify(c *C) {
 	c.Log("Test creating an extra job on the host. Wait for job start in scheduler")
 	form := s.formations.Get(testAppID, testReleaseID)
 	host, err := s.Host(testHostID)
-	request := NewJobRequest(form, JobRequestTypeUp, testJobType, "", "")
+	request := NewJobRequest(form, testJobType, "", "")
 	config := jobConfig(request, testHostID)
 	host.AddJob(config)
 	job = s.waitJobStart()
@@ -285,7 +285,7 @@ func (TestSuite) TestRectify(c *C) {
 	processes := map[string]int{testJobType: testJobCount}
 	release := NewRelease("test-release-2", artifact, processes)
 	form = NewFormation(&ct.ExpandedFormation{App: app, Release: release, Artifact: artifact, Processes: processes})
-	request = NewJobRequest(form, JobRequestTypeUp, testJobType, "", "")
+	request = NewJobRequest(form, testJobType, "", "")
 	config = jobConfig(request, testHostID)
 	// Add the job to the host without adding the formation. Expected error.
 	c.Log("Create a new job on the host without adding the formation to the controller. Wait for job start, expect error.")

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -264,7 +264,7 @@ func (TestSuite) TestRectify(c *C) {
 	form := s.formations.Get(testAppID, testReleaseID)
 	host, err := s.Host(testHostID)
 	request := NewJobRequest(form, testJobType, "", "")
-	config := jobConfig(request, testHostID)
+	config := jobConfig(request.Job, testHostID)
 	host.AddJob(config)
 	job = s.waitJobStart()
 	jobs[job.JobID] = job
@@ -286,7 +286,7 @@ func (TestSuite) TestRectify(c *C) {
 	release := NewRelease("test-release-2", artifact, processes)
 	form = NewFormation(&ct.ExpandedFormation{App: app, Release: release, Artifact: artifact, Processes: processes})
 	request = NewJobRequest(form, testJobType, "", "")
-	config = jobConfig(request, testHostID)
+	config = jobConfig(request.Job, testHostID)
 	// Add the job to the host without adding the formation. Expected error.
 	c.Log("Create a new job on the host without adding the formation to the controller. Wait for job start, expect error.")
 	host.AddJob(config)

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -40,6 +40,7 @@ var preparedStatements = map[string]string{
 	"formation_list_active":                 formationListActiveQuery,
 	"formation_list_since":                  formationListSinceQuery,
 	"formation_select":                      formationSelectQuery,
+	"formation_select_expanded":             formationSelectExpandedQuery,
 	"formation_insert":                      formationInsertQuery,
 	"formation_update":                      formationUpdateQuery,
 	"formation_delete":                      formationDeleteQuery,
@@ -203,6 +204,17 @@ FROM formations WHERE updated_at >= $1 ORDER BY updated_at DESC`
 	formationSelectQuery = `
 SELECT app_id, release_id, processes, created_at, updated_at
 FROM formations WHERE app_id = $1 AND release_id = $2 AND deleted_at IS NULL`
+	formationSelectExpandedQuery = `
+SELECT
+  apps.app_id, apps.name,
+  releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
+  artifacts.artifact_id, artifacts.type, artifacts.uri,
+  formations.processes, formations.updated_at
+FROM formations
+JOIN apps USING (app_id)
+JOIN releases ON releases.release_id = formations.release_id
+JOIN artifacts USING (artifact_id)
+WHERE formations.app_id = $1 AND formations.release_id = $2 AND formations.deleted_at IS NULL`
 	formationInsertQuery = `
 INSERT INTO formations (app_id, release_id, processes)
 VALUES ($1, $2, $3) RETURNING created_at, updated_at`

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -53,6 +53,35 @@ func (c *FakeControllerClient) GetFormation(appID, releaseID string) (*ct.Format
 	return nil, controller.ErrNotFound
 }
 
+func (c *FakeControllerClient) GetExpandedFormation(appID, releaseID string) (*ct.ExpandedFormation, error) {
+	app, ok := c.apps[appID]
+	if !ok {
+		return nil, controller.ErrNotFound
+	}
+	release, ok := c.releases[releaseID]
+	if !ok {
+		return nil, controller.ErrNotFound
+	}
+	releases, ok := c.formations[appID]
+	if !ok {
+		return nil, controller.ErrNotFound
+	}
+	formation, ok := releases[releaseID]
+	if !ok {
+		return nil, controller.ErrNotFound
+	}
+	procs := make(map[string]int, len(formation.Processes))
+	for typ, n := range formation.Processes {
+		procs[typ] = n
+	}
+	return &ct.ExpandedFormation{
+		App:       app,
+		Release:   release,
+		Artifact:  c.artifacts[release.ArtifactID],
+		Processes: procs,
+	}, nil
+}
+
 func (c *FakeControllerClient) GetApp(appID string) (*ct.App, error) {
 	if app, ok := c.apps[appID]; ok {
 		return app, nil

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -163,7 +163,7 @@ type ControllerClient interface {
 	PutFormation(formation *ct.Formation) error
 	StreamFormations(since *time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	AppList() ([]*ct.App, error)
-	FormationList(appID string) ([]*ct.Formation, error)
+	FormationListActive() ([]*ct.ExpandedFormation, error)
 	PutJob(*ct.Job) error
 }
 

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -156,7 +156,7 @@ type ControllerClient interface {
 	GetApp(appID string) (*ct.App, error)
 	GetRelease(releaseID string) (*ct.Release, error)
 	GetArtifact(artifactID string) (*ct.Artifact, error)
-	GetFormation(appID, releaseID string) (*ct.Formation, error)
+	GetExpandedFormation(appID, releaseID string) (*ct.ExpandedFormation, error)
 	CreateApp(app *ct.App) error
 	CreateRelease(release *ct.Release) error
 	CreateArtifact(artifact *ct.Artifact) error

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flynn/flynn/pkg/stream"
 )
 
-func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
+func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.Job {
 	t := f.Release.Processes[name]
 	env := make(map[string]string, len(f.Release.Env)+len(t.Env)+4)
 	for k, v := range f.Release.Env {
@@ -26,7 +26,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string) *host.Job {
 	for k, v := range t.Env {
 		env[k] = v
 	}
-	id := cluster.GenerateJobID(hostID)
+	id := cluster.GenerateJobID(hostID, uuid)
 	env["FLYNN_APP_ID"] = f.App.ID
 	env["FLYNN_APP_NAME"] = f.App.Name
 	env["FLYNN_RELEASE_ID"] = f.Release.ID

--- a/host/cli/fix.go
+++ b/host/cli/fix.go
@@ -159,7 +159,7 @@ func (f *clusterFixer) startAppJob(app, typ, service string) ([]*discoverd.Insta
 	for _, job = range releases[0] {
 		break
 	}
-	job.ID = cluster.GenerateJobID(f.hosts[0].ID())
+	job.ID = cluster.GenerateJobID(f.hosts[0].ID(), "")
 	f.fixJobEnv(job)
 	// run it on a host
 	f.l.Info(fmt.Sprintf("starting %s %s job", app, typ), "job.id", job.ID, "release", job.Metadata["flynn-controller.release"])
@@ -196,7 +196,7 @@ outer:
 				}
 			}
 
-			job.ID = cluster.GenerateJobID(h.ID())
+			job.ID = cluster.GenerateJobID(h.ID(), "")
 			f.fixJobEnv(job)
 			if err := h.AddJob(job); err != nil {
 				return fmt.Errorf("error starting discoverd on %s: %s", h.ID(), err)
@@ -254,7 +254,7 @@ func (f *clusterFixer) fixFlannel() error {
 		if _, ok := flannelJobs[h.ID()]; ok {
 			continue
 		}
-		job.ID = cluster.GenerateJobID(h.ID())
+		job.ID = cluster.GenerateJobID(h.ID(), "")
 		f.fixJobEnv(job)
 		if err := h.AddJob(job); err != nil {
 			return fmt.Errorf("error starting flannel job: %s", err)
@@ -333,7 +333,7 @@ func (f *clusterFixer) fixController(instances []*discoverd.Instance, startSched
 		if err != nil {
 			return err
 		}
-		schedulerJob := utils.JobConfig(ef, "scheduler", f.hosts[0].ID())
+		schedulerJob := utils.JobConfig(ef, "scheduler", f.hosts[0].ID(), "")
 		if err := f.hosts[0].AddJob(schedulerJob); err != nil {
 			return fmt.Errorf("error starting scheduler job on %s: %s", f.hosts[0].ID(), err)
 		}
@@ -472,7 +472,7 @@ func (f *clusterFixer) fixPostgres() error {
 	f.l.Info("attempting to start missing postgres jobs", "want", want, "have", have)
 	if leader == nil {
 		// if no postgres, attempt to start
-		job.ID = cluster.GenerateJobID(host.ID())
+		job.ID = cluster.GenerateJobID(host.ID(), "")
 		f.fixJobEnv(job)
 		f.l.Info("starting postgres primary job", "job.id", job.ID)
 		wait, err = waitForInstance(job.ID)
@@ -497,7 +497,7 @@ func (f *clusterFixer) fixPostgres() error {
 			// if there are no other hosts, use the same one we put the primary on
 			secondHost = host
 		}
-		job.ID = cluster.GenerateJobID(secondHost.ID())
+		job.ID = cluster.GenerateJobID(secondHost.ID(), "")
 		f.fixJobEnv(job)
 		f.l.Info("starting second postgres job", "job.id", job.ID)
 		if wait == nil {

--- a/host/state.go
+++ b/host/state.go
@@ -132,7 +132,7 @@ func (s *State) Restore(backend Backend, buffers host.LogBuffers) (func(), error
 		for _, job := range resurrect {
 			go func(job *host.ActiveJob) {
 				// generate a new job id, this is a new job
-				newID := cluster.GenerateJobID(s.id)
+				newID := cluster.GenerateJobID(s.id, "")
 				log.Printf("resurrecting %s as %s", job.Job.ID, newID)
 				job.Job.ID = newID
 				config := &RunConfig{

--- a/pkg/cluster/utils.go
+++ b/pkg/cluster/utils.go
@@ -17,7 +17,20 @@ func ExtractHostID(id string) (string, error) {
 	return ids[0], nil
 }
 
+// ExtractUUID returns the UUID component of a job ID, returning an error if
+// the given ID is invalid.
+func ExtractUUID(id string) (string, error) {
+	ids := strings.SplitN(id, "-", 2)
+	if len(ids) != 2 || ids[0] == "" || ids[1] == "" {
+		return "", errors.New("invalid ID")
+	}
+	return ids[1], nil
+}
+
 // GenerateJobID returns a random job identifier, prefixed with the given host ID.
-func GenerateJobID(hostID string) string {
-	return hostID + "-" + random.UUID()
+func GenerateJobID(hostID, uuid string) string {
+	if uuid == "" {
+		uuid = random.UUID()
+	}
+	return hostID + "-" + uuid
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -205,7 +205,7 @@ func (c *Cmd) Start() error {
 		c.Job.Artifact = c.Artifact
 	}
 	if c.Job.ID == "" {
-		c.Job.ID = cluster.GenerateJobID(c.HostID)
+		c.Job.ID = cluster.GenerateJobID(c.HostID, "")
 	}
 
 	if c.host == nil {

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -179,7 +179,7 @@ func (s *SchedulerSuite) TestJobStatus(t *c.C) {
 	t.Assert(list, c.HasLen, 3)
 	jobs := make(map[string]*ct.Job, len(list))
 	for _, job := range list {
-		debug(t, job.Type, "job started with ID ", job.ID)
+		debugf(t, "%s job started with ID %s", job.Type, job.ID)
 		jobs[job.Type] = job
 	}
 


### PR DESCRIPTION
Apologies for the big diff with lots of small changes, but it was hard to split these up and still have the tests pass.

To summarise:

* Add `Job.InternalID`, distinct from `Job.JobID`, making jobs easier to track (see [this comment](https://github.com/flynn/flynn/blob/scheduler-updates/controller/scheduler/job.go#L44-L49))
* Reduce logging
* Support getting only "active" formations from the controller (i.e. ones with at least one process scaled up) so the scheduler only needs to make a single request in `SyncFormations` (rather than getting all apps, then a request per app for formations)
* Support getting expanded formations from the controller to avoid the scheduler needing to lookup apps / releases / artifacts separately
* Start jobs in a goroutine (part of fixing #1920), using "placement requests" to the main loop to determine which host to start the job on at each attempt
* Refactor handling of job events & comment to make it much clearer
* Replace `JobStateCrashed` with `JobStateScheduled` to indicate the job is scheduled to start in the future
* Add a job restart timer so restarts can be cancelled before trying to stop running jobs (fixes #1922)
* Jobs with a type not from the release (e.g. slugbuilder jobs) don't trigger a rectify
* Track failed formation lookups and trigger a rectify if the formation appears in a future sync
* Track type-less jobs in memory (fixes #2013)
* Don't handle crashed jobs in non-leaders (fixes #2030)
* Cancel new jobs (i.e. ones in the process of being started) when stopping jobs so they do not continue to be started (fixes #2133, fixes #2004)