### PR TITLE
test: Skip migrating cluster domain in TestExampleOutput

### DIFF
--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -112,7 +112,10 @@ func main() {
 		{"event_get", e.eventGet},
 		{"ca_cert", e.getCACert},
 		{"cluster_backup", e.clusterBackup},
-		{"migrate_cluster_domain", e.migrateClusterDomain},
+	}
+
+	if os.Getenv("SKIP_MIGRATE_DOMAIN") != "true" {
+		examples = append(examples, g.Example{"migrate_cluster_domain", e.migrateClusterDomain})
 	}
 
 	var out io.Writer

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -116,7 +116,10 @@ func unmarshalControllerExample(data []byte) (map[string]interface{}, error) {
 
 func (s *ControllerSuite) generateControllerExamples(t *c.C) map[string]interface{} {
 	cmd := exec.Command(exec.DockerImage(imageURIs["controller-examples"]), "/bin/flynn-controller-examples")
-	cmd.Env = map[string]string{"CONTROLLER_KEY": s.clusterConf(t).Key}
+	cmd.Env = map[string]string{
+		"CONTROLLER_KEY":      s.clusterConf(t).Key,
+		"SKIP_MIGRATE_DOMAIN": "true",
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
The examples attempt to migrate the cluster domain to `127.0.0.1.xip.io` [here](https://github.com/flynn/flynn/blob/master/controller/examples/examples.go#L549-L552), which breaks the cluster and is unnecessary as the test [skips checking the output](https://github.com/flynn/flynn/blob/master/test/test_controller.go#L145) anyway.