### PR TITLE
all: Fix CORS handler usage

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -293,9 +293,8 @@ func appHandler(c handlerConfig) http.Handler {
 }
 
 func muxHandler(main http.Handler, authKeys []string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		httphelper.CORSAllowAllHandler(w, r)
-		if r.URL.Path == "/ping" || r.Method == "OPTIONS" {
+	return httphelper.CORSAllowAll.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ping" {
 			w.WriteHeader(200)
 			return
 		}
@@ -315,7 +314,7 @@ func muxHandler(main http.Handler, authKeys []string) http.Handler {
 			return
 		}
 		main.ServeHTTP(w, r)
-	})
+	}))
 }
 
 type controllerAPI struct {

--- a/dashboard/api.go
+++ b/dashboard/api.go
@@ -119,23 +119,20 @@ func (api *API) CorsHandler(main http.Handler) http.Handler {
 	if strings.HasPrefix(api.conf.InterfaceURL, "https") {
 		httpInterfaceURL = "http" + strings.TrimPrefix(api.conf.InterfaceURL, "https")
 	}
-	corsHandler := cors.Allow(&cors.Options{
+	return (&cors.Options{
 		AllowOrigins:     []string{api.conf.InterfaceURL, httpInterfaceURL},
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},
 		AllowHeaders:     []string{"Authorization", "Accept", "Content-Type", "If-Match", "If-None-Match"},
 		ExposeHeaders:    []string{"ETag"},
 		AllowCredentials: true,
 		MaxAge:           time.Hour,
-	})
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if strings.HasSuffix(req.URL.Path, "/ping") || req.Method == "OPTIONS" {
-			httphelper.CORSAllowAllHandler(w, req)
+	}).Handler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "/ping") {
 			w.WriteHeader(200)
 			return
 		}
-		corsHandler(w, req)
 		main.ServeHTTP(w, req)
-	})
+	}))
 }
 
 func (api *API) ServeStatic(ctx context.Context, w http.ResponseWriter, req *http.Request, path string) {

--- a/installer/http.go
+++ b/installer/http.go
@@ -105,18 +105,14 @@ func ServeHTTP() error {
 }
 
 func (api *httpAPI) CorsHandler(main http.Handler, addr string) http.Handler {
-	corsHandler := cors.Allow(&cors.Options{
+	return (&cors.Options{
 		AllowOrigins:     []string{addr},
 		AllowMethods:     []string{"GET", "POST"},
 		AllowHeaders:     []string{"Authorization", "Accept", "Content-Type", "If-Match", "If-None-Match"},
 		ExposeHeaders:    []string{"ETag"},
 		AllowCredentials: false,
 		MaxAge:           time.Hour,
-	})
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		corsHandler(w, r)
-		main.ServeHTTP(w, r)
-	})
+	}).Handler(main)
 }
 
 func (api *httpAPI) Asset(path string) (io.ReadSeeker, error) {

--- a/pkg/cors/cors_test.go
+++ b/pkg/cors/cors_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func serveHTTP(w http.ResponseWriter, req *http.Request, opts *Options) {
-	Allow(opts)(w, req)
-	w.WriteHeader(200)
+	opts.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).ServeHTTP(w, req)
 }
 
 func Test_AllowAll(t *testing.T) {

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -78,14 +78,14 @@ func IsRetryableError(err error) bool {
 	return ok && e.Retry
 }
 
-var CORSAllowAllHandler = cors.Allow(&cors.Options{
+var CORSAllowAll = &cors.Options{
 	AllowAllOrigins:  true,
 	AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},
 	AllowHeaders:     []string{"Authorization", "Accept", "Content-Type", "If-Match", "If-None-Match"},
 	ExposeHeaders:    []string{"ETag"},
 	AllowCredentials: true,
 	MaxAge:           time.Hour,
-})
+}
 
 // Handler is an extended version of http.Handler that also takes a context
 // argument ctx.


### PR DESCRIPTION
Avoid a double `WriteHeader` call by only calling the next handler when the request is not an OPTIONS request.

Closes #2229