### PR TITLE
test: Trace commands in runner Upstart script

### DIFF
--- a/test/scripts/upstart.conf
+++ b/test/scripts/upstart.conf
@@ -18,6 +18,10 @@ script
     exit 1
   fi
 
+  # trace commands, making sure this is *after* sourcing the credentials
+  # file so they are not echoed into the log file
+  set -x
+
   cd "${src_dir}"
   git fetch origin
   git checkout --force --quiet origin/master


### PR DESCRIPTION
This makes it easier to know what is going on when tailing the log file.