### PR TITLE
test: Increase the deploy timeout

### DIFF
--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -97,7 +97,7 @@ loop:
 				break loop
 			}
 			debugf(t, "got deployment event: %s %s", e.JobType, e.JobState)
-		case <-time.After(15 * time.Second):
+		case <-time.After(60 * time.Second):
 			t.Fatal("timed out waiting for deployment event")
 		}
 	}


### PR DESCRIPTION
The scheduler occasionally does not receive job events from hosts, so only updates the job status in the controller when a sync happens. Bumping the deploy timeout to be greater than the sync period ensures deployments don't timeout because of this.

We should probably investigate why some events are being dropped, see for example `DeployerSuite.TestOmniProcess` in the following build:

https://s3.amazonaws.com/flynn-ci-logs/20160207043827-c2d85abb-build-1542c912ced512b896132a9b99eaa51ffcff1fde-2016-02-07-05-00-21.txt