### PR TITLE
controller: Deploy web processes using service events

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -181,6 +181,7 @@
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
           "cmd": ["controller"],
+          "service": "controller",
           "resurrect": true
         },
         "scheduler": {


### PR DESCRIPTION
When deploying the controller under heavy load, the web process can actually take a few seconds before it starts listening for HTTP requests, so we need to use service events so that there is always a functioning web process during the deployment.