### PR TITLE
host/cli: Disable log round-trip during `flynn-host run`

### DIFF
--- a/host/cli/run.go
+++ b/host/cli/run.go
@@ -36,6 +36,7 @@ func runRun(args *docopt.Args, client *cluster.Client) error {
 				Cmd:        args.All["<argument>"].([]string),
 				TTY:        term.IsTerminal(os.Stdin.Fd()) && term.IsTerminal(os.Stdout.Fd()),
 				Stdin:      true,
+				DisableLog: true,
 			},
 		},
 		HostID: args.String["--host"],


### PR DESCRIPTION
Having this flag off ends up mangling output.

Closes #2276