### PR TITLE
Bake integration

### DIFF
--- a/Bakefile.lua
+++ b/Bakefile.lua
@@ -1,0 +1,7 @@
+ImageRepository = "https://dl.flynn.io/tuf"
+RootKeys = '[{"keytype":"ed25519","keyval":{"public":"6cfda23aa48f530aebd5b9c01030d06d02f25876b5508d681675270027af4731"}}]'
+
+target("script/install-flynn", depends("host/bin/flynn-host.gz"), function()
+  sh('sed "s/{{FLYNN-HOST-CHECKSUM}}/$(sha512sum host/bin/flynn-host.gz | cut -d " " -f 1)/g" script/install-flynn.tmpl > script/install-flynn')
+end)
+

--- a/appliance/postgresql/Bakefile.lua
+++ b/appliance/postgresql/Bakefile.lua
@@ -1,0 +1,13 @@
+target("bin/flynn-postgres", function()
+  go.build(".", {"-o", "bin/flynn-postgres"})
+end)
+
+target("bin/flynn-postgres-api", function()
+  go.build("./api", {"-o", "bin/flynn-postgres-api"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/postgresql"})
+end)
+
+

--- a/blobstore/Bakefile.lua
+++ b/blobstore/Bakefile.lua
@@ -1,0 +1,7 @@
+target("bin/flynn-blobstore", function()
+  go.build(".", {"-o", "./bin/flynn-blobstore"})
+end)
+
+target("docker", depends("bin/flynn-blobstore"), function()
+  docker.build(".", {"-t", "flynn/blobstore"})
+end)

--- a/bootstrap/Bakefile.lua
+++ b/bootstrap/Bakefile.lua
@@ -1,0 +1,8 @@
+target("manifest", depends("../util/release/flynn-release"), function()
+  exec(
+    "../util/release/flynn-release",
+    "manifest",
+    "--output=bin/manifest.json",
+    "--image-repository=" .. ImageRepository,
+    "manifest_template.json")
+end)

--- a/controller/Bakefile.lua
+++ b/controller/Bakefile.lua
@@ -1,0 +1,29 @@
+target("bin/flynn-controller", function()
+  go.build(".", {"-o", "bin/flynn-controller"})
+end)
+
+target("bin/flynn-scheduler", function()
+  go.build("./scheduler", {"-o", "bin/flynn-scheduler"})
+end)
+
+target("bin/flynn-worker", function()
+  go.build("./worker", {"-o", "bin/flynn-worker"})
+end)
+
+target("copy-schema", function()
+  sh("cp ../schema/*.json bin/jsonschema")
+  sh("cp ../schema/controller/*.json bin/jsonschema/controller")
+  sh("cp ../schema/router/*.json bin/jsonschema/router")
+end)
+
+target("examples/flynn-controller-examples", function()
+  go.build("./examples", {"-o", "examples/flynn-controller-examples"})
+end)
+
+target("examples/docker", depends("examples/flynn-controller-examples"), function()
+  docker.build("examples", {"-t", "flynn/controller-examples"})
+end)
+
+target("docker", depends("bin/*", "copy-schema", "examples/flynn-controller-examples"), function()
+  docker.build(".", {"-t", "flynn/controller"})
+end)

--- a/dashboard/Bakefile.lua
+++ b/dashboard/Bakefile.lua
@@ -1,0 +1,27 @@
+target("bin/go-bindata", function()
+  go.build("../Godeps/_workspace/src/github.com/jteeuwen/go-bindata/go-bindata", {
+    "-o", "bin/go-bindata",
+  })
+end)
+
+target("app/compiler", function()
+  go.build("./app", {"-o", "app/compiler"})
+end)
+
+target("assets", function()
+  sh("cp ../installer/app/src/images/*.png app/lib/installer/images")
+  sh("cp ../installer/app/src/views/*.js.jsx app/lib/installer/views")
+  sh("cp ../installer/app/src/views/css/*.js app/lib/installer/views/css")
+end)
+
+target("bindata.go", depends("assets", "bin/go-bindata", "app/compiler"), function()
+  exec("../util/assetbuilder/build.sh", "app", "dashboard")
+end)
+
+target("bin/flynn-dashboard", depends("bindata.go"), function()
+  go.build("./dashboard", {"-o", "bin/flynn-dashboard"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/dashboard"})
+end)

--- a/discoverd/Bakefile.lua
+++ b/discoverd/Bakefile.lua
@@ -1,0 +1,8 @@
+target("bin/discoverd", function()
+  go.build(".", {"-o", "bin/discoverd"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/discoverd"})
+end)
+

--- a/flannel/Bakefile.lua
+++ b/flannel/Bakefile.lua
@@ -1,0 +1,11 @@
+target("bin/flanneld", function()
+  go.build(".", {"-o", "bin/flanneld"})
+end)
+
+target("bin/flannel-wrapper", function()
+  go.build("./wrapper", {"-o", "bin/flannel-wrapper"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/flannel"})
+end)

--- a/gitreceive/Bakefile.lua
+++ b/gitreceive/Bakefile.lua
@@ -1,0 +1,11 @@
+target("flynn-receiver", function()
+  go.build("./receiver", {"-o", "flynn-receiver"})
+end)
+
+target("gitreceived", depends("flynn-receiver"), function()
+  go.build(".", {"-o", "gitreceived"})
+end)
+
+target("docker", depends("gitreceived"), function()
+  docker.build(".", {"-t", "flynn/gitreceive"})
+end)

--- a/host/Bakefile.lua
+++ b/host/Bakefile.lua
@@ -1,0 +1,19 @@
+target("root-keys", function()
+  sh("sed s/{{TUF-ROOT-KEYS}}/" .. RootKeys .. "/g cli/root_keys.go.tmpl > cli/root_keys.go")
+end)
+
+target("bin/flynn-host", depends("root-keys"), function()
+  go.build(".", {"-o", "bin/flynn-host"})
+end)
+
+target("bin/flynn-host.gz", depends("bin/flynn-host"), function()
+  exec("gzip", "-f", "-9", "--keep", "bin/flynn-host")
+end)
+
+target("bin/flynn-init", function()
+  go.build("./flynn-init", {"-o", "bin/flynn-init"})
+end)
+
+target("bin/flynn-nsumount", function()
+  exec("gcc", "-o", "bin/flynn-nsumount", "-Wall", "-std=c99", "nsumount/nsumount.c")
+end)

--- a/logaggregator/Bakefile.lua
+++ b/logaggregator/Bakefile.lua
@@ -1,0 +1,7 @@
+target("bin/logaggregator", function() 
+  go.build(".", {"-o", "bin/logaggregator"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/logaggregator"})
+end)

--- a/pinkerton/Bakefile.lua
+++ b/pinkerton/Bakefile.lua
@@ -1,0 +1,3 @@
+target("cmd/pinkerton/pinkerton", function()
+  go.build(".", {"-o", "cmd/pinkerton/pinkerton"})
+end)

--- a/router/Bakefile.lua
+++ b/router/Bakefile.lua
@@ -1,0 +1,4 @@
+target("bin/flynn-router", function()
+  go.build(".", {"-o", "bin/flynn-router"})
+end)
+

--- a/router/example-generator/Bakefile.lua
+++ b/router/example-generator/Bakefile.lua
@@ -1,0 +1,8 @@
+target("flynn-router-examples", function()
+  go.build(".", {"-o", "flynn-router-examples"})
+end)
+
+target("docker", depends("flynn-router-examples"), function() 
+  docker.build(".", {"-t", "flynn/router-examples", })
+end)
+

--- a/slugbuilder/Bakefile.lua
+++ b/slugbuilder/Bakefile.lua
@@ -1,0 +1,3 @@
+target("docker", function()
+  docker.build(".", {"-t", "flynn/slugbuilder"})
+end)

--- a/slugrunner/Bakefile.lua
+++ b/slugrunner/Bakefile.lua
@@ -1,0 +1,3 @@
+target("@docker", function()
+  docker.build(".", {"-t", "flynn/slugrunner"})
+end)

--- a/status/Bakefile.lua
+++ b/status/Bakefile.lua
@@ -1,0 +1,7 @@
+target("bin/flynn-status", function()
+  go.build(".", {"-o", "bin/flynn-status"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/status"})
+end)

--- a/taffy/Bakefile.lua
+++ b/taffy/Bakefile.lua
@@ -1,0 +1,11 @@
+target("bin/flynn-receiver", depends("../gitreceive/flynn-receiver"), function()
+  sh("cp ../gitreceive/flynn-receiver bin/flynn-receiver")
+end)
+
+target("bin/taffy", function()
+  go.build(".", {"-o", "bin/taffy"})
+end)
+
+target("docker", depends("bin/*"), function()
+  docker.build(".", {"-t", "flynn/taffy"})
+end)

--- a/test/Bakefile.lua
+++ b/test/Bakefile.lua
@@ -1,0 +1,7 @@
+target("bin/flynn-test", function()
+  go.build(".", {"-o", "bin/flynn-test"})
+end)
+
+target("bin/flynn-test-runner", function()
+  go.build("./runner", {"-o", "bin/flynn-test-runner"})
+end)

--- a/test/apps/Bakefile.lua
+++ b/test/apps/Bakefile.lua
@@ -1,0 +1,23 @@
+target("bin/echoer", function()
+  go.build("./echoer", {"-o", "bin/echoer"})
+end)
+
+target("bin/ping", function()
+  go.build("./ping", {"-o", "bin/ping"})
+end)
+
+target("bin/signal", function()
+  go.build("./signal", {"-o", "bin/signal"})
+end)
+
+target("bin/ish", function()
+  go.build("./ish", {"-o", "bin/ish"})
+end)
+
+target("bin/partial-logger", function()
+  go.build("./partial-logger", {"-o", "bin/partial-logger"})
+end)
+
+target("docker", depends("bin/*"), function() 
+    docker.build(".", {"-t", "flynn/test-apps"})
+end)

--- a/updater/Bakefile.lua
+++ b/updater/Bakefile.lua
@@ -1,0 +1,7 @@
+target("updater", function()
+  go.build(".", {"-o", "updater"})
+end)
+
+target("docker", depends("updater"), function()
+  docker.build(".", {"-t", "flynn/updater"})
+end)


### PR DESCRIPTION
## Overview

This pull request adds support for using [`bake`](https://github.com/flynn/bake) for building the flynn codebase instead of `tup`.


### Notes

Bake currently needs to be run as `root` because it uses a mounted 9p file system for tracking file access. For development purposes of building bake and flynn in the same Vagrant instance, I added the following inside `Vagrant.configure()`:

```
config.vm.synced_folder "/Users/benbjohnson/Dropbox/go/src/github.com/flynn/bake", "/root/go/src/github.com/flynn/bake", owner: "root", group: "root"
config.vm.synced_folder "/Users/benbjohnson/go/src/github.com/flynn/flynn", "/root/go/src/github.com/flynn/flynn", owner: "root", group: "root"
```

And then added the `GOPATH` to the `root` user.