### PR TITLE
host: Start flynn-host at boot by default

### DIFF
--- a/host/upstart.conf
+++ b/host/upstart.conf
@@ -1,8 +1,8 @@
 description "Flynn layer 0"
 
-#start on (started libvirt-bin and started networking)
+start on (started libvirt-bin and started networking)
 stop on stopping libvirt-bin
-#respawn
-#respawn limit 1000 60
+respawn
+respawn limit 100 60
 
 exec /usr/local/bin/flynn-host daemon

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -202,6 +202,7 @@ install_flynn() {
   fi
 
   bash -es -- -r "${repo}" < <(curl -sL --fail "${repo}/${script}")
+  sed -i 's/start on/#start on/' /etc/init/flynn-host.conf
 }
 
 disable_docker_auto_restart() {


### PR DESCRIPTION
Disabled in EC2 and Vagrant images so that bootstrap scripts can do their thing.