### PR TITLE
controller: Ignore deleted apps when inserting new resource records

### DIFF
--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -291,11 +291,11 @@ VALUES ($1, $2, $3, $4) RETURNING created_at`
 UPDATE resources SET deleted_at = now() WHERE resource_id = $1 AND deleted_at IS NULL`
 	appResourceInsertAppByNameQuery = `
 INSERT INTO app_resources (app_id, resource_id)
-VALUES ((SELECT app_id FROM apps WHERE name = $1), $2)
+VALUES ((SELECT app_id FROM apps WHERE name = $1 AND deleted_at IS NULL), $2)
 RETURNING app_id`
 	appResourceInsertAppByNameOrIDQuery = `
 INSERT INTO app_resources (app_id, resource_id)
-VALUES ((SELECT app_id FROM apps WHERE app_id = $1 OR name = $2), $3)
+VALUES ((SELECT app_id FROM apps WHERE (app_id = $1 OR name = $2) AND deleted_at IS NULL), $3)
 RETURNING app_id`
 	appResourceDeleteByAppQuery = `
 UPDATE app_resources SET deleted_at = now() WHERE app_id = $1 AND deleted_at IS NULL`

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -388,6 +388,24 @@ func (s *ControllerSuite) TestAppDeleteCleanup(t *c.C) {
 	t.Assert(r.git("push", "flynn", "master"), Succeeds)
 }
 
+// https://github.com/flynn/flynn/issues/2257
+func (s *ControllerSuite) TestResourceProvisionRecreatedApp(t *c.C) {
+	app := "app-recreate-" + random.String(8)
+	client := s.controllerClient(t)
+
+	// create, delete, and recreate app
+	r := s.newGitRepo(t, "http")
+	t.Assert(r.flynn("create", app), Succeeds)
+	t.Assert(r.flynn("delete", "--yes"), Succeeds)
+	t.Assert(r.flynn("create", app), Succeeds)
+
+	// provision resource
+	t.Assert(r.flynn("resource", "add", "postgres"), Succeeds)
+	resources, err := client.AppResourceList(app)
+	t.Assert(err, c.IsNil)
+	t.Assert(resources, c.HasLen, 1)
+}
+
 func (s *ControllerSuite) TestRouteEvents(t *c.C) {
 	app := "app-route-events-" + random.String(8)
 	client := s.controllerClient(t)


### PR DESCRIPTION
This prevents an error when two or more apps with the same name (all but one deleted) are selected by the query.

Closes #2257