### PR TITLE
discoverd: Close mux before closing store

### DIFF
--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -256,13 +256,13 @@ func (m *Main) Close() (info dt.ShutdownInfo, err error) {
 		m.dnsServer.Close()
 		m.dnsServer = nil
 	}
-	if m.store != nil {
-		info.LastIndex, err = m.store.Close()
-		m.store = nil
-	}
 	if m.ln != nil {
 		m.ln.Close()
 		m.ln = nil
+	}
+	if m.store != nil {
+		info.LastIndex, err = m.store.Close()
+		m.store = nil
 	}
 	return info, err
 }


### PR DESCRIPTION
This works around a strange behavior during deployments where the mux
socket is unable to be bound to be the new process because it's still
in use. Despite having just been closed... by closing it before closing
the store the race is avoided.

Signed-off-by: Joseph Glanville <jpg@jpg.id.au>