### PR TITLE
controller/scheduler: Wait for controller API to start

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -138,6 +138,13 @@ func main() {
 		log.Error("error creating controller client", "err", err)
 		shutdown.Fatal(err)
 	}
+
+	log.Info("waiting for controller API to come up")
+	if _, err := discoverd.GetInstances("controller", 5*time.Minute); err != nil {
+		log.Error("error waiting for controller API", "err", err)
+		shutdown.Fatal(err)
+	}
+
 	s := NewScheduler(clusterClient, controllerClient, newDiscoverdWrapper())
 	log.Info("started scheduler", "backoffPeriod", s.backoffPeriod)
 


### PR DESCRIPTION
Explicitly wait for the controller API to be registered in discoverd.

If we do not do this and it takes longer than expected to start, the scheduler may crash later when doing the initial job sync. This was observed during a restore from a backup by @temujin9.