### PR TITLE
host: Ensure new jobs are added to state when resurrecting

### DIFF
--- a/host/state.go
+++ b/host/state.go
@@ -135,6 +135,7 @@ func (s *State) Restore(backend Backend, buffers host.LogBuffers) (func(), error
 				newID := cluster.GenerateJobID(s.id, "")
 				log.Printf("resurrecting %s as %s", job.Job.ID, newID)
 				job.Job.ID = newID
+				s.AddJob(job.Job)
 				config := &RunConfig{
 					// TODO(titanous): Use Job instead of ActiveJob in
 					// resurrection bucket once InternalIP is not used.


### PR DESCRIPTION
New jobs from API requests are now added to the state independently of the backend (see #2270), so we need to do the same when resurrecting jobs.

Fixes #2338.