### PR TITLE
script: Add keep state option to start-flynn-host

### DIFF
--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -15,9 +15,14 @@ USAGE
 
 main() {
   local destroy_vols=true
+  local destroy_state=true
 
   while true; do
     case "$1" in
+      -k | --no-destroy-state)
+        destroy_state=false
+        shift
+        ;;
       -z | --no-destroy-vols)
         destroy_vols=false
         shift
@@ -49,7 +54,9 @@ main() {
   ln -nfs "${log}" "/tmp/flynn-host-${index}.log"
 
   # delete the old state
-  sudo rm -f "${state}"
+  if $destroy_state; then
+    sudo rm -f "${state}"
+  fi
 
   if $destroy_vols; then
     sudo "${flynn_host}" destroy-volumes --volpath="${vol_path}" --include-data


### PR DESCRIPTION
Helpful when writing scripts to test things like resurrection or host reboots.