### PR TITLE
util/packer: Pin kernel version to work around Docker/AUFS bug

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -68,7 +68,8 @@ echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
 # update packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install --install-recommends linux-generic-lts-vivid \
+# install backported kernel, pin version to 3.19.0-39 to work around https://github.com/docker/docker/issues/18180 / https://github.com/flynn/flynn/issues/2365
+apt-get install --install-recommends linux-headers-3.19.0-39 linux-headers-3.19.0-39-generic linux-image-3.19.0-39-generic linux-image-extra-3.19.0-39-generic \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"

--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -35,7 +35,8 @@ if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then
   apt-get remove --purge -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 fi
 
-apt-get install --install-recommends linux-generic-lts-vivid linux-image-generic-lts-vivid \
+# install backported kernel, pin version to 3.19.0-39 to work around https://github.com/docker/docker/issues/18180 / https://github.com/flynn/flynn/issues/2365
+apt-get install --install-recommends linux-headers-3.19.0-39 linux-headers-3.19.0-39-generic linux-image-3.19.0-39-generic linux-image-extra-3.19.0-39-generic \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
Ubuntu kernel 3.19.0-39 is does not trigger this bug: https://github.com/docker/docker/issues/18180

Verified with:

    docker run -it --rm akihirosuda/test18180

Fixes #2365