### PR TITLE
appliance/redis: add dump & restore

### DIFF
--- a/appliance/redis/Dockerfile
+++ b/appliance/redis/Dockerfile
@@ -5,12 +5,17 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update &&\
     apt-get dist-upgrade -y &&\
     apt-get update &&\
+    apt-get install -y curl &&\
     apt-get install -y -q redis-server &&\
     apt-get clean &&\
-    apt-get autoremove -y
+    apt-get autoremove -y &&\
+    mkdir /data
 
 ADD bin/flynn-redis /bin/flynn-redis
 ADD bin/flynn-redis-api /bin/flynn-redis-api
+
 ADD start.sh /bin/start-flynn-redis
+ADD dump.sh /bin/dump-flynn-redis
+ADD restore.sh /bin/restore-flynn-redis
 
 ENTRYPOINT ["/bin/start-flynn-redis"]

--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -199,9 +199,12 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 		Meta:       make(map[string]string),
 		Processes: map[string]ct.ProcessType{
 			"redis": {
-				Ports: []ct.Port{{Port: 6379, Proto: "tcp"}},
-				Data:  true,
-				Cmd:   []string{"redis"},
+				Ports: []ct.Port{
+					{Port: 6379, Proto: "tcp"},
+					{Port: 6380, Proto: "tcp"},
+				},
+				Data: true,
+				Cmd:  []string{"redis"},
 				Env: map[string]string{
 					"FLYNN_REDIS":    serviceName,
 					"REDIS_PASSWORD": password,

--- a/appliance/redis/cmd/flynn-redis/main.go
+++ b/appliance/redis/cmd/flynn-redis/main.go
@@ -22,7 +22,7 @@ const (
 	DefaultServiceName = "redis"
 
 	// DefaultAddr is the default bind address for the HTTP API.
-	DefaultAddr = ":5433"
+	DefaultAddr = ":6380"
 
 	// DefaultDataDir is the default base directory for data storage.
 	DefaultDataDir = "/data"
@@ -114,7 +114,7 @@ func (m *Main) Run() error {
 		return err
 	}
 	m.Process.ID = id
-	m.Process.DataDir = filepath.Join(m.DataDir, "db")
+	m.Process.DataDir = m.DataDir
 	m.Process.Logger = m.Logger.New("component", "process", "id", id)
 
 	// Start process.

--- a/appliance/redis/dump.sh
+++ b/appliance/redis/dump.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Passthrough arguments and dump RDB to temporary location.
+TMPFILE=`mktemp /tmp/dump.XXXXXXXXXX`
+/usr/bin/redis-cli $@ --rdb $TMPFILE
+
+# Write dump to STDOUT.
+cat $TMPFILE
+
+# Remove dump file.
+rm $TMPFILE

--- a/appliance/redis/handler.go
+++ b/appliance/redis/handler.go
@@ -27,6 +27,7 @@ func NewHandler() *Handler {
 	h.router.Handler("GET", status.Path, status.Handler(h.healthStatus))
 	h.router.GET("/status", h.handleGetStatus)
 	h.router.POST("/stop", h.handlePostStop)
+	h.router.POST("/restore", h.handlePostRestore)
 	return h
 }
 
@@ -54,6 +55,14 @@ func (h *Handler) handleGetStatus(w http.ResponseWriter, req *http.Request, _ ht
 
 func (h *Handler) handlePostStop(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	if err := h.Heartbeater.Close(); err != nil {
+		httphelper.Error(w, err)
+		return
+	}
+	w.WriteHeader(200)
+}
+
+func (h *Handler) handlePostRestore(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	if err := h.Process.Restore(req.Body); err != nil {
 		httphelper.Error(w, err)
 		return
 	}

--- a/appliance/redis/restore.sh
+++ b/appliance/redis/restore.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+HOST=
+while getopts :h: FLAG; do
+  case $FLAG in
+    h)
+      HOST=$OPTARG
+      ;;
+  esac
+done
+
+# Send STDIN as body to redis process HTTP interface.
+curl -X POST --data-binary @- http://$HOST:6380/restore

--- a/test/test_redis.go
+++ b/test/test_redis.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"path/filepath"
+
+	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+)
+
+type RedisSuite struct {
+	Helper
+}
+
+var _ = c.ConcurrentSuite(&RedisSuite{})
+
+func (s *RedisSuite) TestDumpRestore(t *c.C) {
+	r := s.newGitRepo(t, "empty")
+	t.Assert(r.flynn("create"), Succeeds)
+
+	t.Assert(r.flynn("resource", "add", "redis"), Succeeds)
+
+	t.Assert(r.flynn("redis", "redis-cli", "set", "foo", "bar"), Succeeds)
+
+	file := filepath.Join(t.MkDir(), "dump.rdb")
+	t.Assert(r.flynn("redis", "dump", "-f", file), Succeeds)
+	t.Assert(r.flynn("redis", "redis-cli", "del", "foo"), Succeeds)
+
+	r.flynn("redis", "restore", "-f", file)
+
+	query := r.flynn("redis", "redis-cli", "get", "foo")
+	t.Assert(query, SuccessfulOutputContains, "bar")
+}


### PR DESCRIPTION
## Overview

Adds support for two new subcommands, `dump` & `restore`


## Example

```sh
$ flynn redis dump -f /path/to/mydump
```

```sh
$ flynn redis restore -f /path/to/mydump
```
