### PR TITLE
router: Specify service in release

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -346,7 +346,8 @@
         "app": {
           "host_network": true,
           "cmd": ["-http-port", "80", "-https-port", "443", "-tcp-range-start", "3000", "-tcp-range-end", "3500"],
-          "omni": true
+          "omni": true,
+          "service": "router-api"
         }
       }
     },

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -218,7 +218,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 		case <-d.stop:
 			return worker.ErrStopped
 		case event := <-d.serviceEvents:
-			if event.Kind != discoverd.EventKindUp {
+			if !event.Kind.Any(discoverd.EventKindUp, discoverd.EventKindUpdate) {
 				continue
 			}
 			if id, ok := event.Instance.Meta["FLYNN_APP_ID"]; !ok || id != d.AppID {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -120,7 +120,7 @@ type Runner struct {
 
 var args *arg.Args
 
-const maxConcurrentBuilds = 2
+const maxConcurrentBuilds = 1
 
 func init() {
 	args = arg.Parse()


### PR DESCRIPTION
This means deployments will not succeed if the router job fails to register the service (e.g. if the `COOKIE_KEY` or TLS env vars are invalid).