### PR TITLE
logaggregator/buffer: Skip duplicate log lines

### DIFF
--- a/logaggregator/buffer/buffer.go
+++ b/logaggregator/buffer/buffer.go
@@ -1,6 +1,7 @@
 package buffer
 
 import (
+	"bytes"
 	"errors"
 	"sync"
 
@@ -60,6 +61,10 @@ func (b *Buffer) Add(m *rfc5424.Message) error {
 		// iterate from newest to oldest through messages to find position
 		// to insert new message
 		for other := b.tail; other != nil; other = other.prev {
+			if m.Timestamp.Equal(other.Timestamp) && bytes.Equal(m.StructuredData, other.StructuredData) {
+				// duplicate log line
+				return nil
+			}
 			if m.Timestamp.Before(other.Timestamp) {
 				if other.prev == nil {
 					// insert before other at head

--- a/logaggregator/buffer/buffer_test.go
+++ b/logaggregator/buffer/buffer_test.go
@@ -287,6 +287,10 @@ func (s *S) TestAddSort(c *C) {
 	b.Add(first)
 	c.Assert(b.Read(), DeepEquals, []*rfc5424.Message{first})
 
+	// add duplicate
+	b.Add(first)
+	c.Assert(b.Read(), DeepEquals, []*rfc5424.Message{first})
+
 	// add new, before head
 	newHead := rfc5424.NewMessage(nil, []byte("msg2"))
 	newHead.Timestamp = first.Timestamp.Add(-time.Second)

--- a/logaggregator/iterator_test.go
+++ b/logaggregator/iterator_test.go
@@ -255,13 +255,15 @@ func (s *LogAggregatorTestSuite) TestReadLastNAndSubscribe(c *C) {
 }
 
 var timeNow = time.Now()
+var msgIdx int
 
 func buildTestData(n int, hdr *rfc5424.Header) []*rfc5424.Message {
 	data := make([]*rfc5424.Message, n)
 	for i := range data {
 		line := []byte(fmt.Sprintf("line %d\n", i))
 		msg := rfc5424.NewMessage(hdr, line)
-		msg.StructuredData = []byte(fmt.Sprintf(`[flynn seq="%d"]`, i))
+		msg.StructuredData = []byte(fmt.Sprintf(`[flynn seq="%d"]`, msgIdx))
+		msgIdx++
 		msg.Timestamp = timeNow
 
 		data[i] = msg


### PR DESCRIPTION
Duplicate log lines can be sent when flynn-host is reconnecting.

Closes #2056