### PR TITLE
script: Support booting clusters using released versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ demo/*.log
 util/_toolchain/**
 *.swp
 *.test
+/tmp

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -20,6 +20,7 @@ OPTIONS:
   -s, --size=SIZE          Cluster size [default: 1]
   -d, --domain=DOMAIN      The default domain to use [default: `dev.localflynn.com`]
   -z, --no-destroy-vols    Don't destroy volumes
+  -v, --version=VERSION    Boot using the released VERSION (e.g. v20151104.1)
 USAGE
 }
 
@@ -27,6 +28,7 @@ main() {
   local size="1"
   local domain="${CLUSTER_DOMAIN:="dev.localflynn.com"}"
   local destroy_vols=true
+  local version=""
 
   while true; do
     case "$1" in
@@ -54,6 +56,14 @@ main() {
         destroy_vols=false
         shift
         ;;
+      -v | --version)
+        if [[ -z "$2" ]]; then
+          usage
+          exit 1
+        fi
+        version="$2"
+        shift 2
+        ;;
       *)
         break
         ;;
@@ -65,12 +75,23 @@ main() {
     exit 1
   fi
 
+  local bin_dir="${ROOT}/host/bin"
+  local flynn_host="${bin_dir}/flynn-host"
+  local manifest="${ROOT}/bootstrap/bin/manifest.json"
+
+  if [[ -n "${version}" ]]; then
+    local dir="${ROOT}/tmp/${version}"
+    mkdir -p "${dir}"
+
+    info "downloading ${version} into ${dir}"
+    sudo FLYNN_VERSION="${version}" "${flynn_host}" download --config-dir "${dir}" --bin-dir "${dir}"
+    flynn_host="${dir}/flynn-host"
+    bin_dir="${dir}"
+    manifest="${dir}/bootstrap-manifest.json"
+  fi
 
   # kill flynn first
   "${ROOT}/script/kill-flynn"
-
-  local host_dir="${ROOT}/host"
-  local bootstrap_dir="${ROOT}/bootstrap"
 
   local ips=()
   if [[ "${size}" -eq "1" ]]; then
@@ -98,11 +119,11 @@ main() {
   info "bootstrapping Flynn"
   export CLUSTER_DOMAIN="${domain}"
   export DISCOVERD="${ips[0]}:1111"
-  "${host_dir}/bin/flynn-host" \
+  "${flynn_host}" \
     bootstrap \
     --min-hosts="${size}" \
     --peer-ips="$(join "," ${ips[@]})" \
-    "${bootstrap_dir}/bin/manifest.json"
+    "${manifest}"
 }
 
 start_flynn_host() {
@@ -133,7 +154,7 @@ start_flynn_host() {
   sudo rm -f "${state}"
 
   if $destroy_vols; then
-    sudo "${ROOT}/host/bin/flynn-host" destroy-volumes --volpath="${vol_path}" --include-data
+    sudo "${flynn_host}" destroy-volumes --volpath="${vol_path}" --include-data
   fi
 
   # ensure log dir exists
@@ -144,7 +165,7 @@ start_flynn_host() {
     --background \
     --no-close \
     --pidfile "${pidfile}" \
-    --exec "${host_dir}/bin/flynn-host" \
+    --exec "${flynn_host}" \
     -- \
     daemon \
     --id "${id}" \
@@ -155,8 +176,8 @@ start_flynn_host() {
     --state "${state}" \
     --volpath "${vol_path}" \
     --log-dir "${log_dir}" \
-    --flynn-init "${host_dir}/bin/flynn-init" \
-    --nsumount "${host_dir}/bin/flynn-nsumount" \
+    --flynn-init "${bin_dir}/flynn-init" \
+    --nsumount "${bin_dir}/flynn-nsumount" \
     &>"${log}"
 
   ips+=("${external_ip}")

--- a/script/kill-flynn
+++ b/script/kill-flynn
@@ -9,15 +9,15 @@ usage() {
   cat <<USAGE >&2
 usage: $0 [options]
 
-Kill running flynn-host daemons
+Kill running flynn-host daemons.
 
 OPTIONS:
-  -h            Show this message
+  -h, --help            Show this message
 USAGE
 }
 
 main() {
-  if [[ $1 = "-h" ]]; then
+  if [[ $1 = "-h" ]] || [[ $1 = "--help" ]]; then
     usage
     exit 0
   fi
@@ -27,14 +27,12 @@ main() {
     exit 1
   fi
 
-  local flynn_host="${ROOT}/host/bin/flynn-host"
-
-  info "killing running libvirt-lxc flynn-host, if any"
+  info "killing running flynn-host, if any"
   sudo start-stop-daemon \
     --stop \
     --oknodo \
     --retry 15 \
-    --exec "${flynn_host}"
+    --name "flynn-host"
 
   # force kill any remaining containers
   virsh -c lxc:/// list --name | xargs -L 1 virsh -c lxc:/// destroy || true

--- a/script/update
+++ b/script/update
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/ui.sh"
+
+usage() {
+  cat <<USAGE >&2
+usage: $0 [options] APP
+
+Update a Flynn system app.
+
+OPTIONS:
+  -h, --help               Show this message
+USAGE
+}
+
+main() {
+  if [[ $1 = "-h" ]] || [[ $1 = "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  local app=$1
+
+  local config="$(mktemp)"
+  trap "rm -f ${config}" EXIT
+
+  local image_name="flynn/${app}"
+  local image_id="$(jq -r ".\"${image_name}\"" "${ROOT}/version.json")"
+  if [[ -z "${image_id}" ]]; then
+    fail "could not determine ID for image ${image_name} in version.json"
+  fi
+
+  alias flynn="${ROOT}/cli/bin/flynn"
+  flynn -a "${app}" release show --json | jq -r 'del(.id)' > "${config}"
+  flynn -a "${app}" release add --file "${config}" "https://dl.flynn.io/tuf?name=${image_name}&id=${image_id}"
+}
+
+main $@


### PR DESCRIPTION
This adds a `--version` argument to `script/bootstrap-flynn` so you can boot a released version of Flynn:

```
$ script/bootstrap-flynn --version v20151104.1
===> 00:20:49.408 downloading v20151104.1 into /home/ubuntu/go/src/github.com/flynn/flynn/tmp/v20151104.1
INFO[12-16|00:20:49] initializing TUF client 
INFO[12-16|00:20:50] downloading components with version v20151104.1 
INFO[12-16|00:20:50] downloading images 
flynn/router image 8c39bc6460719e982ec9d43a2f274c0f3fc8255661bcd6eee8343cb1217ab894 exists
flynn/slugbuilder image 9f0e2d019b848ab6cf2d9f82a5c8fc5b0a5ad323305f41bd30d1068e9be1ae3c exists
flynn/slugrunner image 0d5e9340854252b197f3ffcf24879fe25884bc103e3d0192441fe37b8b97c431 exists
flynn/flannel image f855ca6aabc6dcd7529d9547d92d338e723292198b333d0145e0956c0740dc98 exists
flynn/postgresql image 66ae63030fc631c8287a7f29c8db21b3c5f67ad731d801bf82f62aa4133e88cb exists
flynn/gitreceive image f3e0d4602d2c144e7f8521dc9cd37d11560935320207feea814efcde98300a0d exists
flynn/dashboard image 8bfa3633add18c6228d57010cef81f92938a222f0172069a33ce0d04a07917e0 exists
flynn/logaggregator image 98d56452f8e8c58359d4eb2443b181c79703e5034cf5717a784edc14719b2685 exists
flynn/controller image e4118f25ad7f0908fa8805e47893ff4c4a12813fa3d29a6d0a05304f28d0beb7 exists
flynn/taffy image eedf52e1afb7141f147fee552b19019dcfbf38182957b2aba28756dfad8fa619 exists
flynn/status image 6b6f5821e49b73a6cc659e48d9a8afa7d8b8fc5a96526fc713c11e7cf295c716 exists
flynn/discoverd image 32da0beafea68a19a701d0485446459ba953ff259a3b99dfa577f1f1ab82a133 exists
flynn/blobstore image c583ef46844ec90361556b08e79c54bb20dd45ce17dfb76e4e492d12c4ea6fa9 exists
flynn/updater image 08ed88b190eac6746fa196d9a52d1e61b23642c848418e45f7e7f5057faad353 exists
INFO[12-16|00:20:50] downloading config to /home/ubuntu/go/src/github.com/flynn/flynn/tmp/v20151104.1 
INFO[12-16|00:20:50] downloading binaries to /home/ubuntu/go/src/github.com/flynn/flynn/tmp/v20151104.1 
INFO[12-16|00:21:02] download complete 
===> 00:21:02.460 killing running flynn-host, if any
error: command 'destroy' requires <domain> option
===> 00:21:12.893 done!
===> 00:21:12.894 starting single node cluster
...
```

I've also added `script/update` which will create a release with the latest image from `version.json` for an app.

This means you can boot a stable version of Flynn and then test what happens when you release an app from code you have changed:

```
$ script/bootstrap-flynn --version "v20151104.1"
$ make
...
$ script/update controller
Created release 52585121-de13-4148-8116-ca5f5f7bcc27.
```