### PR TITLE
receiver: show deploy progress in git push like flynn scale

### DIFF
--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -104,5 +104,5 @@ func (a *DeployAppAction) Run(s *State) error {
 	}
 	as.Formation = formation
 
-	return client.DeployAppRelease(a.App.ID, a.Release.ID)
+	return client.DeployAppRelease(a.App.ID, a.Release.ID, nil)
 }

--- a/cli/env.go
+++ b/cli/env.go
@@ -189,7 +189,7 @@ func setEnv(client *controller.Client, proc string, env map[string]*string) (str
 	if err := client.CreateRelease(release); err != nil {
 		return "", err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return "", err
 	}
 	return release.ID, nil

--- a/cli/limit.go
+++ b/cli/limit.go
@@ -134,7 +134,7 @@ func runLimitSet(args *docopt.Args, client *controller.Client) error {
 	if err := client.CreateRelease(release); err != nil {
 		return err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 	fmt.Printf("Created release %s\n", release.ID)

--- a/cli/release.go
+++ b/cli/release.go
@@ -175,7 +175,7 @@ func runReleaseAddDocker(args *docopt.Args, client *controller.Client) error {
 		return err
 	}
 
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -492,7 +492,7 @@ func (c *Client) StreamDeployment(d *ct.Deployment, output chan *ct.DeploymentEv
 	}, appEvents)
 }
 
-func (c *Client) DeployAppRelease(appID, releaseID string) error {
+func (c *Client) DeployAppRelease(appID, releaseID string, logf func(*ct.DeploymentEvent)) error {
 	d, err := c.CreateDeployment(appID, releaseID)
 	if err != nil {
 		return err
@@ -524,6 +524,9 @@ outer:
 		case e, ok := <-events:
 			if !ok {
 				return errors.New("unexpected close of deployment event stream")
+			}
+			if logf != nil {
+				logf(e)
 			}
 			switch e.Status {
 			case "complete":

--- a/controller/worker/domain_migration/domain_migration.go
+++ b/controller/worker/domain_migration/domain_migration.go
@@ -222,7 +222,7 @@ func (m *migration) maybeDeployController() error {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID); err != nil {
+	if err := m.client.DeployAppRelease(appName, release.ID, nil); err != nil {
 		log.Error("error deploying release", "error", err)
 		return err
 	}
@@ -251,7 +251,7 @@ func (m *migration) maybeDeployRouter() error {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID); err != nil {
+	if err := m.client.DeployAppRelease(appName, release.ID, nil); err != nil {
 		log.Error("error deploying release", "error", err)
 		return err
 	}
@@ -282,7 +282,7 @@ func (m *migration) maybeDeployDashboard() error {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID); err != nil {
+	if err := m.client.DeployAppRelease(appName, release.ID, nil); err != nil {
 		log.Error("error deploying release", "error", err)
 		return err
 	}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -165,7 +165,7 @@ func deployApp(client *controller.Client, app *ct.App, uri string, log log15.Log
 		log.Error("error creating new release", "err", err)
 		return err
 	}
-	if err := client.DeployAppRelease(app.ID, release.ID); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		log.Error("error deploying app", "err", err)
 		return err
 	}


### PR DESCRIPTION
Closes #2161 

```
$ git push flynn master
Counting objects: 40, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (39/39), done.
Writing objects: 100% (40/40), 3.73 KiB | 0 bytes/s, done.
Total 40 (delta 20), reused 0 (delta 0)
-----> Building example...
-----> Node.js app detected

-----> Creating runtime environment

       NPM_CONFIG_LOGLEVEL=error
       NPM_CONFIG_PRODUCTION=true
       NODE_ENV=production
       NODE_MODULES_CACHE=true

-----> Installing binaries
       engines.node (package.json):  0.10.x
       engines.npm (package.json):   2.x

       Resolving node version 0.10.x via semver.io...
       Downloading and installing node 0.10.40...
       Resolving npm version 2.x via semver.io...
       Downloading and installing npm 2.14.13 (replacing version 1.4.28)...

-----> Restoring cache
       Skipping cache (new runtime signature)

-----> Building dependencies
       Pruning any extraneous modules
       Installing node modules (package.json)

-----> Caching build
       Clearing previous node cache
       Saving 1 cacheDirectories (default):
       - node_modules (nothing to cache)

-----> Build succeeded!
       └── (empty)

-----> Discovering process types
       Procfile declares types -> web
       Default process types for Node.js -> web
-----> Compiled slug size is 7.0M
-----> Creating release...
=====> Waiting for web job to start...
-----> new web job is starting
-----> new web job is up
=====> Default web formation scaled to 1
=====> Application deployed
To https://git.dev.localflynn.com/example.git
 * [new branch]      master -> master
 ```