### PR TITLE
test/rootfs: Increase size of sparsefile to 32GB

### DIFF
--- a/test/rootfs/build.sh
+++ b/test/rootfs/build.sh
@@ -4,7 +4,7 @@ set -e -x
 src_dir="$(cd "$(dirname "$0")" && pwd)"
 build_dir=${1:-.}
 
-truncate -s 16G ${build_dir}/rootfs.img
+truncate -s 32G ${build_dir}/rootfs.img
 mkfs.ext4 -FqL rootfs ${build_dir}/rootfs.img
 
 dir=$(mktemp -d)


### PR DESCRIPTION
Running into out of space errors during builds, this should give it some more breathing room.