### PR TITLE
controller: Add "pending" job state

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -17,10 +17,11 @@ List flynn jobs.
 Example:
 
 	$ flynn ps
-	ID                                      TYPE  RELEASE
-	flynn-bb97c7dac2fa455dad73459056fabac2  web   b69d7fb5308a4684a09b160b82d267ec
-	flynn-c59e02b3e6ad49809424848809d4749a  web   b69d7fb5308a4684a09b160b82d267ec
-	flynn-46f0d715a9684e4c822e248e84a5a418  web   b69d7fb5308a4684a09b160b82d267ec
+	ID                                         TYPE  STATE    RELEASE
+	318810fb-4679-419b-aed4-b0838c71c0eb       web   pending  d2ab4264-a647-4dc2-ac8d-d5821a475962
+	5bc89fe1-d4b5-4021-a337-10dd2b391358       web   pending  d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-93612073-f06e-41d9-bdae-df3e45f8a11d  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-53dba8f4-561b-460b-b75b-677e8b6660fb  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
 `)
 }
 
@@ -34,15 +35,19 @@ func runPs(args *docopt.Args, client *controller.Client) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	listRec(w, "ID", "TYPE", "RELEASE")
+	listRec(w, "ID", "TYPE", "STATE", "RELEASE")
 	for _, j := range jobs {
 		if j.Type == "" {
 			j.Type = "run"
 		}
-		if j.State != ct.JobStateUp {
+		if j.State != ct.JobStateUp && j.State != ct.JobStatePending {
 			continue
 		}
-		listRec(w, j.ID, j.Type, j.ReleaseID)
+		id := j.ID
+		if id == "" {
+			id = j.UUID
+		}
+		listRec(w, id, j.Type, j.State, j.ReleaseID)
 	}
 
 	return nil

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -10,9 +10,12 @@ import (
 
 func init() {
 	register("ps", runPs, `
-usage: flynn ps
+usage: flynn ps [-a]
 
 List flynn jobs.
+
+Options:
+  -a, --all      Show all jobs (default is running and pending)
 
 Example:
 
@@ -22,6 +25,19 @@ Example:
 	5bc89fe1-d4b5-4021-a337-10dd2b391358       web   pending  d2ab4264-a647-4dc2-ac8d-d5821a475962
 	host-93612073-f06e-41d9-bdae-df3e45f8a11d  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
 	host-53dba8f4-561b-460b-b75b-677e8b6660fb  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
