### PR TITLE
worker: Stop DomainMigration jobs when worker is shutting down

### DIFF
--- a/controller/worker/deployment/context.go
+++ b/controller/worker/deployment/context.go
@@ -2,19 +2,17 @@ package deployment
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/que-go"
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/worker/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/postgres"
 )
-
-var ErrStopped = errors.New("deployment stopped")
 
 type context struct {
 	db     *postgres.DB
@@ -71,7 +69,7 @@ func (c *context) HandleDeployment(job *que.Job) (e error) {
 		log.Info("stopped watching deployment events")
 	}()
 	defer func() {
-		if e == ErrStopped {
+		if e == worker.ErrStopped {
 			return
 		}
 		log.Info("marking the deployment as done")

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/worker/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/cluster"
 )
@@ -99,7 +100,7 @@ func (d *DeployJob) Perform() error {
 		for {
 			select {
 			case <-d.stop:
-				return ErrStopped
+				return worker.ErrStopped
 			case event, ok := <-events:
 				if !ok {
 					log.Error("error creating service discovery watcher, channel closed", "service", proc.Service)
@@ -215,7 +216,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 	for {
 		select {
 		case <-d.stop:
-			return ErrStopped
+			return worker.ErrStopped
 		case event := <-d.serviceEvents:
 			if event.Kind != discoverd.EventKindUp {
 				continue

--- a/controller/worker/types/types.go
+++ b/controller/worker/types/types.go
@@ -1,0 +1,5 @@
+package worker
+
+import "errors"
+
+var ErrStopped = errors.New("worker stopped")

--- a/pkg/httpclient/stream.go
+++ b/pkg/httpclient/stream.go
@@ -81,7 +81,7 @@ func Stream(res *http.Response, outputCh interface{}) stream.Stream {
 }
 
 var connectAttempts = attempt.Strategy{
-	Total: 10 * time.Second,
+	Total: 20 * time.Second,
 	Delay: 100 * time.Millisecond,
 }
 


### PR DESCRIPTION
A `DomainMigration` job deploys the controller and so may result in the worker which is performing the migration killing itself, in which case the domain migration needs to stop waiting straight away so a new worker can continue with both the controller deploy and the domain migration.

I've also increased the stream reconnect timeout (see explanation in b9d3e51).