### PR TITLE
discoverd/client: Cluster awareness/failover

### DIFF
--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -118,7 +118,7 @@ func (h *heartbeater) SetMeta(meta map[string]string) error {
 	h.Lock()
 	defer h.Unlock()
 	h.inst.Meta = meta
-	return h.client().c.Put(fmt.Sprintf("/services/%s/instances/%s", h.service, h.inst.ID), h.inst, nil)
+	return h.client().Put(fmt.Sprintf("/services/%s/instances/%s", h.service, h.inst.ID), h.inst, nil)
 }
 
 func (h *heartbeater) Addr() string {
@@ -144,7 +144,7 @@ func (h *heartbeater) run(firstErr chan<- error) {
 	register := func() error {
 		h.Lock()
 		defer h.Unlock()
-		return h.client().c.Put(path, h.inst, nil)
+		return h.client().Put(path, h.inst, nil)
 	}
 
 	err := register()
@@ -163,7 +163,7 @@ func (h *heartbeater) run(firstErr chan<- error) {
 			}
 			timer.Reset(nextHeartbeat())
 		case <-h.stop:
-			h.client().c.Delete(path)
+			h.client().Delete(path)
 			close(h.done)
 			return
 		}

--- a/discoverd/client/service.go
+++ b/discoverd/client/service.go
@@ -1,0 +1,195 @@
+package discoverd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	hh "github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/stream"
+)
+
+type Service interface {
+	Leader() (*Instance, error)
+	Instances() ([]*Instance, error)
+	Addrs() ([]string, error)
+	Leaders(chan *Instance) (stream.Stream, error)
+	Watch(events chan *Event) (stream.Stream, error)
+	GetMeta() (*ServiceMeta, error)
+	SetMeta(*ServiceMeta) error
+	SetLeader(string) error
+}
+
+type LeaderType string
+
+const (
+	LeaderTypeManual LeaderType = "manual"
+	LeaderTypeOldest LeaderType = "oldest"
+)
+
+type ServiceConfig struct {
+	LeaderType LeaderType `json:"leader_type"`
+}
+
+func (c *Client) AddService(name string, conf *ServiceConfig) error {
+	if conf == nil {
+		conf = &ServiceConfig{}
+	}
+	if conf.LeaderType == "" {
+		conf.LeaderType = LeaderTypeOldest
+	}
+	return c.Put("/services/"+name, conf, nil)
+}
+
+func (c *Client) RemoveService(name string) error {
+	return c.Delete("/services/" + name)
+}
+
+func (c *Client) Service(name string) Service {
+	return newService(c, name)
+}
+
+func IsNotFound(err error) bool {
+	return hh.IsObjectNotFoundError(err)
+}
+
+func (c *Client) Instances(service string, timeout time.Duration) ([]*Instance, error) {
+	s := c.Service(service)
+	instances, err := s.Instances()
+	if len(instances) > 0 || err != nil && !IsNotFound(err) {
+		return instances, err
+	}
+
+	events := make(chan *Event)
+	stream, err := s.Watch(events)
+	if err != nil {
+		return nil, err
+	}
+	defer stream.Close()
+	// get any current instances
+outer:
+	for event := range events {
+		switch event.Kind {
+		case EventKindCurrent:
+			break outer
+		case EventKindUp:
+			instances = append(instances, event.Instance)
+		}
+	}
+	if len(instances) > 0 {
+		return instances, nil
+	}
+	// wait for an instance to come up
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return nil, stream.Err()
+			}
+			if event.Kind != EventKindUp {
+				continue
+			}
+			return []*Instance{event.Instance}, nil
+		case <-time.After(timeout):
+			return nil, ErrTimedOut
+		}
+	}
+}
+
+type service struct {
+	client *Client
+	name   string
+}
+
+func newService(client *Client, name string) Service {
+	return &service{
+		client: client,
+		name:   name,
+	}
+}
+
+func (s *service) Leader() (*Instance, error) {
+	res := &Instance{}
+	return res, s.client.Get(fmt.Sprintf("/services/%s/leader", s.name), res)
+}
+
+func (s *service) Instances() ([]*Instance, error) {
+	var res []*Instance
+	return res, s.client.Get(fmt.Sprintf("/services/%s/instances", s.name), &res)
+}
+
+func (s *service) Addrs() ([]string, error) {
+	instances, err := s.Instances()
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]string, len(instances))
+	for i, inst := range instances {
+		addrs[i] = inst.Addr
+	}
+	return addrs, nil
+}
+
+// Leaders sends leader events to the given channel (sending nil when there is
+// no leader, for example if there are no instances currently registered).
+func (s *service) Leaders(leaders chan *Instance) (stream.Stream, error) {
+	events := make(chan *Event)
+	eventStream, err := s.client.Stream("GET", fmt.Sprintf("/services/%s/leader", s.name), nil, events)
+	if err != nil {
+		return nil, err
+	}
+	stream := stream.New()
+	go func() {
+		defer func() {
+			eventStream.Close()
+			// wait for stream to close to prevent race with Err read
+			for range events {
+			}
+			if err := eventStream.Err(); err != nil {
+				stream.Error = err
+			}
+			close(leaders)
+		}()
+		for {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				if event.Kind != EventKindLeader {
+					continue
+				}
+				select {
+				case leaders <- event.Instance:
+				case <-stream.StopCh:
+					return
+				}
+			case <-stream.StopCh:
+				return
+			}
+		}
+	}()
+	return stream, nil
+}
+
+type ServiceMeta struct {
+	Data json.RawMessage `json:"data"`
+
+	// When calling SetMeta, Index is checked against the current index and the
+	// set only succeeds if the index is the same. A zero index means the meta
+	// does not currently exist.
+	Index uint64 `json:"index"`
+}
+
+func (s *service) GetMeta() (*ServiceMeta, error) {
+	meta := &ServiceMeta{}
+	return meta, s.client.Get(fmt.Sprintf("/services/%s/meta", s.name), meta)
+}
+
+func (s *service) SetMeta(m *ServiceMeta) error {
+	return s.client.Put(fmt.Sprintf("/services/%s/meta", s.name), m, m)
+}
+
+func (s *service) SetLeader(id string) error {
+	return s.client.Put(fmt.Sprintf("/services/%s/leader", s.name), &Instance{ID: id}, nil)
+}

