### PR TITLE
controller: Make Job.HostError a pointer

### DIFF
--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -138,6 +138,7 @@ func (j *Job) ControllerJob() *ct.Job {
 		ReleaseID: j.ReleaseID,
 		Type:      j.Type,
 		Meta:      utils.JobMetaFromMetadata(j.metadata),
+		HostError: j.hostError,
 	}
 
 	switch j.state {
@@ -151,9 +152,6 @@ func (j *Job) ControllerJob() *ct.Job {
 
 	if j.exitStatus != nil {
 		job.ExitStatus = typeconv.Int32Ptr(int32(*j.exitStatus))
-	}
-	if j.hostError != nil {
-		job.HostError = *j.hostError
 	}
 
 	return job

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -97,7 +97,7 @@ type Job struct {
 	Cmd        []string          `json:"cmd,omitempty"`
 	Meta       map[string]string `json:"meta,omitempty"`
 	ExitStatus *int32            `json:"exit_status,omitempty"`
-	HostError  string            `json:"host_error,omitempty"`
+	HostError  *string           `json:"host_error,omitempty"`
 	CreatedAt  *time.Time        `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time        `json:"updated_at,omitempty"`
 }

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -265,8 +265,8 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 				actual[event.Type] = make(map[ct.JobState]int)
 			}
 			handleEvent(event.ID, event.Type, event.State)
-			if event.HostError != "" {
-				return fmt.Errorf("deployer: %s job failed to start: %s", event.Type, event.HostError)
+			if event.HostError != nil {
+				return fmt.Errorf("deployer: %s job failed to start: %s", event.Type, *event.HostError)
 			}
 			if expected.Equals(actual) {
 				return nil


### PR DESCRIPTION
It can be NULL in the database, so fetching a NULL value into a string will result in a "Cannot decode NULL into type string" error.

This affects any users updating to the latest released version, so we need to release this soon.