### PR TITLE
slugbuilder: Only exclude '.git' at the root of the slug

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -190,7 +190,7 @@ fi
 
 if [[ -f "${build_root}/.slugignore" ]]; then
   tar \
-    --exclude='.git' \
+    --exclude='./.git' \
     --use-compress-program=pigz \
     -X "${build_root}/.slugignore" \
     -C ${build_root} \
@@ -199,7 +199,7 @@ if [[ -f "${build_root}/.slugignore" ]]; then
     | cat
 else
   tar \
-    --exclude='.git' \
+    --exclude='./.git' \
     --use-compress-program=pigz \
     -C ${build_root} \
     -cf ${slug_file} \


### PR DESCRIPTION
This avoids removing `.git` directories in subdirectories. We still want to exclude the top level `.git` directory because there is a large overhead to storing it when working with large repositories.

Refs #2346