### PR TITLE
appliance/postgres: Extract state machine to pkg/sirenia

### DIFF
--- a/appliance/postgresql/client/client.go
+++ b/appliance/postgresql/client/client.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/httpclient"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 type PostgresInfo struct {
-	Config           *state.PgConfig     `json:"config"`
+	Config           *state.Config       `json:"config"`
 	Running          bool                `json:"running"`
 	SyncedDownstream *discoverd.Instance `json:"synced_downstream"`
 	XLog             string              `json:"xlog,omitempty"`

--- a/appliance/postgresql/http.go
+++ b/appliance/postgresql/http.go
@@ -6,9 +6,9 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/appliance/postgresql/client"
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 	"github.com/flynn/flynn/pkg/status"
 )
 
@@ -35,7 +35,7 @@ type HTTP struct {
 
 func (h *HTTP) GetHealthStatus() status.Status {
 	info := h.peer.Info()
-	if info.State == nil || info.PgRetryPending != nil ||
+	if info.State == nil || info.RetryPending != nil ||
 		(info.Role != state.RolePrimary && info.Role != state.RoleSync && info.Role != state.RoleAsync) {
 		return status.Unhealthy
 	}

--- a/appliance/postgresql/postgres_test.go
+++ b/appliance/postgresql/postgres_test.go
@@ -10,10 +10,9 @@ import (
 
 	. "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
-	"github.com/flynn/flynn/appliance/postgresql/state"
-	"github.com/flynn/flynn/appliance/postgresql/xlog"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/attempt"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 // Hook gocheck up to the "go test" runner
@@ -33,7 +32,7 @@ func (PostgresSuite) TestSingletonPrimary(c *C) {
 	}
 
 	pg := NewPostgres(cfg)
-	err := pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	err := pg.Reconfigure(&state.Config{Role: state.RolePrimary})
 	c.Assert(err, IsNil)
 
 	err = pg.Start()
@@ -50,7 +49,7 @@ func (PostgresSuite) TestSingletonPrimary(c *C) {
 
 	// ensure that we can start a new instance from the same directory
 	pg = NewPostgres(cfg)
-	err = pg.Reconfigure(&state.PgConfig{Role: state.RolePrimary})
+	err = pg.Reconfigure(&state.Config{Role: state.RolePrimary})
 	c.Assert(err, IsNil)
 	c.Assert(pg.Start(), IsNil)
 	defer pg.Stop()
@@ -64,18 +63,18 @@ func (PostgresSuite) TestSingletonPrimary(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func instance(pg state.Postgres) *discoverd.Instance {
+func instance(pg state.Database) *discoverd.Instance {
 	p := pg.(*Postgres)
 	return &discoverd.Instance{
 		ID:   p.id,
 		Addr: "127.0.0.1:" + p.port,
-		Meta: map[string]string{"POSTGRES_ID": p.id},
+		Meta: map[string]string{pgIdKey: p.id},
 	}
 }
 
 var newPort uint32 = 0
 
-func newPostgres(c *C, n int) state.Postgres {
+func newPostgres(c *C, n int) state.Database {
 	return NewPostgres(Config{
 		ID:        fmt.Sprintf("node%d", n),
 		DataDir:   c.MkDir(),
@@ -84,7 +83,7 @@ func newPostgres(c *C, n int) state.Postgres {
 	})
 }
 
-func connect(c *C, s state.Postgres, db string) *pgx.Conn {
+func connect(c *C, s state.Database, db string) *pgx.Conn {
 	port, _ := strconv.Atoi(s.(*Postgres).port)
 	conn, err := pgx.Connect(pgx.ConnConfig{
 		Host:     "127.0.0.1",
@@ -97,8 +96,8 @@ func connect(c *C, s state.Postgres, db string) *pgx.Conn {
 	return conn
 }
 
-func pgConfig(role state.Role, upstream, downstream state.Postgres) *state.PgConfig {
-	c := &state.PgConfig{Role: role}
+func pgConfig(role state.Role, upstream, downstream state.Database) *state.Config {
+	c := &state.Config{Role: role}
 	if upstream != nil {
 		c.Upstream = instance(upstream)
 	}
@@ -166,7 +165,7 @@ var syncAttempts = attempt.Strategy{
 	Delay: 200 * time.Millisecond,
 }
 
-func waitReplSync(c *C, pg state.Postgres, n int) {
+func waitReplSync(c *C, pg state.Database, n int) {
 	id := fmt.Sprintf("node%d", n)
 	err := syncAttempts.Run(func() error {
 		info, err := pg.(*Postgres).Info()
@@ -227,11 +226,11 @@ func (PostgresSuite) TestIntegration(c *C) {
 	// try to query primary until it comes up as read-write
 	waitReadWrite(c, node1Conn)
 
-	for _, n := range []state.Postgres{node1, node2} {
+	for _, n := range []state.Database{node1, node2} {
 		pos, err := n.XLogPosition()
 		c.Assert(err, IsNil)
 		c.Assert(pos, Not(Equals), "")
-		c.Assert(pos, Not(Equals), xlog.Zero)
+		c.Assert(pos, Not(Equals), n.XLog().Zero())
 	}
 
 	// make sure the sync is listed as sync and remote_write is enabled

--- a/controller/worker/deployment/postgres.go
+++ b/controller/worker/deployment/postgres.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/appliance/postgresql/client"
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 func (d *DeployJob) deployPostgres() (err error) {

--- a/host/fixer/fixer.go
+++ b/host/fixer/fixer.go
@@ -11,13 +11,13 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/appliance/postgresql/client"
-	pgstate "github.com/flynn/flynn/appliance/postgresql/state"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
+	pgstate "github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 type ClusterFixer struct {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/shutdown"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 const (

--- a/pkg/sirenia/discoverd/discoverd.go
+++ b/pkg/sirenia/discoverd/discoverd.go
@@ -1,4 +1,4 @@
-package main
+package discoverd
 
 import (
 	"encoding/json"
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 type Discoverd struct {

--- a/pkg/sirenia/state/state.go
+++ b/pkg/sirenia/state/state.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
-	"github.com/flynn/flynn/appliance/postgresql/xlog"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/sirenia/xlog"
 )
 
 type State struct {
@@ -115,7 +115,7 @@ func (r *Role) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type PgConfig struct {
+type Config struct {
 	Role       Role                `json:"role"`
 	Upstream   *discoverd.Instance `json:"upstream"`
 	Downstream *discoverd.Instance `json:"downstream"`
@@ -129,7 +129,7 @@ func peersEqual(a, b *discoverd.Instance) bool {
 
 }
 
-func (x *PgConfig) Equal(y *PgConfig) bool {
+func (x *Config) Equal(y *Config) bool {
 	if x == nil || y == nil {
 		return x == y
 	}
@@ -137,7 +137,7 @@ func (x *PgConfig) Equal(y *PgConfig) bool {
 	return x.Role == y.Role && peersEqual(x.Upstream, y.Upstream) && peersEqual(x.Downstream, y.Downstream)
 }
 
-func (x *PgConfig) IsNewDownstream(y *PgConfig) bool {
+func (x *Config) IsNewDownstream(y *Config) bool {
 	if x == nil || y == nil {
 		return false
 	}
@@ -147,15 +147,20 @@ func (x *PgConfig) IsNewDownstream(y *PgConfig) bool {
 	return y.Downstream != nil && !peersEqual(x.Downstream, y.Downstream)
 }
 
-type Postgres interface {
+type Database interface {
+	// TODO(jpg): need a more generic representation of database log position.
+	// the only important thing here is to ensure we have an ordering.
+	// the comparison of this should also be handed of to the underlying database wrapper
 	XLogPosition() (xlog.Position, error)
-	Reconfigure(*PgConfig) error
+	// Returns the implementation of the XLog interface for this database
+	XLog() xlog.XLog
+	Reconfigure(*Config) error
 	Start() error
 	Stop() error
 
 	// Ready returns a channel that returns a single event when the interface
 	// is ready.
-	Ready() <-chan PostgresEvent
+	Ready() <-chan DatabaseEvent
 }
 
 type Discoverd interface {
@@ -163,7 +168,7 @@ type Discoverd interface {
 	Events() <-chan *DiscoverdEvent
 }
 
-type PostgresEvent struct {
+type DatabaseEvent struct {
 	Online bool
 	Setup  bool
 }
@@ -188,23 +193,24 @@ type DiscoverdEvent struct {
 }
 
 type PeerInfo struct {
-	ID             string                `json:"id"`
-	Role           Role                  `json:"role"`
-	PgRetryPending *time.Time            `json:"pg_retry_pending,omitempty"`
-	State          *State                `json:"state"`
-	Peers          []*discoverd.Instance `json:"peers"`
+	ID           string                `json:"id"`
+	Role         Role                  `json:"role"`
+	RetryPending *time.Time            `json:"retry_pending,omitempty"`
+	State        *State                `json:"state"`
+	Peers        []*discoverd.Instance `json:"peers"`
 }
 
 type Peer struct {
 	// Configuration
 	id        string
+	idKey     string
 	self      *discoverd.Instance
 	singleton bool
 
 	// External Interfaces
 	log       log15.Logger
 	discoverd Discoverd
-	postgres  Postgres
+	db        Database
 
 	// Dynamic state
 	info          atomic.Value // *PeerInfo, replaced after each change
@@ -212,11 +218,11 @@ type Peer struct {
 	updatingState *State       // new state object
 	stateIndex    uint64       // last received cluster state index
 
-	pgOnline     *bool               // nil for unknown
-	pgSetup      bool                // whether db existed at start
-	pgApplied    *PgConfig           // last configuration applied
-	pgUpstream   *discoverd.Instance // upstream replication target
-	pgDownstream *discoverd.Instance // downstream replication target
+	online     *bool               // nil for unknown
+	setup      bool                // whether db existed at start
+	applied    *Config             // last configuration applied
+	upstream   *discoverd.Instance // upstream replication target
+	downstream *discoverd.Instance // downstream replication target
 
 	evalStateCh chan struct{}
 	applyConfCh chan struct{}
@@ -228,12 +234,13 @@ type Peer struct {
 	closeOnce sync.Once
 }
 
-func NewPeer(self *discoverd.Instance, id string, singleton bool, d Discoverd, pg Postgres, log log15.Logger) *Peer {
+func NewPeer(self *discoverd.Instance, id string, idKey string, singleton bool, d Discoverd, db Database, log log15.Logger) *Peer {
 	p := &Peer{
 		id:          id,
+		idKey:       idKey,
 		self:        self,
 		singleton:   singleton,
-		postgres:    pg,
+		db:          db,
 		discoverd:   d,
 		log:         log,
 		evalStateCh: make(chan struct{}, 1),
@@ -251,7 +258,7 @@ func (p *Peer) SetDebugChannels(restCh, retryCh chan struct{}) {
 
 func (p *Peer) Run() {
 	discoverdCh := p.discoverd.Events()
-	postgresCh := p.postgres.Ready()
+	dbCh := p.db.Ready()
 	for {
 		select {
 		// drain discoverdCh to avoid evaluating out-of-date state
@@ -266,14 +273,14 @@ func (p *Peer) Run() {
 		case e := <-discoverdCh:
 			p.handleDiscoverdEvent(e)
 			continue
-		case e := <-postgresCh:
-			p.handlePgInit(e)
+		case e := <-dbCh:
+			p.handleInit(e)
 			continue
 		case <-p.evalStateCh:
 			p.evalClusterState()
 			continue
 		case <-p.applyConfCh:
-			p.pgApplyConfig()
+			p.applyConfig()
 			continue
 		case <-p.stopCh:
 			return
@@ -284,12 +291,12 @@ func (p *Peer) Run() {
 		select {
 		case e := <-discoverdCh:
 			p.handleDiscoverdEvent(e)
-		case e := <-postgresCh:
-			p.handlePgInit(e)
+		case e := <-dbCh:
+			p.handleInit(e)
 		case <-p.evalStateCh:
 			p.evalClusterState()
 		case <-p.applyConfCh:
-			p.pgApplyConfig()
+			p.applyConfig()
 		case <-p.workDoneCh:
 			// There is no work to do, we are now at rest
 			p.rest()
@@ -301,7 +308,7 @@ func (p *Peer) Run() {
 
 func (p *Peer) Stop() error {
 	p.Close()
-	return p.postgres.Stop()
+	return p.db.Stop()
 }
 
 func (p *Peer) Close() error {
@@ -337,20 +344,20 @@ func (p *Peer) setRole(role Role) {
 	p.setInfo(info)
 }
 
-func (p *Peer) setPgRetryPending(t *time.Time) {
+func (p *Peer) setRetryPending(t *time.Time) {
 	info := *p.Info()
-	info.PgRetryPending = t
+	info.RetryPending = t
 	p.setInfo(info)
 }
 
-func (p *Peer) handlePgInit(e PostgresEvent) {
-	p.log.Info("postgres init", "online", e.Online, "setup", e.Setup)
-	if p.pgOnline != nil {
-		panic("received postgres init event after already initialized")
+func (p *Peer) handleInit(e DatabaseEvent) {
+	p.log.Info("db init", "online", e.Online, "setup", e.Setup)
+	if p.online != nil {
+		panic("received db init event after already initialized")
 	}
 
-	p.pgOnline = &e.Online
-	p.pgSetup = e.Setup
+	p.online = &e.Online
+	p.setup = e.Setup
 
 	if p.Info().Peers != nil {
 		p.evalClusterState()
@@ -375,7 +382,7 @@ func (p *Peer) handleDiscoverdInit(e *DiscoverdEvent) {
 	}
 	p.setPeers(e.Peers)
 	p.decodeState(e)
-	if p.pgOnline != nil {
+	if p.online != nil {
 		p.triggerEval()
 	}
 }
@@ -486,15 +493,15 @@ func (p *Peer) evalClusterState() {
 			"peers", len(info.Peers),
 			"self", p.id,
 			"singleton", p.singleton,
-			"leader", len(info.Peers) > 0 && info.Peers[0].Meta["POSTGRES_ID"] == p.id,
+			"leader", len(info.Peers) > 0 && info.Peers[0].Meta[p.idKey] == p.id,
 		)
 
 		if len(info.Peers) == 0 {
 			return
 		}
 
-		if !p.pgSetup &&
-			info.Peers[0].Meta["POSTGRES_ID"] == p.id &&
+		if !p.setup &&
+			info.Peers[0].Meta[p.idKey] == p.id &&
 			(p.singleton || len(info.Peers) > 1) {
 			p.startInitialSetup()
 		} else if info.Role != RoleUnassigned {
@@ -519,7 +526,7 @@ func (p *Peer) evalClusterState() {
 		p.generation = p.Info().State.Generation
 
 		if p.Info().Role == RolePrimary {
-			if p.Info().State.Primary.Meta["POSTGRES_ID"] != p.id {
+			if p.Info().State.Primary.Meta[p.idKey] != p.id {
 				p.assumeDeposed()
 			}
 		} else {
@@ -542,10 +549,10 @@ func (p *Peer) evalClusterState() {
 		if whichAsync := p.whichAsync(); whichAsync == -1 {
 			p.assumeUnassigned()
 		} else {
-			upstream := p.upstream(whichAsync)
-			downstream := p.downstream(whichAsync)
-			if upstream.Meta["POSTGRES_ID"] != p.pgUpstream.Meta["POSTGRES_ID"] ||
-				downstream != nil && (p.pgDownstream == nil || downstream.Meta["POSTGRES_ID"] != p.pgDownstream.Meta["POSTGRES_ID"]) {
+			upstream := p.lookupUpstream(whichAsync)
+			downstream := p.lookupDownstream(whichAsync)
+			if upstream.Meta[p.idKey] != p.upstream.Meta[p.idKey] ||
+				downstream != nil && (p.downstream == nil || downstream.Meta[p.idKey] != p.downstream.Meta[p.idKey]) {
 				p.assumeAsync(whichAsync)
 			}
 		}
@@ -558,7 +565,7 @@ func (p *Peer) evalClusterState() {
 	if p.Info().Role == RoleSync {
 		if !p.peerIsPresent(p.Info().State.Primary) {
 			p.startTakeover("primary gone", p.Info().State.InitWAL)
-		} else if len(p.Info().State.Async) > 0 && (p.pgDownstream == nil || p.pgDownstream.Meta["POSTGRES_ID"] != p.Info().State.Async[0].Meta["POSTGRES_ID"]) {
+		} else if len(p.Info().State.Async) > 0 && (p.downstream == nil || p.downstream.Meta[p.idKey] != p.Info().State.Async[0].Meta[p.idKey]) {
 			p.assumeSync()
 		}
 		return
@@ -571,7 +578,7 @@ func (p *Peer) evalClusterState() {
 	// write new state with updated discoverd instance ID if our discoverd
 	// instance has changed (new job with the same local instance ID saved in
 	// the data volume)
-	if p.Info().State.Primary.ID != p.self.ID && p.Info().State.Primary.Meta["POSTGRES_ID"] == p.id {
+	if p.Info().State.Primary.ID != p.self.ID && p.Info().State.Primary.Meta[p.idKey] == p.id {
 		log.Info("role is primary, but discoverd id in state differs from self, updating")
 		p.updatingState = p.Info().State
 		p.updatingState.Primary = p.self
@@ -590,8 +597,8 @@ func (p *Peer) evalClusterState() {
 
 	if !p.singleton && p.Info().State.Singleton {
 		log.Info("configured for normal mode but found cluster in singleton mode, transitioning cluster to normal mode")
-		if p.Info().State.Primary.Meta["POSTGRES_ID"] != p.id {
-			panic(fmt.Sprintf("unexpected cluster state, we should be the primary, but %s is", p.Info().State.Primary.Meta["POSTGRES_ID"]))
+		if p.Info().State.Primary.Meta[p.idKey] != p.id {
+			panic(fmt.Sprintf("unexpected cluster state, we should be the primary, but %s is", p.Info().State.Primary.Meta[p.idKey]))
 		}
 		p.startTransitionToNormalMode()
 		return
@@ -618,32 +625,32 @@ func (p *Peer) evalClusterState() {
 	}
 
 	presentPeers := make(map[string]struct{}, len(p.Info().Peers))
-	presentPeers[p.Info().State.Primary.Meta["POSTGRES_ID"]] = struct{}{}
-	presentPeers[p.Info().State.Sync.Meta["POSTGRES_ID"]] = struct{}{}
+	presentPeers[p.Info().State.Primary.Meta[p.idKey]] = struct{}{}
+	presentPeers[p.Info().State.Sync.Meta[p.idKey]] = struct{}{}
 
 	newAsync := make([]*discoverd.Instance, 0, len(p.Info().Peers))
 	changes := false
 
 	for _, a := range p.Info().State.Async {
 		if p.peerIsPresent(a) {
-			presentPeers[a.Meta["POSTGRES_ID"]] = struct{}{}
+			presentPeers[a.Meta[p.idKey]] = struct{}{}
 			newAsync = append(newAsync, a)
 		} else {
-			log.Debug("peer missing", "async.id", a.Meta["POSTGRES_ID"], "async.addr", a.Addr)
+			log.Debug("peer missing", "async.id", a.Meta[p.idKey], "async.addr", a.Addr)
 			changes = true
 		}
 	}
 
 	// Deposed peers should not be assigned as asyncs
 	for _, d := range p.Info().State.Deposed {
-		presentPeers[d.Meta["POSTGRES_ID"]] = struct{}{}
+		presentPeers[d.Meta[p.idKey]] = struct{}{}
 	}
 
 	for _, peer := range p.Info().Peers {
-		if _, ok := presentPeers[peer.Meta["POSTGRES_ID"]]; ok {
+		if _, ok := presentPeers[peer.Meta[p.idKey]]; ok {
 			continue
 		}
-		log.Debug("new peer", "async.id", peer.Meta["POSTGRES_ID"], "async.addr", peer.Addr)
+		log.Debug("new peer", "async.id", peer.Meta[p.idKey], "async.addr", peer.Addr)
 		newAsync = append(newAsync, peer)
 		changes = true
 	}
@@ -663,7 +670,7 @@ func (p *Peer) startInitialSetup() {
 	p.updatingState = &State{
 		Generation: 1,
 		Primary:    p.self,
-		InitWAL:    xlog.Zero,
+		InitWAL:    p.db.XLog().Zero(),
 	}
 	if p.singleton {
 		p.updatingState.Singleton = true
@@ -693,24 +700,24 @@ func (p *Peer) startInitialSetup() {
 func (p *Peer) assumeUnassigned() {
 	p.log.Info("assuming unassigned role", "role", "unassigned", "fn", "assumeUnassigned")
 	p.setRole(RoleUnassigned)
-	p.pgUpstream = nil
-	p.pgDownstream = nil
+	p.upstream = nil
+	p.downstream = nil
 	p.triggerApplyConfig()
 }
 
 func (p *Peer) assumeDeposed() {
 	p.log.Info("assuming deposed role", "role", "deposed", "fn", "assumeDeposed")
 	p.setRole(RoleDeposed)
-	p.pgUpstream = nil
-	p.pgDownstream = nil
+	p.upstream = nil
+	p.downstream = nil
 	p.triggerApplyConfig()
 }
 
 func (p *Peer) assumePrimary() {
 	p.log.Info("assuming primary role", "role", "primary", "fn", "assumePrimary")
 	p.setRole(RolePrimary)
-	p.pgUpstream = nil
-	p.pgDownstream = p.Info().State.Sync
+	p.upstream = nil
+	p.downstream = p.Info().State.Sync
 
 	// It simplifies things to say that evalClusterState() only deals with one
 	// change at a time. Now that we've handled the change to become primary,
@@ -721,10 +728,10 @@ func (p *Peer) assumePrimary() {
 	// not present. The first call to evalClusterState() will get us here, and
 	// we call it again to check for the presence of the synchronous peer.
 	//
-	// We invoke pgApplyConfig() after evalClusterState(), though it may well
+	// We invoke applyConfig() after evalClusterState(), though it may well
 	// turn out that evalClusterState() kicked off an operation that will
 	// change the desired postgres configuration. In that case, we'll end up
-	// calling pgApplyConfig() again.
+	// calling applyConfig() again.
 	p.evalClusterState()
 	p.triggerApplyConfig()
 }
@@ -736,9 +743,9 @@ func (p *Peer) assumeSync() {
 	p.log.Info("assuming sync role", "role", "sync", "fn", "assumeSync")
 
 	p.setRole(RoleSync)
-	p.pgUpstream = p.Info().State.Primary
+	p.upstream = p.Info().State.Primary
 	if len(p.Info().State.Async) > 0 {
-		p.pgDownstream = p.Info().State.Async[0]
+		p.downstream = p.Info().State.Async[0]
 	}
 	// See assumePrimary()
 	p.evalClusterState()
@@ -752,8 +759,8 @@ func (p *Peer) assumeAsync(i int) {
 	p.log.Info("assuming async role", "role", "async", "fn", "assumeAsync")
 
 	p.setRole(RoleAsync)
-	p.pgUpstream = p.upstream(i)
-	p.pgDownstream = p.downstream(i)
+	p.upstream = p.lookupUpstream(i)
+	p.downstream = p.lookupDownstream(i)
 
 	// See assumePrimary(). We don't need to check the cluster state here
 	// because there's never more than one thing to do when becoming the async
@@ -762,7 +769,7 @@ func (p *Peer) assumeAsync(i int) {
 }
 
 func (p *Peer) evalInitClusterState() {
-	if p.Info().State.Primary.Meta["POSTGRES_ID"] == p.id {
+	if p.Info().State.Primary.Meta[p.idKey] == p.id {
 		p.assumePrimary()
 		return
 	}
@@ -770,13 +777,13 @@ func (p *Peer) evalInitClusterState() {
 		p.assumeUnassigned()
 		return
 	}
-	if p.Info().State.Sync.Meta["POSTGRES_ID"] == p.id {
+	if p.Info().State.Sync.Meta[p.idKey] == p.id {
 		p.assumeSync()
 		return
 	}
 
 	for _, d := range p.Info().State.Deposed {
-		if p.id == d.Meta["POSTGRES_ID"] {
+		if p.id == d.Meta[p.idKey] {
 			p.assumeDeposed()
 			return
 		}
@@ -810,13 +817,13 @@ func (p *Peer) startTakeover(reason string, minWAL xlog.Position) bool {
 	log.Debug("preparing for new generation")
 	newAsync := make([]*discoverd.Instance, 0, len(p.Info().State.Async))
 	for _, a := range p.Info().State.Async {
-		if a.Meta["POSTGRES_ID"] != newSync.Meta["POSTGRES_ID"] && p.peerIsPresent(a) {
+		if a.Meta[p.idKey] != newSync.Meta[p.idKey] && p.peerIsPresent(a) {
 			newAsync = append(newAsync, a)
 		}
 	}
 
 	newDeposed := append(make([]*discoverd.Instance, 0, len(p.Info().State.Deposed)+1), p.Info().State.Deposed...)
-	if p.Info().State.Primary.Meta["POSTGRES_ID"] != p.id {
+	if p.Info().State.Primary.Meta[p.idKey] != p.id {
 		newDeposed = append(newDeposed, p.Info().State.Primary)
 	}
 
@@ -830,7 +837,7 @@ func (p *Peer) startTakeover(reason string, minWAL xlog.Position) bool {
 
 var (
 	ErrClusterFrozen   = errors.New("cluster is frozen")
-	ErrPostgresOffline = errors.New("postgres is offline")
+	ErrDatabaseOffline = errors.New("database is offline")
 	ErrPeerNotCaughtUp = errors.New("peer is not caught up")
 )
 
@@ -845,7 +852,7 @@ func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newSta
 	newState.Primary = p.self
 	p.updatingState = newState
 
-	if p.updatingState.Primary.Meta["POSTGRES_ID"] != p.Info().State.Primary.Meta["POSTGRES_ID"] && len(p.updatingState.Deposed) == 0 {
+	if p.updatingState.Primary.Meta[p.idKey] != p.Info().State.Primary.Meta[p.idKey] && len(p.updatingState.Deposed) == 0 {
 		panic("startTakeoverWithPeer without deposing old primary")
 	}
 
@@ -856,8 +863,8 @@ func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newSta
 		p.updatingState = nil
 
 		switch err {
-		case ErrPostgresOffline:
-			// If postgres is offline, it's because we haven't started yet, so
+		case ErrDatabaseOffline:
+			// If database is offline, it's because we haven't started yet, so
 			// trigger another state evaluation after we start it.
 			log.Error("failed to declare new generation, trying later", "err", err)
 			p.triggerEval()
@@ -866,7 +873,7 @@ func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newSta
 		default:
 			// In the event of an error, back off a bit and check state again in
 			// a second. There are several transient failure modes that will resolve
-			// themselves (e.g. postgres synchronous replication not yet caught up).
+			// themselves (e.g. synchronous replication not yet caught up).
 			log.Error("failed to declare new generation, backing off", "err", err)
 			p.evalLater(1 * time.Second)
 		}
@@ -877,21 +884,21 @@ func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newSta
 	}
 
 	// In order to declare a new generation, we'll need to fetch our current
-	// transaction log position, which requires that postres be online. In most
+	// transaction log position, which requires that database be online. In most
 	// cases, it will be, since we only declare a new generation as a primary or
 	// a caught-up sync. During initial startup, however, we may find out
 	// simultaneously that we're the primary or sync AND that the other is gone,
 	// so we may attempt to declare a new generation before we've started
-	// postgres. In this case, this step will fail, but we'll just skip the
-	// takeover attempt until postgres is running.
-	if !*p.pgOnline {
-		return ErrPostgresOffline
+	// the database. In this case, this step will fail, but we'll just skip the
+	// takeover attempt until the database is running.
+	if !*p.online {
+		return ErrDatabaseOffline
 	}
-	wal, err := p.postgres.XLogPosition()
+	wal, err := p.db.XLogPosition()
 	if err != nil {
 		return err
 	}
-	if x, err := xlog.Compare(wal, minWAL); err != nil || x < 0 {
+	if x, err := p.db.XLog().Compare(wal, minWAL); err != nil || x < 0 {
 		if err == nil {
 			log.Warn("would attempt takeover but not caught up with primary yet", "found_wal", wal)
 			err = ErrPeerNotCaughtUp
@@ -921,7 +928,7 @@ func (p *Peer) startTakeoverWithPeer(reason string, minWAL xlog.Position, newSta
 // mode.
 func (p *Peer) startTransitionToNormalMode() {
 	log := p.log.New("fn", "startTransitionToNormalMode")
-	if p.Info().State.Primary.Meta["POSTGRES_ID"] != p.id || p.Info().Role != RolePrimary {
+	if p.Info().State.Primary.Meta[p.idKey] != p.id || p.Info().Role != RolePrimary {
 		panic("startTransitionToNormalMode called when not primary")
 	}
 
@@ -929,7 +936,7 @@ func (p *Peer) startTransitionToNormalMode() {
 	// any other peer because we know none of them has anything replicated.
 	var newSync *discoverd.Instance
 	for _, peer := range p.Info().Peers {
-		if peer.Meta["POSTGRES_ID"] != p.id {
+		if peer.Meta[p.idKey] != p.id {
 			newSync = peer
 		}
 	}
@@ -939,13 +946,13 @@ func (p *Peer) startTransitionToNormalMode() {
 	}
 	newAsync := make([]*discoverd.Instance, 0, len(p.Info().Peers))
 	for _, a := range p.Info().Peers {
-		if a.Meta["POSTGRES_ID"] != p.id && a.Meta["POSTGRES_ID"] != newSync.Meta["POSTGRES_ID"] {
+		if a.Meta[p.idKey] != p.id && a.Meta[p.idKey] != newSync.Meta[p.idKey] {
 			newAsync = append(newAsync, a)
 		}
 	}
 
 	log.Debug("transitioning to normal mode")
-	p.startTakeoverWithPeer("transitioning to normal mode", xlog.Zero, &State{
+	p.startTakeoverWithPeer("transitioning to normal mode", p.db.XLog().Zero(), &State{
 		Sync:  newSync,
 		Async: newAsync,
 	})
@@ -977,21 +984,21 @@ func (p *Peer) startUpdateAsyncs(newAsync []*discoverd.Instance) {
 	p.triggerEval()
 }
 
-// Reconfigure postgres based on the current configuration. During
+// Reconfigure database based on the current configuration. During
 // reconfiguration, new requests to reconfigure will be ignored, and incoming
 // cluster state changes will be recorded but otherwise ignored. When
 // reconfiguration completes, if the desired configuration has changed, we'll
 // take another lap to apply the updated configuration.
-func (p *Peer) pgApplyConfig() (err error) {
+func (p *Peer) applyConfig() (err error) {
 	p.moving()
-	log := p.log.New("fn", "pgApplyConfig")
+	log := p.log.New("fn", "applyConfig")
 
-	if p.pgOnline == nil {
-		panic("pgApplyConfig with postgres in unknown state")
+	if p.online == nil {
+		panic("applyConfig with database in unknown state")
 	}
 
-	config := p.pgConfig()
-	if p.pgApplied != nil && p.pgApplied.Equal(config) {
+	config := p.Config()
+	if p.applied != nil && p.applied.Equal(config) {
 		log.Info("skipping config apply, no changes")
 		return nil
 	}
@@ -1007,30 +1014,30 @@ func (p *Peer) pgApplyConfig() (err error) {
 		// there's no reason to believe any other peer is in a better position
 		// to deal with this, and we don't want to flap unnecessarily. So just
 		// log an error and try again shortly.
-		log.Error("error applying pg config", "err", err)
+		log.Error("error applying database config", "err", err)
 		t := TimeNow()
-		p.setPgRetryPending(&t)
+		p.setRetryPending(&t)
 		p.applyConfigLater(1 * time.Second)
 	}()
 
-	log.Info("reconfiguring postgres")
-	if err := p.postgres.Reconfigure(config); err != nil {
+	log.Info("reconfiguring database")
+	if err := p.db.Reconfigure(config); err != nil {
 		return err
 	}
 
 	if config.Role != RoleNone {
-		if *p.pgOnline {
+		if *p.online {
 			log.Debug("skipping start, already online")
 		} else {
-			log.Debug("starting postgres")
-			if err := p.postgres.Start(); err != nil {
+			log.Debug("starting database")
+			if err := p.db.Start(); err != nil {
 				return err
 			}
 		}
 	} else {
-		if *p.pgOnline {
-			log.Debug("stopping postgres")
-			if err := p.postgres.Stop(); err != nil {
+		if *p.online {
+			log.Debug("stopping database")
+			if err := p.db.Stop(); err != nil {
 				return err
 			}
 		} else {
@@ -1038,11 +1045,11 @@ func (p *Peer) pgApplyConfig() (err error) {
 		}
 	}
 
-	log.Info("applied pg config")
-	p.setPgRetryPending(nil)
-	p.pgApplied = config
+	log.Info("applied database config")
+	p.setRetryPending(nil)
+	p.applied = config
 	online := config.Role != RoleNone
-	p.pgOnline = &online
+	p.online = &online
 
 	// Try applying the configuration again in case anything's
 	// changed. If not, this will be a no-op.
@@ -1050,13 +1057,13 @@ func (p *Peer) pgApplyConfig() (err error) {
 	return nil
 }
 
-func (p *Peer) pgConfig() *PgConfig {
+func (p *Peer) Config() *Config {
 	role := p.Info().Role
 	switch role {
 	case RolePrimary, RoleSync, RoleAsync:
-		return &PgConfig{Role: role, Upstream: p.pgUpstream, Downstream: p.pgDownstream}
+		return &Config{Role: role, Upstream: p.upstream, Downstream: p.downstream}
 	case RoleUnassigned, RoleDeposed:
-		return &PgConfig{Role: RoleNone}
+		return &Config{Role: RoleNone}
 	default:
 		panic(fmt.Sprintf("unexpected role %v", role))
 	}
@@ -1065,7 +1072,7 @@ func (p *Peer) pgConfig() *PgConfig {
 // Determine our index in the async peer list. -1 means not present.
 func (p *Peer) whichAsync() int {
 	for i, a := range p.Info().State.Async {
-		if p.id == a.Meta["POSTGRES_ID"] {
+		if p.id == a.Meta[p.idKey] {
 			return i
 		}
 	}
@@ -1073,7 +1080,7 @@ func (p *Peer) whichAsync() int {
 }
 
 // Return the upstream peer for a given one of the async peers
-func (p *Peer) upstream(whichAsync int) *discoverd.Instance {
+func (p *Peer) lookupUpstream(whichAsync int) *discoverd.Instance {
 	if whichAsync == 0 {
 		return p.Info().State.Sync
 	}
@@ -1081,7 +1088,7 @@ func (p *Peer) upstream(whichAsync int) *discoverd.Instance {
 }
 
 // Return the downstream peer for a given one of the async peers
-func (p *Peer) downstream(whichAsync int) *discoverd.Instance {
+func (p *Peer) lookupDownstream(whichAsync int) *discoverd.Instance {
 	async := p.Info().State.Async
 	if whichAsync == len(async)-1 {
 		return nil
@@ -1095,11 +1102,11 @@ func (p *Peer) peerIsPresent(other *discoverd.Instance) bool {
 	// We should never even be asking whether we're present. If we need to do
 	// this at some point in the future, we need to consider we should always
 	// consider ourselves present or whether we should check the list.
-	if other.Meta["POSTGRES_ID"] == p.id {
+	if other.Meta[p.idKey] == p.id {
 		panic("peerIsPresent with self")
 	}
-	for _, p := range p.Info().Peers {
-		if p.Meta["POSTGRES_ID"] == other.Meta["POSTGRES_ID"] {
+	for _, peer := range p.Info().Peers {
+		if peer.Meta[p.idKey] == other.Meta[p.idKey] {
 			return true
 		}
 	}

--- a/pkg/sirenia/xlog/xlog.go
+++ b/pkg/sirenia/xlog/xlog.go
@@ -1,0 +1,11 @@
+package xlog
+
+type Position string
+
+type XLog interface {
+	// Returns the zero position for this xlog
+	Zero() Position
+	// Compare compares two xlog positions returning -1 if xlog1 < xlog2, 0 if xlog1
+	// == xlog2, and 1 if xlog1 > xlog2.
+	Compare(Position, Position) (int, error)
+}

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
-	"github.com/flynn/flynn/appliance/postgresql/state"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
 type PostgresSuite struct {


### PR DESCRIPTION
This changeset extracts the implementation of the Manatee state machine from the `appliance/postgres` package along with it's simulator/test-harness.

I renamed it Sirenia as it's the greater family of sea cows that encompass both Manatees and Dugongs. :grinning: 

Of note is that it attempts a generalisation of the `xlog` interface. To implement this interface a database must have a history with a total ordering that can be serialised to a string format. (`xlog.Position`)

Apart from this requirement databases wishing to use the Sirenia state machine must also implement synchronous replication and be capable of blocking writes when it's downstream synchronous peer is unable to ack them. 