### PR TITLE
script: Revert to upstream godeb

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -148,7 +148,7 @@ chmod ug+s /usr/bin/tup
 sed 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
 
 # install go
-curl -L https://s3.amazonaws.com/flynn-temp/godeb.tar.gz | tar xz
+curl https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz | tar xz
 ./godeb install 1.4.3
 rm godeb
 

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -209,8 +209,7 @@ disable_docker_auto_restart() {
 
 install_go() {
   cd /tmp
-  wget https://s3.amazonaws.com/flynn-temp/godeb.tar.gz
-  tar xvzf godeb
+  curl https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz | tar xz
   ./godeb install 1.4.3
 }
 


### PR DESCRIPTION
This reverts commit fce7e7da3da06d08829cf3510fef30a044612bdc.

Godeb accepted my patch upstream so we no-longer need our own fork.