### PR TITLE
controller: Copy deploy_timeout to deployment on insertion

### DIFF
--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -40,7 +40,7 @@ func (r *DeploymentRepo) Add(data interface{}) (*ct.Deployment, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.QueryRow("deployment_insert", d.ID, d.AppID, oldReleaseID, d.NewReleaseID, d.Strategy, d.Processes).Scan(&d.CreatedAt); err != nil {
+	if err := tx.QueryRow("deployment_insert", d.ID, d.AppID, oldReleaseID, d.NewReleaseID, d.Strategy, d.Processes, d.DeployTimeout).Scan(&d.CreatedAt); err != nil {
 		tx.Rollback()
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func scanDeployment(s postgres.Scanner) (*ct.Deployment, error) {
 	d := &ct.Deployment{}
 	var oldReleaseID *string
 	var status *string
-	err := s.Scan(&d.ID, &d.AppID, &oldReleaseID, &d.NewReleaseID, &d.Strategy, &status, &d.Processes, &d.CreatedAt, &d.FinishedAt)
+	err := s.Scan(&d.ID, &d.AppID, &oldReleaseID, &d.NewReleaseID, &d.Strategy, &status, &d.Processes, &d.DeployTimeout, &d.CreatedAt, &d.FinishedAt)
 	if err == pgx.ErrNoRows {
 		err = ErrNotFound
 	}

--- a/controller/deployment_test.go
+++ b/controller/deployment_test.go
@@ -36,6 +36,7 @@ func (s *S) TestCreateDeployment(c *C) {
 	c.Assert(d.AppID, Equals, app.ID)
 	c.Assert(d.NewReleaseID, Equals, newRelease.ID)
 	c.Assert(d.OldReleaseID, Equals, release.ID)
+	c.Assert(d.DeployTimeout, Equals, app.DeployTimeout)
 
 	// quickly recreating a deployment should error
 	_, err = s.c.CreateDeployment(app.ID, newRelease.ID)

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -207,5 +207,8 @@ $$ LANGUAGE plpgsql`,
 		`ALTER TABLE events ADD CONSTRAINT events_object_type_fkey FOREIGN KEY (object_type) REFERENCES event_types (name)`,
 		`DROP TYPE event_type`,
 	)
+	m.Add(5,
+		`ALTER TABLE deployments ADD COLUMN deploy_timeout integer NOT NULL DEFAULT 30`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -134,8 +134,8 @@ SELECT artifact_id, created_at FROM artifacts WHERE type = $1 AND uri = $2`
 	artifactInsertQuery = `
 INSERT INTO artifacts (artifact_id, type, uri) VALUES ($1, $2, $3) RETURNING created_at`
 	deploymentInsertQuery = `
-INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes)
-VALUES ($1, $2, $3, $4, $5, $6) RETURNING created_at`
+INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes, deploy_timeout)
+VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING created_at`
 	deploymentUpdateFinishedAtQuery = `
 UPDATE deployments SET finished_at = $2 WHERE deployment_id = $1`
 	deploymentUpdateFinishedAtNowQuery = `
@@ -146,7 +146,7 @@ DELETE FROM deployments WHERE deployment_id = $1`
 WITH deployment_events AS (SELECT * FROM events WHERE object_type = 'deployment')
 SELECT d.deployment_id, d.app_id, d.old_release_id, d.new_release_id,
   strategy, e1.data->>'status' AS status,
-  processes, d.created_at, d.finished_at
+  processes, deploy_timeout, d.created_at, d.finished_at
 FROM deployments d
 LEFT JOIN deployment_events e1
   ON d.deployment_id = e1.object_id::uuid
@@ -157,7 +157,7 @@ WHERE e2.created_at IS NULL AND d.deployment_id = $1`
 WITH deployment_events AS (SELECT * FROM events WHERE object_type = 'deployment')
 SELECT d.deployment_id, d.app_id, d.old_release_id, d.new_release_id,
   strategy, e1.data->>'status' AS status,
-  processes, d.created_at, d.finished_at
+  processes, deploy_timeout, d.created_at, d.finished_at
 FROM deployments d
 LEFT JOIN deployment_events e1
   ON d.deployment_id = e1.object_id::uuid


### PR DESCRIPTION
This will allow the controller endpoints `/apps/:app_id/deployments` and `/deployments/:id` to return the `deploy_timeout` value that was used at the time the deployment was created. Currently it always returns 0 despite whatever is set on the app record, which is somewhat surprising.