### PR TITLE
controller: Close database listeners on shutdown

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -76,7 +76,7 @@ func main() {
 	rc := routerc.New()
 
 	doneCh := make(chan struct{})
-	defer close(doneCh)
+	shutdown.BeforeExit(func() { close(doneCh) })
 	go func() {
 		if err := streamRouterEvents(rc, db, doneCh); err != nil {
 			shutdown.Fatal(err)

--- a/pkg/postgres/listener.go
+++ b/pkg/postgres/listener.go
@@ -42,7 +42,7 @@ type Listener struct {
 
 func (l *Listener) Close() (err error) {
 	l.closeOnce.Do(func() {
-		l.conn.Exec("UNLISTEN " + l.channel)
+		l.conn.Close()
 		l.db.Release(l.conn)
 	})
 	return

--- a/pkg/postgres/migrate.go
+++ b/pkg/postgres/migrate.go
@@ -94,6 +94,7 @@ func ResetOnMigration(db *DB, log log15.Logger, doneCh chan struct{}) {
 				db.Reset()
 			case <-doneCh:
 				listener.Close()
+				return
 			}
 		}
 	}


### PR DESCRIPTION
I also patched the postgres listener to simply close connections on shutdown rather than trying to unlisten as I ran into the same RxMsg bug from the initial migration. I think I might have a better idea of the root cause of that bug though so I might try work with with pgx maintainer to fix it.

Closes #2327