+
+	$ flynn ps --all
+	ID                                         TYPE  STATE    RELEASE
+	318810fb-4679-419b-aed4-b0838c71c0eb       web   pending  d2ab4264-a647-4dc2-ac8d-d5821a475962
+	5bc89fe1-d4b5-4021-a337-10dd2b391358       web   pending  d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-93612073-f06e-41d9-bdae-df3e45f8a11d  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-53dba8f4-561b-460b-b75b-677e8b6660fb  web   up       d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-0f0472ad-272d-4bf3-a873-bc542cf16e31  web   down     d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-12657e64-adb9-4121-904f-4896231f3bc4  web   down     d2ab4264-a647-4dc2-ac8d-d5821a475962
+	host-c7f5d522-974d-4be1-8103-49f7eb309cb5  web   down     1a675dd8-9c44-468b-bef0-b3f8a25f5bdc
+	host-380c5ea6-d503-454e-a2a4-6b20dc9f4b81  web   down     1a675dd8-9c44-468b-bef0-b3f8a25f5bdc
+	host-cb4fed31-d84d-45d9-a566-c18907101f6f  web   down     1a675dd8-9c44-468b-bef0-b3f8a25f5bdc
+	host-9af9b2a9-1c53-4616-985a-e81da943fb95  web   down     1a675dd8-9c44-468b-bef0-b3f8a25f5bdc
 `)
 }
 
@@ -40,7 +56,7 @@ func runPs(args *docopt.Args, client *controller.Client) error {
 		if j.Type == "" {
 			j.Type = "run"
 		}
-		if j.State != ct.JobStateUp && j.State != ct.JobStatePending {
+		if !args.Bool["--all"] && j.State != ct.JobStateUp && j.State != ct.JobStatePending {
 			continue
 		}
 		id := j.ID

--- a/cli/scale.go
+++ b/cli/scale.go
@@ -147,8 +147,12 @@ func runScale(args *docopt.Args, client *controller.Client) error {
 	}
 
 	start := time.Now()
-	err = watcher.WaitFor(expected, scaleTimeout, func(e *ct.Job) error {
-		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), e.Type, e.ID, e.State)
+	err = watcher.WaitFor(expected, scaleTimeout, func(job *ct.Job) error {
+		id := job.ID
+		if id == "" {
+			id = job.UUID
+		}
+		fmt.Printf("%s ==> %s %s %s\n", time.Now().Format("15:04:05.000"), job.Type, id, job.State)
 		return nil
 	})
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -327,10 +327,10 @@ func (c *Client) PutFormation(formation *ct.Formation) error {
 
 // PutJob updates an existing job.
 func (c *Client) PutJob(job *ct.Job) error {
-	if job.ID == "" || job.AppID == "" {
-		return errors.New("controller: missing job id and/or app id")
+	if job.UUID == "" || job.AppID == "" {
+		return errors.New("controller: missing job uuid and/or app id")
 	}
-	return c.Put(fmt.Sprintf("/apps/%s/jobs/%s", job.AppID, job.ID), job, job)
+	return c.Put(fmt.Sprintf("/apps/%s/jobs/%s", job.AppID, job.UUID), job, job)
 }
 
 // DeleteJob kills a specific job id under the specified app.

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -730,6 +730,12 @@ func (c *Client) JobList(appID string) ([]*ct.Job, error) {
 	return jobs, c.Get(fmt.Sprintf("/apps/%s/jobs", appID), &jobs)
 }
 
+// JobListActive returns a list of all active jobs.
+func (c *Client) JobListActive() ([]*ct.Job, error) {
+	var jobs []*ct.Job
+	return jobs, c.Get("/active-jobs", &jobs)
+}
+
 // AppList returns a list of all apps.
 func (c *Client) AppList() ([]*ct.App, error) {
 	var apps []*ct.App

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -267,6 +267,7 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.PUT("/apps/:apps_id/jobs/:jobs_id", httphelper.WrapHandler(api.appLookup(api.PutJob)))
 	httpRouter.GET("/apps/:apps_id/jobs", httphelper.WrapHandler(api.appLookup(api.ListJobs)))
 	httpRouter.DELETE("/apps/:apps_id/jobs/:jobs_id", httphelper.WrapHandler(api.appLookup(api.KillJob)))
+	httpRouter.GET("/active-jobs", httphelper.WrapHandler(api.ListActiveJobs))
 
 	httpRouter.POST("/apps/:apps_id/deploy", httphelper.WrapHandler(api.appLookup(api.CreateDeployment)))
 	httpRouter.GET("/apps/:apps_id/deployments", httphelper.WrapHandler(api.appLookup(api.ListDeployments)))

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	cc "github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/random"
 )
 
 func (s *S) TestEvents(c *C) {
@@ -15,16 +16,16 @@ func (s *S) TestEvents(c *C) {
 	app2 := s.createTestApp(c, &ct.App{Name: "app2"})
 	release := s.createTestRelease(c, &ct.Release{})
 
-	jobID1 := "host-job1"
-	jobID2 := "host-job2"
-	jobID3 := "host-job3"
+	jobID1 := random.UUID()
+	jobID2 := random.UUID()
+	jobID3 := random.UUID()
 	jobs := []*ct.Job{
-		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
-		{ID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
-		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
-		{ID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
-		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
-		{ID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
+		{UUID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{UUID: jobID1, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
+		{UUID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{UUID: jobID2, AppID: app1.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
+		{UUID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting},
+		{UUID: jobID3, AppID: app2.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateUp},
 	}
 
 	listener := newEventListener(&EventRepo{db: s.hc.db})

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -385,7 +385,7 @@ func (e *generator) runJob() {
 	}
 	job, err := e.client.RunJobDetached(e.resourceIds["app"], new_job)
 	if err == nil {
-		e.resourceIds["job"] = job.ID
+		e.resourceIds["job"] = job.UUID
 	}
 }
 
@@ -395,7 +395,7 @@ func (e *generator) listJobs() {
 
 func (e *generator) updateJob() {
 	job := &ct.Job{
-		ID:        e.resourceIds["job"],
+		UUID:      e.resourceIds["job"],
 		AppID:     e.resourceIds["app"],
 		ReleaseID: e.resourceIds["release"],
 		State:     "down",

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -49,28 +49,6 @@ func (s *S) TestJobGet(c *C) {
 	c.Assert(job.Meta, DeepEquals, map[string]string{"some": "info"})
 }
 
-func (s *S) TestJobStateTransition(c *C) {
-	app := s.createTestApp(c, &ct.App{Name: "job-state-transition"})
-	release := s.createTestRelease(c, &ct.Release{})
-	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	job := s.createTestJob(c, &ct.Job{ID: "host0-job2", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting})
-
-	job.State = ct.JobStateUp
-	c.Assert(s.c.PutJob(job), IsNil)
-
-	// duplicates are ignored
-	c.Assert(s.c.PutJob(job), IsNil)
-
-	job.State = ct.JobStateStarting
-	c.Assert(s.c.PutJob(job), ErrorMatches, ".*invalid job state transition.*")
-
-	job.State = ct.JobStateDown
-	c.Assert(s.c.PutJob(job), IsNil)
-
-	job.State = ct.JobStateUp
-	c.Assert(s.c.PutJob(job), ErrorMatches, ".*invalid job state transition.*")
-}
-
 func newFakeLog(r io.Reader) *fakeLog {
 	return &fakeLog{r}
 }

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
-	controller "github.com/flynn/flynn/controller/client"
 	tu "github.com/flynn/flynn/controller/testutils"
 	ct "github.com/flynn/flynn/controller/types"
 	host "github.com/flynn/flynn/host/types"
@@ -23,13 +22,14 @@ func (s *S) TestJobList(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-list"})
 	release := s.createTestRelease(c, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	s.createTestJob(c, &ct.Job{ID: "host0-job0", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}})
+	id := random.UUID()
+	s.createTestJob(c, &ct.Job{UUID: id, AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}})
 
 	list, err := s.c.JobList(app.ID)
 	c.Assert(err, IsNil)
 	c.Assert(len(list), Equals, 1)
 	job := list[0]
-	c.Assert(job.ID, Equals, "host0-job0")
+	c.Assert(job.UUID, Equals, id)
 	c.Assert(job.AppID, Equals, app.ID)
 	c.Assert(job.ReleaseID, Equals, release.ID)
 	c.Assert(job.Meta, DeepEquals, map[string]string{"some": "info"})
@@ -39,14 +39,31 @@ func (s *S) TestJobGet(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-get"})
 	release := s.createTestRelease(c, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
-	jobID := s.createTestJob(c, &ct.Job{ID: "host0-job1", AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}}).ID
+	uuid := random.UUID()
+	hostID := "host0"
+	jobID := cluster.GenerateJobID(hostID, uuid)
+	s.createTestJob(c, &ct.Job{
+		ID:        jobID,
+		UUID:      uuid,
+		HostID:    hostID,
+		AppID:     app.ID,
+		ReleaseID: release.ID,
+		Type:      "web",
+		State:     ct.JobStateStarting,
+		Meta:      map[string]string{"some": "info"},
+	})
 
-	job, err := s.c.GetJob(app.ID, jobID)
-	c.Assert(err, IsNil)
-	c.Assert(job.ID, Equals, "host0-job1")
-	c.Assert(job.AppID, Equals, app.ID)
-	c.Assert(job.ReleaseID, Equals, release.ID)
-	c.Assert(job.Meta, DeepEquals, map[string]string{"some": "info"})
+	// test getting the job with both the job ID and the UUID
+	for _, id := range []string{jobID, uuid} {
+		job, err := s.c.GetJob(app.ID, id)
+		c.Assert(err, IsNil)
+		c.Assert(job.ID, Equals, jobID)
+		c.Assert(job.UUID, Equals, uuid)
+		c.Assert(job.HostID, Equals, hostID)
+		c.Assert(job.AppID, Equals, app.ID)
+		c.Assert(job.ReleaseID, Equals, release.ID)
+		c.Assert(job.Meta, DeepEquals, map[string]string{"some": "info"})
+	}
 }
 
 func newFakeLog(r io.Reader) *fakeLog {
@@ -68,13 +85,26 @@ func (l *fakeLog) Write([]byte) (int, error) {
 
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
+	release := s.createTestRelease(c, &ct.Release{})
 	hostID := fakeHostID()
-	jobID := cluster.GenerateJobID(hostID, "")
+	uuid := random.UUID()
+	jobID := cluster.GenerateJobID(hostID, uuid)
+	s.createTestJob(c, &ct.Job{
+		ID:        jobID,
+		UUID:      uuid,
+		HostID:    hostID,
+		AppID:     app.ID,
+		ReleaseID: release.ID,
+		Type:      "web",
+		State:     ct.JobStateStarting,
+		Meta:      map[string]string{"some": "info"},
+	})
 	hc := tu.NewFakeHostClient(hostID)
+	hc.AddJob(&host.Job{ID: jobID})
 	s.cc.AddHost(hc)
 
 	err := s.c.DeleteJob(app.ID, jobID)
-	c.Assert(err, Equals, controller.ErrNotFound)
+	c.Assert(err, IsNil)
 	c.Assert(hc.IsStopped(jobID), Equals, true)
 }
 

--- a/controller/migrate_test.go
+++ b/controller/migrate_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/random"
+
+	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+type MigrateSuite struct{}
+
+var _ = Suite(&MigrateSuite{})
+
+// TestMigrateJobStates checks that migrating to ID 9 does not break existing
+// job records
+func (MigrateSuite) TestMigrateJobStates(c *C) {
+	db := setupTestDB(c, "controller_migrate_test")
+
+	currID := 0
+	migrateTo := func(id int) {
+		c.Assert((*migrations)[currID:id].Migrate(db), IsNil)
+		currID = id
+	}
+
+	// start from ID 7
+	migrateTo(7)
+
+	// insert a job
+	hostID := "host1"
+	uuid := random.UUID()
+	jobID := cluster.GenerateJobID(hostID, uuid)
+	appID := random.UUID()
+	releaseID := random.UUID()
+	c.Assert(db.Exec(`INSERT INTO apps (app_id, name) VALUES ($1, $2)`, appID, "migrate-app"), IsNil)
+	c.Assert(db.Exec(`INSERT INTO releases (release_id) VALUES ($1)`, releaseID), IsNil)
+	c.Assert(db.Exec(`INSERT INTO job_cache (job_id, app_id, release_id, state) VALUES ($1, $2, $3, $4)`, jobID, appID, releaseID, "up"), IsNil)
+
+	// migrate to 8 and check job states are still constrained
+	migrateTo(8)
+	err := db.Exec(`UPDATE job_cache SET state = 'foo' WHERE job_id = $1`, jobID)
+	c.Assert(err, NotNil)
+	if !postgres.IsPostgresCode(err, postgres.ForeignKeyViolation) {
+		c.Fatalf("expected postgres foreign key violation, got %s", err)
+	}
+
+	// migrate to 9 and check job IDs are correct, pending state is valid
+	migrateTo(9)
+	var clusterID, dbUUID, dbHostID string
+	c.Assert(db.QueryRow("SELECT cluster_id, job_id, host_id FROM job_cache WHERE cluster_id = $1", jobID).Scan(&clusterID, &dbUUID, &dbHostID), IsNil)
+	c.Assert(clusterID, Equals, jobID)
+	c.Assert(dbUUID, Equals, uuid)
+	c.Assert(dbHostID, Equals, hostID)
+	c.Assert(db.Exec(`UPDATE job_cache SET state = 'pending' WHERE job_id = $1`, uuid), IsNil)
+}

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -6,7 +6,6 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
-	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/typeconv"
 )
 
@@ -135,7 +134,9 @@ func (j *Job) IsInFormation(key utils.FormationKey) bool {
 
 func (j *Job) ControllerJob() *ct.Job {
 	job := &ct.Job{
-		ID:        cluster.GenerateJobID(j.HostID, j.ID),
+		ID:        j.JobID,
+		UUID:      j.ID,
+		HostID:    j.HostID,
 		AppID:     j.AppID,
 		ReleaseID: j.ReleaseID,
 		Type:      j.Type,

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -602,6 +602,10 @@ func (s *Scheduler) HandleLeaderChange(isLeader bool) {
 	s.isLeader = isLeader
 	if isLeader {
 		log.Info("handling leader promotion")
+		// ensure we are in sync and then rectify
+		s.SyncHosts()
+		s.SyncFormations()
+		s.SyncJobs()
 		s.rectifyAll()
 	} else {
 		log.Info("handling leader demotion")

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -540,7 +540,7 @@ func (TestSuite) TestStopJob(c *C) {
 		{
 			desc: "one running and one scheduled, stops scheduled job",
 			jobs: Jobs{
-				"job1": &Job{ID: "job1", Formation: formation, Type: "web", state: JobStateScheduled, startedAt: recent.Add(-5 * time.Minute), restartTimer: time.NewTimer(0)},
+				"job1": &Job{ID: "job1", Formation: formation, Type: "web", state: JobStatePending, startedAt: recent.Add(-5 * time.Minute), restartTimer: time.NewTimer(0)},
 				"job2": &Job{ID: "job2", Formation: formation, Type: "web", state: JobStateRunning, startedAt: recent},
 			},
 			shouldStop: "job1",
@@ -549,7 +549,7 @@ func (TestSuite) TestStopJob(c *C) {
 		{
 			desc: "one running and one new, stops new job",
 			jobs: Jobs{
-				"job1": &Job{ID: "job1", Formation: formation, Type: "web", state: JobStateNew, startedAt: recent.Add(-5 * time.Minute)},
+				"job1": &Job{ID: "job1", Formation: formation, Type: "web", state: JobStatePending, startedAt: recent.Add(-5 * time.Minute)},
 				"job2": &Job{ID: "job2", Formation: formation, Type: "web", state: JobStateRunning, startedAt: recent},
 			},
 			shouldStop: "job1",

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -217,5 +217,13 @@ $$ LANGUAGE plpgsql`,
 		`ALTER TABLE job_cache ADD COLUMN exit_status integer`,
 		`ALTER TABLE job_cache ADD COLUMN host_error text`,
 	)
