### PR TITLE
all: Use curl --fail whenever we pipe output with --silent

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,7 +98,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sudo chmod +x "/usr/local/bin/jq"
 
     # For controller tests
-    curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    curl --fail --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'
     sudo apt-get update
     sudo apt-get install -y postgresql-9.4 postgresql-contrib-9.4

--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update &&\
     update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 &&\
     dpkg-reconfigure locales &&\
     apt-get -y install curl sudo &&\
-    curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - &&\
+    curl --silent --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - &&\
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list' &&\
     apt-get update &&\
     apt-get install -y -q \

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -78,7 +78,7 @@ main() {
 
   if [[ -z "${commit}" ]]; then
     info "determining commit"
-    commit=$(curl -s https://api.github.com/repos/flynn/flynn/git/refs/heads/master | jq --raw-output .object.sha)
+    commit=$(curl --fail --silent https://api.github.com/repos/flynn/flynn/git/refs/heads/master | jq --raw-output .object.sha)
     if [[ -z "${commit}" ]]; then
       fail "could not determine commit"
     fi

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -54,7 +54,7 @@ run_unprivileged() {
 
 # run curl silently and retry upto 3 times
 curl() {
-  $(which curl) --silent --retry 3 $@
+  $(which curl) --fail --silent --retry 3 $@
 }
 
 cd ${app_dir}

--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -9,7 +9,7 @@ mkdir -p "${HOME}"
 if [[ -n $(ls -A "${HOME}") ]]; then
   true
 elif ! [[ -z "${SLUG_URL}" ]]; then
-  curl --silent --location --noproxy "discoverd" --retry 5 --show-error "${SLUG_URL}" | tar -xzC "${HOME}"
+  curl --silent --location --noproxy "discoverd" --retry 5 --fail "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL
 else
   cat | tar -xzC "${HOME}"

--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -130,7 +130,7 @@ apt-get install -y \
 apt-get -qy --fix-missing --force-yes install language-pack-en
 update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
 dpkg-reconfigure locales
-curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+curl --fail --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
 apt-get update
 apt-get install -y postgresql-9.4 postgresql-contrib-9.4
@@ -166,7 +166,7 @@ tmpdir=$(mktemp --directory)
 trap "rm -rf ${tmpdir}" EXIT
 git clone https://github.com/sstephenson/bats.git "${tmpdir}/bats"
 "${tmpdir}/bats/install.sh" "/usr/local"
-curl -sLo "/usr/local/bin/jq" "http://stedolan.github.io/jq/download/linux64/jq"
+curl -fsLo "/usr/local/bin/jq" "http://stedolan.github.io/jq/download/linux64/jq"
 chmod +x "/usr/local/bin/jq"
 
 # cleanup

--- a/util/assetbuilder/Dockerfile
+++ b/util/assetbuilder/Dockerfile
@@ -4,7 +4,7 @@ ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
 
 # Install NodeSource repo and nodejs, install then run bundler and download npm deps
-RUN curl -sL https://deb.nodesource.com/setup | bash - &&\
+RUN curl --fail --silent --location https://deb.nodesource.com/setup | bash - &&\
     apt-get update &&\
     apt-get install -y nodejs build-essential &&\
     gem install bundler --no-rdoc --no-ri &&\


### PR DESCRIPTION
This ensures that the shell pipeline terminates on error instead of continuing with useless output from curl.

Refs #2308