### PR TITLE
util/release: Strip leading "v" from version in vagrant manifest

### DIFF
--- a/util/release/types/manifest.go
+++ b/util/release/types/manifest.go
@@ -3,6 +3,7 @@ package release
 import (
 	"bytes"
 	"sort"
+	"strings"
 )
 
 const maxVersions = 5
@@ -111,6 +112,10 @@ type VagrantManifest struct {
 //
 // The number of versions in the manifest is capped at the value of maxVersions.
 func (m *VagrantManifest) Add(version string, provider *VagrantProvider) {
+	// strip the leading "v" from the version as Vagrant only supports
+	// versions like X.Y.Z, see https://github.com/flynn/flynn/issues/2230
+	version = strings.TrimPrefix(version, "v")
+
 	versions := make(sortVersions, 0, len(m.Versions)+1)
 	for _, v := range m.Versions {
 		if v.version() == version {


### PR DESCRIPTION
Fixes #2230.