+	m.Add(8,
+		`CREATE TABLE job_states (name text PRIMARY KEY)`,
+		`INSERT INTO job_states (name) VALUES ('starting'), ('up'), ('down'), ('crashed'), ('failed')`,
+		`ALTER TABLE job_cache ALTER COLUMN state TYPE text`,
+		`ALTER TABLE job_cache ADD CONSTRAINT job_state_fkey FOREIGN KEY (state) REFERENCES job_states (name)`,
+		`DROP TRIGGER job_state_trigger ON job_cache`,
+		`DROP TYPE job_state`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -229,6 +229,12 @@ $$ LANGUAGE plpgsql`,
 		`INSERT INTO job_states (name) VALUES ('pending')`,
 		`ALTER TABLE job_cache ADD COLUMN run_at timestamptz`,
 		`ALTER TABLE job_cache ADD COLUMN restarts integer`,
+		`ALTER TABLE job_cache RENAME COLUMN job_id TO cluster_id`,
+		`ALTER TABLE job_cache ALTER COLUMN cluster_id TYPE text`,
+		`ALTER TABLE job_cache DROP CONSTRAINT job_cache_pkey`,
+		`ALTER TABLE job_cache ADD COLUMN job_id uuid PRIMARY KEY DEFAULT uuid_generate_v4()`,
+		`ALTER TABLE job_cache ADD COLUMN host_id text`,
+		`UPDATE job_cache SET host_id = s.split[1], job_id = s.split[2]::uuid FROM (SELECT cluster_id, regexp_matches(cluster_id, '([^-]+)-(.*)') AS split FROM job_cache) AS s WHERE job_cache.cluster_id = s.cluster_id`,
 	)
 	return m.Migrate(db)
 }

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -225,5 +225,10 @@ $$ LANGUAGE plpgsql`,
 		`DROP TRIGGER job_state_trigger ON job_cache`,
 		`DROP TYPE job_state`,
 	)
