### PR TITLE
Tag based scheduling

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -249,13 +249,13 @@ func checkOnlineHosts(expected int, state *State, urls []string, timeoutSecs int
 		if known >= expected {
 			state.Hosts = make([]*cluster.Host, 0, known)
 			for _, url := range urls {
-				h := cluster.NewHost("", url, nil)
+				h := cluster.NewHost("", url, nil, nil)
 				status, err := h.GetStatus()
 				if err != nil {
 					continue
 				}
 				online++
-				state.Hosts = append(state.Hosts, cluster.NewHost(status.ID, status.URL, nil))
+				state.Hosts = append(state.Hosts, cluster.NewHost(status.ID, status.URL, nil, nil))
 			}
 			if online >= expected {
 				break

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -105,14 +105,14 @@ func (r *FormationRepo) Add(f *ct.Formation) error {
 	if err != nil {
 		return err
 	}
-	err = tx.QueryRow("formation_insert", f.AppID, f.ReleaseID, f.Processes).Scan(&f.CreatedAt, &f.UpdatedAt)
+	err = tx.QueryRow("formation_insert", f.AppID, f.ReleaseID, f.Processes, f.Tags).Scan(&f.CreatedAt, &f.UpdatedAt)
 	if postgres.IsUniquenessError(err, "") {
 		tx.Rollback()
 		tx, err = r.db.Begin()
 		if err != nil {
 			return err
 		}
-		err = tx.QueryRow("formation_update", f.AppID, f.ReleaseID, f.Processes).Scan(&f.CreatedAt, &f.UpdatedAt)
+		err = tx.QueryRow("formation_update", f.AppID, f.ReleaseID, f.Processes, f.Tags).Scan(&f.CreatedAt, &f.UpdatedAt)
 	}
 	if err != nil {
 		tx.Rollback()
@@ -131,7 +131,7 @@ func (r *FormationRepo) Add(f *ct.Formation) error {
 
 func scanFormation(s postgres.Scanner) (*ct.Formation, error) {
 	f := &ct.Formation{}
-	err := s.Scan(&f.AppID, &f.ReleaseID, &f.Processes, &f.CreatedAt, &f.UpdatedAt)
+	err := s.Scan(&f.AppID, &f.ReleaseID, &f.Processes, &f.Tags, &f.CreatedAt, &f.UpdatedAt)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			err = ErrNotFound
@@ -160,6 +160,7 @@ func scanExpandedFormation(s postgres.Scanner) (*ct.ExpandedFormation, error) {
 		&f.Artifact.Type,
 		&f.Artifact.URI,
 		&f.Processes,
+		&f.Tags,
 		&f.UpdatedAt,
 	)
 	if err != nil {
@@ -290,6 +291,7 @@ func (r *FormationRepo) expandFormation(formation *ct.Formation) (*ct.ExpandedFo
 		Release:   release.(*ct.Release),
 		Artifact:  artifact.(*ct.Artifact),
 		Processes: formation.Processes,
+		Tags:      formation.Tags,
 		UpdatedAt: *formation.UpdatedAt,
 	}
 	return f, nil

--- a/controller/scheduler/host.go
+++ b/controller/scheduler/host.go
@@ -33,6 +33,18 @@ func NewHost(h utils.HostClient) *Host {
 	}
 }
 
+func (h *Host) TagsEqual(tags map[string]string) bool {
+	if len(h.Tags) != len(tags) {
+		return false
+	}
+	for k, v := range h.Tags {
+		if w, ok := tags[k]; !ok || w != v {
+			return false
+		}
+	}
+	return true
+}
+
 // StreamEventsTo streams all job events from the host to the given channel in
 // a goroutine, returning the current list of active jobs.
 func (h *Host) StreamEventsTo(ch chan *host.Event) (map[string]host.ActiveJob, error) {

--- a/controller/scheduler/host.go
+++ b/controller/scheduler/host.go
@@ -13,6 +13,7 @@ import (
 
 type Host struct {
 	ID       string
+	Tags     map[string]string
 	client   utils.HostClient
 	healthy  bool
 	checks   int
@@ -24,6 +25,7 @@ type Host struct {
 func NewHost(h utils.HostClient) *Host {
 	return &Host{
 		ID:      h.ID(),
+		Tags:    h.Tags(),
 		client:  h,
 		healthy: true,
 		stop:    make(chan struct{}),

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -99,6 +99,17 @@ type Job struct {
 	hostError *string
 }
 
+// TagsMatchHost checks whether all of the job's tags match the corresponding
+// host's tags
+func (j *Job) TagsMatchHost(host *Host) bool {
+	for k, v := range j.Formation.Tags[j.Type] {
+		if w, ok := host.Tags[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
 // needsVolume indicates whether a volume should be provisioned in the cluster
 // for the job, determined from the corresponding process type in the release
 func (j *Job) needsVolume() bool {
@@ -210,6 +221,7 @@ func (js Jobs) GetProcesses(key utils.FormationKey) Processes {
 	return procs
 }
 
-func (js Jobs) Add(j *Job) {
+func (js Jobs) Add(j *Job) *Job {
 	js[j.ID] = j
+	return j
 }

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -99,10 +99,15 @@ type Job struct {
 	hostError *string
 }
 
+// Tags returns the tags for the job's process type from the formation
+func (j *Job) Tags() map[string]string {
+	return j.Formation.Tags[j.Type]
+}
+
 // TagsMatchHost checks whether all of the job's tags match the corresponding
 // host's tags
 func (j *Job) TagsMatchHost(host *Host) bool {
-	for k, v := range j.Formation.Tags[j.Type] {
+	for k, v := range j.Tags() {
 		if w, ok := host.Tags[k]; !ok || v != w {
 			return false
 		}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -587,6 +587,9 @@ func (s *Scheduler) HandlePlacementRequest(req *PlacementRequest) {
 	counts := s.jobs.GetHostJobCounts(formation.key(), req.Job.Type)
 	var minCount int = math.MaxInt32
 	for _, h := range s.SortedHosts() {
+		if !req.Job.TagsMatchHost(h) {
+			continue
+		}
 		count, ok := counts[h.ID]
 		if !ok || count == 0 {
 			req.Host = h

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -550,7 +550,6 @@ func (TestSuite) TestStopJob(c *C) {
 				"job2": &Job{ID: "job2", Formation: formation, Type: "web", state: JobStateRunning, startedAt: recent},
 			},
 			shouldStop: "job1",
-			jobCheck:   func(job *Job) { c.Assert(job.state, Equals, JobStateStopped) },
 		},
 		{
 			desc: "one running and one new, stops new job",
@@ -559,7 +558,6 @@ func (TestSuite) TestStopJob(c *C) {
 				"job2": &Job{ID: "job2", Formation: formation, Type: "web", state: JobStateRunning, startedAt: recent},
 			},
 			shouldStop: "job1",
-			jobCheck:   func(job *Job) { c.Assert(job.state, Equals, JobStateStopped) },
 		},
 	} {
 		s.jobs = t.jobs
@@ -570,9 +568,6 @@ func (TestSuite) TestStopJob(c *C) {
 			continue
 		}
 		c.Assert(job.ID, Equals, t.shouldStop, Commentf(t.desc))
-		if t.jobCheck != nil {
-			t.jobCheck(job)
-		}
 	}
 }
 

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/stream"
+	"github.com/flynn/flynn/pkg/typeconv"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -572,5 +573,75 @@ func (TestSuite) TestStopJob(c *C) {
 		if t.jobCheck != nil {
 			t.jobCheck(job)
 		}
+	}
+}
+
+func (TestSuite) TestJobPlacementTags(c *C) {
+	// create a scheduler with tagged hosts
+	s := &Scheduler{
+		isLeader: typeconv.BoolPtr(true),
+		jobs:     make(Jobs),
+		hosts: map[string]*Host{
+			"host1": {ID: "host1", Tags: map[string]string{"disk": "mag", "cpu": "fast"}},
+			"host2": {ID: "host2", Tags: map[string]string{"disk": "ssd", "cpu": "slow"}},
+			"host3": {ID: "host3", Tags: map[string]string{"disk": "ssd", "cpu": "fast"}},
+		},
+	}
+
+	// use a formation with tagged process types
+	formation := NewFormation(&ct.ExpandedFormation{
+		App: &ct.App{ID: "app"},
+		Release: &ct.Release{ID: "release", Processes: map[string]ct.ProcessType{
+			"web":    {},
+			"db":     {},
+			"worker": {},
+			"clock":  {},
+		}},
+		Artifact: &ct.Artifact{},
+		Tags: map[string]map[string]string{
+			"web":    nil,
+			"db":     {"disk": "ssd"},
+			"worker": {"cpu": "fast"},
+			"clock":  {"disk": "ssd", "cpu": "slow"},
+		},
+	})
+
+	// continually place jobs, and check they get placed in a round-robin
+	// fashion on the hosts matching the type's tags
+	type test struct {
+		typ  string
+		host string
+	}
+	for i, t := range []*test{
+		// web go on all hosts
+		{typ: "web", host: "host1"},
+		{typ: "web", host: "host2"},
+		{typ: "web", host: "host3"},
+		{typ: "web", host: "host1"},
+		{typ: "web", host: "host2"},
+		{typ: "web", host: "host3"},
+		// db go on hosts 2 and 3
+
+		{typ: "db", host: "host2"},
+		{typ: "db", host: "host3"},
+		{typ: "db", host: "host2"},
+		{typ: "db", host: "host3"},
+		// worker go on hosts 1 and 3
+
+		{typ: "worker", host: "host1"},
+		{typ: "worker", host: "host3"},
+		{typ: "worker", host: "host1"},
+		{typ: "worker", host: "host3"},
+
+		// clock go on host 2
+		{typ: "clock", host: "host2"},
+		{typ: "clock", host: "host2"},
+		{typ: "clock", host: "host2"},
+	} {
+		job := s.jobs.Add(&Job{ID: fmt.Sprintf("job%d", i), Formation: formation, Type: t.typ})
+		req := &PlacementRequest{Job: job, Err: make(chan error, 1)}
+		s.HandlePlacementRequest(req)
+		c.Assert(<-req.Err, IsNil, Commentf("placing job %d", i))
+		c.Assert(req.Host.ID, Equals, t.host, Commentf("placing job %d", i))
 	}
 }

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -238,6 +238,9 @@ $$ LANGUAGE plpgsql`,
 		`ALTER TABLE job_cache ADD COLUMN host_id text`,
 		`UPDATE job_cache SET host_id = s.split[1], job_id = s.split[2]::uuid FROM (SELECT cluster_id, regexp_matches(cluster_id, '([^-]+)-(.*)') AS split FROM job_cache) AS s WHERE job_cache.cluster_id = s.cluster_id`,
 	)
+	migrations.Add(10,
+		`ALTER TABLE formations ADD COLUMN tags jsonb`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -177,7 +177,7 @@ VALUES ($1, $2, $3, $4)`
 INSERT INTO events (app_id, object_id, unique_id, object_type, data)
 VALUES ($1, $2, $3, $4, $5)`
 	formationListByAppQuery = `
-SELECT app_id, release_id, processes, created_at, updated_at
+SELECT app_id, release_id, processes, tags, created_at, updated_at
 FROM formations WHERE app_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC
 	`
 	formationListActiveQuery = `
@@ -185,7 +185,7 @@ SELECT
   apps.app_id, apps.name,
   releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
   artifacts.artifact_id, artifacts.type, artifacts.uri,
-  formations.processes, formations.updated_at
+  formations.processes, formations.tags, formations.updated_at
 FROM formations
 JOIN apps USING (app_id)
 JOIN releases ON releases.release_id = formations.release_id
@@ -200,27 +200,27 @@ WHERE (formations.app_id, formations.release_id) IN (
 AND formations.deleted_at IS NULL
 ORDER BY updated_at DESC`
 	formationListSinceQuery = `
-SELECT app_id, release_id, processes, created_at, updated_at
+SELECT app_id, release_id, processes, tags, created_at, updated_at
 FROM formations WHERE updated_at >= $1 ORDER BY updated_at DESC`
 	formationSelectQuery = `
-SELECT app_id, release_id, processes, created_at, updated_at
+SELECT app_id, release_id, processes, tags, created_at, updated_at
 FROM formations WHERE app_id = $1 AND release_id = $2 AND deleted_at IS NULL`
 	formationSelectExpandedQuery = `
 SELECT
   apps.app_id, apps.name,
   releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
   artifacts.artifact_id, artifacts.type, artifacts.uri,
-  formations.processes, formations.updated_at
+  formations.processes, formations.tags, formations.updated_at
 FROM formations
 JOIN apps USING (app_id)
 JOIN releases ON releases.release_id = formations.release_id
 JOIN artifacts USING (artifact_id)
 WHERE formations.app_id = $1 AND formations.release_id = $2 AND formations.deleted_at IS NULL`
 	formationInsertQuery = `
-INSERT INTO formations (app_id, release_id, processes)
-VALUES ($1, $2, $3) RETURNING created_at, updated_at`
+INSERT INTO formations (app_id, release_id, processes, tags)
+VALUES ($1, $2, $3, $4) RETURNING created_at, updated_at`
 	formationUpdateQuery = `
-UPDATE formations SET processes = $3, updated_at = now(), deleted_at = NULL
+UPDATE formations SET processes = $3, tags = $4, updated_at = now(), deleted_at = NULL
 WHERE app_id = $1 AND release_id = $2 RETURNING created_at, updated_at`
 	formationDeleteQuery = `
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -40,6 +40,8 @@ type FakeHostClient struct {
 
 func (c *FakeHostClient) ID() string { return c.hostID }
 
+func (c *FakeHostClient) Tags() map[string]string { return nil }
+
 func (c *FakeHostClient) Attach(req *host.AttachReq, wait bool) (cluster.AttachClient, error) {
 	f, ok := c.attach[req.JobID]
 	if !ok {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -15,11 +15,12 @@ import (
 const RouteParentRefPrefix = "controller/apps/"
 
 type ExpandedFormation struct {
-	App       *App           `json:"app,omitempty"`
-	Release   *Release       `json:"release,omitempty"`
-	Artifact  *Artifact      `json:"artifact,omitempty"`
-	Processes map[string]int `json:"processes,omitempty"`
-	UpdatedAt time.Time      `json:"updated_at,omitempty"`
+	App       *App                         `json:"app,omitempty"`
+	Release   *Release                     `json:"release,omitempty"`
+	Artifact  *Artifact                    `json:"artifact,omitempty"`
+	Processes map[string]int               `json:"processes,omitempty"`
+	Tags      map[string]map[string]string `json:"tags,omitempty"`
+	UpdatedAt time.Time                    `json:"updated_at,omitempty"`
 }
 
 type App struct {
@@ -74,11 +75,12 @@ type Artifact struct {
 }
 
 type Formation struct {
-	AppID     string         `json:"app,omitempty"`
-	ReleaseID string         `json:"release,omitempty"`
-	Processes map[string]int `json:"processes,omitempty"`
-	CreatedAt *time.Time     `json:"created_at,omitempty"`
-	UpdatedAt *time.Time     `json:"updated_at,omitempty"`
+	AppID     string                       `json:"app,omitempty"`
+	ReleaseID string                       `json:"release,omitempty"`
+	Processes map[string]int               `json:"processes,omitempty"`
+	Tags      map[string]map[string]string `json:"tags,omitempty"`
+	CreatedAt *time.Time                   `json:"created_at,omitempty"`
+	UpdatedAt *time.Time                   `json:"updated_at,omitempty"`
 }
 
 type Key struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -125,6 +125,7 @@ func ExpandFormation(c ControllerClient, f *ct.Formation) (*ct.ExpandedFormation
 		Release:   release,
 		Artifact:  artifact,
 		Processes: procs,
+		Tags:      f.Tags,
 		UpdatedAt: time.Now(),
 	}
 	if f.UpdatedAt != nil {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -225,3 +225,17 @@ func ParseBasicAuth(h http.Header) (username, password string, err error) {
 
 	return s[0], s[1], nil
 }
+
+func FormationTagsEqual(a, b map[string]map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for typ, tags := range b {
+		for k, v := range tags {
+			if w, ok := a[typ][k]; !ok || w != v {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -141,6 +141,7 @@ type VolumeCreator interface {
 type HostClient interface {
 	VolumeCreator
 	ID() string
+	Tags() map[string]string
 	AddJob(*host.Job) error
 	GetJob(id string) (*host.ActiveJob, error)
 	Attach(*host.AttachReq, bool) (cluster.AttachClient, error)

--- a/host/cli/fix.go
+++ b/host/cli/fix.go
@@ -68,11 +68,11 @@ func (f *clusterFixer) Run(args *docopt.Args, c *cluster.Client) error {
 		f.hosts = make([]*cluster.Host, len(ips))
 		for i, ip := range ips {
 			url := fmt.Sprintf("http://%s:1113", ip)
-			status, err := cluster.NewHost("", url, nil).GetStatus()
+			status, err := cluster.NewHost("", url, nil, nil).GetStatus()
 			if err != nil {
 				return fmt.Errorf("error connecting to %s: %s", ip, err)
 			}
-			f.hosts[i] = cluster.NewHost(status.ID, url, nil)
+			f.hosts[i] = cluster.NewHost(status.ID, url, nil, nil)
 		}
 	}
 	// check expected number of hosts

--- a/host/cli/tags.go
+++ b/host/cli/tags.go
@@ -7,7 +7,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
-	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 )
 
@@ -33,21 +32,19 @@ func runTags(args *docopt.Args, client *cluster.Client) error {
 	} else if args.Bool["del"] {
 		return runTagsDel(args, client)
 	}
-	instances, err := client.HostInstances()
+	hosts, err := client.Hosts()
 	if err != nil {
 		return err
 	}
 	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
 	defer w.Flush()
 	listRec(w, "HOST", "TAGS")
-	for _, inst := range instances {
-		tags := make([]string, 0, len(inst.Meta))
-		for k, v := range inst.Meta {
-			if strings.HasPrefix(k, host.TagPrefix) {
-				tags = append(tags, fmt.Sprintf("%s=%s", strings.TrimPrefix(k, host.TagPrefix), v))
-			}
+	for _, host := range hosts {
+		tags := make([]string, 0, len(host.Tags()))
+		for k, v := range host.Tags() {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 		}
-		listRec(w, inst.Meta["id"], strings.Join(tags, " "))
+		listRec(w, host.ID(), strings.Join(tags, " "))
 	}
 	return nil
 }

--- a/host/host.go
+++ b/host/host.go
@@ -81,6 +81,7 @@ Commands:
   list                       Lists ID and IP of each host
   version                    Show current version
   fix                        Fix a broken cluster
+  tags                       Manage flynn-host daemon tags
 
 See 'flynn-host help <command>' for more information on a specific command.
 `

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -18,13 +18,14 @@ import (
 
 // Host is a client for a host daemon.
 type Host struct {
-	id string
-	c  *httpclient.Client
+	id   string
+	tags map[string]string
+	c    *httpclient.Client
 }
 
-// NewHostClient creates a new Host that uses client to communicate with it.
+// NewHost creates a new Host that uses client to communicate with it.
 // addr is used by Attach.
-func NewHost(id string, addr string, h *http.Client) *Host {
+func NewHost(id string, addr string, h *http.Client, tags map[string]string) *Host {
 	if h == nil {
 		h = http.DefaultClient
 	}
@@ -32,7 +33,8 @@ func NewHost(id string, addr string, h *http.Client) *Host {
 		addr = "http://" + addr
 	}
 	return &Host{
-		id: id,
+		id:   id,
+		tags: tags,
 		c: &httpclient.Client{
 			ErrNotFound: ErrNotFound,
 			URL:         addr,
@@ -44,6 +46,11 @@ func NewHost(id string, addr string, h *http.Client) *Host {
 // ID returns the ID of the host this client communicates with.
 func (c *Host) ID() string {
 	return c.id
+}
+
+// Tags returns the hosts tags
+func (c *Host) Tags() map[string]string {
+	return c.tags
 }
 
 // Addr returns the IP/port that the host API is listening on.
@@ -64,7 +71,7 @@ func (c *Host) GetStatus() (*host.HostStatus, error) {
 func WaitForHostStatus(hostIP string, desired func(*host.HostStatus) bool) (*host.HostStatus, error) {
 	const waitMax = time.Minute
 	const waitInterval = 500 * time.Millisecond
-	h := NewHost("", fmt.Sprintf("http://%s:1113", hostIP), nil)
+	h := NewHost("", fmt.Sprintf("http://%s:1113", hostIP), nil, nil)
 	timeout := time.After(waitMax)
 	for {
 		status, err := h.GetStatus()

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -7,3 +7,4 @@ func Int32Ptr(i int32) *int32        { return &i }
 func Int64Ptr(i int64) *int64        { return &i }
 func StringPtr(s string) *string     { return &s }
 func TimePtr(t time.Time) *time.Time { return &t }
+func BoolPtr(b bool) *bool           { return &b }

--- a/schema/controller/formation.json
+++ b/schema/controller/formation.json
@@ -26,6 +26,10 @@
         "type": "integer"
       }
     },
+    "tags": {
+      "description": "process tags",
+      "type": "object"
+    },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"
     },

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -371,7 +371,7 @@ func (s *HostSuite) TestUpdate(t *c.C) {
 	defer cmd.Process.Kill()
 
 	httpClient := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	client := cluster.NewHost(id, "http://127.0.0.1:11113", httpClient)
+	client := cluster.NewHost(id, "http://127.0.0.1:11113", httpClient, nil)
 
 	// exec a program which exits straight away
 	_, err := client.Update("/bin/true")
@@ -457,7 +457,7 @@ func (s *HostSuite) TestUpdateTags(t *c.C) {
 	for {
 		e := nextEvent()
 		if e.Kind == discoverd.EventKindUp && client == nil {
-			client = cluster.NewHost(e.Instance.Meta["id"], e.Instance.Addr, nil)
+			client = cluster.NewHost(e.Instance.Meta["id"], e.Instance.Addr, nil, nil)
 		}
 		if e.Kind == discoverd.EventKindCurrent {
 			break

--- a/test/test_host_update.go
+++ b/test/test_host_update.go
@@ -29,7 +29,7 @@ func (s *HostUpdateSuite) TestUpdateLogs(t *c.C) {
 	instance := s.addHost(t)
 	defer s.removeHost(t, instance)
 	httpClient := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	client := cluster.NewHost(instance.ID, fmt.Sprintf("http://%s:1113", instance.IP), httpClient)
+	client := cluster.NewHost(instance.ID, fmt.Sprintf("http://%s:1113", instance.IP), httpClient, nil)
 
 	// start partial logger job
 	cmd := exec.JobUsingHost(


### PR DESCRIPTION
Still some changes I need to make + more testing, but opening for feedback.

Summary of changes:

* Add `Formation.Tags` which is a map of process types to tags for that process type
* Update `flynn scale` to handle adding tags (e.g. `flynn scale web=3,active=true db=2,active=true,disk=ssd`)
* Only place jobs on hosts whose tags are a superset of the process type's tags
* When either host or formation tags change, stop any jobs which no longer match the tags of the host they are on (e.g. if I have scaled to `web=3,active=true`, and I set `active=false` on one of my hosts, then I want the web job running on that host to be stopped and subsequently restarted on a different, still matching host)

Caveats:

* I originally planned to support more fine grained tags per process type (e.g. I want 3 web jobs on `type=big` and 1 on `type=small`) but the logic was hard to get right, I do think what I have done here though is a good start in getting to that
* I wanted to make `Formation.Processes` a `map[string]Process`, with `Process` something like `struct { Count int, Tags map[string]string }` but it would be difficult to manage that change during an update (the controller would need to handle both the old and new formats because the deployment will be posting the formations)