### PR TITLE
bootstrap: Use deploy-app to launch Redis provider

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -131,34 +131,6 @@
     "data": "{{ getenv \"CONTROLLER_KEY\" }}"
   },
   {
-    "id": "redis-api",
-    "app": {
-      "name": "redis-api",
-      "meta": {"flynn-system-app": "true"}
-    },
-    "action": "run-app",
-    "release": {
-      "env": {
-        "FLYNN_REDIS": "redis",
-        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
-        "REDIS_IMAGE_URI": "$image_repository?name=flynn/redis&id=$image_id[redis]"
-      },
-      "processes": {
-        "web": {
-          "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"]
-        }
-      }
-    },
-    "artifact": {
-      "type": "docker",
-      "uri": "$image_repository?name=flynn/redis&id=$image_id[redis]"
-    },
-    "processes": {
-      "web": 2
-    }
-  },
-  {
     "id": "dashboard-session-secret",
     "action": "gen-random"
   },
@@ -181,11 +153,6 @@
     "id": "postgres-wait",
     "action": "wait",
     "url": "http://postgres-api.discoverd/ping"
-  },
-  {
-    "id": "redis-api-wait",
-    "action": "wait",
-    "url": "http://redis-api.discoverd/ping"
   },
   {
     "id": "controller-cert",
@@ -268,12 +235,6 @@
     }
   },
   {
-    "id": "add-redis-provider",
-    "action": "add-provider",
-    "name":"redis",
-    "url":"http://redis-api.discoverd/clusters"
-  },
-  {
     "id": "flannel-app",
     "action": "add-app",
     "from_step": "flannel",
@@ -311,6 +272,40 @@
     "processes": {
       "scheduler": 1
     }
+  },
+  {
+    "id": "redis",
+    "app": {
+      "name": "redis",
+      "meta": {"flynn-system-app": "true"}
+    },
+    "action": "deploy-app",
+    "release": {
+      "env": {
+        "FLYNN_REDIS": "redis",
+        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
+        "REDIS_IMAGE_URI": "$image_repository?name=flynn/redis&id=$image_id[redis]"
+      },
+      "processes": {
+        "web": {
+          "ports": [{"port": 80, "proto": "tcp"}],
+          "cmd": ["api"]
+        }
+      }
+    },
+    "artifact": {
+      "type": "docker",
+      "uri": "$image_repository?name=flynn/redis&id=$image_id[redis]"
+    },
+    "processes": {
+      "web": 2
+    }
+  },
+  {
+    "id": "add-redis-provider",
+    "action": "add-provider",
+    "name":"redis",
+    "url":"http://redis-api.discoverd/clusters"
   },
   {
     "id": "blobstore",
@@ -570,6 +565,11 @@
     "type": "http",
     "service": "status-web",
     "domain": "status.{{ getenv \"CLUSTER_DOMAIN\" }}"
+  },
+  {
+    "id": "redis-wait",
+    "action": "wait",
+    "url": "http://redis-api.discoverd/ping"
   },
   {
     "id": "blobstore-wait",


### PR DESCRIPTION
The Redis app wasn't using `deploy-app` or `add-app` so it wasn't being managed by the controller.
I moved it to `deploy-app` and also renamed it `redis` inline with the `postgres` provider.