### PR TITLE
controller: Migration listener

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -475,7 +475,8 @@
 		},
 		{
 			"ImportPath": "github.com/jackc/pgx",
-			"Rev": "8b296b9d5840d0624dd2f61c990b5304a5e6fcaa"
+			"Comment": "v2.7.1-16-g8577dcc",
+			"Rev": "8577dccd65312eecac353c96d908f8796d49f54c"
 		},
 		{
 			"ImportPath": "github.com/julienschmidt/httprouter",

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/batch_benchmark_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/batch_benchmark_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 func validateBatchBench(b *testing.B, db *TestDB) {

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/batch_example_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/batch_example_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 // Set this to see how the counts are actually updated.

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/batch_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/batch_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 // Ensure two functions can perform updates in a single batch.

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/bucket_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/bucket_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 // Ensure that a bucket that gets a non-existent key returns nil.

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/cursor_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/cursor_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 // Ensure that a cursor can return a reference to the bucket that created it.

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/db_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/db_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 var statsFlag = flag.Bool("stats", false, "show performance stats")

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/simulation_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/simulation_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 func TestSimulate_1op_1p(t *testing.T)     { testSimulate(t, 100, 1) }

--- a/Godeps/_workspace/src/github.com/boltdb/bolt/tx_test.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/tx_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/boltdb/bolt"
 )
 
 // Ensure that committing a closed transaction returns an error.

--- a/Godeps/_workspace/src/github.com/jackc/pgx/.travis.yml
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4
+  - 1.5
   - tip
 
 # Derived from https://github.com/lib/pq/blob/master/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - psql -U postgres -c "create user pgx_pw  SUPERUSER PASSWORD 'secret'"
 
 script:
-  - go test -v -race -cover ./...
+  - go test -v -race -cover -short ./...
 
 matrix:
   allow_failures:

--- a/Godeps/_workspace/src/github.com/jackc/pgx/CHANGELOG.md
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/CHANGELOG.md
@@ -1,5 +1,24 @@
-# Master
+# Tip
 
+* Add ConnPool.Reset method
+* []byte skips encoding/decoding
+* Rows.Scan errors now include which argument caused error
+
+# 2.7.1 (October 26, 2015)
+
+* Disable SSL renegotiation
+
+# 2.7.0 (October 16, 2015)
+
+* Add RuntimeParams to ConnConfig
+* ParseURI extracts RuntimeParams
+* ParseDSN extracts RuntimeParams
+* ParseEnvLibpq extracts PGAPPNAME
+* Prepare is now idempotent
+* Rows.Values now supports oid type
+* ConnPool.Release automatically unlistens connections (Joseph Glanville)
+* Add trace log level
+* Add more efficient log leveling
 * Retry automatically on ConnPool.Begin (Joseph Glanville)
 * Encode from net.IP to inet and cidr
 * Generalize encoding pointer to string to any PostgreSQL type

--- a/Godeps/_workspace/src/github.com/jackc/pgx/bench_test.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/bench_test.go
@@ -1,9 +1,11 @@
 package pgx_test
 
 import (
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
 	"testing"
 	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	log "github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 )
 
 func BenchmarkConnPool(b *testing.B) {
@@ -261,5 +263,151 @@ func BenchmarkPointerPointerWithPresentValues(b *testing.B) {
 		if record.lastLoginTime == nil || *record.lastLoginTime != time.Date(2015, 1, 1, 0, 0, 0, 0, time.Local) {
 			b.Fatalf("bad value for lastLoginTime: %v", record.lastLoginTime)
 		}
+	}
+}
+
+func BenchmarkSelectWithoutLogging(b *testing.B) {
+	conn := mustConnect(b, *defaultConnConfig)
+	defer closeConn(b, conn)
+
+	benchmarkSelectWithLog(b, conn)
+}
+
+func BenchmarkSelectWithLoggingTraceWithLog15(b *testing.B) {
+	connConfig := *defaultConnConfig
+
+	logger := log.New()
+	lvl, err := log.LvlFromString("debug")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logger.SetHandler(log.LvlFilterHandler(lvl, log.DiscardHandler()))
+	connConfig.Logger = logger
+	connConfig.LogLevel = pgx.LogLevelTrace
+	conn := mustConnect(b, connConfig)
+	defer closeConn(b, conn)
+
+	benchmarkSelectWithLog(b, conn)
+}
+
+func BenchmarkSelectWithLoggingDebugWithLog15(b *testing.B) {
+	connConfig := *defaultConnConfig
+
+	logger := log.New()
+	lvl, err := log.LvlFromString("debug")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logger.SetHandler(log.LvlFilterHandler(lvl, log.DiscardHandler()))
+	connConfig.Logger = logger
+	connConfig.LogLevel = pgx.LogLevelDebug
+	conn := mustConnect(b, connConfig)
+	defer closeConn(b, conn)
+
+	benchmarkSelectWithLog(b, conn)
+}
+
+func BenchmarkSelectWithLoggingInfoWithLog15(b *testing.B) {
+	connConfig := *defaultConnConfig
+
+	logger := log.New()
+	lvl, err := log.LvlFromString("info")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logger.SetHandler(log.LvlFilterHandler(lvl, log.DiscardHandler()))
+	connConfig.Logger = logger
+	connConfig.LogLevel = pgx.LogLevelInfo
+	conn := mustConnect(b, connConfig)
+	defer closeConn(b, conn)
+
+	benchmarkSelectWithLog(b, conn)
+}
+
+func BenchmarkSelectWithLoggingErrorWithLog15(b *testing.B) {
+	connConfig := *defaultConnConfig
+
+	logger := log.New()
+	lvl, err := log.LvlFromString("error")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logger.SetHandler(log.LvlFilterHandler(lvl, log.DiscardHandler()))
+	connConfig.Logger = logger
+	connConfig.LogLevel = pgx.LogLevelError
+	conn := mustConnect(b, connConfig)
+	defer closeConn(b, conn)
+
+	benchmarkSelectWithLog(b, conn)
+}
+
+func benchmarkSelectWithLog(b *testing.B, conn *pgx.Conn) {
+	_, err := conn.Prepare("test", "select 1::int4, 'johnsmith', 'johnsmith@example.com', 'John Smith', 'male', '1970-01-01'::date, '2015-01-01 00:00:00'::timestamptz")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var record struct {
+			id            int32
+			userName      string
+			email         string
+			name          string
+			sex           string
+			birthDate     time.Time
+			lastLoginTime time.Time
+		}
+
+		err = conn.QueryRow("test").Scan(
+			&record.id,
+			&record.userName,
+			&record.email,
+			&record.name,
+			&record.sex,
+			&record.birthDate,
+			&record.lastLoginTime,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// These checks both ensure that the correct data was returned
+		// and provide a benchmark of accessing the returned values.
+		if record.id != 1 {
+			b.Fatalf("bad value for id: %v", record.id)
+		}
+		if record.userName != "johnsmith" {
+			b.Fatalf("bad value for userName: %v", record.userName)
+		}
+		if record.email != "johnsmith@example.com" {
+			b.Fatalf("bad value for email: %v", record.email)
+		}
+		if record.name != "John Smith" {
+			b.Fatalf("bad value for name: %v", record.name)
+		}
+		if record.sex != "male" {
+			b.Fatalf("bad value for sex: %v", record.sex)
+		}
+		if record.birthDate != time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local) {
+			b.Fatalf("bad value for birthDate: %v", record.birthDate)
+		}
+		if record.lastLoginTime != time.Date(2015, 1, 1, 0, 0, 0, 0, time.Local) {
+			b.Fatalf("bad value for lastLoginTime: %v", record.lastLoginTime)
+		}
+	}
+}
+
+func BenchmarkLog15Discard(b *testing.B) {
+	logger := log.New()
+	lvl, err := log.LvlFromString("error")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logger.SetHandler(log.LvlFilterHandler(lvl, log.DiscardHandler()))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Debug("benchmark", "i", i, "b.N", b.N)
 	}
 }

