### PR TITLE
script: Use flynn fork of godeb

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -148,7 +148,7 @@ chmod ug+s /usr/bin/tup
 sed 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
 
 # install go
-curl -L j.mp/godeb | tar xz
+curl -L https://s3.amazonaws.com/flynn-temp/godeb.tar.gz | tar xz
 ./godeb install 1.4.3
 rm godeb
 

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -209,7 +209,7 @@ disable_docker_auto_restart() {
 
 install_go() {
   cd /tmp
-  wget j.mp/godeb
+  wget https://s3.amazonaws.com/flynn-temp/godeb.tar.gz
   tar xvzf godeb
   ./godeb install 1.4.3
 }


### PR DESCRIPTION
godeb hasn't been updated to reflect the shutdown of code.google.com
for now use the Flynn fork at https://github.com/flynn/godeb