### PR TITLE
scheduler: Fix restarting jobs which failed to start

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1172,7 +1172,7 @@ func (s *Scheduler) restartJob(job *Job) {
 	restarts := job.restarts
 	// reset the restart count if it has been running for longer than the
 	// back off period
-	if job.startedAt.Before(time.Now().Add(-s.backoffPeriod)) {
+	if !job.startedAt.IsZero() && job.startedAt.Before(time.Now().Add(-s.backoffPeriod)) {
 		restarts = 0
 	}
 	backoff := s.getBackoffDuration(restarts)

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -237,7 +237,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 			if !ok {
 				continue
 			}
-			log.Info("got service event", "job_id", jobID, "type", typ, "state", event.Kind)
+			log.Info("got service event", "job.id", jobID, "job.type", typ, "job.state", event.Kind)
 			handleEvent(jobID, typ, ct.JobStateUp)
 			if expected.Equals(actual) {
 				return nil
@@ -262,7 +262,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 				}
 			}
 
-			log.Info("got job event", "job_id", event.ID, "type", event.Type, "state", event.State)
+			log.Info("got job event", "job.id", event.ID, "job.type", event.Type, "job.state", event.State)
 			if event.State == ct.JobStateStarting {
 				continue
 			}


### PR DESCRIPTION
Jobs which failed have a zero `StartedAt` time and should be treated as though they have been running for a zero amount of time, so therefore should not have their restarts reset.