### PR TITLE
router: Handle route deletions missed on reconnect

### DIFF
--- a/router/setup_test.go
+++ b/router/setup_test.go
@@ -70,19 +70,15 @@ type S struct {
 
 var _ = Suite(&S{})
 
+const dbname = "routertest"
+
 func (s *S) SetUpSuite(c *C) {
 	s.discoverd, s.cleanup = setup(c)
 
-	dbname := "routertest"
 	if err := pgtestutils.SetupPostgres(dbname); err != nil {
 		c.Fatal(err)
 	}
-	pgxpool, err := pgx.NewConnPool(pgx.ConnPoolConfig{
-		ConnConfig: pgx.ConnConfig{
-			Host:     os.Getenv("PGHOST"),
-			Database: dbname,
-		},
-	})
+	pgxpool, err := pgx.NewConnPool(newPgxConnPoolConfig())
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -93,6 +89,15 @@ func (s *S) SetUpSuite(c *C) {
 	}
 	s.pgx = db.ConnPool
 	s.pgx.Exec(sqlCreateTruncateTables)
+}
+
+func newPgxConnPoolConfig() pgx.ConnPoolConfig {
+	return pgx.ConnPoolConfig{
+		ConnConfig: pgx.ConnConfig{
+			Host:     os.Getenv("PGHOST"),
+			Database: dbname,
+		},
+	}
 }
 
 func (s *S) TearDownSuite(c *C) {

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -188,6 +188,16 @@ type tcpSyncHandler struct {
 	l *TCPListener
 }
 
+func (h *tcpSyncHandler) Current() map[string]struct{} {
+	h.l.mtx.RLock()
+	defer h.l.mtx.RUnlock()
+	ids := make(map[string]struct{}, len(h.l.routes))
+	for id := range h.l.routes {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
 func (h *tcpSyncHandler) Set(data *router.Route) error {
 	route := data.TCPRoute()
 	r := &tcpRoute{


### PR DESCRIPTION
This tracks which routes were removed while the sync is disconnected and removes them on reconnect.
Right now on reconnect we still fetch the entire route table from the database.

Closes #1002