--- a/discoverd/client/watch.go
+++ b/discoverd/client/watch.go
@@ -103,7 +103,7 @@ func (s *service) Watch(ch chan *Event) (stream.Stream, error) {
 	watch := NewWatch()
 	connect := func() error {
 		events = make(chan *Event)
-		stream, err := s.client.c.Stream("GET", fmt.Sprintf("/services/%s", s.name), nil, events)
+		stream, err := s.client.Stream("GET", fmt.Sprintf("/services/%s", s.name), nil, events)
 		if err != nil {
 			return err
 		}

--- a/discoverd/server/handler_test.go
+++ b/discoverd/server/handler_test.go
@@ -715,6 +715,11 @@ type Handler struct {
 func NewHandler() *Handler {
 	h := &Handler{Handler: server.NewHandler(false, []string{""})}
 	h.Handler.Store = &h.Store
+	h.Store.IsLeaderFn = func() bool { return true }
+	h.Store.GetPeersFn = func() ([]string, error) {
+		return []string{""}, nil
+	}
+	h.Store.LastIndexFn = func() uint64 { return 0 }
 	return h
 }
 

--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -308,8 +308,8 @@ func (s *Store) LeaderCh() <-chan bool {
 	return s.leaderCh
 }
 
-// isLeader returns true if the store is currently the leader.
-func (s *Store) isLeader() bool { return s.raft.Leader() == s.Advertise.String() }
+// IsLeader returns true if the store is currently the leader.
+func (s *Store) IsLeader() bool { return s.raft.Leader() == s.Advertise.String() }
 
 // AddPeer adds a peer to the raft cluster. Panic if store is not open yet.
 func (s *Store) AddPeer(peer string) error {
@@ -460,7 +460,7 @@ func (s *Store) AddInstance(service string, inst *discoverd.Instance) error {
 	// Check if it's the leader.
 	// This check is needed because the heartbeats don't go through raft so
 	// it is not verified here like it normally would be when calling raftApply().
-	if !s.isLeader() {
+	if !s.IsLeader() {
 		return ErrNotLeader
 	}
 
@@ -798,7 +798,7 @@ func (s *Store) EnforceExpiry() error {
 		defer s.mu.Unlock()
 
 		// Ignore if this store is not the leader and hasn't been for at least 2 TTLs intervals.
-		if !s.isLeader() {
+		if !s.IsLeader() {
 			return raft.ErrNotLeader
 		} else if s.leaderTime.IsZero() || time.Since(s.leaderTime) < (2*s.InstanceTTL) {
 			return ErrLeaderWait

--- a/discoverd/server/store_test.go
+++ b/discoverd/server/store_test.go
@@ -690,6 +690,7 @@ func (s *Store) MustWaitForLeader() {
 // MockStore represents a mock implementation of Handler.Store.
 type MockStore struct {
 	LeaderFn           func() string
+	IsLeaderFn         func() bool
 	GetPeersFn         func() ([]string, error)
 	AddPeerFn          func(peer string) error
 	RemovePeerFn       func(peer string) error
@@ -708,6 +709,7 @@ type MockStore struct {
 }
 
 func (s *MockStore) Leader() string { return s.LeaderFn() }
+func (s *MockStore) IsLeader() bool { return s.IsLeaderFn() }
 
 func (s *MockStore) GetPeers() ([]string, error)  { return s.GetPeersFn() }
 func (s *MockStore) AddPeer(peer string) error    { return s.AddPeerFn(peer) }

--- a/discoverd/testutil/testutil.go
+++ b/discoverd/testutil/testutil.go
@@ -89,7 +89,7 @@ func BootDiscoverd(t TestingT, port string) (*discoverd.Client, func()) {
 	addr, killDiscoverd := RunDiscoverdServer(t, port)
 
 	client := discoverd.NewClientWithURL("http://" + addr)
-	if err := Attempts.Run(client.Ping); err != nil {
+	if err := Attempts.Run(func() error { return client.Ping("http://" + addr) }); err != nil {
 		t.Fatal("Failed to connect to discoverd: ", err)
 	}
 	return client, killDiscoverd

--- a/host/cli/discoverd.go
+++ b/host/cli/discoverd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -32,8 +31,8 @@ func runPromote(args *docopt.Args, client *cluster.Client) error {
 	if err != nil {
 		return err
 	}
-	dd := discoverd.NewClientWithHTTP(addr, &http.Client{})
-	if err := dd.Promote(); err != nil {
+	dd := discoverd.NewClientWithURL(addr)
+	if err := dd.Promote(addr); err != nil {
 		return err
 	}
 	log.Println("Promoted peer", addr)
@@ -48,11 +47,11 @@ func runDemote(args *docopt.Args, client *cluster.Client) error {
 	}
 	force := args.Bool["--force"]
 	// first try to connect to the peer and gracefully demote it
-	dd := discoverd.NewClientWithHTTP(addr, &http.Client{})
-	err = dd.Ping()
+	dd := discoverd.NewClientWithURL(addr)
+	err = dd.Ping(addr)
 	if err == nil {
 		log.Println("Attempting to gracefully demote peer.")
-		err = dd.Demote()
+		err = dd.Demote(addr)
 	} else if !force {
 		return errors.New("Failed to contact peer to attempt graceful demotion and --force not given.")
 	}

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -31,6 +31,7 @@ const (
 	UnauthorizedErrorCode       ErrorCode = "unauthorized"
 	UnknownErrorCode            ErrorCode = "unknown_error"
 	RatelimitedErrorCode        ErrorCode = "ratelimited"
+	ServiceUnavailableErrorCode ErrorCode = "service_unavailable"
 )
 
 var errorResponseCodes = map[ErrorCode]int{
@@ -44,6 +45,7 @@ var errorResponseCodes = map[ErrorCode]int{
 	UnauthorizedErrorCode:       401,
 	UnknownErrorCode:            500,
 	RatelimitedErrorCode:        429,
+	ServiceUnavailableErrorCode: 503,
 }
 
 type JSONError struct {
@@ -220,6 +222,10 @@ func ConflictError(w http.ResponseWriter, message string) {
 
 func PreconditionFailedErr(message string) error {
 	return JSONError{Code: PreconditionFailedErrorCode, Message: message}
+}
+
+func ServiceUnavailableError(w http.ResponseWriter, message string) {
+	Error(w, JSONError{Code: ServiceUnavailableErrorCode, Message: message})
 }
 
 func ValidationError(w http.ResponseWriter, field, message string) {

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -113,7 +113,7 @@ main() {
 
   info "bootstrapping Flynn"
   export CLUSTER_DOMAIN="${size}.localflynn.com"
-  export DISCOVERD="${ips[0]}:1111"
+  export DISCOVERD="$(join "," ${ips[@]/%/:1111})"
   "${flynn_host}" \
     bootstrap \
     ${backup} \

--- a/test/test_z_discoverd.go
+++ b/test/test_z_discoverd.go
@@ -95,8 +95,9 @@ func (s *ZDiscoverdSuite) TestPromoteDemote(t *c.C) {
 	time.Sleep(2 * time.Second)
 
 	// Promote the new node to a Raft member
-	dd := discoverd.NewClientWithURL("http://" + newHost.IP + ":1111")
-	err = dd.Promote()
+	url := "http://" + newHost.IP + ":1111"
+	dd := discoverd.NewClientWithURL(url)
+	err = dd.Promote(url)
 	t.Assert(err, c.IsNil)
 
 	// Check that we now have one additional peer, also ensure our new peer is in the list
@@ -106,7 +107,7 @@ func (s *ZDiscoverdSuite) TestPromoteDemote(t *c.C) {
 	t.Assert(peerPresent(newHost, newPeers), c.Equals, true)
 
 	// Now demote the newly promoted node
-	err = dd.Demote()
+	err = dd.Demote(url)
 	t.Assert(err, c.IsNil)
 
 	//XXX(jpg): Better way to wait for leadership?


### PR DESCRIPTION
This changeset makes the discoverd client cluster aware.

It can now be initialised with a connection string of comma delimited servers.
The first server is considered to be preferred and it will use it unless it's unavailable.
If it does become unavailable then the rest of the servers configured will be tried until a working one is found, this server will then be pinned for 60 seconds, after the TTL expires the client will attempt to use the preferred server once more.
Writes are directed to the leader by recording where redirects are sent, if at any point the leader becomes unavailable we will try issue the write to another server and have it redirect us to the new leader.

Closes #2091