+	m.Add(9,
+		`INSERT INTO job_states (name) VALUES ('pending')`,
+		`ALTER TABLE job_cache ADD COLUMN run_at timestamptz`,
+		`ALTER TABLE job_cache ADD COLUMN restarts integer`,
+	)
 	return m.Migrate(db)
 }

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -228,16 +228,16 @@ WHERE app_id = $1 AND release_id = $2`
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
 WHERE app_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, created_at, updated_at
+SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
 	jobSelectQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, created_at, updated_at
+SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE job_id = $1`
 	jobInsertQuery = `
-INSERT INTO job_cache (job_id, app_id, release_id, process_type, state, meta, exit_status, host_error)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING created_at, updated_at`
+INSERT INTO job_cache (job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING created_at, updated_at`
 	jobUpdateQuery = `
-UPDATE job_cache SET state = $2, exit_status = $3, host_error = $4, updated_at = now()
+UPDATE job_cache SET state = $2, exit_status = $3, host_error = $4, run_at = $5, restarts = $6, updated_at = now()
 WHERE job_id = $1 RETURNING created_at, updated_at`
 	providerListQuery = `
 SELECT provider_id, name, url, created_at, updated_at

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -228,16 +228,16 @@ WHERE app_id = $1 AND release_id = $2`
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
 WHERE app_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
 	jobSelectQuery = `
-SELECT job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE job_id = $1`
 	jobInsertQuery = `
-INSERT INTO job_cache (job_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING created_at, updated_at`
+INSERT INTO job_cache (cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING created_at, updated_at`
 	jobUpdateQuery = `
-UPDATE job_cache SET state = $2, exit_status = $3, host_error = $4, run_at = $5, restarts = $6, updated_at = now()
+UPDATE job_cache SET cluster_id = $2, host_id = $3, state = $4, exit_status = $5, host_error = $6, run_at = $7, restarts = $8, updated_at = now()
 WHERE job_id = $1 RETURNING created_at, updated_at`
 	providerListQuery = `
 SELECT provider_id, name, url, created_at, updated_at

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -46,6 +46,7 @@ var preparedStatements = map[string]string{
 	"formation_delete":                      formationDeleteQuery,
 	"formation_delete_by_app":               formationDeleteByAppQuery,
 	"job_list":                              jobListQuery,
+	"job_list_active":                       jobListActiveQuery,
 	"job_select":                            jobSelectQuery,
 	"job_insert":                            jobInsertQuery,
 	"job_update":                            jobUpdateQuery,
@@ -230,6 +231,9 @@ WHERE app_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
 SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
+	jobListActiveQuery = `
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+FROM job_cache WHERE state = 'starting' OR state = 'up' ORDER BY updated_at DESC`
 	jobSelectQuery = `
 SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE job_id = $1`

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -190,6 +190,16 @@ func (c *FakeControllerClient) PutJob(job *ct.Job) error {
 	return nil
 }
 
+func (c *FakeControllerClient) JobListActive() ([]*ct.Job, error) {
+	list := make([]*ct.Job, 0, len(c.jobs))
+	for _, job := range c.jobs {
+		if job.State == ct.JobStateStarting || job.State == ct.JobStateUp {
+			list = append(list, job)
+		}
+	}
+	return list, nil
+}
+
 func NewRelease(id string, artifact *ct.Artifact, processes map[string]int) *ct.Release {
 	return NewReleaseOmni(id, artifact, processes, false)
 }

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -98,6 +98,8 @@ type Job struct {
 	Meta       map[string]string `json:"meta,omitempty"`
 	ExitStatus *int32            `json:"exit_status,omitempty"`
 	HostError  *string           `json:"host_error,omitempty"`
+	RunAt      *time.Time        `json:"run_at,omitempty"`
+	Restarts   *int32            `json:"restarts,omitempty"`
 	CreatedAt  *time.Time        `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time        `json:"updated_at,omitempty"`
 }
@@ -105,6 +107,7 @@ type Job struct {
 type JobState string
 
 const (
+	JobStatePending  JobState = "pending"
 	JobStateStarting JobState = "starting"
 	JobStateUp       JobState = "up"
 	JobStateStopping JobState = "stopping"

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -89,7 +89,18 @@ type Key struct {
 }
 
 type Job struct {
-	ID         string            `json:"id,omitempty"`
+	// ID is the job's full cluster ID (i.e. hostID-UUID) and can be empty
+	// if the job is pending
+	ID string `json:"id,omitempty"`
+
+	// UUID is the uuid part of the job's full cluster ID and is the
+	// primary key field in the database (so it is always set)
+	UUID string `json:"uuid"`
+
+	// HostID is the host ID part of the job's full cluster ID and can be
+	// empty if the job is pending
+	HostID string `json:"host_id,omitempty"`
+
 	AppID      string            `json:"app,omitempty"`
 	ReleaseID  string            `json:"release,omitempty"`
 	Type       string            `json:"type,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -168,6 +168,7 @@ type ControllerClient interface {
 	AppList() ([]*ct.App, error)
 	FormationListActive() ([]*ct.ExpandedFormation, error)
 	PutJob(*ct.Job) error
+	JobListActive() ([]*ct.Job, error)
 }
 
 func ClusterClientWrapper(c *cluster.Client) clusterClientWrapper {

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -190,6 +190,11 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 	actual := make(ct.JobEvents)
 
 	handleEvent := func(jobID, typ string, state ct.JobState) {
+		// ignore pending events
+		if state == ct.JobStatePending {
+			return
+		}
+
 		// don't send duplicate events
 		if _, ok := d.knownJobStates[jobIDState{jobID, state}]; ok {
 			return

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -19,6 +19,7 @@ const (
 	CheckViolation            = "23514"
 	UniqueViolation           = "23505"
 	RaiseException            = "P0001"
+	ForeignKeyViolation       = "23503"
 )
 
 type Conf struct {

--- a/pkg/testutils/postgres/utils.go
+++ b/pkg/testutils/postgres/utils.go
@@ -8,11 +8,6 @@ import (
 )
 
 func SetupPostgres(dbname string) error {
-	if os.Getenv("PGDATABASE") != "" {
-		dbname = os.Getenv("PGDATABASE")
-	} else {
-		os.Setenv("PGDATABASE", dbname)
-	}
 	if os.Getenv("PGSSLMODE") == "" {
 		os.Setenv("PGSSLMODE", "disable")
 	}

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -1,6 +1,9 @@
 package typeconv
 
-func IntPtr(i int) *int          { return &i }
-func Int32Ptr(i int32) *int32    { return &i }
-func Int64Ptr(i int64) *int64    { return &i }
-func StringPtr(s string) *string { return &s }
+import "time"
+
+func IntPtr(i int) *int              { return &i }
+func Int32Ptr(i int32) *int32        { return &i }
+func Int64Ptr(i int64) *int64        { return &i }
+func StringPtr(s string) *string     { return &s }
+func TimePtr(t time.Time) *time.Time { return &t }

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -28,7 +28,7 @@
     },
     "state": {
       "type": "string",
-      "enum": ["starting", "up", "down", "crashed", "failed"]
+      "enum": ["pending", "starting", "up", "down", "crashed", "failed"]
     },
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"
@@ -43,6 +43,15 @@
     "host_error": {
       "type": "string",
       "description": "host error if job failed to start"
+    },
+    "run_at": {
+      "type": "string",
+      "description": "time a pending job will be started",
+      "format": "date-time"
+    },
+    "restarts": {
+      "type": "integer",
+      "description": "number of times this job has been restarted"
     },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -14,7 +14,15 @@
   "additionalProperties": false,
   "properties": {
     "id": {
+      "type": "string",
+      "description": "the job's cluster ID"
+    },
+    "uuid": {
       "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "host_id": {
+      "type": "string",
+      "description": "the ID of the host the job is running on"
     },
     "app": {
       "$ref": "/schema/controller/common#/definitions/id"

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -137,7 +137,11 @@ func (s *CLISuite) TestScale(t *c.C) {
 		}
 		t.Assert(app.watcher.WaitFor(events, scaleTimeout, f), c.IsNil)
 		for _, e := range actual {
-			t.Assert(scale, OutputContains, fmt.Sprintf("==> %s %s %s", e.Type, e.ID, e.State))
+			id := e.ID
+			if id == "" {
+				id = e.UUID
+			}
+			t.Assert(scale, OutputContains, fmt.Sprintf("==> %s %s %s", e.Type, id, e.State))
 		}
 	}
 


### PR DESCRIPTION
Pending jobs are ones which are scheduled to start in the future (either they have been created in-memory by the scheduler and a host is being picked to place the job on, or it is a scheduled restart of a crashed job).

Since pending jobs do not have a host ID, I have migrated the database so the primary key for jobs is the UUID part of the job ID, and the UUID is shown by the CLI whenever the job ID is not set (e.g. `flynn ps` showing pending jobs).

I have also changed the schedulers so that only the leader persists job state to the database, meaning we can drop the state transition validation and use a table rather than an enum.