### PR TITLE
test: Give initial VM more memory for running tests

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -271,11 +271,17 @@ func (c *Cluster) startVMs(typ ClusterType, rootFS string, count int, initial bo
 
 	instances := make([]*Instance, count)
 	for i := 0; i < count; i++ {
+		memory := "2048"
+		if initial && i == 0 {
+			// give the first instance more memory as that is where
+			// the test binary runs, and the tests use a lot of memory
+			memory = "8192"
+		}
 		inst, err := c.vm.NewInstance(&VMConfig{
 			Kernel: c.bc.Kernel,
 			User:   uid,
 			Group:  gid,
-			Memory: "2048",
+			Memory: memory,
 			Cores:  2,
 			Drives: map[string]*VMDrive{
 				"hda": {FS: rootFS, COW: true, Temp: true},


### PR DESCRIPTION
The introduction of `ControllerSuite.TestBackup` has caused the following types of errors in CI:

```
    t.Assert(run(t, exec.Command("cp", "-r", filepath.Join("apps", nameOrURL), dir)), Succeeds)
... result *main.CmdResult = &main.CmdResult{Cmd:[]string{"cp", "-r", "apps/empty", "/tmp/check-6334824724549167320/0/repo"}, Output:"", Err:(*os.PathError)(0xc23fc6f3b0)}
... command failed with error: fork/exec /bin/cp: cannot allocate memory
```

Giving the initial VM more memory should prevent this from being an issue.