### PR TITLE
host: Prevent multiple attachers to interactive jobs

### DIFF
--- a/host/cli/log.go
+++ b/host/cli/log.go
@@ -76,7 +76,7 @@ func getLog(hostID, jobID string, client *cluster.Client, follow, init bool, std
 	attachClient, err := hostClient.Attach(attachReq, false)
 	if err != nil {
 		switch err {
-		case host.ErrJobNotRunning:
+		case host.ErrJobNotRunning, host.ErrAttached:
 			return nil
 		case cluster.ErrWouldWait:
 			return errors.New("no such job")

--- a/host/http.go
+++ b/host/http.go
@@ -499,7 +499,7 @@ func (h *jobAPI) RegisterRoutes(r *httprouter.Router) error {
 func (h *Host) ServeHTTP() {
 	r := httprouter.New()
 
-	r.POST("/attach", (&attachHandler{state: h.state, backend: h.backend}).ServeHTTP)
+	r.POST("/attach", newAttachHandler(h.state, h.backend).ServeHTTP)
 
 	jobAPI := &jobAPI{host: h}
 	jobAPI.RegisterRoutes(r)

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -209,7 +209,10 @@ type ActiveJob struct {
 	Error       *string   `json:"error,omitempty"`
 }
 
-var ErrJobNotRunning = errors.New("host: job not running")
+var (
+	ErrJobNotRunning = errors.New("host: job not running")
+	ErrAttached      = errors.New("host: job is attached")
+)
 
 type AttachReq struct {
 	JobID  string     `json:"job_id,omitempty"`

--- a/pkg/cluster/attach.go
+++ b/pkg/cluster/attach.go
@@ -47,8 +47,11 @@ func (c *Host) Attach(req *host.AttachReq, wait bool) (AttachClient, error) {
 				errBytes = errBytes[4:]
 			}
 			errMsg := string(errBytes)
-			if errMsg == host.ErrJobNotRunning.Error() {
+			switch errMsg {
+			case host.ErrJobNotRunning.Error():
 				return host.ErrJobNotRunning
+			case host.ErrAttached.Error():
+				return host.ErrAttached
 			}
 			return errors.New(errMsg)
 		default:


### PR DESCRIPTION
This means running `flynn-host log` for a job which has `DisableLog` set and is already attached now just returns as if there is no log.

I was lead to this by the fact that CI logs are currently around 100MB, with about 70MB of that being the output of the [controller backup test](https://github.com/flynn/flynn/blob/master/test/test_controller.go#L534-L537) because the postgres dump job is still running when the logs are dumped.

Fixes #1697.