### PR TITLE
host/cli: Work around segfault in TUF update

### DIFF
--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -35,6 +35,24 @@ Download container images and Flynn binaries from a TUF repository.
 Set FLYNN_VERSION to download an explicit version.`)
 }
 
+// This patch works around https://github.com/flynn/flynn/issues/2211
+//
+// The buffer pool that ioutil.Discard.ReadFrom uses is apparently
+// intermittently causing segfaults when ioutil.Discard is used from go-tuf in
+// this command on Go 1.4.3. It is unknown whether this issue exists in Go 1.5.
+type devNull struct{}
+
+func (devNull) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func init() {
+	if !strings.HasPrefix(runtime.Version(), "go1.4") {
+		panic("please remove this devnull segfault patch and check if the issue is fixed in Go 1.5")
+	}
+	ioutil.Discard = devNull{}
+}
+
 func runDownload(args *docopt.Args) error {
 	if err := os.MkdirAll(args.String["--root"], 0755); err != nil {
 		return fmt.Errorf("error creating root dir: %s", err)


### PR DESCRIPTION
Add a temporary workaround that avoids an apparent intermittent segfault in the buffer pool implementation of `ioutil.Discard.ReadFrom` observed on EC2 with Go 1.4.3.

This patch should be removed on Go 1.5 to test if the problem still exists.

Closes #2211