### PR TITLE
discoverd: mux

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -22,13 +22,13 @@
     "action": "run-app",
     "release": {
       "env": {
-        "DISCOVERD_PEERS": "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1110,{{ end }}",
+        "DISCOVERD_PEERS": "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1111,{{ end }}",
         "DISCOVERD": "none",
         "DEBUG": "{{ getenv \"DEBUG\" }}"
       },
       "processes": {
         "app": {
-          "ports": [{"port": 1110, "proto": "tcp"}, {"port": 1111, "proto": "tcp"}, {"port": 53, "proto": "tcp"}],
+          "ports": [{"port": 1110, "proto": "tcp"}, {"port": 53, "proto": "tcp"}],
           "data": true,
           "resurrect": true,
           "host_network": true,

--- a/discoverd/client/watch_test.go
+++ b/discoverd/client/watch_test.go
@@ -20,10 +20,7 @@ var _ = Suite(&ClientSuite{})
 func (s *ClientSuite) TestWatchReconnect(c *C) {
 	c.Skip("fix discoverd watch reconnect") // FIXME(benbjohnson)
 
-	raftPort, err := testutil.RandomPort()
-	c.Assert(err, IsNil)
-
-	httpPort, err := testutil.RandomPort()
+	port, err := testutil.RandomPort()
 	c.Assert(err, IsNil)
 
 	// clientA is used to register services and instances, and remains connected
@@ -32,7 +29,7 @@ func (s *ClientSuite) TestWatchReconnect(c *C) {
 
 	// clientB is connected to the server which will be restarted, and is used to
 	// test that the watch generates the correct events after reconnecting
-	clientB, killDiscoverd := testutil.BootDiscoverd(c, raftPort, httpPort)
+	clientB, killDiscoverd := testutil.BootDiscoverd(c, port)
 	defer func() { killDiscoverd() }()
 
 	// create a service with manual leader and some metadata
@@ -121,7 +118,7 @@ func (s *ClientSuite) TestWatchReconnect(c *C) {
 	waitForEvent(eventsA, "", discoverd.EventKindServiceMeta)
 
 	// restart clientB's server and wait for the watch to reconnect
-	_, killDiscoverd = testutil.RunDiscoverdServer(c, raftPort, httpPort)
+	_, killDiscoverd = testutil.RunDiscoverdServer(c, port)
 	waitForWatchState(stateCh, discoverd.WatchStateConnected)
 
 	type expectedEvent struct {

--- a/discoverd/main_test.go
+++ b/discoverd/main_test.go
@@ -16,7 +16,7 @@ func TestMain_ParseFlags(t *testing.T) {
 	opt, err := m.ParseFlags(
 		"-data-dir", "/tmp/data/dir",
 		"-host", "127.0.0.1",
-		"-http-addr", "127.0.0.1:1000",
+		"-addr", "127.0.0.1:1000",
 		"-dns-addr", "127.0.0.1:2000",
 		"-recursors", "7.7.7.7,6.6.6.6",
 		"-notify", "localhost",
@@ -29,8 +29,8 @@ func TestMain_ParseFlags(t *testing.T) {
 	// Verify parsed options.
 	if opt.DataDir != "/tmp/data/dir" {
 		t.Fatalf("unexpected data dir: %s", opt.DataDir)
-	} else if opt.HTTPAddr != "127.0.0.1:1000" {
-		t.Fatalf("unexpected http addr: %s", opt.HTTPAddr)
+	} else if opt.Addr != "127.0.0.1:1000" {
+		t.Fatalf("unexpected addr: %s", opt.Addr)
 	} else if opt.DNSAddr != "127.0.0.1:2000" {
 		t.Fatalf("unexpected dns addr: %s", opt.DNSAddr)
 	} else if !reflect.DeepEqual(opt.Recursors, []string{"7.7.7.7", "6.6.6.6"}) {

--- a/discoverd/server/handler_test.go
+++ b/discoverd/server/handler_test.go
@@ -100,7 +100,7 @@ func TestHandler_PutService_ErrInvalidJSON(t *testing.T) {
 // Ensure the handler redirects when the store is not the leader.
 func TestHandler_PutService_ErrNotLeader(t *testing.T) {
 	h := NewHandler()
-	h.Store.LeaderFn = func() string { return "host1:1110" }
+	h.Store.LeaderFn = func() string { return "host1:1111" }
 	h.Store.AddServiceFn = func(service string, config *discoverd.ServiceConfig) error { return server.ErrNotLeader }
 
 	w := httptest.NewRecorder()

--- a/discoverd/server/server.go
+++ b/discoverd/server/server.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net"
+
+	"github.com/flynn/flynn/pkg/mux"
+)
+
+// Mux multiplexes a listener into two listeners.
+func Mux(ln net.Listener) (storeLn, httpLn net.Listener) {
+	m := mux.New(ln)
+
+	// The store listens to everything prefixed with its header byte.
+	storeLn = m.Listen([]byte{storeHdr})
+
+	// HTTP listens to all methods: CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, TRACE.
+	httpLn = m.Listen([]byte{'C', 'D', 'G', 'H', 'O', 'P', 'T'})
+
+	go m.Serve()
+
+	return
+}

--- a/discoverd/start.sh
+++ b/discoverd/start.sh
@@ -4,7 +4,6 @@ exec /bin/discoverd \
   -data-dir=/data \
   -host="${EXTERNAL_IP}" \
   -peers="${DISCOVERD_PEERS}" \
-  -raft-addr="${LISTEN_IP}:${PORT_0}" \
-  -http-addr="${LISTEN_IP}:${PORT_1}" \
+  -addr="${LISTEN_IP}:${PORT_0}" \
   -notify="http://${EXTERNAL_IP}:1113/host/discoverd" \
   -wait-net-dns=true

--- a/discoverd/testutil/testutil.go
+++ b/discoverd/testutil/testutil.go
@@ -18,24 +18,16 @@ import (
 	"github.com/flynn/flynn/pkg/attempt"
 )
 
-func RunDiscoverdServer(t TestingT, raftPort, httpPort string) (string, func()) {
+func RunDiscoverdServer(t TestingT, port string) (string, func()) {
 	killCh := make(chan struct{})
 	doneCh := make(chan struct{})
 
-	if raftPort == "" {
-		port, err := RandomPort()
+	if port == "" {
+		p, err := RandomPort()
 		if err != nil {
-			t.Fatal("error getting random discoverd raft port: ", err)
+			t.Fatal("error getting random discoverd port: ", err)
 		}
-		raftPort = port
-	}
-
-	if httpPort == "" {
-		port, err := RandomPort()
-		if err != nil {
-			t.Fatal("error getting random discoverd http port: ", err)
-		}
-		httpPort = port
+		port = p
 	}
 
 	// Generate a data directory.
@@ -44,8 +36,7 @@ func RunDiscoverdServer(t TestingT, raftPort, httpPort string) (string, func()) 
 	go func() {
 		cmd := exec.Command("discoverd",
 			"-host", "127.0.0.1",
-			"-raft-addr", "127.0.0.1:"+raftPort,
-			"-http-addr", "127.0.0.1:"+httpPort,
+			"-addr", "127.0.0.1:"+port,
 			"-dns-addr", "127.0.0.1:0",
 			"-data-dir", dataDir,
 		)
@@ -83,19 +74,19 @@ func RunDiscoverdServer(t TestingT, raftPort, httpPort string) (string, func()) 
 	}()
 
 	// Ping server and wait for leadership.
-	if err := waitForLeader(t, "127.0.0.1:"+httpPort, 5*time.Second); err != nil {
+	if err := waitForLeader(t, "127.0.0.1:"+port, 5*time.Second); err != nil {
 		t.Fatal("waiting for leader: ", err)
 	}
 
-	return "127.0.0.1:" + httpPort, func() {
+	return "127.0.0.1:" + port, func() {
 		close(killCh)
 		os.RemoveAll(dataDir)
 		<-doneCh
 	}
 }
 
-func BootDiscoverd(t TestingT, raftPort, httpPort string) (*discoverd.Client, func()) {
-	addr, killDiscoverd := RunDiscoverdServer(t, raftPort, httpPort)
+func BootDiscoverd(t TestingT, port string) (*discoverd.Client, func()) {
+	addr, killDiscoverd := RunDiscoverdServer(t, port)
 
 	client := discoverd.NewClientWithURL("http://" + addr)
 	if err := Attempts.Run(client.Ping); err != nil {
@@ -105,7 +96,7 @@ func BootDiscoverd(t TestingT, raftPort, httpPort string) (*discoverd.Client, fu
 }
 
 func SetupDiscoverd(t TestingT) (*discoverd.Client, func()) {
-	client, killDiscoverd := BootDiscoverd(t, "", "")
+	client, killDiscoverd := BootDiscoverd(t, "")
 	return client, func() {
 		killDiscoverd()
 	}

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -216,7 +216,7 @@ WHERE artifact_id = (SELECT artifact_id FROM releases
 	}
 
 	data.Discoverd.Artifact.URI = artifactURIs["discoverd"]
-	data.Discoverd.Release.Env["DISCOVERD_PEERS"] = "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1110,{{ end }}"
+	data.Discoverd.Release.Env["DISCOVERD_PEERS"] = "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1111,{{ end }}"
 	data.Postgres.Artifact.URI = artifactURIs["postgres"]
 	data.Flannel.Artifact.URI = artifactURIs["flannel"]
 	data.Controller.Artifact.URI = artifactURIs["controller"]

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -1,0 +1,193 @@
+// Package mux provides a multiplexer for net.Listener.
+package mux
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Mux represents a multiplexer for a net.Listener.
+type Mux struct {
+	ln   net.Listener
+	once sync.Once
+	wg   sync.WaitGroup
+
+	handlers map[byte]*handler
+
+	Timeout   time.Duration
+	LogOutput io.Writer
+}
+
+// New returns a new instance of Mux.
+func New(ln net.Listener) *Mux {
+	return &Mux{
+		ln:        ln,
+		handlers:  make(map[byte]*handler),
+		Timeout:   30 * time.Second,
+		LogOutput: os.Stderr,
+	}
+}
+
+// Close closes the underlying listener.
+func (mux *Mux) Close() (err error) {
+	mux.once.Do(func() {
+		// Close underlying listener.
+		if mux.ln != nil {
+			err = mux.ln.Close()
+		}
+
+		// Wait for open connections to close and then close handlers.
+		mux.wg.Wait()
+		for _, h := range mux.handlers {
+			h.Close()
+		}
+	})
+	return
+}
+
+// Serve handles connections from ln and multiplexes then across registered listener.
+func (mux *Mux) Serve() error {
+	logger := log.New(mux.LogOutput, "", log.LstdFlags)
+
+	for {
+		// Handle incoming connections. Retry temporary errors.
+		conn, err := mux.ln.Accept()
+		if err, ok := err.(interface {
+			Temporary() bool
+		}); ok && err.Temporary() {
+			logger.Printf("tcp.Mux: temporary error: %s", err)
+			continue
+		}
+
+		// Other errors should close the muxer and wait for outstanding conns.
+		if err != nil {
+			mux.Close()
+			return err
+		}
+
+		// Hand off connection to a separate goroutine.
+		mux.wg.Add(1)
+		go func(conn net.Conn) {
+			defer mux.wg.Done()
+			if err := mux.handleConn(conn); err != nil {
+				conn.Close()
+				logger.Printf("tcp.Mux: %s", err)
+			}
+		}(conn)
+	}
+}
+
+func (mux *Mux) handleConn(conn net.Conn) error {
+	// Wrap in a buffered connection in order to peek at the first byte.
+	bufConn := newBufConn(conn)
+
+	// Set a read deadline so connections with no data timeout.
+	if err := conn.SetReadDeadline(time.Now().Add(mux.Timeout)); err != nil {
+		return fmt.Errorf("set read deadline: %s", err)
+	}
+
+	// Peek at first byte from connection to determine handler.
+	typ, err := bufConn.r.ReadByte()
+	if err != nil {
+		return fmt.Errorf("read header byte: %s", err)
+	} else if err = bufConn.r.UnreadByte(); err != nil {
+		return fmt.Errorf("unread header byte: %s", err)
+	}
+
+	// Reset read deadline and let the listener handle that.
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("reset set read deadline: %s", err)
+	}
+
+	// Lookup handler.
+	h := mux.handlers[typ]
+	if h == nil {
+		return fmt.Errorf("unregistered header byte: 0x%02x", typ)
+	}
+
+	// Hand off connection to handler.
+	h.c <- bufConn
+	return nil
+}
+
+// Listen returns a listener that receives connections from any byte in hdrs.
+func (mux *Mux) Listen(hdrs []byte) net.Listener {
+	// Create new handler.
+	h := mux.handler()
+
+	// Register each header byte.
+	for _, hdr := range hdrs {
+		// Ensure header is not already registered.
+		if _, ok := mux.handlers[hdr]; ok {
+			panic(fmt.Sprintf("header byte already registered: 0x%02x", hdr))
+		}
+
+		// Create a new listener and assign it.
+		mux.handlers[hdr] = h
+	}
+
+	return h
+}
+
+// handler returns a new instance of handler.
+func (mux *Mux) handler() *handler {
+	return &handler{
+		mux: mux,
+		c:   make(chan net.Conn),
+	}
+}
+
+// handler is a receiver for connections received by Mux. Implements net.Listener.
+type handler struct {
+	mux  *Mux
+	c    chan net.Conn
+	once sync.Once
+}
+
+// Accept waits for and returns the next connection.
+func (h *handler) Accept() (c net.Conn, err error) {
+	conn, ok := <-h.c
+	if !ok {
+		return nil, errors.New("network connection closed")
+	}
+	return conn, nil
+}
+
+// Close closes the original listener.
+func (h *handler) Close() error {
+	h.once.Do(func() { close(h.c) })
+	return nil
+}
+
+// Addr returns the address of the original listener.
+func (h *handler) Addr() net.Addr { return h.mux.ln.Addr() }
+
+// bufConn represents a buffered connection.
+type bufConn struct {
+	conn net.Conn
+	r    *bufio.Reader
+}
+
+// newBufConn returns a new instance of bufConn.
+func newBufConn(conn net.Conn) *bufConn {
+	return &bufConn{
+		conn: conn,
+		r:    bufio.NewReader(conn),
+	}
+}
+
+func (c *bufConn) Read(b []byte) (n int, err error)   { return c.r.Read(b) }
+func (c *bufConn) Write(b []byte) (n int, err error)  { return c.conn.Write(b) }
+func (c *bufConn) Close() error                       { return c.conn.Close() }
+func (c *bufConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+func (c *bufConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *bufConn) SetDeadline(t time.Time) error      { return c.conn.SetDeadline(t) }
+func (c *bufConn) SetReadDeadline(t time.Time) error  { return c.conn.SetReadDeadline(t) }
+func (c *bufConn) SetWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }

--- a/pkg/mux/mux_test.go
+++ b/pkg/mux/mux_test.go
@@ -1,0 +1,138 @@
+package mux_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flynn/flynn/pkg/mux"
+)
+
+// Ensure the muxer can split a listener's connections across multiple listeners.
+func TestMux_Listen(t *testing.T) {
+	// Open single listener on random port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Create muxer for listener.
+	m := mux.New(ln)
+	m.Timeout = 1 * time.Second
+	if testing.Verbose() {
+		m.LogOutput = os.Stderr
+	}
+
+	// Create listeners and begin serving mux.
+	m.Listen([]byte{'\x00'})
+	subln := m.Listen([]byte{'G', 'P', 'D'})
+	go m.Serve()
+
+	// Send message to listener.
+	go func() {
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close()
+
+		// Write data & close.
+		if _, err := conn.Write([]byte("GET")); err != nil {
+			t.Fatal(err)
+		} else if err = conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Receive connection on appropriate listener.
+	conn, err := subln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Read message.
+	if buf, err := ioutil.ReadAll(conn); err != nil {
+		t.Fatal(err)
+	} else if string(buf) != "GET" {
+		t.Fatalf("unexpected message: %q", string(buf))
+	} else if err = conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure the muxer closes connections that don't have a registered header byte.
+func TestMux_Listen_ErrUnregisteredHandler(t *testing.T) {
+	// Open single listener on random port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Write log output to a buffer to verify.
+	var buf bytes.Buffer
+
+	// Mux listener.
+	m := mux.New(ln)
+	m.Timeout = 1 * time.Second
+	m.LogOutput = &buf
+	if testing.Verbose() {
+		m.LogOutput = io.MultiWriter(m.LogOutput, os.Stderr)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.Serve()
+	}()
+
+	// Send message to listener.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Write unregistered header byte.
+	if _, err := conn.Write([]byte{'\x80'}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Connection should close immediately.
+	if _, err := ioutil.ReadAll(conn); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Close connection and wait for server to finish.
+	ln.Close()
+	wg.Wait()
+
+	// Verify error was logged.
+	time.Sleep(100 * time.Millisecond)
+	if s := buf.String(); !strings.Contains(s, `unregistered header byte: 0x80`) {
+		t.Fatalf("unexpected log output:\n\n%s", s)
+	}
+}
+
+// Ensure two handlers cannot be registered for the same header byte.
+func TestMux_Listen_ErrAlreadyRegistered(t *testing.T) {
+	defer func() {
+		if r := recover(); r != `header byte already registered: 0x05` {
+			t.Fatalf("unexpected recover: %#v", r)
+		}
+	}()
+
+	// Register two listeners with the same header byte.
+	mux := mux.New(nil)
+	mux.Listen([]byte{'\x05'})
+	mux.Listen([]byte{'\x05'})
+}


### PR DESCRIPTION
## Overview

This pull request adds support for multiplexing a single TCP socket for `discoverd` to communicate over HTTP and Raft. This simplifies deployment and fixes an issue where HTTP ports are not managed by Raft (#2003).

The multiplexing is required for splitting off the forwarding of instance heartbeats to raft nodes without going through raft itself.


### Details

The bulk of the multiplexing code is isolated to the `pkg/mux`. The multiplexer works by checking the first byte of a connection and redirecting the connection to the appropriate listener. The Raft store expects a leading `0xFF` byte while the HTTP handler expects a byte corresponding to the first letter of one of the possible HTTP methods (`CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `TRACE`).

---

/cc @titanous @josephglanville 