### PR TITLE
router: Leader routing

### DIFF
--- a/router/api_test.go
+++ b/router/api_test.go
@@ -54,6 +54,7 @@ func (s *S) TestAPIAddTCPRoute(c *C) {
 	c.Assert(tcpRoute.UpdatedAt, Not(IsNil))
 	c.Assert(tcpRoute.Service, Equals, "test")
 	c.Assert(tcpRoute.Port, Not(Equals), 0)
+	c.Assert(tcpRoute.Leader, Equals, false)
 
 	route, err := srv.GetRoute("tcp", tcpRoute.ID)
 	c.Assert(err, IsNil)
@@ -64,6 +65,7 @@ func (s *S) TestAPIAddTCPRoute(c *C) {
 	c.Assert(getTCPRoute.UpdatedAt, DeepEquals, tcpRoute.UpdatedAt)
 	c.Assert(getTCPRoute.Service, Equals, "test")
 	c.Assert(getTCPRoute.Port, Equals, tcpRoute.Port)
+	c.Assert(getTCPRoute.Leader, Equals, false)
 
 	err = srv.DeleteRoute("tcp", route.ID)
 	c.Assert(err, IsNil)
@@ -85,6 +87,8 @@ func (s *S) TestAPIAddHTTPRoute(c *C) {
 	c.Assert(httpRoute.UpdatedAt, Not(IsNil))
 	c.Assert(httpRoute.Service, Equals, "test")
 	c.Assert(httpRoute.Domain, Equals, "example.com")
+	c.Assert(httpRoute.Sticky, Equals, false)
+	c.Assert(httpRoute.Leader, Equals, false)
 
 	route, err := srv.GetRoute("http", httpRoute.ID)
 	c.Assert(err, IsNil)
@@ -96,6 +100,8 @@ func (s *S) TestAPIAddHTTPRoute(c *C) {
 	c.Assert(getHTTPRoute.UpdatedAt, DeepEquals, httpRoute.UpdatedAt)
 	c.Assert(getHTTPRoute.Service, Equals, "test")
 	c.Assert(getHTTPRoute.Domain, Equals, "example.com")
+	c.Assert(getHTTPRoute.Sticky, Equals, false)
+	c.Assert(getHTTPRoute.Leader, Equals, false)
 
 	err = srv.DeleteRoute("http", route.ID)
 	c.Assert(err, IsNil)
@@ -141,9 +147,14 @@ func (s *S) TestAPISetHTTPRoute(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r.ID, Not(IsNil))
 
-	r = router.HTTPRoute{ID: r.ID, Domain: "example.com", Service: "bar"}.ToRoute()
+	r = router.HTTPRoute{ID: r.ID, Domain: "example.com", Service: "bar", Leader: true, Sticky: true}.ToRoute()
 	err = srv.UpdateRoute(r)
 	c.Assert(err, IsNil)
+	r, err = srv.GetRoute("http", r.ID)
+	c.Assert(err, IsNil)
+	c.Assert(r.Sticky, Equals, true)
+	c.Assert(r.Leader, Equals, true)
+	c.Assert(r.Service, Equals, "bar")
 }
 
 func (s *S) TestAPISetTCPRoute(c *C) {
@@ -155,9 +166,13 @@ func (s *S) TestAPISetTCPRoute(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r.ID, Not(IsNil))
 
-	r = router.TCPRoute{ID: r.ID, Service: "bar", Port: int(r.Port)}.ToRoute()
+	r = router.TCPRoute{ID: r.ID, Service: "bar", Port: int(r.Port), Leader: true}.ToRoute()
 	err = srv.UpdateRoute(r)
 	c.Assert(err, IsNil)
+	r, err = srv.GetRoute("tcp", r.ID)
+	c.Assert(err, IsNil)
+	c.Assert(r.Leader, Equals, true)
+	c.Assert(r.Service, Equals, "bar")
 }
 
 func (s *S) TestAPIListRoutes(c *C) {

--- a/router/schema.go
+++ b/router/schema.go
@@ -145,5 +145,9 @@ CREATE TRIGGER check_http_route_update
 		// migration 2.
 		`ALTER TABLE http_routes ALTER COLUMN path SET DEFAULT '/'`,
 	)
+	m.Add(4,
+		`ALTER TABLE tcp_routes ADD COLUMN leader boolean NOT NULL DEFAULT FALSE`,
+		`ALTER TABLE http_routes ADD COLUMN leader boolean NOT NULL DEFAULT FALSE`,
+	)
 	return m.Migrate(db)
 }

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -226,6 +226,7 @@ func (h *tcpSyncHandler) Set(data *router.Route) error {
 		if err != nil {
 			return err
 		}
+
 		service = &tcpService{
 			name: r.Service,
 			sc:   sc,
@@ -233,7 +234,13 @@ func (h *tcpSyncHandler) Set(data *router.Route) error {
 		h.l.services[r.Service] = service
 	}
 	r.service = service
-	r.rp = proxy.NewReverseProxy(service.sc.Addrs, nil, false)
+	var bf proxy.BackendListFunc
+	if r.Leader {
+		bf = service.sc.LeaderAddr
+	} else {
+		bf = service.sc.Addrs
+	}
+	r.rp = proxy.NewReverseProxy(bf, nil, false)
 	if listener, ok := h.l.listeners[r.Port]; ok {
 		r.l = listener
 		delete(h.l.listeners, r.Port)

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -17,6 +17,9 @@ type Route struct {
 	ParentRef string `json:"parent_ref,omitempty"`
 	// Service is the ID of the service.
 	Service string `json:"service"`
+	// Leader is whether or not traffic should only be routed to the leader or
+	// all instances
+	Leader bool `json:"leader"`
 	// CreatedAt is the time this Route was created.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt is the time this Route was last updated.
@@ -51,6 +54,7 @@ func (r Route) HTTPRoute() *HTTPRoute {
 		ID:        r.ID,
 		ParentRef: r.ParentRef,
 		Service:   r.Service,
+		Leader:    r.Leader,
 		CreatedAt: r.CreatedAt,
 		UpdatedAt: r.UpdatedAt,
 
@@ -67,6 +71,7 @@ func (r Route) TCPRoute() *TCPRoute {
 		ID:        r.ID,
 		ParentRef: r.ParentRef,
 		Service:   r.Service,
+		Leader:    r.Leader,
 		CreatedAt: r.CreatedAt,
 		UpdatedAt: r.UpdatedAt,
 
@@ -79,6 +84,7 @@ type HTTPRoute struct {
 	ID        string
 	ParentRef string
 	Service   string
+	Leader    bool
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -104,6 +110,7 @@ func (r HTTPRoute) ToRoute() *Route {
 		ID:        r.ID,
 		ParentRef: r.ParentRef,
 		Service:   r.Service,
+		Leader:    r.Leader,
 		CreatedAt: r.CreatedAt,
 		UpdatedAt: r.UpdatedAt,
 
@@ -121,6 +128,7 @@ type TCPRoute struct {
 	ID        string
 	ParentRef string
 	Service   string
+	Leader    bool
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -141,6 +149,7 @@ func (r TCPRoute) ToRoute() *Route {
 		ID:        r.ID,
 		ParentRef: r.ParentRef,
 		Service:   r.Service,
+		Leader:    r.Leader,
 		CreatedAt: r.CreatedAt,
 		UpdatedAt: r.UpdatedAt,
 

--- a/schema/router/route.json
+++ b/schema/router/route.json
@@ -47,6 +47,10 @@
       "type": "boolean",
       "description": "Whether or not to use sticky sessions for this route. It is only used for HTTP routes."
     },
+    "leader": {
+      "type": "boolean",
+      "description": "Whether to route traffic to just the leader or all instances."
+    },
     "port": {
       "type": "integer",
       "description": "The TCP port to listen on for TCP Routes."


### PR DESCRIPTION
This implements a `--leader` switch to allow routing only to the leader. If no leader is elected "no backends available" will be logged and a service unavailable message returned.

The main usecase of this feature is to expose data appliances like PostgreSQL to the outside world.
For instance to use this changeset to add a route for postgres one would use the following:
```
flynn -a postgres route add tcp --service postgres --leader
```

TODO
- [x] Update support
- [x] Unit tests

Closes #2126