### PR TITLE
controller: Remove "crashed" and "failed" job states

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -39,7 +39,7 @@ func runPs(args *docopt.Args, client *controller.Client) error {
 		if j.Type == "" {
 			j.Type = "run"
 		}
-		if j.State != "up" {
+		if j.State != ct.JobStateUp {
 			continue
 		}
 		listRec(w, j.ID, j.Type, j.ReleaseID)

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -19,12 +19,12 @@ func (s *S) TestEvents(c *C) {
 	jobID2 := "host-job2"
 	jobID3 := "host-job3"
 	jobs := []*ct.Job{
-		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
-		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "up"},
-		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
-		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: "up"},
-		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: "starting"},
-		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: "up"},
+		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
+		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
+		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
 	}
 
 	listener := newEventListener(&EventRepo{db: s.hc.db})

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -23,7 +23,7 @@ func (s *S) TestJobList(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-list"})
 	release := s.createTestRelease(c, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	s.createTestJob(c, &ct.Job{ID: "host0-job0", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: "starting", Meta: map[string]string{"some": "info"}})
+	s.createTestJob(c, &ct.Job{ID: "host0-job0", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}})
 
 	list, err := s.c.JobList(app.ID)
 	c.Assert(err, IsNil)
@@ -39,7 +39,7 @@ func (s *S) TestJobGet(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-get"})
 	release := s.createTestRelease(c, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	jobID := s.createTestJob(c, &ct.Job{ID: "host0-job1", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: "starting", Meta: map[string]string{"some": "info"}}).ID
+	jobID := s.createTestJob(c, &ct.Job{ID: "host0-job1", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}}).ID
 
 	job, err := s.c.GetJob(app.ID, jobID)
 	c.Assert(err, IsNil)
@@ -53,21 +53,21 @@ func (s *S) TestJobStateTransition(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-state-transition"})
 	release := s.createTestRelease(c, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	job := s.createTestJob(c, &ct.Job{ID: "host0-job2", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: "starting"})
+	job := s.createTestJob(c, &ct.Job{ID: "host0-job2", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting})
 
-	job.State = "up"
+	job.State = ct.JobStateUp
 	c.Assert(s.c.PutJob(job), IsNil)
 
 	// duplicates are ignored
 	c.Assert(s.c.PutJob(job), IsNil)
 
-	job.State = "starting"
+	job.State = ct.JobStateStarting
 	c.Assert(s.c.PutJob(job), ErrorMatches, ".*invalid job state transition.*")
 
-	job.State = "down"
+	job.State = ct.JobStateDown
 	c.Assert(s.c.PutJob(job), IsNil)
 
-	job.State = "up"
+	job.State = ct.JobStateUp
 	c.Assert(s.c.PutJob(job), ErrorMatches, ".*invalid job state transition.*")
 }
 

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -6,6 +6,7 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
+	"github.com/flynn/flynn/pkg/typeconv"
 )
 
 // JobState is a job's in-memory state
@@ -91,7 +92,7 @@ type Job struct {
 	metadata map[string]string
 
 	// exitStatus is the job's exit status once it has stopped running
-	exitStatus int32
+	exitStatus *int
 
 	// hostError is the error from the host if the job fails to start
 	hostError *string
@@ -132,12 +133,11 @@ func (j *Job) IsInFormation(key utils.FormationKey) bool {
 
 func (j *Job) ControllerJob() *ct.Job {
 	job := &ct.Job{
-		ID:         j.JobID,
-		AppID:      j.AppID,
-		ReleaseID:  j.ReleaseID,
-		Type:       j.Type,
-		Meta:       utils.JobMetaFromMetadata(j.metadata),
-		ExitStatus: j.exitStatus,
+		ID:        j.JobID,
+		AppID:     j.AppID,
+		ReleaseID: j.ReleaseID,
+		Type:      j.Type,
+		Meta:      utils.JobMetaFromMetadata(j.metadata),
 	}
 
 	switch j.state {
@@ -149,6 +149,9 @@ func (j *Job) ControllerJob() *ct.Job {
 		job.State = ct.JobStateDown
 	}
 
+	if j.exitStatus != nil {
+		job.ExitStatus = typeconv.Int32Ptr(int32(*j.exitStatus))
+	}
 	if j.hostError != nil {
 		job.HostError = *j.hostError
 	}

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -6,7 +6,6 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
-	"github.com/flynn/flynn/host/types"
 )
 
 // JobState is a job's in-memory state
@@ -90,6 +89,12 @@ type Job struct {
 	// event is received for the job, and is used when persisting the job
 	// to the controller
 	metadata map[string]string
+
+	// exitStatus is the job's exit status once it has stopped running
+	exitStatus int32
+
+	// hostError is the error from the host if the job fails to start
+	hostError *string
 }
 
 // needsVolume indicates whether a volume should be provisioned in the cluster
@@ -123,6 +128,32 @@ func (j *Job) IsSchedulable() bool {
 
 func (j *Job) IsInFormation(key utils.FormationKey) bool {
 	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key && j.HasTypeFromRelease()
+}
+
+func (j *Job) ControllerJob() *ct.Job {
+	job := &ct.Job{
+		ID:         j.JobID,
+		AppID:      j.AppID,
+		ReleaseID:  j.ReleaseID,
+		Type:       j.Type,
+		Meta:       utils.JobMetaFromMetadata(j.metadata),
+		ExitStatus: j.exitStatus,
+	}
+
+	switch j.state {
+	case JobStateStarting:
+		job.State = ct.JobStateStarting
+	case JobStateRunning:
+		job.State = ct.JobStateUp
+	case JobStateStopped:
+		job.State = ct.JobStateDown
+	}
+
+	if j.hostError != nil {
+		job.HostError = *j.hostError
+	}
+
+	return job
 }
 
 type Jobs map[string]*Job
@@ -171,33 +202,4 @@ func (js Jobs) GetProcesses(key utils.FormationKey) Processes {
 
 func (js Jobs) Add(j *Job) {
 	js[j.ID] = j
-}
-
-// TODO refactor `state` to JobStatus type and consolidate statuses across scheduler/controller/host
-func controllerJobFromSchedulerJob(job *Job, state string) *ct.Job {
-	return &ct.Job{
-		ID:        job.JobID,
-		AppID:     job.AppID,
-		ReleaseID: job.ReleaseID,
-		Type:      job.Type,
-		State:     state,
-		Meta:      utils.JobMetaFromMetadata(job.metadata),
-	}
-}
-
-func jobState(status host.JobStatus) string {
-	switch status {
-	case host.StatusStarting:
-		return "starting"
-	case host.StatusRunning:
-		return "up"
-	case host.StatusDone:
-		return "down"
-	case host.StatusCrashed:
-		return "crashed"
-	case host.StatusFailed:
-		return "failed"
-	default:
-		return ""
-	}
 }

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -863,7 +863,7 @@ func (s *Scheduler) handleActiveJob(activeJob *host.ActiveJob) *Job {
 
 	job.startedAt = activeJob.StartedAt
 	job.metadata = hostJob.Metadata
-	job.exitStatus = int32(activeJob.ExitStatus)
+	job.exitStatus = activeJob.ExitStatus
 	job.hostError = activeJob.Error
 
 	s.handleJobStatus(job, activeJob.Status)

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -863,6 +863,8 @@ func (s *Scheduler) handleActiveJob(activeJob *host.ActiveJob) *Job {
 
 	job.startedAt = activeJob.StartedAt
 	job.metadata = hostJob.Metadata
+	job.exitStatus = int32(activeJob.ExitStatus)
+	job.hostError = activeJob.Error
 
 	s.handleJobStatus(job, activeJob.Status)
 
@@ -890,10 +892,7 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 	// if the job's state has changed, persist it to the controller
 	if job.state != previousState {
 		log.Info("handling job status change", "from", previousState, "to", job.state)
-		s.putJobs <- controllerJobFromSchedulerJob(
-			job,
-			jobState(status),
-		)
+		s.persistJob(job)
 	}
 
 	// ensure the job has a known formation
@@ -947,6 +946,10 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 	// trigger a rectify for the job's formation in case we have too many
 	// jobs of the given type and we need to stop some
 	s.triggerRectify(job.Formation.key())
+}
+
+func (s *Scheduler) persistJob(job *Job) {
+	s.putJobs <- job.ControllerJob()
 }
 
 func (s *Scheduler) handleFormation(ef *ct.ExpandedFormation) (formation *Formation) {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -213,5 +213,9 @@ $$ LANGUAGE plpgsql`,
 	m.Add(6,
 		`INSERT INTO deployment_strategies (name) VALUES ('discoverd-meta')`,
 	)
+	m.Add(7,
+		`ALTER TABLE job_cache ADD COLUMN exit_status integer NOT NULL DEFAULT 0`,
+		`ALTER TABLE job_cache ADD COLUMN host_error text`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -214,7 +214,7 @@ $$ LANGUAGE plpgsql`,
 		`INSERT INTO deployment_strategies (name) VALUES ('discoverd-meta')`,
 	)
 	m.Add(7,
-		`ALTER TABLE job_cache ADD COLUMN exit_status integer NOT NULL DEFAULT 0`,
+		`ALTER TABLE job_cache ADD COLUMN exit_status integer`,
 		`ALTER TABLE job_cache ADD COLUMN host_error text`,
 	)
 	return m.Migrate(db)

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -228,16 +228,16 @@ WHERE app_id = $1 AND release_id = $2`
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
 WHERE app_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, created_at, updated_at
+SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
 	jobSelectQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, created_at, updated_at
+SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, created_at, updated_at
 FROM job_cache WHERE job_id = $1`
 	jobInsertQuery = `
-INSERT INTO job_cache (job_id, app_id, release_id, process_type, state, meta)
-VALUES ($1, $2, $3, $4, $5, $6) RETURNING created_at, updated_at`
+INSERT INTO job_cache (job_id, app_id, release_id, process_type, state, meta, exit_status, host_error)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING created_at, updated_at`
 	jobUpdateQuery = `
-UPDATE job_cache SET state = $2, updated_at = now()
+UPDATE job_cache SET state = $2, exit_status = $3, host_error = $4, updated_at = now()
 WHERE job_id = $1 RETURNING created_at, updated_at`
 	providerListQuery = `
 SELECT provider_id, name, url, created_at, updated_at

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -89,16 +89,33 @@ type Key struct {
 }
 
 type Job struct {
-	ID        string            `json:"id,omitempty"`
-	AppID     string            `json:"app,omitempty"`
-	ReleaseID string            `json:"release,omitempty"`
-	Type      string            `json:"type,omitempty"`
-	State     string            `json:"state,omitempty"`
-	Cmd       []string          `json:"cmd,omitempty"`
-	Meta      map[string]string `json:"meta,omitempty"`
-	CreatedAt *time.Time        `json:"created_at,omitempty"`
-	UpdatedAt *time.Time        `json:"updated_at,omitempty"`
+	ID         string            `json:"id,omitempty"`
+	AppID      string            `json:"app,omitempty"`
+	ReleaseID  string            `json:"release,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	State      JobState          `json:"state,omitempty"`
+	Cmd        []string          `json:"cmd,omitempty"`
+	Meta       map[string]string `json:"meta,omitempty"`
+	ExitStatus int32             `json:"exit_status"`
+	HostError  string            `json:"host_error,omitempty"`
+	CreatedAt  *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt  *time.Time        `json:"updated_at,omitempty"`
 }
+
+type JobState string
+
+const (
+	JobStateStarting JobState = "starting"
+	JobStateUp       JobState = "up"
+	JobStateStopping JobState = "stopping"
+	JobStateDown     JobState = "down"
+
+	// JobStateCrashed and JobStateFailed are no longer valid job states,
+	// but we still need to handle them in case they are set by old
+	// schedulers still using the legacy code.
+	JobStateCrashed JobState = "crashed"
+	JobStateFailed  JobState = "failed"
+)
 
 type DomainMigration struct {
 	ID         string        `json:"id"`
@@ -111,10 +128,43 @@ type DomainMigration struct {
 }
 
 func (e *Job) IsDown() bool {
-	return e.State == "failed" || e.State == "crashed" || e.State == "down"
+	return e.State == JobStateDown || e.State == JobStateCrashed || e.State == JobStateFailed
 }
 
-type JobEvents map[string]map[string]int
+type JobEvents map[string]map[JobState]int
+
+func (j JobEvents) Count() int {
+	var n int
+	for _, procs := range j {
+		for _, i := range procs {
+			n += i
+		}
+	}
+	return n
+}
+
+func (j JobEvents) Equals(other JobEvents) bool {
+	for typ, events := range j {
+		diff, ok := other[typ]
+		if !ok {
+			return false
+		}
+		for state, count := range events {
+			if diff[state] != count {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func JobUpEvents(count int) map[JobState]int {
+	return map[JobState]int{JobStateUp: count}
+}
+
+func JobDownEvents(count int) map[JobState]int {
+	return map[JobState]int{JobStateDown: count}
+}
 
 type NewJob struct {
 	ReleaseID  string             `json:"release,omitempty"`
@@ -150,13 +200,13 @@ type DeployID struct {
 }
 
 type DeploymentEvent struct {
-	AppID        string `json:"app,omitempty"`
-	DeploymentID string `json:"deployment,omitempty"`
-	ReleaseID    string `json:"release,omitempty"`
-	Status       string `json:"status,omitempty"`
-	JobType      string `json:"job_type,omitempty"`
-	JobState     string `json:"job_state,omitempty"`
-	Error        string `json:"error,omitempty"`
+	AppID        string   `json:"app,omitempty"`
+	DeploymentID string   `json:"deployment,omitempty"`
+	ReleaseID    string   `json:"release,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	JobType      string   `json:"job_type,omitempty"`
+	JobState     JobState `json:"job_state,omitempty"`
+	Error        string   `json:"error,omitempty"`
 }
 
 func (e *DeploymentEvent) Err() error {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -96,7 +96,7 @@ type Job struct {
 	State      JobState          `json:"state,omitempty"`
 	Cmd        []string          `json:"cmd,omitempty"`
 	Meta       map[string]string `json:"meta,omitempty"`
-	ExitStatus int32             `json:"exit_status"`
+	ExitStatus *int32            `json:"exit_status,omitempty"`
 	HostError  string            `json:"host_error,omitempty"`
 	CreatedAt  *time.Time        `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time        `json:"updated_at,omitempty"`

--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -6,7 +6,7 @@ func (d *DeployJob) deployAllAtOnce() error {
 	log := d.logger.New("fn", "deployAllAtOnce")
 	log.Info("starting all-at-once deployment")
 
-	expected := make(jobEvents)
+	expected := make(ct.JobEvents)
 	for typ, n := range d.Processes {
 		total := n
 		if d.isOmni(typ) {
@@ -16,12 +16,12 @@ func (d *DeployJob) deployAllAtOnce() error {
 		for i := existing; i < total; i++ {
 			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.NewReleaseID,
-				JobState:  "starting",
+				JobState:  ct.JobStateStarting,
 				JobType:   typ,
 			}
 		}
 		if total > existing {
-			expected[typ] = map[string]int{"up": total - existing}
+			expected[typ] = ct.JobUpEvents(total - existing)
 		}
 	}
 	if expected.Count() > 0 {
@@ -43,18 +43,18 @@ func (d *DeployJob) deployAllAtOnce() error {
 		}
 	}
 
-	expected = make(jobEvents)
+	expected = make(ct.JobEvents)
 	for typ := range d.Processes {
 		existing := d.oldReleaseState[typ]
 		for i := 0; i < existing; i++ {
 			d.deployEvents <- ct.DeploymentEvent{
 				ReleaseID: d.OldReleaseID,
-				JobState:  "stopping",
+				JobState:  ct.JobStateStopping,
 				JobType:   typ,
 			}
 		}
 		if existing > 0 {
-			expected[typ] = map[string]int{"down": existing}
+			expected[typ] = ct.JobDownEvents(existing)
 		}
 	}
 

--- a/controller/worker/deployment/context.go
+++ b/controller/worker/deployment/context.go
@@ -147,7 +147,7 @@ func (c *context) rollback(l log15.Logger, deployment *ct.Deployment, original *
 		if j.ReleaseID != deployment.OldReleaseID {
 			continue
 		}
-		if j.State == "up" {
+		if j.State == ct.JobStateUp {
 			runningJobs[j.Type]++
 		}
 	}
@@ -155,7 +155,7 @@ func (c *context) rollback(l log15.Logger, deployment *ct.Deployment, original *
 	for name, count := range original.Processes {
 		count = count - runningJobs[name]
 		if count > 0 {
-			expectedJobEvents[name] = map[string]int{"up": count}
+			expectedJobEvents[name] = ct.JobUpEvents(count)
 		}
 	}
 

--- a/controller/worker/deployment/discoverd_meta.go
+++ b/controller/worker/deployment/discoverd_meta.go
@@ -46,6 +46,9 @@ func (d *DeployJob) deployDiscoverdMeta() (err error) {
 				}
 			}
 		}
+		if expected.Count() == 0 {
+			return nil
+		}
 		return d.waitForJobEvents(releaseID, expected, log)
 	})
 }

--- a/controller/worker/deployment/discoverd_meta.go
+++ b/controller/worker/deployment/discoverd_meta.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	ct "github.com/flynn/flynn/controller/types"
 	dd "github.com/flynn/flynn/discoverd/deployment"
 )
 
@@ -32,16 +33,16 @@ func (d *DeployJob) deployDiscoverdMeta() (err error) {
 		defer discDeploy.Close()
 	}
 
-	return d.deployOneByOneWithWaitFn(func(releaseID string, expected jobEvents, log log15.Logger) error {
+	return d.deployOneByOneWithWaitFn(func(releaseID string, expected ct.JobEvents, log log15.Logger) error {
 		for typ, events := range expected {
-			if count, ok := events["up"]; ok && count > 0 {
+			if count, ok := events[ct.JobStateUp]; ok && count > 0 {
 				if discDeploy, ok := discDeploys[typ]; ok {
 					if err := discDeploy.Wait(count, 120, log); err != nil {
 						return err
 					}
 					// clear up events for this type so we can safely
 					// process job down events if needed
-					expected[typ]["up"] = 0
+					expected[typ][ct.JobStateUp] = 0
 				}
 			}
 		}

--- a/controller/worker/deployment/postgres.go
+++ b/controller/worker/deployment/postgres.go
@@ -61,7 +61,7 @@ func (d *DeployJob) deployPostgres() (err error) {
 
 		d.deployEvents <- ct.DeploymentEvent{
 			ReleaseID: d.OldReleaseID,
-			JobState:  "stopping",
+			JobState:  ct.JobStateStopping,
 			JobType:   "postgres",
 		}
 		pg := pgmanager.NewClient(inst.Addr)
@@ -77,7 +77,7 @@ func (d *DeployJob) deployPostgres() (err error) {
 				if event.Kind == discoverd.EventKindDown && event.Instance.ID == inst.ID {
 					d.deployEvents <- ct.DeploymentEvent{
 						ReleaseID: d.OldReleaseID,
-						JobState:  "down",
+						JobState:  ct.JobStateDown,
 						JobType:   "postgres",
 					}
 					return nil
@@ -94,7 +94,7 @@ func (d *DeployJob) deployPostgres() (err error) {
 		log.Info("starting new instance")
 		d.deployEvents <- ct.DeploymentEvent{
 			ReleaseID: d.NewReleaseID,
-			JobState:  "starting",
+			JobState:  ct.JobStateStarting,
 			JobType:   "postgres",
 		}
 		d.newReleaseState["postgres"]++
@@ -130,7 +130,7 @@ func (d *DeployJob) deployPostgres() (err error) {
 		}
 		d.deployEvents <- ct.DeploymentEvent{
 			ReleaseID: d.NewReleaseID,
-			JobState:  "up",
+			JobState:  ct.JobStateUp,
 			JobType:   "postgres",
 		}
 		return inst, nil
@@ -228,7 +228,7 @@ loop:
 				return loggedErr("unexpected close of job event stream")
 			}
 			log.Info("got job event", "job_id", event.ID, "type", event.Type, "state", event.State)
-			if event.State == "down" && event.Type == "postgres" && event.ReleaseID == d.OldReleaseID {
+			if event.State == ct.JobStateDown && event.Type == "postgres" && event.ReleaseID == d.OldReleaseID {
 				actual++
 				if actual == d.Processes["postgres"] {
 					break loop

--- a/dashboard/app/lib/javascripts/dashboard/stores/app-jobs.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/app-jobs.js
@@ -1,3 +1,4 @@
+import { extend } from 'marbles/utils';
 import Store from '../store';
 import JobsStream from './jobs-stream';
 import Dispatcher from '../dispatcher';
@@ -62,7 +63,13 @@ var AppJobs = Store.createClass({
 					if (item.hasOwnProperty("State")) {
 						item.state = item.State;
 					}
-					return item;
+					var state = item.state;
+					if (item.state === 'down' && item.exit_status !== 0) {
+						state = 'crashed';
+					} else if (item.state === 'down' && item.host_error) {
+						state = 'failed';
+					}
+					return extend({}, item, { state: state });
 				})
 			});
 		}.bind(this));

--- a/dashboard/app/lib/javascripts/dashboard/stores/job-output.js
+++ b/dashboard/app/lib/javascripts/dashboard/stores/job-output.js
@@ -1,6 +1,5 @@
 import { extend } from 'marbles/utils';
 import Store from '../store';
-import Dispatcher from '../dispatcher';
 import Config from '../config';
 import JobsStream from './jobs-stream';
 
@@ -44,23 +43,6 @@ var JobOutput = Store.createClass({
 			output: [],
 			streamError: null
 		};
-	},
-
-	handleEvent: function (event) {
-		if (event.name === "JOB_STATE_CHANGE" && event.jobId === this.props.jobId) {
-			if (event.state === "down") {
-				this.setState({
-					eof: true,
-					open: false
-				});
-			} else if (event.state === "crashed") {
-				this.setState({
-					open: false,
-					eof: false,
-					streamError: "Non-zero exit status"
-				});
-			}
-		}
 	},
 
 	__openEventStream: function (retryCount) {
@@ -127,7 +109,5 @@ var JobOutput = Store.createClass({
 JobOutput.isValidId = function (id) {
 	return id.appId && id.jobId;
 };
-
-JobOutput.registerWithDispatcher(Dispatcher);
 
 export default JobOutput;

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -201,11 +201,11 @@ Options:
 		}
 		fmt.Println("=====> Waiting for web job to start...")
 
-		err = watcher.WaitFor(ct.JobEvents{"web": {"up": 1}}, scaleTimeout, func(e *ct.Job) error {
+		err = watcher.WaitFor(ct.JobEvents{"web": ct.JobUpEvents(1)}, scaleTimeout, func(e *ct.Job) error {
 			switch e.State {
-			case "up":
+			case ct.JobStateUp:
 				fmt.Println("=====> Default web formation scaled to 1")
-			case "down", "crashed":
+			case ct.JobStateDown:
 				return fmt.Errorf("Failed to scale web process type")
 			}
 			return nil

--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -190,14 +190,6 @@ func (c *ContainerInit) GetState(arg *struct{}, status *State) error {
 	return nil
 }
 
-// Get the exit code (or -1 if running)
-func (c *ContainerInit) GetExitStatus(arg *struct{}, status *int) error {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	*status = c.exitStatus
-	return nil
-}
-
 func (c *ContainerInit) Resume(arg, res *struct{}) error {
 	c.resume <- struct{}{}
 	return nil

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -1001,7 +1001,7 @@ func (l *LibvirtLXCBackend) Attach(req *AttachRequest) (err error) {
 			<-client.done
 			job := l.state.GetJob(req.Job.Job.ID)
 			if job.Status == host.StatusDone || job.Status == host.StatusCrashed {
-				err = ExitError(job.ExitStatus)
+				err = ExitError(*job.ExitStatus)
 				return
 			}
 			err = errors.New(*job.Error)

--- a/host/state.go
+++ b/host/state.go
@@ -445,7 +445,7 @@ func (s *State) setStatusDone(job *host.ActiveJob, exitStatus int) {
 		return
 	}
 	job.EndedAt = time.Now().UTC()
-	job.ExitStatus = exitStatus
+	job.ExitStatus = &exitStatus
 	if exitStatus == 0 {
 		job.Status = host.StatusDone
 	} else {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -210,7 +210,7 @@ type ActiveJob struct {
 	Status      JobStatus `json:"status,omitempty"`
 	StartedAt   time.Time `json:"started_at,omitempty"`
 	EndedAt     time.Time `json:"ended_at,omitempty"`
-	ExitStatus  int       `json:"exit_status,omitempty"`
+	ExitStatus  *int      `json:"exit_status,omitempty"`
 	Error       *string   `json:"error,omitempty"`
 }
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -267,7 +267,7 @@ func (c *Cmd) Start() error {
 			for e := range c.eventChan {
 				switch e.Event {
 				case "stop":
-					c.exitStatus = e.Job.ExitStatus
+					c.exitStatus = *e.Job.ExitStatus
 					break outer
 				case "error":
 					c.streamErr = errors.New(*e.Job.Error)

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -1,5 +1,6 @@
 package typeconv
 
 func IntPtr(i int) *int          { return &i }
+func Int32Ptr(i int32) *int32    { return &i }
 func Int64Ptr(i int64) *int64    { return &i }
 func StringPtr(s string) *string { return &s }

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -35,6 +35,14 @@
     "meta": {
       "$ref": "/schema/controller/common#/definitions/meta"
     },
+    "exit_status": {
+      "type": "integer",
+      "description": "job exit status"
+    },
+    "host_error": {
+      "type": "string",
+      "description": "host error if job failed to start"
+    },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"
     },

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -230,7 +230,7 @@ func (s *ControllerSuite) TestResourceLimitsReleaseJob(t *c.C) {
 		Processes: map[string]int{"resources": 1},
 	}), c.IsNil)
 	var jobID string
-	err = watcher.WaitFor(ct.JobEvents{"resources": {"up": 1, "down": 1}}, scaleTimeout, func(e *ct.Job) error {
+	err = watcher.WaitFor(ct.JobEvents{"resources": {ct.JobStateUp: 1, ct.JobStateDown: 1}}, scaleTimeout, func(e *ct.Job) error {
 		jobID = e.ID
 		return nil
 	})
@@ -491,7 +491,7 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 	defer watcher.Close()
 	runJob(app2.ID, release2.ID)
 	t.Assert(watcher.WaitFor(
-		ct.JobEvents{"": {"up": 1, "down": 1}},
+		ct.JobEvents{"": {ct.JobStateUp: 1, ct.JobStateDown: 1}},
 		10*time.Second,
 		func(e *ct.Job) error {
 			debugf(t, "got %s job event for app2", e.State)
@@ -511,7 +511,7 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 			}
 			t.Assert(e.AppID, c.Equals, app1.ID)
 			debugf(t, "got %s job event for app1", e.State)
-			if e.State == "down" {
+			if e.State == ct.JobStateDown {
 				return
 			}
 		case <-time.After(10 * time.Second):

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -30,7 +30,7 @@ func (s *DeployerSuite) createRelease(t *c.C, process, strategy string) (*ct.App
 		Processes: map[string]int{process: 2},
 	}), c.IsNil)
 
-	err = watcher.WaitFor(ct.JobEvents{process: {"up": 2}}, scaleTimeout, nil)
+	err = watcher.WaitFor(ct.JobEvents{process: {ct.JobStateUp: 2}}, scaleTimeout, nil)
 	t.Assert(err, c.IsNil)
 
 	return app, release
@@ -106,6 +106,7 @@ loop:
 		t.Assert(i.JobType, c.Equals, j.JobType)
 		t.Assert(i.JobState, c.Equals, j.JobState)
 		t.Assert(i.Status, c.Equals, j.Status)
+		t.Assert(i.Error, c.Equals, j.Error)
 	}
 
 	for i, e := range expected {
@@ -124,14 +125,14 @@ func (s *DeployerSuite) TestOneByOneStrategy(t *c.C) {
 
 	expected := []*ct.DeploymentEvent{
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "pending"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "up", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "down", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "up", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "down", Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "complete"},
 	}
 	waitForDeploymentEvents(t, events, expected)
@@ -148,14 +149,14 @@ func (s *DeployerSuite) TestAllAtOnceStrategy(t *c.C) {
 
 	expected := []*ct.DeploymentEvent{
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "pending"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "up", Status: "running"},
-		{ReleaseID: releaseID, JobType: "printer", JobState: "up", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "down", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "printer", JobState: "down", Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: releaseID, JobType: "printer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "complete"},
 	}
 	waitForDeploymentEvents(t, events, expected)
@@ -172,14 +173,14 @@ func (s *DeployerSuite) TestServiceEvents(t *c.C) {
 
 	expected := []*ct.DeploymentEvent{
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "pending"},
-		{ReleaseID: releaseID, JobType: "echoer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "echoer", JobState: "starting", Status: "running"},
-		{ReleaseID: releaseID, JobType: "echoer", JobState: "up", Status: "running"},
-		{ReleaseID: releaseID, JobType: "echoer", JobState: "up", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: "stopping", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: "down", Status: "running"},
-		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: "down", Status: "running"},
+		{ReleaseID: releaseID, JobType: "echoer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "echoer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: releaseID, JobType: "echoer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: releaseID, JobType: "echoer", JobState: ct.JobStateUp, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: ct.JobStateStopping, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: ct.JobStateDown, Status: "running"},
+		{ReleaseID: oldReleaseID, JobType: "echoer", JobState: ct.JobStateDown, Status: "running"},
 		{ReleaseID: releaseID, JobType: "", JobState: "", Status: "complete"},
 	}
 	waitForDeploymentEvents(t, events, expected)
@@ -222,10 +223,10 @@ func (s *DeployerSuite) TestRollbackFailedJob(t *c.C) {
 	defer stream.Close()
 	expected := []*ct.DeploymentEvent{
 		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "pending"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "failed", Status: "running"},
-		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "failed"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
+		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "failed", Error: `deployer: printer job failed to start: exec: "this-is-gonna-fail": executable file not found in $PATH`},
 	}
 	waitForDeploymentEvents(t, events, expected)
 
@@ -268,10 +269,10 @@ func (s *DeployerSuite) TestRollbackNoService(t *c.C) {
 	defer stream.Close()
 	expected := []*ct.DeploymentEvent{
 		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "pending"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "starting", Status: "running"},
-		{ReleaseID: release.ID, JobType: "printer", JobState: "down", Status: "running"},
-		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "failed"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateStarting, Status: "running"},
+		{ReleaseID: release.ID, JobType: "printer", JobState: ct.JobStateDown, Status: "running"},
+		{ReleaseID: release.ID, JobType: "", JobState: "", Status: "failed", Error: "printer process type failed to start, got down job event"},
 	}
 	waitForDeploymentEvents(t, events, expected)
 
@@ -302,7 +303,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 		ReleaseID: release.ID,
 		Processes: map[string]int{"omni": omniScale},
 	}), c.IsNil)
-	err = watcher.WaitFor(ct.JobEvents{"omni": {"up": totalJobs}}, scaleTimeout, nil)
+	err = watcher.WaitFor(ct.JobEvents{"omni": {ct.JobStateUp: totalJobs}}, scaleTimeout, nil)
 	t.Assert(err, c.IsNil)
 
 	// deploy using all-at-once and check we get the correct events
@@ -317,7 +318,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	expected := make([]*ct.DeploymentEvent, 0, 4*totalJobs+1)
-	appendEvents := func(releaseID, state string, count int) {
+	appendEvents := func(releaseID string, state ct.JobState, count int) {
 		for i := 0; i < count; i++ {
 			event := &ct.DeploymentEvent{
 				ReleaseID: releaseID,
@@ -329,10 +330,10 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 		}
 	}
 	expected = append(expected, &ct.DeploymentEvent{ReleaseID: deployment.NewReleaseID, Status: "pending"})
-	appendEvents(deployment.NewReleaseID, "starting", totalJobs)
-	appendEvents(deployment.NewReleaseID, "up", totalJobs)
-	appendEvents(deployment.OldReleaseID, "stopping", totalJobs)
-	appendEvents(deployment.OldReleaseID, "down", totalJobs)
+	appendEvents(deployment.NewReleaseID, ct.JobStateStarting, totalJobs)
+	appendEvents(deployment.NewReleaseID, ct.JobStateUp, totalJobs)
+	appendEvents(deployment.OldReleaseID, ct.JobStateStopping, totalJobs)
+	appendEvents(deployment.OldReleaseID, ct.JobStateDown, totalJobs)
 	expected = append(expected, &ct.DeploymentEvent{ReleaseID: deployment.NewReleaseID, Status: "complete"})
 	waitForDeploymentEvents(t, events, expected)
 
@@ -348,14 +349,14 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	t.Assert(err, c.IsNil)
 	expected = make([]*ct.DeploymentEvent, 0, 4*totalJobs+1)
 	expected = append(expected, &ct.DeploymentEvent{ReleaseID: deployment.NewReleaseID, Status: "pending"})
-	appendEvents(deployment.NewReleaseID, "starting", testCluster.Size())
-	appendEvents(deployment.NewReleaseID, "up", testCluster.Size())
-	appendEvents(deployment.OldReleaseID, "stopping", testCluster.Size())
-	appendEvents(deployment.OldReleaseID, "down", testCluster.Size())
-	appendEvents(deployment.NewReleaseID, "starting", testCluster.Size())
-	appendEvents(deployment.NewReleaseID, "up", testCluster.Size())
-	appendEvents(deployment.OldReleaseID, "stopping", testCluster.Size())
-	appendEvents(deployment.OldReleaseID, "down", testCluster.Size())
+	appendEvents(deployment.NewReleaseID, ct.JobStateStarting, testCluster.Size())
+	appendEvents(deployment.NewReleaseID, ct.JobStateUp, testCluster.Size())
+	appendEvents(deployment.OldReleaseID, ct.JobStateStopping, testCluster.Size())
+	appendEvents(deployment.OldReleaseID, ct.JobStateDown, testCluster.Size())
+	appendEvents(deployment.NewReleaseID, ct.JobStateStarting, testCluster.Size())
+	appendEvents(deployment.NewReleaseID, ct.JobStateUp, testCluster.Size())
+	appendEvents(deployment.OldReleaseID, ct.JobStateStopping, testCluster.Size())
+	appendEvents(deployment.OldReleaseID, ct.JobStateDown, testCluster.Size())
 	expected = append(expected, &ct.DeploymentEvent{ReleaseID: deployment.NewReleaseID, Status: "complete"})
 	waitForDeploymentEvents(t, events, expected)
 }

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -151,7 +151,7 @@ func (s *GitDeploySuite) runBuildpackTestWithResponsePattern(t *c.C, name string
 	t.Assert(push, c.Not(OutputContains), "timed out waiting for scale")
 	t.Assert(push, SuccessfulOutputContains, "=====> Default web formation scaled to 1")
 
-	watcher.WaitFor(ct.JobEvents{"web": {"up": 1}}, scaleTimeout, nil)
+	watcher.WaitFor(ct.JobEvents{"web": {ct.JobStateUp: 1}}, scaleTimeout, nil)
 
 	route := name + ".dev"
 	newRoute := r.flynn("route", "add", "http", route)

--- a/test/test_logaggregator.go
+++ b/test/test_logaggregator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/logaggregator/client"
 )
@@ -119,7 +120,7 @@ func (s *LogAggregatorSuite) TestReplication(t *c.C) {
 	jobs, err := cc.JobList("logaggregator")
 	t.Assert(err, c.IsNil)
 	for _, j := range jobs {
-		if j.State == "up" {
+		if j.State == ct.JobStateUp {
 			t.Assert(cc.DeleteJob(app.name, j.ID), c.IsNil)
 		}
 	}

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -214,7 +214,7 @@ func (s *PostgresSuite) testDeploy(t *c.C, d *pgDeploy) {
 				t.Fatalf("job event stream closed: %s", jobStream.Err())
 			}
 			debugf(t, "got job event: %s %s %s", e.Type, e.ID, e.State)
-			if e.Type == "web" && e.State == "up" {
+			if e.Type == "web" && e.State == ct.JobStateUp {
 				webJobs++
 			}
 		case <-time.After(30 * time.Second):
@@ -344,7 +344,7 @@ loop:
 				t.Fatalf("deployment failed: %s", e.Error)
 			}
 			debugf(t, "got deployment event: %s %s", e.JobType, e.JobState)
-			if e.JobState != "up" && e.JobState != "down" {
+			if e.JobState != ct.JobStateUp && e.JobState != ct.JobStateDown {
 				continue
 			}
 			switch e.JobType {
@@ -356,7 +356,7 @@ loop:
 				skipped := assertNextState(expected[expectedIndex:])
 				expectedIndex += 1 + skipped
 			case "web":
-				if e.JobState == "up" && e.ReleaseID == newRelease {
+				if e.JobState == ct.JobStateUp && e.ReleaseID == newRelease {
 					newWebJobs++
 				}
 			}


### PR DESCRIPTION
This consolidates "crashed" and "failed" job states into the "down" state, adding `job.ExitStatus` and `job.HostError` to distinguish between those states.

It also makes the states an explicit type.