--- a/Godeps/_workspace/src/github.com/jackc/pgx/conn_pool.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/conn_pool.go
@@ -17,8 +17,10 @@ type ConnPool struct {
 	cond                 *sync.Cond
 	config               ConnConfig // config used when establishing connection
 	maxConnections       int
+	resetCount           int
 	afterConnect         func(*Conn) error
 	logger               Logger
+	logLevel             int
 	closed               bool
 }
 
@@ -42,10 +44,16 @@ func NewConnPool(config ConnPoolConfig) (p *ConnPool, err error) {
 	}
 
 	p.afterConnect = config.AfterConnect
-	if config.Logger != nil {
-		p.logger = config.Logger
+
+	if config.LogLevel != 0 {
+		p.logLevel = config.LogLevel
 	} else {
-		p.logger = &discardLogger{}
+		// Preserve pre-LogLevel behavior by defaulting to LogLevelDebug
+		p.logLevel = LogLevelDebug
+	}
+	p.logger = config.Logger
+	if p.logger == nil {
+		p.logLevel = LogLevelNone
 	}
 
 	p.allConnections = make([]*Conn, 0, p.maxConnections)
@@ -76,6 +84,7 @@ func (p *ConnPool) Acquire() (c *Conn, err error) {
 	// A connection is available
 	if len(p.availableConnections) > 0 {
 		c = p.availableConnections[len(p.availableConnections)-1]
+		c.poolResetCount = p.resetCount
 		p.availableConnections = p.availableConnections[:len(p.availableConnections)-1]
 		return
 	}
@@ -86,19 +95,23 @@ func (p *ConnPool) Acquire() (c *Conn, err error) {
 		if err != nil {
 			return
 		}
+		c.poolResetCount = p.resetCount
 		p.allConnections = append(p.allConnections, c)
 		return
 	}
 
 	// All connections are in use and we cannot create more
 	if len(p.availableConnections) == 0 {
-		p.logger.Warn("All connections in pool are busy - waiting...")
+		if p.logLevel >= LogLevelWarn {
+			p.logger.Warn("All connections in pool are busy - waiting...")
+		}
 		for len(p.availableConnections) == 0 {
 			p.cond.Wait()
 		}
 	}
 
 	c = p.availableConnections[len(p.availableConnections)-1]
+	c.poolResetCount = p.resetCount
 	p.availableConnections = p.availableConnections[:len(p.availableConnections)-1]
 
 	return
@@ -110,7 +123,23 @@ func (p *ConnPool) Release(conn *Conn) {
 		conn.Exec("rollback")
 	}
 
+	if len(conn.channels) > 0 {
+		if err := conn.Unlisten("*"); err != nil {
+			conn.die(err)
+		}
+		conn.channels = make(map[string]struct{})
+	}
+	conn.notifications = nil
+
 	p.cond.L.Lock()
+
+	if conn.poolResetCount != p.resetCount {
+		conn.Close()
+		p.cond.L.Unlock()
+		p.cond.Signal()
+		return
+	}
+
 	if conn.IsAlive() {
 		p.availableConnections = append(p.availableConnections, conn)
 	} else {
@@ -146,6 +175,21 @@ func (p *ConnPool) Close() {
 	for _, c := range p.allConnections {
 		_ = c.Close()
 	}
+}
+
+// Reset closes all open connections, but leaves the pool open. It is intended
+// for use when an error is detected that would disrupt all connections (such as
+// a network interruption or a server state change).
+//
+// It is safe to reset a pool while connections are checked out. Those
+// connections will be closed when they are returned to the pool.
+func (p *ConnPool) Reset() {
+	p.cond.L.Lock()
+	defer p.cond.L.Unlock()
+
+	p.resetCount++
+	p.allConnections = make([]*Conn, 0, p.maxConnections)
+	p.availableConnections = make([]*Conn, 0, p.maxConnections)
 }
 
 // Stat returns connection pool statistics

--- a/Godeps/_workspace/src/github.com/jackc/pgx/conn_pool_test.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/conn_pool_test.go
@@ -295,6 +295,53 @@ func TestPoolReleaseDiscardsDeadConnections(t *testing.T) {
 	}
 }
 
+func TestConnPoolReset(t *testing.T) {
+	t.Parallel()
+
+	pool := createConnPool(t, 5)
+	defer pool.Close()
+
+	inProgressRows := []*pgx.Rows{}
+
+	// Start some queries and reset pool while they are in progress
+	for i := 0; i < 10; i++ {
+		rows, err := pool.Query("select generate_series(1,5)::bigint")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		inProgressRows = append(inProgressRows, rows)
+		pool.Reset()
+	}
+
+	// Check that the queries are completed
+	for _, rows := range inProgressRows {
+		var expectedN int64
+
+		for rows.Next() {
+			expectedN++
+			var n int64
+			err := rows.Scan(&n)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if expectedN != n {
+				t.Fatalf("Expected n to be %d, but it was %d", expectedN, n)
+			}
+		}
+
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// pool should be in fresh state due to previous reset
+	stats := pool.Stat()
+	if stats.CurrentConnections != 0 || stats.AvailableConnections != 0 {
+		t.Fatalf("Unexpected connection pool stats: %v", stats)
+	}
+}
+
 func TestConnPoolTransaction(t *testing.T) {
 	t.Parallel()
 
@@ -481,11 +528,16 @@ func TestConnPoolQueryConcurrentLoad(t *testing.T) {
 			}
 
 			if rows.Err() != nil {
-				t.Fatalf("conn.Query failed: ", err)
+				t.Fatalf("conn.Query failed: ", rows.Err())
 			}
 
 			if rowCount != 1000 {
 				t.Error("Select called onDataRow wrong number of times")
+			}
+
+			_, err = pool.Exec("--;")
+			if err != nil {
+				t.Fatalf("pool.Exec failed: %v", err)
 			}
 		}()
 	}

--- a/Godeps/_workspace/src/github.com/jackc/pgx/doc.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/doc.go
@@ -181,6 +181,14 @@ Conn.PgTypes.
 See example_custom_type_test.go for an example of a custom type for the
 PostgreSQL point type.
 
+Raw Bytes Mapping
+
+[]byte passed as arguments to Query, QueryRow, and Exec are passed unmodified
+to PostgreSQL. In like manner, a *[]byte passed to Scan will be filled with
+the raw bytes returned by PostgreSQL. This can be especially useful for reading
+varchar, text, json, and jsonb values directly into a []byte and avoiding the
+type conversion from string.
+
 TLS
 
 The pgx ConnConfig struct has a TLSConfig field. If this field is
@@ -192,7 +200,8 @@ Logging
 
 pgx defines a simple logger interface. Connections optionally accept a logger
 that satisfies this interface. The log15 package
-(http://gopkg.in/inconshreveable/log15.v2) satisfies this interface
-and it is simple to define adapters for other loggers.
+(http://gopkg.in/inconshreveable/log15.v2) satisfies this interface and it is
+simple to define adapters for other loggers. Set LogLevel to control logging
+verbosity.
 */
 package pgx

--- a/Godeps/_workspace/src/github.com/jackc/pgx/msg_reader.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/msg_reader.go
@@ -14,6 +14,8 @@ type msgReader struct {
 	buf               [128]byte
 	msgBytesRemaining int32
 	err               error
+	logger            Logger
+	logLevel          int
 }
 
 // Err returns any error that the msgReader has experienced
@@ -23,6 +25,9 @@ func (r *msgReader) Err() error {
 
 // fatal tells r that a Fatal error has occurred
 func (r *msgReader) fatal(err error) {
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.fatal", "error", err, "msgBytesRemaining", r.msgBytesRemaining)
+	}
 	r.err = err
 }
 
@@ -33,6 +38,10 @@ func (r *msgReader) rxMsg() (t byte, err error) {
 	}
 
 	if r.msgBytesRemaining > 0 {
+		if r.logLevel >= LogLevelTrace {
+			r.logger.Debug("msgReader.rxMsg discarding unread previous message", "msgBytesRemaining", r.msgBytesRemaining)
+		}
+
 		io.CopyN(ioutil.Discard, r.reader, int64(r.msgBytesRemaining))
 	}
 
@@ -59,6 +68,10 @@ func (r *msgReader) readByte() byte {
 		return 0
 	}
 
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readByte", "value", b, "byteAsString", string(b), "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
 	return b
 }
 
@@ -80,7 +93,13 @@ func (r *msgReader) readInt16() int16 {
 		return 0
 	}
 
-	return int16(binary.BigEndian.Uint16(b))
+	n := int16(binary.BigEndian.Uint16(b))
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readInt16", "value", n, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return n
 }
 
 func (r *msgReader) readInt32() int32 {
@@ -101,7 +120,13 @@ func (r *msgReader) readInt32() int32 {
 		return 0
 	}
 
-	return int32(binary.BigEndian.Uint32(b))
+	n := int32(binary.BigEndian.Uint32(b))
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readInt32", "value", n, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return n
 }
 
 func (r *msgReader) readInt64() int64 {
@@ -122,7 +147,13 @@ func (r *msgReader) readInt64() int64 {
 		return 0
 	}
 
-	return int64(binary.BigEndian.Uint64(b))
+	n := int64(binary.BigEndian.Uint64(b))
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readInt64", "value", n, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return n
 }
 
 func (r *msgReader) readOid() Oid {
@@ -147,7 +178,13 @@ func (r *msgReader) readCString() string {
 		return ""
 	}
 
-	return string(b[0 : len(b)-1])
+	s := string(b[0 : len(b)-1])
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readCString", "value", s, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return s
 }
 
 // readString reads count bytes and returns as string
@@ -175,7 +212,13 @@ func (r *msgReader) readString(count int32) string {
 		return ""
 	}
 
-	return string(b)
+	s := string(b)
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readString", "value", s, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return s
 }
 
 // readBytes reads count bytes and returns as []byte
@@ -196,6 +239,10 @@ func (r *msgReader) readBytes(count int32) []byte {
 	if err != nil {
 		r.fatal(err)
 		return nil
+	}
+
+	if r.logLevel >= LogLevelTrace {
+		r.logger.Debug("msgReader.readBytes", "value", b, "msgBytesRemaining", r.msgBytesRemaining)
 	}
 
 	return b

--- a/Godeps/_workspace/src/github.com/jackc/pgx/stress_test.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/stress_test.go
@@ -1,0 +1,323 @@
+package pgx_test
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
+	"github.com/jackc/fake"
+)
+
+type execer interface {
+	Exec(sql string, arguments ...interface{}) (commandTag pgx.CommandTag, err error)
+}
+type queryer interface {
+	Query(sql string, args ...interface{}) (*pgx.Rows, error)
+}
+type queryRower interface {
+	QueryRow(sql string, args ...interface{}) *pgx.Row
+}
+
+func TestStressConnPool(t *testing.T) {
+	maxConnections := 8
+	pool := createConnPool(t, maxConnections)
+	defer pool.Close()
+
+	setupStressDB(t, pool)
+
+	actions := []struct {
+		name string
+		fn   func(*pgx.ConnPool, int) error
+	}{
+		{"insertUnprepared", func(p *pgx.ConnPool, n int) error { return insertUnprepared(p, n) }},
+		{"queryRowWithoutParams", func(p *pgx.ConnPool, n int) error { return queryRowWithoutParams(p, n) }},
+		{"query", func(p *pgx.ConnPool, n int) error { return queryCloseEarly(p, n) }},
+		{"queryCloseEarly", func(p *pgx.ConnPool, n int) error { return query(p, n) }},
+		{"queryErrorWhileReturningRows", func(p *pgx.ConnPool, n int) error { return queryErrorWhileReturningRows(p, n) }},
+		{"txInsertRollback", txInsertRollback},
+		{"txInsertCommit", txInsertCommit},
+		{"txMultipleQueries", txMultipleQueries},
+		{"notify", notify},
+		{"listenAndPoolUnlistens", listenAndPoolUnlistens},
+		{"reset", func(p *pgx.ConnPool, n int) error { p.Reset(); return nil }},
+	}
+
+	var timer *time.Timer
+	if testing.Short() {
+		timer = time.NewTimer(5 * time.Second)
+	} else {
+		timer = time.NewTimer(60 * time.Second)
+	}
+	workerCount := 16
+
+	workChan := make(chan int)
+	doneChan := make(chan struct{})
+	errChan := make(chan error)
+
+	work := func() {
+		for n := range workChan {
+			action := actions[rand.Intn(len(actions))]
+			err := action.fn(pool, n)
+			if err != nil {
+				errChan <- err
+				break
+			}
+		}
+		doneChan <- struct{}{}
+	}
+
+	for i := 0; i < workerCount; i++ {
+		go work()
+	}
+
+	var stop bool
+	for i := 0; !stop; i++ {
+		select {
+		case <-timer.C:
+			stop = true
+		case workChan <- i:
+		case err := <-errChan:
+			close(workChan)
+			t.Fatal(err)
+		}
+	}
+	close(workChan)
+
+	for i := 0; i < workerCount; i++ {
+		<-doneChan
+	}
+}
+
+func TestStressTLSConnection(t *testing.T) {
+	t.Parallel()
+
+	if tlsConnConfig == nil {
+		t.Skip("Skipping due to undefined tlsConnConfig")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping due to testing -short")
+	}
+
+	conn, err := pgx.Connect(*tlsConnConfig)
+	if err != nil {
+		t.Fatalf("Unable to establish connection: %v", err)
+	}
+	defer conn.Close()
+
+	for i := 0; i < 50; i++ {
+		sql := `select * from generate_series(1, $1)`
+
+		rows, err := conn.Query(sql, 2000000)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var n int32
+		for rows.Next() {
+			rows.Scan(&n)
+		}
+
+		if rows.Err() != nil {
+			t.Fatalf("queryCount: %d, Row number: %d. %v", i, n, rows.Err())
+		}
+	}
+}
+
+func setupStressDB(t *testing.T, pool *pgx.ConnPool) {
+	_, err := pool.Exec(`
+		drop table if exists widgets;
+		create table widgets(
+			id serial primary key,
+			name varchar not null,
+			description text,
+			creation_time timestamptz
+		);
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertUnprepared(e execer, actionNum int) error {
+	sql := `
+		insert into widgets(name, description, creation_time)
+		values($1, $2, $3)`
+
+	_, err := e.Exec(sql, fake.ProductName(), fake.Sentences(), time.Now())
+	return err
+}
+
+func queryRowWithoutParams(qr queryRower, actionNum int) error {
+	var id int32
+	var name, description string
+	var creationTime time.Time
+
+	sql := `select * from widgets order by random() limit 1`
+
+	err := qr.QueryRow(sql).Scan(&id, &name, &description, &creationTime)
+	if err == pgx.ErrNoRows {
+		return nil
+	}
+	return err
+}
+
+func query(q queryer, actionNum int) error {
+	sql := `select * from widgets order by random() limit $1`
+
+	rows, err := q.Query(sql, 10)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int32
+		var name, description string
+		var creationTime time.Time
+		rows.Scan(&id, &name, &description, &creationTime)
+	}
+
+	return rows.Err()
+}
+
+func queryCloseEarly(q queryer, actionNum int) error {
+	sql := `select * from generate_series(1,$1)`
+
+	rows, err := q.Query(sql, 100)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for i := 0; i < 10 && rows.Next(); i++ {
+		var n int32
+		rows.Scan(&n)
+	}
+	rows.Close()
+
+	return rows.Err()
+}
+
+func queryErrorWhileReturningRows(q queryer, actionNum int) error {
+	// This query should divide by 0 within the first number of rows
+	sql := `select 42 / (random() * 20)::integer from generate_series(1,100000)`
+
+	rows, err := q.Query(sql)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var n int32
+		rows.Scan(&n)
+	}
+
+	if _, ok := rows.Err().(pgx.PgError); ok {
+		return nil
+	}
+	return rows.Err()
+}
+
+func notify(pool *pgx.ConnPool, actionNum int) error {
+	_, err := pool.Exec("notify stress")
+	return err
+}
+
+func listenAndPoolUnlistens(pool *pgx.ConnPool, actionNum int) error {
+	conn, err := pool.Acquire()
+	if err != nil {
+		return err
+	}
+	defer pool.Release(conn)
+
+	err = conn.Listen("stress")
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.WaitForNotification(100 * time.Millisecond)
+	if err == pgx.ErrNotificationTimeout {
+		return nil
+	}
+	return err
+}
+
+func txInsertRollback(pool *pgx.ConnPool, actionNum int) error {
+	tx, err := pool.Begin()
+	if err != nil {
+		return err
+	}
+
+	sql := `
+		insert into widgets(name, description, creation_time)
+		values($1, $2, $3)`
+
+	_, err = tx.Exec(sql, fake.ProductName(), fake.Sentences(), time.Now())
+	if err != nil {
+		return err
+	}
+
+	return tx.Rollback()
+}
+
+func txInsertCommit(pool *pgx.ConnPool, actionNum int) error {
+	tx, err := pool.Begin()
+	if err != nil {
+		return err
+	}
+
+	sql := `
+		insert into widgets(name, description, creation_time)
+		values($1, $2, $3)`
+
+	_, err = tx.Exec(sql, fake.ProductName(), fake.Sentences(), time.Now())
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func txMultipleQueries(pool *pgx.ConnPool, actionNum int) error {
+	tx, err := pool.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	errExpectedTxDeath := errors.New("Expected tx death")
+
+	actions := []struct {
+		name string
+		fn   func() error
+	}{
+		{"insertUnprepared", func() error { return insertUnprepared(tx, actionNum) }},
+		{"queryRowWithoutParams", func() error { return queryRowWithoutParams(tx, actionNum) }},
+		{"query", func() error { return query(tx, actionNum) }},
+		{"queryCloseEarly", func() error { return queryCloseEarly(tx, actionNum) }},
+		{"queryErrorWhileReturningRows", func() error {
+			err := queryErrorWhileReturningRows(tx, actionNum)
+			if err != nil {
+				return err
+			}
+			return errExpectedTxDeath
+		}},
+	}
+
+	for i := 0; i < 20; i++ {
+		action := actions[rand.Intn(len(actions))]
+		err := action.fn()
+		if err == errExpectedTxDeath {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/Godeps/_workspace/src/github.com/jackc/pgx/values.go
+++ b/Godeps/_workspace/src/github.com/jackc/pgx/values.go
@@ -22,6 +22,7 @@ const (
 	OidOid              = 26
 	JsonOid             = 114
 	CidrOid             = 650
+	CidrArrayOid        = 651
 	Float4Oid           = 700
 	Float8Oid           = 701
 	InetOid             = 869
@@ -33,6 +34,7 @@ const (
 	Int8ArrayOid        = 1016
 	Float4ArrayOid      = 1021
 	Float8ArrayOid      = 1022
+	InetArrayOid        = 1041
 	VarcharOid          = 1043
 	DateOid             = 1082
 	TimestampOid        = 1114
@@ -59,8 +61,10 @@ var DefaultTypeFormats map[string]int16
 func init() {
 	DefaultTypeFormats = map[string]int16{
 		"_bool":        BinaryFormatCode,
+		"_cidr":        BinaryFormatCode,
 		"_float4":      BinaryFormatCode,
 		"_float8":      BinaryFormatCode,
+		"_inet":        BinaryFormatCode,
 		"_int2":        BinaryFormatCode,
 		"_int4":        BinaryFormatCode,
 		"_int8":        BinaryFormatCode,
@@ -204,7 +208,7 @@ func (n NullFloat64) Encode(w *WriteBuf, oid Oid) error {
 // If Valid is false then the value is NULL.
 type NullString struct {
 	String string
-	Valid  bool // Valid is true if Int64 is not NULL
+	Valid  bool // Valid is true if String is not NULL
 }
 
 func (s *NullString) Scan(vr *ValueReader) error {
@@ -277,7 +281,7 @@ func (n NullInt16) Encode(w *WriteBuf, oid Oid) error {
 // If Valid is false then the value is NULL.
 type NullInt32 struct {
 	Int32 int32
-	Valid bool // Valid is true if Int64 is not NULL
+	Valid bool // Valid is true if Int32 is not NULL
 }
 
 func (n *NullInt32) Scan(vr *ValueReader) error {
@@ -1698,6 +1702,75 @@ func encodeTimestampArray(w *WriteBuf, value interface{}, elOid Oid) error {
 		microsecSinceUnixEpoch := t.Unix()*1000000 + int64(t.Nanosecond())/1000
 		microsecSinceY2K := microsecSinceUnixEpoch - microsecFromUnixEpochToY2K
 		w.WriteInt64(microsecSinceY2K)
+	}
+
+	return nil
+}
+
+func decodeInetArray(vr *ValueReader) []net.IPNet {
+	if vr.Len() == -1 {
+		return nil
+	}
+
+	if vr.Type().DataType != InetArrayOid && vr.Type().DataType != CidrArrayOid {
+		vr.Fatal(ProtocolError(fmt.Sprintf("Cannot decode oid %v into []net.IP", vr.Type().DataType)))
+		return nil
+	}
+
+	if vr.Type().FormatCode != BinaryFormatCode {
+		vr.Fatal(ProtocolError(fmt.Sprintf("Unknown field description format code: %v", vr.Type().FormatCode)))
+		return nil
+	}
+
+	numElems, err := decode1dArrayHeader(vr)
+	if err != nil {
+		vr.Fatal(err)
+		return nil
+	}
+
+	a := make([]net.IPNet, int(numElems))
+	for i := 0; i < len(a); i++ {
+		elSize := vr.ReadInt32()
+		if elSize == -1 {
+			vr.Fatal(ProtocolError("Cannot decode null element"))
+			return nil
+		}
+
+		vr.ReadByte() // ignore family
+		bits := vr.ReadByte()
+		vr.ReadByte() // ignore is_cidr
+		addressLength := vr.ReadByte()
+
+		var ipnet net.IPNet
+		ipnet.IP = vr.ReadBytes(int32(addressLength))
+		ipnet.Mask = net.CIDRMask(int(bits), int(addressLength)*8)
+
+		a[i] = ipnet
+	}
+
+	return a
+}
+
+func encodeInetArray(w *WriteBuf, value interface{}, elOid Oid) error {
+	slice, ok := value.([]net.IPNet)
+	if !ok {
+		return fmt.Errorf("Expected []net.IPNet, received %T", value)
+	}
+
+	size := int32(20) // array header size
+	for _, ipnet := range slice {
+		size += 4 + 4 + int32(len(ipnet.IP)) // size of element + inet/cidr metadata + IP bytes
+	}
+	w.WriteInt32(int32(size))
+
+	w.WriteInt32(1)                 // number of dimensions
+	w.WriteInt32(0)                 // no nulls
+	w.WriteInt32(int32(elOid))      // type of elements
+	w.WriteInt32(int32(len(slice))) // number of elements
+	w.WriteInt32(1)                 // index of first element
+
+	for _, ipnet := range slice {
+		encodeInet(w, ipnet)
 	}
 
 	return nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -83,6 +83,9 @@ func main() {
 		}
 	}()
 
+	// Listen for database migration, reset connpool on new migration
+	go postgres.ResetOnMigration(db, logger, doneCh)
+
 	hb, err := discoverd.DefaultClient.AddServiceAndRegisterInstance("controller", &discoverd.Instance{
 		Addr:  addr,
 		Proto: "http",


### PR DESCRIPTION
This change implements a listen/notify setup on the `schema_migrations` table in order to reset the connection pool after a migration takes place. This is to ensure any session level cached or prepared query plans can be refreshed.

Refs #2295 
Closes #2235