### PR TITLE
Make updater aware of versions

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 var commit, branch, tag, dirty string
 
@@ -19,4 +22,23 @@ func String() string {
 
 func Tagged() bool {
 	return tag != "none" && dirty == "false"
+}
+
+type Version struct {
+	Dev       bool
+	Date      string
+	Iteration int
+}
+
+func (v *Version) Before(other *Version) bool {
+	return v.Date < other.Date || v.Date == other.Date && v.Iteration < other.Iteration
+}
+
+func Parse(s string) *Version {
+	if len(s) == 0 || s[0] != 'v' || len(s) < 11 {
+		return &Version{Dev: true}
+	}
+	v := &Version{Date: s[1:9]}
+	v.Iteration, _ = strconv.Atoi(s[10:])
+	return v
 }

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -184,21 +184,21 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 
 	// check system apps were deployed correctly
 	for _, app := range updater.SystemApps {
-		image := "flynn/" + app
-		if app == "postgres" {
+		image := "flynn/" + app.Name
+		if app.Name == "postgres" {
 			image = "flynn/postgresql"
 		}
-		debugf(t, "checking new %s release is using image %s", app, versions[image])
-		expected := fmt.Sprintf(`"finished deploy of system app" name=%s`, app)
+		debugf(t, "checking new %s release is using image %s", app.Name, versions[image])
+		expected := fmt.Sprintf(`"finished deploy of system app" name=%s`, app.Name)
 		if !strings.Contains(updateOutput.String(), expected) {
-			t.Fatalf(`expected update to deploy %s`, app)
+			t.Fatalf(`expected update to deploy %s`, app.Name)
 		}
-		release, err := client.GetAppRelease(app)
+		release, err := client.GetAppRelease(app.Name)
 		t.Assert(err, c.IsNil)
-		debugf(t, "new %s release ID: %s", app, release.ID)
+		debugf(t, "new %s release ID: %s", app.Name, release.ID)
 		artifact, err := client.GetArtifact(release.ArtifactID)
 		t.Assert(err, c.IsNil)
-		debugf(t, "new %s artifact: %+v", app, artifact)
+		debugf(t, "new %s artifact: %+v", app.Name, artifact)
 		uri, err := url.Parse(artifact.URI)
 		t.Assert(err, c.IsNil)
 		t.Assert(uri.Query().Get("id"), c.Equals, versions[image])

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -184,11 +184,13 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 
 	// check system apps were deployed correctly
 	for _, app := range updater.SystemApps {
-		image := "flynn/" + app.Name
-		if app.Name == "postgres" {
-			image = "flynn/postgresql"
+		if app.ImageOnly {
+			continue // we don't deploy ImageOnly updates
 		}
-		debugf(t, "checking new %s release is using image %s", app.Name, versions[image])
+		if app.Image == "" {
+			app.Image = "flynn/" + app.Name
+		}
+		debugf(t, "checking new %s release is using image %s", app.Name, versions[app.Image])
 		expected := fmt.Sprintf(`"finished deploy of system app" name=%s`, app.Name)
 		if !strings.Contains(updateOutput.String(), expected) {
 			t.Fatalf(`expected update to deploy %s`, app.Name)
@@ -201,6 +203,6 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 		debugf(t, "new %s artifact: %+v", app.Name, artifact)
 		uri, err := url.Parse(artifact.URI)
 		t.Assert(err, c.IsNil)
-		t.Assert(uri.Query().Get("id"), c.Equals, versions[image])
+		t.Assert(uri.Query().Get("id"), c.Equals, versions[app.Image])
 	}
 }

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -1,13 +1,23 @@
 package updater
 
-var SystemApps = []string{
-	"blobstore",
-	"taffy",
-	"dashboard",
-	"router",
-	"gitreceive",
-	"controller",
-	"logaggregator",
-	"postgres",
-	"status",
+type SystemApp struct {
+	Name       string
+	MinVersion string // minimum version this updater binary is capable of updating
+}
+
+var SystemApps = []SystemApp{
+	{
+		Name: "discoverd",
+		// versions prior to this one do not have hooks to update
+		MinVersion: "v20151129.0",
+	},
+	{Name: "blobstore"},
+	{Name: "taffy"},
+	{Name: "dashboard"},
+	{Name: "router"},
+	{Name: "gitreceive"},
+	{Name: "controller"},
+	{Name: "logaggregator"},
+	{Name: "postgres"},
+	{Name: "status"},
 }

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -3,6 +3,8 @@ package updater
 type SystemApp struct {
 	Name       string
 	MinVersion string // minimum version this updater binary is capable of updating
+	Image      string // image name if not same as flynn/<name>, ignored if empty
+	ImageOnly  bool   // no application, just update the image
 }
 
 var SystemApps = []SystemApp{
@@ -18,6 +20,8 @@ var SystemApps = []SystemApp{
 	{Name: "gitreceive"},
 	{Name: "controller"},
 	{Name: "logaggregator"},
-	{Name: "postgres"},
+	{Name: "postgres", Image: "flynn/postgresql"},
 	{Name: "status"},
+	{Name: "slugbuilder", ImageOnly: true},
+	{Name: "slugrunner", ImageOnly: true},
 }


### PR DESCRIPTION
This introduces behaviour into the updater to manage skipping system applications that can't be updated if the running version is not recent enough.