### PR TITLE
host: Ensure log stream fds are closed

### DIFF
--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -905,6 +905,13 @@ func (c *libvirtContainer) cleanup() error {
 	g := grohl.NewContext(grohl.Data{"backend": "libvirt-lxc", "fn": "cleanup", "job.id": c.job.ID})
 	g.Log(grohl.Data{"at": "start"})
 
+	c.l.logStreamMtx.Lock()
+	for _, s := range c.l.logStreams[c.job.ID] {
+		s.Close()
+	}
+	delete(c.l.logStreams, c.job.ID)
+	c.l.logStreamMtx.Unlock()
+
 	c.unbindMounts()
 	if err := c.l.pinkerton.Cleanup(c.job.ID); err != nil {
 		g.Log(grohl.Data{"at": "pinkerton", "status": "error", "err": err})


### PR DESCRIPTION
Before this patch, each job leaked the three fds used for log streams plus one for the app log file. After this patch, no fds are leaked after a job is cleaned up (verified with `lsof`).

Refs #1556
Closes #2178