### PR TITLE
host: Add jobs to state as early as possible

### DIFF
--- a/host/http.go
+++ b/host/http.go
@@ -285,6 +285,8 @@ func (h *jobAPI) AddJob(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		return
 	}
 
+	h.host.state.AddJob(job)
+
 	go func() {
 		// TODO(titanous): ratelimit this goroutine?
 		log.Info("running job")

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -344,6 +344,12 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 	g := grohl.NewContext(grohl.Data{"backend": "libvirt-lxc", "fn": "run", "job.id": job.ID})
 	g.Log(grohl.Data{"at": "start", "job.artifact.uri": job.Artifact.URI, "job.cmd": job.Config.Cmd})
 
+	defer func() {
+		if err != nil {
+			l.state.SetStatusFailed(job.ID, err)
+		}
+	}()
+
 	if !job.Config.HostNetwork {
 		<-l.networkConfigured
 	}
@@ -547,7 +553,7 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 		return err
 	}
 
-	l.state.AddJob(job, container.IP)
+	l.state.SetContainerIP(job.ID, container.IP)
 	domain := &lt.Domain{
 		Type:   "lxc",
 		Name:   job.ID,

--- a/host/state.go
+++ b/host/state.go
@@ -325,13 +325,10 @@ func (s *State) persist(jobID string) {
 	}
 }
 
-func (s *State) AddJob(j *host.Job, ip net.IP) {
+func (s *State) AddJob(j *host.Job) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	job := &host.ActiveJob{Job: j, HostID: s.id}
-	if len(ip) > 0 {
-		job.InternalIP = ip.String()
-	}
 	s.jobs[j.ID] = job
 	s.sendEvent(job, host.JobEventCreate)
 	s.persist(j.ID)
@@ -381,6 +378,13 @@ func (s *State) SetContainerID(jobID, containerID string) {
 	defer s.mtx.Unlock()
 	s.jobs[jobID].ContainerID = containerID
 	s.containers[containerID] = s.jobs[jobID]
+	s.persist(jobID)
+}
+
+func (s *State) SetContainerIP(jobID string, ip net.IP) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.jobs[jobID].InternalIP = ip.String()
 	s.persist(jobID)
 }
 

--- a/host/state_test.go
+++ b/host/state_test.go
@@ -20,7 +20,7 @@ func (S) TestStateHostID(c *C) {
 	state := NewState(hostID, filepath.Join(workdir, "host-state-db"))
 	c.Assert(state.OpenDB(), IsNil)
 	defer state.CloseDB()
-	state.AddJob(&host.Job{ID: "a"}, nil)
+	state.AddJob(&host.Job{ID: "a"})
 	job := state.GetJob("a")
 	if job.HostID != hostID {
 		c.Errorf("expected job.HostID to equal %s, got %s", hostID, job.HostID)
@@ -32,7 +32,7 @@ func (S) TestStatePersistRestore(c *C) {
 	hostID := "abc123"
 	state := NewState(hostID, filepath.Join(workdir, "host-state-db"))
 	c.Assert(state.OpenDB(), IsNil)
-	state.AddJob(&host.Job{ID: "a"}, nil)
+	state.AddJob(&host.Job{ID: "a"})
 	state.CloseDB()
 
 	// exercise the restore path.  failures will panic.


### PR DESCRIPTION
This means that if a job fails to start, event consumers will always be notified.

Fixes #2134.