### PR TITLE
scheduler: Don't log triggers

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -964,7 +964,6 @@ func (s *Scheduler) handleFormation(ef *ct.ExpandedFormation) (formation *Format
 }
 
 func (s *Scheduler) triggerRectify(key utils.FormationKey) {
-	logger.Info("triggering rectify", "key", key)
 	s.rectifyBatch[key] = struct{}{}
 	select {
 	case s.rectify <- struct{}{}:
@@ -1160,14 +1159,12 @@ func (s *Scheduler) tickSyncHosts(d time.Duration) {
 }
 
 func (s *Scheduler) rectifyAll() {
-	logger.Info("triggering rectify for all formations")
 	for key := range s.formations {
 		s.triggerRectify(key)
 	}
 }
 
 func (s *Scheduler) triggerSyncJobs() {
-	logger.Info("triggering job sync")
 	select {
 	case s.syncJobs <- struct{}{}:
 	default:
@@ -1175,7 +1172,6 @@ func (s *Scheduler) triggerSyncJobs() {
 }
 
 func (s *Scheduler) triggerSyncFormations() {
-	logger.Info("triggering formation sync")
 	select {
 	case s.syncFormations <- struct{}{}:
 	default:
@@ -1183,7 +1179,6 @@ func (s *Scheduler) triggerSyncFormations() {
 }
 
 func (s *Scheduler) triggerSyncHosts() {
-	logger.Info("triggering host sync")
 	select {
 	case s.syncHosts <- struct{}{}:
 	default:
@@ -1191,7 +1186,6 @@ func (s *Scheduler) triggerSyncHosts() {
 }
 
 func (s *Scheduler) triggerHostChecks() {
-	logger.Info("triggering host checks")
 	select {
 	case s.hostChecks <- struct{}{}:
 	default:


### PR DESCRIPTION
They don't provide useful information and just bloat the log.