### PR TITLE
Add file artifacts

### DIFF
--- a/bootstrap/add_app_action.go
+++ b/bootstrap/add_app_action.go
@@ -45,10 +45,10 @@ func (a *AddAppAction) Run(s *State) error {
 		return err
 	}
 	as.App = a.App
-	if err := client.CreateArtifact(data.Artifact); err != nil {
+	if err := client.CreateArtifact(data.ImageArtifact); err != nil {
 		return err
 	}
-	as.Artifact = data.Artifact
+	as.ImageArtifact = data.ImageArtifact
 	if err := client.CreateRelease(data.Release); err != nil {
 		return err
 	}

--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -78,12 +78,12 @@ func (a *DeployAppAction) Run(s *State) error {
 		}
 	}
 
-	if err := client.CreateArtifact(a.Artifact); err != nil {
+	if err := client.CreateArtifact(a.ImageArtifact); err != nil {
 		return err
 	}
-	as.Artifact = a.Artifact
+	as.ImageArtifact = a.ImageArtifact
 
-	a.Release.ArtifactID = a.Artifact.ID
+	a.Release.ArtifactIDs = []string{a.ImageArtifact.ID}
 	if err := client.CreateRelease(a.Release); err != nil {
 		return err
 	}

--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -62,11 +62,11 @@ func (a *RunAppAction) Run(s *State) error {
 	if a.App.ID == "" {
 		a.App.ID = random.UUID()
 	}
-	if a.Artifact == nil {
+	if a.ImageArtifact == nil {
 		return errors.New("bootstrap: artifact must be set")
 	}
-	if a.Artifact.ID == "" {
-		a.Artifact.ID = random.UUID()
+	if a.ImageArtifact.ID == "" {
+		a.ImageArtifact.ID = random.UUID()
 	}
 	if a.Release == nil {
 		return errors.New("bootstrap: release must be set")
@@ -74,7 +74,7 @@ func (a *RunAppAction) Run(s *State) error {
 	if a.Release.ID == "" {
 		a.Release.ID = random.UUID()
 	}
-	a.Release.ArtifactID = a.Artifact.ID
+	a.Release.ArtifactIDs = []string{a.ImageArtifact.ID}
 	if a.Release.Env == nil {
 		a.Release.Env = make(map[string]string)
 	}

--- a/cli/app.go
+++ b/cli/app.go
@@ -172,7 +172,7 @@ func runInfo(_ *docopt.Args, client *controller.Client) error {
 	defer w.Flush()
 
 	if release, err := client.GetAppRelease(appName); err == nil || err == controller.ErrNotFound {
-		if err == controller.ErrNotFound || release.Env["SLUG_URL"] != "" {
+		if err == controller.ErrNotFound || release.IsGitDeploy() {
 			listRec(w, "Git URL:", gitURL(clusterConf, appName))
 		}
 	} else {

--- a/cli/export.go
+++ b/cli/export.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/backup"
 	hh "github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/random"
@@ -110,7 +111,7 @@ func runExport(args *docopt.Args, client *controller.Client) error {
 		}
 	}
 
-	artifact, err := client.GetArtifact(release.ArtifactID)
+	artifact, err := client.GetArtifact(release.ImageArtifactID())
 	if err != nil && err != controller.ErrNotFound {
 		return fmt.Errorf("error retrieving artifact: %s", err)
 	} else if err == nil {
@@ -244,7 +245,7 @@ func runImport(args *docopt.Args, client *controller.Client) error {
 				return fmt.Errorf("error decoding release: %s", err)
 			}
 			release.ID = ""
-			release.ArtifactID = ""
+			release.ArtifactIDs = nil
 		case "artifact.json":
 			artifact = &ct.Artifact{}
 			if err := json.NewDecoder(tr).Decode(artifact); err != nil {
@@ -425,7 +426,7 @@ func runImport(args *docopt.Args, client *controller.Client) error {
 			return fmt.Errorf("unable to retrieve gitreceive release: %s", err)
 		}
 		artifact = &ct.Artifact{
-			Type: "docker",
+			Type: host.ArtifactTypeDocker,
 			URI:  gitreceiveRelease.Env["SLUGRUNNER_IMAGE_URI"],
 		}
 		if artifact.URI == "" {
@@ -438,7 +439,7 @@ func runImport(args *docopt.Args, client *controller.Client) error {
 		if err := client.CreateArtifact(artifact); err != nil {
 			return fmt.Errorf("error creating artifact: %s", err)
 		}
-		release.ArtifactID = artifact.ID
+		release.ArtifactIDs = []string{artifact.ID}
 	}
 
 	if release != nil {

--- a/cli/release.go
+++ b/cli/release.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
 )
 
 func init() {
@@ -150,13 +151,13 @@ func runReleaseShow(args *docopt.Args, client *controller.Client) error {
 	if args.Bool["--json"] {
 		return json.NewEncoder(os.Stdout).Encode(release)
 	}
-	var artifactDesc string
-	if release.ArtifactID != "" {
-		artifact, err := client.GetArtifact(release.ArtifactID)
+	var artifacts []string
+	for _, id := range release.ArtifactIDs {
+		artifact, err := client.GetArtifact(id)
 		if err != nil {
 			return err
 		}
-		artifactDesc = fmt.Sprintf("%s+%s", artifact.Type, artifact.URI)
+		artifacts = append(artifacts, fmt.Sprintf("%s+%s", artifact.Type, artifact.URI))
 	}
 	types := make([]string, 0, len(release.Processes))
 	for typ := range release.Processes {
@@ -165,7 +166,9 @@ func runReleaseShow(args *docopt.Args, client *controller.Client) error {
 	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
 	defer w.Flush()
 	listRec(w, "ID:", release.ID)
-	listRec(w, "Artifact:", artifactDesc)
+	for i, artifact := range artifacts {
+		listRec(w, fmt.Sprintf("Artifact[%d]:", i), artifact)
+	}
 	listRec(w, "Process Types:", strings.Join(types, ", "))
 	listRec(w, "Created At:", release.CreatedAt)
 	for k, v := range release.Env {
@@ -187,14 +190,14 @@ func runReleaseAddDocker(args *docopt.Args, client *controller.Client) error {
 	}
 
 	artifact := &ct.Artifact{
-		Type: "docker",
+		Type: host.ArtifactTypeDocker,
 		URI:  args.String["<uri>"],
 	}
 	if err := client.CreateArtifact(artifact); err != nil {
 		return err
 	}
 
-	release.ArtifactID = artifact.ID
+	release.ArtifactIDs = []string{artifact.ID}
 	if err := client.CreateRelease(release); err != nil {
 		return err
 	}
@@ -232,7 +235,7 @@ func runReleaseUpdate(args *docopt.Args, client *controller.Client) error {
 	// Basically, there's no way to merge JSON that can reliably knock out set values.
 	// Instead, throw the --clean flag to start from a largely empty Release.
 	if args.Bool["--clean"] {
-		updates.ArtifactID = release.ArtifactID
+		updates.ArtifactIDs = release.ArtifactIDs
 		release = updates
 	} else {
 		release.ID = ""

--- a/controller/artifact.go
+++ b/controller/artifact.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/jackc/pgx"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
 )
@@ -31,16 +35,15 @@ func (r *ArtifactRepo) Add(data interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = tx.QueryRow("artifact_insert",
-		a.ID, a.Type, a.URI).Scan(&a.CreatedAt)
+
+	err = tx.QueryRow("artifact_insert", a.ID, string(a.Type), a.URI, a.Meta).Scan(&a.CreatedAt)
 	if postgres.IsUniquenessError(err, "") {
 		tx.Rollback()
 		tx, err = r.db.Begin()
 		if err != nil {
 			return err
 		}
-		err = tx.QueryRow("artifact_select_by_type_and_uri",
-			a.Type, a.URI).Scan(&a.ID, &a.CreatedAt)
+		err = tx.QueryRow("artifact_select_by_type_and_uri", string(a.Type), a.URI).Scan(&a.ID, &a.Meta, &a.CreatedAt)
 		if err != nil {
 			tx.Rollback()
 			return err
@@ -63,10 +66,12 @@ func (r *ArtifactRepo) Add(data interface{}) error {
 
 func scanArtifact(s postgres.Scanner) (*ct.Artifact, error) {
 	artifact := &ct.Artifact{}
-	err := s.Scan(&artifact.ID, &artifact.Type, &artifact.URI, &artifact.CreatedAt)
+	var typ string
+	err := s.Scan(&artifact.ID, &typ, &artifact.URI, &artifact.Meta, &artifact.CreatedAt)
 	if err == pgx.ErrNoRows {
 		err = ErrNotFound
 	}
+	artifact.Type = host.ArtifactType(typ)
 	return artifact, err
 }
 
@@ -80,7 +85,7 @@ func (r *ArtifactRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	artifacts := []*ct.Artifact{}
+	var artifacts []*ct.Artifact
 	for rows.Next() {
 		artifact, err := scanArtifact(rows)
 		if err != nil {
@@ -89,5 +94,38 @@ func (r *ArtifactRepo) List() (interface{}, error) {
 		}
 		artifacts = append(artifacts, artifact)
 	}
-	return artifacts, nil
+	return artifacts, rows.Err()
+}
+
+func (r *ArtifactRepo) ListIDs(ids ...string) (map[string]*ct.Artifact, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := r.db.Query("artifact_list_ids", fmt.Sprintf("{%s}", strings.Join(ids, ",")))
+	if err != nil {
+		return nil, err
+	}
+	artifacts := make(map[string]*ct.Artifact, len(ids))
+	for rows.Next() {
+		artifact, err := scanArtifact(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		artifacts[artifact.ID] = artifact
+	}
+	return artifacts, rows.Err()
+}
+
+func scanArtifacts(rows *pgx.Rows) (interface{}, error) {
+	var artifacts []*ct.Artifact
+	for rows.Next() {
+		artifact, err := scanArtifact(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts, rows.Err()
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/controller/schema"
 	tu "github.com/flynn/flynn/controller/testutils"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/certgen"
 	hh "github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
@@ -214,7 +215,7 @@ func (s *S) TestUpdateAppMeta(c *C) {
 
 func (s *S) createTestArtifact(c *C, in *ct.Artifact) *ct.Artifact {
 	if in.Type == "" {
-		in.Type = "docker"
+		in.Type = host.ArtifactTypeDocker
 	}
 	if in.URI == "" {
 		in.URI = fmt.Sprintf("https://example.com/%s", random.String(8))
@@ -227,7 +228,7 @@ func (s *S) TestCreateArtifact(c *C) {
 	for i, id := range []string{"", random.UUID()} {
 		in := &ct.Artifact{
 			ID:   id,
-			Type: "docker",
+			Type: host.ArtifactTypeDocker,
 			URI:  fmt.Sprintf("docker://flynn/host?id=adsf%d", i),
 		}
 		out := s.createTestArtifact(c, in)
@@ -249,8 +250,9 @@ func (s *S) TestCreateArtifact(c *C) {
 }
 
 func (s *S) createTestRelease(c *C, in *ct.Release) *ct.Release {
-	if in.ArtifactID == "" {
-		in.ArtifactID = s.createTestArtifact(c, &ct.Artifact{}).ID
+	if len(in.ArtifactIDs) == 0 {
+		in.ArtifactIDs = []string{s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeDocker}).ID}
+		in.LegacyArtifactID = in.ArtifactIDs[0]
 	}
 	c.Assert(s.c.CreateRelease(in), IsNil)
 	return in
@@ -309,7 +311,7 @@ func (s *S) TestCreateFormation(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(expanded.App.ID, Equals, app.ID)
 		c.Assert(expanded.Release.ID, Equals, release.ID)
-		c.Assert(expanded.Artifact.ID, Equals, release.ArtifactID)
+		c.Assert(expanded.ImageArtifact.ID, Equals, release.ImageArtifactID())
 		c.Assert(expanded.Processes, DeepEquals, out.Processes)
 
 		_, err = s.c.GetFormation(appID, release.ID+"fail")
@@ -363,6 +365,75 @@ func (s *S) TestReleaseList(c *C) {
 
 	c.Assert(len(list) > 0, Equals, true)
 	c.Assert(list[0].ID, Not(Equals), "")
+}
+
+func (s *S) TestReleaseArtifacts(c *C) {
+	// a release with no artifacts is ok
+	release := &ct.Release{}
+	c.Assert(s.c.CreateRelease(release), IsNil)
+	gotRelease, err := s.c.GetRelease(release.ID)
+	c.Assert(err, IsNil)
+	c.Assert(gotRelease.ArtifactIDs, IsNil)
+	c.Assert(gotRelease.ImageArtifactID(), Equals, "")
+	c.Assert(gotRelease.FileArtifactIDs(), IsNil)
+
+	// a release with a single "docker" artifact is ok
+	imageArtifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeDocker})
+	release = &ct.Release{ArtifactIDs: []string{imageArtifact.ID}}
+	c.Assert(s.c.CreateRelease(release), IsNil)
+	gotRelease, err = s.c.GetRelease(release.ID)
+	c.Assert(err, IsNil)
+	c.Assert(gotRelease.ArtifactIDs, DeepEquals, []string{imageArtifact.ID})
+	c.Assert(gotRelease.ImageArtifactID(), Equals, imageArtifact.ID)
+	c.Assert(gotRelease.FileArtifactIDs(), DeepEquals, []string{})
+
+	// a release with a single "file" artifact is not ok
+	fileArtifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeFile})
+	err = s.c.CreateRelease(&ct.Release{ArtifactIDs: []string{fileArtifact.ID}})
+	c.Assert(err, NotNil)
+	e, ok := err.(hh.JSONError)
+	if !ok {
+		c.Fatalf("expected error to have type httphelper.JSONError, got %T", err)
+	}
+	c.Assert(e.Code, Equals, hh.ValidationErrorCode)
+	c.Assert(e.Message, Equals, `artifacts must have exactly one artifact of type "docker"`)
+
+	// a release with multiple "docker" artifacts is not ok
+	secondImageArtifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeDocker})
+	err = s.c.CreateRelease(&ct.Release{ArtifactIDs: []string{imageArtifact.ID, secondImageArtifact.ID}})
+	c.Assert(err, NotNil)
+	e, ok = err.(hh.JSONError)
+	if !ok {
+		c.Fatalf("expected error to have type httphelper.JSONError, got %T", err)
+	}
+	c.Assert(e.Code, Equals, hh.ValidationErrorCode)
+	c.Assert(e.Message, Equals, `artifacts must have exactly one artifact of type "docker"`)
+
+	// a release with a single "docker" artifact and multiple "file" artifacts is ok
+	secondFileArtifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeFile})
+	artifactIDs := []string{imageArtifact.ID, fileArtifact.ID, secondFileArtifact.ID}
+	release = &ct.Release{ArtifactIDs: artifactIDs}
+	c.Assert(s.c.CreateRelease(release), IsNil)
+	gotRelease, err = s.c.GetRelease(release.ID)
+	c.Assert(err, IsNil)
+	c.Assert(gotRelease.ArtifactIDs, DeepEquals, artifactIDs)
+	c.Assert(gotRelease.ImageArtifactID(), Equals, imageArtifact.ID)
+	fileArtifactIDs := gotRelease.FileArtifactIDs()
+	c.Assert(fileArtifactIDs, HasLen, 2)
+	c.Assert(fileArtifactIDs[0], Equals, fileArtifact.ID)
+	c.Assert(fileArtifactIDs[1], Equals, secondFileArtifact.ID)
+}
+
+func (s *S) TestFileArtifact(c *C) {
+	artifact := &ct.Artifact{
+		Type: host.ArtifactTypeFile,
+		URI:  "http://example.com/slug.tgz",
+	}
+	c.Assert(s.c.CreateArtifact(artifact), IsNil)
+
+	gotArtifact, err := s.c.GetArtifact(artifact.ID)
+	c.Assert(err, IsNil)
+	c.Assert(gotArtifact, DeepEquals, artifact)
 }
 
 func (s *S) TestAppReleaseList(c *C) {

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -185,9 +185,9 @@ func (s *S) TestStreamReleaseEvents(c *C) {
 		c.Assert(json.Unmarshal(e.Data, &eventArtifact), IsNil)
 		c.Assert(e.AppID, Equals, "")
 		c.Assert(e.ObjectType, Equals, ct.EventTypeArtifact)
-		c.Assert(e.ObjectID, Equals, release.ArtifactID)
+		c.Assert(e.ObjectID, Equals, release.ImageArtifactID())
 		c.Assert(eventArtifact, NotNil)
-		c.Assert(eventArtifact.ID, Equals, release.ArtifactID)
+		c.Assert(eventArtifact.ID, Equals, release.ImageArtifactID())
 	case <-time.After(10 * time.Second):
 		c.Fatal("Timed out waiting for artifact event")
 	}

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -15,6 +15,7 @@ import (
 	cc "github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/types"
 	g "github.com/flynn/flynn/pkg/examplegenerator"
 	"github.com/flynn/flynn/pkg/httprecorder"
 	"github.com/flynn/flynn/pkg/random"
@@ -281,7 +282,7 @@ func (e *generator) deleteApp() {
 
 func (e *generator) createArtifact() {
 	artifact := &ct.Artifact{
-		Type: "docker",
+		Type: host.ArtifactTypeDocker,
 		URI:  e.resourceIds["SLUGRUNNER_IMAGE_URI"],
 	}
 	err := e.client.CreateArtifact(artifact)
@@ -297,7 +298,7 @@ func (e *generator) listArtifacts() {
 
 func (e *generator) createRelease() {
 	release := &ct.Release{
-		ArtifactID: e.resourceIds["artifact"],
+		ArtifactIDs: []string{e.resourceIds["artifact"]},
 		Env: map[string]string{
 			"some": "info",
 		},

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -151,14 +151,14 @@ func (s *S) TestKillJob(c *C) {
 
 func (s *S) TestRunJobDetached(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "run-detached"})
+	artifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeDocker, URI: "docker://foo/bar"})
 	hostID := fakeHostID()
 	host := tu.NewFakeHostClient(hostID)
 	s.cc.AddHost(host)
 
-	artifact := s.createTestArtifact(c, &ct.Artifact{Type: "docker", URI: "docker://foo/bar"})
 	release := s.createTestRelease(c, &ct.Release{
-		ArtifactID: artifact.ID,
-		Env:        map[string]string{"RELEASE": "true", "FOO": "bar"},
+		ArtifactIDs: []string{artifact.ID},
+		Env:         map[string]string{"RELEASE": "true", "FOO": "bar"},
 	})
 
 	cmd := []string{"foo", "bar"}
@@ -232,10 +232,10 @@ func (s *S) TestRunJobAttached(c *C) {
 		}{strings.NewReader("test out"), pipeW}), nil
 	})
 
-	artifact := s.createTestArtifact(c, &ct.Artifact{Type: "docker", URI: "docker://foo/bar"})
+	artifact := s.createTestArtifact(c, &ct.Artifact{Type: host.ArtifactTypeDocker, URI: "docker://foo/bar"})
 	release := s.createTestRelease(c, &ct.Release{
-		ArtifactID: artifact.ID,
-		Env:        map[string]string{"RELEASE": "true", "FOO": "bar"},
+		ArtifactIDs: []string{artifact.ID},
+		Env:         map[string]string{"RELEASE": "true", "FOO": "bar"},
 	})
 
 	data := &ct.NewJob{

--- a/controller/migrate_test.go
+++ b/controller/migrate_test.go
@@ -83,3 +83,40 @@ func (MigrateSuite) TestMigrateCriticalApps(c *C) {
 		c.Assert(meta["flynn-system-critical"], Equals, "true")
 	}
 }
+
+// TestMigrateReleaseArtifacts checks that migrating to ID 15 correctly
+// migrates releases by creating appropriate records in the release_artifacts
+// table
+func (MigrateSuite) TestMigrateReleaseArtifacts(c *C) {
+	db := setupTestDB(c, "controllertest_migrate_release_artifacts")
+	m := &testMigrator{c: c, db: db}
+
+	// start from ID 14
+	m.migrateTo(14)
+
+	// add some artifacts and releases
+	releaseArtifacts := map[string]string{
+		random.UUID(): random.UUID(),
+		random.UUID(): random.UUID(),
+		random.UUID(): random.UUID(),
+	}
+	for releaseID, artifactID := range releaseArtifacts {
+		c.Assert(db.Exec(`INSERT INTO artifacts (artifact_id, type, uri) VALUES ($1, $2, $3)`, artifactID, "docker", "http://example.com/"+artifactID), IsNil)
+		c.Assert(db.Exec(`INSERT INTO releases (release_id, artifact_id) VALUES ($1, $2)`, releaseID, artifactID), IsNil)
+	}
+	c.Assert(db.Exec(`INSERT INTO releases (release_id) VALUES ($1)`, random.UUID()), IsNil)
+
+	// migrate to 15 and check release_artifacts was populated correctly
+	m.migrateTo(15)
+	rows, err := db.Query("SELECT release_id, artifact_id FROM release_artifacts")
+	c.Assert(err, IsNil)
+	defer rows.Close()
+	actual := make(map[string]string)
+	for rows.Next() {
+		var releaseID, artifactID string
+		c.Assert(rows.Scan(&releaseID, &artifactID), IsNil)
+		actual[releaseID] = artifactID
+	}
+	c.Assert(rows.Err(), IsNil)
+	c.Assert(actual, DeepEquals, releaseArtifacts)
+}

--- a/controller/migrate_test.go
+++ b/controller/migrate_test.go
@@ -106,9 +106,17 @@ func (MigrateSuite) TestMigrateReleaseArtifacts(c *C) {
 	}
 	c.Assert(db.Exec(`INSERT INTO releases (release_id) VALUES ($1)`, random.UUID()), IsNil)
 
+	// insert a slug based release
+	slugReleaseID := random.UUID()
+	imageArtifactID := random.UUID()
+	slugEnv := map[string]string{"SLUG_URL": "http://example.com/slug.tgz"}
+	c.Assert(db.Exec(`INSERT INTO artifacts (artifact_id, type, uri) VALUES ($1, $2, $3)`, imageArtifactID, "docker", "http://example.com/"+imageArtifactID), IsNil)
+	c.Assert(db.Exec(`INSERT INTO releases (release_id, artifact_id, env) VALUES ($1, $2, $3)`, slugReleaseID, imageArtifactID, slugEnv), IsNil)
+	releaseArtifacts[slugReleaseID] = imageArtifactID
+
 	// migrate to 15 and check release_artifacts was populated correctly
 	m.migrateTo(15)
-	rows, err := db.Query("SELECT release_id, artifact_id FROM release_artifacts")
+	rows, err := db.Query("SELECT release_id, artifact_id FROM release_artifacts INNER JOIN artifacts USING (artifact_id) WHERE type = 'docker'")
 	c.Assert(err, IsNil)
 	defer rows.Close()
 	actual := make(map[string]string)
@@ -119,4 +127,18 @@ func (MigrateSuite) TestMigrateReleaseArtifacts(c *C) {
 	}
 	c.Assert(rows.Err(), IsNil)
 	c.Assert(actual, DeepEquals, releaseArtifacts)
+
+	// check the slug release got "git=true" in metadata
+	var releaseMeta map[string]string
+	err = db.QueryRow("SELECT meta FROM releases WHERE release_id = $1", slugReleaseID).Scan(&releaseMeta)
+	c.Assert(err, IsNil)
+	c.Assert(releaseMeta, DeepEquals, map[string]string{"git": "true"})
+
+	// check the slug release got a file artifact with the correct URI and meta
+	var slugURI string
+	var artifactMeta map[string]string
+	err = db.QueryRow("SELECT uri, meta FROM artifacts INNER JOIN release_artifacts USING (artifact_id) WHERE type = 'file' AND release_id = $1", slugReleaseID).Scan(&slugURI, &artifactMeta)
+	c.Assert(err, IsNil)
+	c.Assert(slugURI, Equals, slugEnv["SLUG_URL"])
+	c.Assert(artifactMeta, DeepEquals, map[string]string{"blobstore": "true"})
 }

--- a/controller/release.go
+++ b/controller/release.go
@@ -40,16 +40,10 @@ func scanRelease(s postgres.Scanner) (*ct.Release, error) {
 
 func (r *ReleaseRepo) Add(data interface{}) error {
 	release := data.(*ct.Release)
-	releaseCopy := *release
 
-	releaseCopy.ID = ""
-	releaseCopy.ArtifactID = ""
-	releaseCopy.CreatedAt = nil
-	releaseCopy.Meta = nil
-
-	for typ, proc := range releaseCopy.Processes {
+	for typ, proc := range release.Processes {
 		resource.SetDefaults(&proc.Resources)
-		releaseCopy.Processes[typ] = proc
+		release.Processes[typ] = proc
 	}
 
 	if release.ID == "" {

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -215,7 +215,7 @@ func (TestSuite) TestFormationChange(c *C) {
 	c.Assert(err, IsNil)
 	release, err := s.GetRelease(testReleaseID)
 	c.Assert(err, IsNil)
-	artifact, err := s.GetArtifact(release.ArtifactID)
+	artifact, err := s.GetArtifact(release.ImageArtifactID())
 	c.Assert(err, IsNil)
 
 	// Test scaling up an existing formation
@@ -293,7 +293,7 @@ func (TestSuite) TestRectify(c *C) {
 	artifact := &ct.Artifact{ID: "test-artifact-2"}
 	processes := map[string]int{testJobType: testJobCount}
 	release := NewRelease("test-release-2", artifact, processes)
-	form = NewFormation(&ct.ExpandedFormation{App: app, Release: release, Artifact: artifact, Processes: processes})
+	form = NewFormation(&ct.ExpandedFormation{App: app, Release: release, ImageArtifact: artifact, Processes: processes})
 	newJob = &Job{Formation: form, AppID: testAppID, ReleaseID: testReleaseID, Type: testJobType}
 	config = jobConfig(newJob, testHostID)
 	// Add the job to the host without adding the formation. Expected error.
@@ -636,7 +636,7 @@ func (TestSuite) TestJobPlacementTags(c *C) {
 			"worker": {},
 			"clock":  {},
 		}},
-		Artifact: &ct.Artifact{},
+		ImageArtifact: &ct.Artifact{},
 		Tags: map[string]map[string]string{
 			"web":    nil,
 			"db":     {"disk": "ssd"},

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -317,6 +317,24 @@ $$ LANGUAGE plpgsql`,
 			AFTER INSERT ON release_artifacts
 			FOR EACH ROW EXECUTE PROCEDURE check_release_artifacts()`,
 		`INSERT INTO release_artifacts (release_id, artifact_id) (SELECT release_id, artifact_id FROM releases WHERE artifact_id IS NOT NULL)`,
+
+		// set "git=true" for releases with SLUG_URL set
+		`UPDATE releases SET meta = jsonb_merge(CASE WHEN meta = 'null' THEN '{}' ELSE meta END, '{"git":"true"}') WHERE env ? 'SLUG_URL'`,
+
+		// create file artifacts for any releases with SLUG_URL set
+		`DO $$
+		DECLARE
+			release RECORD;
+		BEGIN
+			FOR release IN SELECT * FROM releases WHERE env ? 'SLUG_URL' LOOP
+				WITH artifact AS (
+					INSERT INTO artifacts (type, uri, meta)
+					VALUES ('file', release.env->>'SLUG_URL', '{"blobstore":"true"}')
+					RETURNING *
+				)
+				INSERT INTO release_artifacts (release_id, artifact_id) (SELECT release.release_id, artifact_id FROM artifact);
+			END LOOP;
+		END $$`,
 		`ALTER TABLE releases DROP COLUMN artifact_id`,
 	)
 }

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -23,7 +23,9 @@ var preparedStatements = map[string]string{
 	"release_select":                        releaseSelectQuery,
 	"release_insert":                        releaseInsertQuery,
 	"release_app_list":                      releaseAppListQuery,
+	"release_artifacts_insert":              releaseArtifactsInsertQuery,
 	"artifact_list":                         artifactListQuery,
+	"artifact_list_ids":                     artifactListIDsQuery,
 	"artifact_select":                       artifactSelectQuery,
 	"artifact_select_by_type_and_uri":       artifactSelectByTypeAndURIQuery,
 	"artifact_insert":                       artifactInsertQuery,
@@ -114,32 +116,61 @@ UPDATE apps SET deleted_at = now() WHERE app_id = $1 AND deleted_at IS NULL`
 	appNextNameIDQuery = `
 SELECT nextval('name_ids')`
 	appGetReleaseQuery = `
-SELECT r.release_id, r.artifact_id, r.env, r.processes, r.meta, r.created_at
+SELECT r.release_id,
+  ARRAY(
+	SELECT a.artifact_id
+	FROM release_artifacts a
+	WHERE a.release_id = r.release_id AND a.deleted_at IS NULL
+	ORDER BY a.created_at
+  ), r.env, r.processes, r.meta, r.created_at
 FROM apps a JOIN releases r USING (release_id) WHERE a.app_id = $1`
 
 	releaseListQuery = `
-SELECT release_id, artifact_id, env, processes, meta, created_at
-FROM releases WHERE deleted_at IS NULL ORDER BY created_at DESC`
+SELECT r.release_id,
+  ARRAY(
+	SELECT a.artifact_id
+	FROM release_artifacts a
+	WHERE a.release_id = r.release_id AND a.deleted_at IS NULL
+	ORDER BY a.created_at
+  ), r.env, r.processes, r.meta, r.created_at
+FROM releases r WHERE r.deleted_at IS NULL ORDER BY r.created_at DESC`
 	releaseSelectQuery = `
-SELECT release_id, artifact_id, env, processes, meta, created_at
-FROM releases WHERE release_id = $1 AND deleted_at IS NULL`
+SELECT r.release_id,
+  ARRAY(
+	SELECT a.artifact_id
+	FROM release_artifacts a
+	WHERE a.release_id = r.release_id AND a.deleted_at IS NULL
+	ORDER BY a.created_at
+  ), r.env, r.processes, r.meta, r.created_at
+FROM releases r WHERE r.release_id = $1 AND r.deleted_at IS NULL`
 	releaseInsertQuery = `
-INSERT INTO releases (release_id, artifact_id, env, processes, meta)
-VALUES ($1, $2, $3, $4, $5) RETURNING created_at`
+INSERT INTO releases (release_id, env, processes, meta)
+VALUES ($1, $2, $3, $4) RETURNING created_at`
 	releaseAppListQuery = `
-SELECT DISTINCT(r.release_id), r.artifact_id, r.env, r.processes, r.meta, r.created_at
+SELECT DISTINCT(r.release_id),
+  ARRAY(
+	SELECT a.artifact_id
+	FROM release_artifacts a
+	WHERE a.release_id = r.release_id AND a.deleted_at IS NULL
+	ORDER BY a.created_at
+  ), r.env, r.processes, r.meta, r.created_at
 FROM releases r JOIN formations f USING (release_id)
 WHERE f.app_id = $1 AND r.deleted_at IS NULL ORDER BY r.created_at DESC`
+	releaseArtifactsInsertQuery = `
+INSERT INTO release_artifacts (release_id, artifact_id) VALUES ($1, $2)`
 	artifactListQuery = `
-SELECT artifact_id, type, uri, created_at FROM artifacts
+SELECT artifact_id, type, uri, meta, created_at FROM artifacts
 WHERE deleted_at IS NULL ORDER BY created_at DESC`
+	artifactListIDsQuery = `
+SELECT artifact_id, type, uri, meta, created_at FROM artifacts
+WHERE deleted_at IS NULL AND artifact_id = ANY($1)`
 	artifactSelectQuery = `
-SELECT artifact_id, type, uri, created_at FROM artifacts
+SELECT artifact_id, type, uri, meta, created_at FROM artifacts
 WHERE artifact_id = $1 AND deleted_at IS NULL`
 	artifactSelectByTypeAndURIQuery = `
-SELECT artifact_id, created_at FROM artifacts WHERE type = $1 AND uri = $2`
+SELECT artifact_id, meta, created_at FROM artifacts WHERE type = $1 AND uri = $2`
 	artifactInsertQuery = `
-INSERT INTO artifacts (artifact_id, type, uri) VALUES ($1, $2, $3) RETURNING created_at`
+INSERT INTO artifacts (artifact_id, type, uri, meta) VALUES ($1, $2, $3, $4) RETURNING created_at`
 	deploymentInsertQuery = `
 INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes, deploy_timeout)
 VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING created_at`
@@ -187,13 +218,18 @@ FROM formations WHERE app_id = $1 AND deleted_at IS NULL ORDER BY created_at DES
 	formationListActiveQuery = `
 SELECT
   apps.app_id, apps.name, apps.meta,
-  releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
-  artifacts.artifact_id, artifacts.type, artifacts.uri,
+  releases.release_id,
+  ARRAY(
+	SELECT r.artifact_id
+	FROM release_artifacts r
+	WHERE r.release_id = releases.release_id AND r.deleted_at IS NULL
+	ORDER BY r.created_at
+  ),
+  releases.meta, releases.env, releases.processes,
   formations.processes, formations.tags, formations.updated_at
 FROM formations
 JOIN apps USING (app_id)
 JOIN releases ON releases.release_id = formations.release_id
-JOIN artifacts USING (artifact_id)
 WHERE (formations.app_id, formations.release_id) IN (
   SELECT app_id, release_id
   FROM formations, json_each_text(formations.processes::json)
@@ -212,13 +248,18 @@ FROM formations WHERE app_id = $1 AND release_id = $2 AND deleted_at IS NULL`
 	formationSelectExpandedQuery = `
 SELECT
   apps.app_id, apps.name, apps.meta,
-  releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
-  artifacts.artifact_id, artifacts.type, artifacts.uri,
+  releases.release_id,
+  ARRAY(
+	SELECT a.artifact_id
+	FROM release_artifacts a
+	WHERE a.release_id = releases.release_id AND a.deleted_at IS NULL
+	ORDER BY a.created_at
+  ),
+  releases.meta, releases.env, releases.processes,
   formations.processes, formations.tags, formations.updated_at
 FROM formations
 JOIN apps USING (app_id)
 JOIN releases ON releases.release_id = formations.release_id
-JOIN artifacts USING (artifact_id)
 WHERE formations.app_id = $1 AND formations.release_id = $2 AND formations.deleted_at IS NULL`
 	formationInsertQuery = `
 INSERT INTO formations (app_id, release_id, processes, tags)

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -75,10 +75,10 @@ func (c *FakeControllerClient) GetExpandedFormation(appID, releaseID string) (*c
 		procs[typ] = n
 	}
 	return &ct.ExpandedFormation{
-		App:       app,
-		Release:   release,
-		Artifact:  c.artifacts[release.ArtifactID],
-		Processes: procs,
+		App:           app,
+		Release:       release,
+		ImageArtifact: c.artifacts[release.ImageArtifactID()],
+		Processes:     procs,
 	}, nil
 }
 
@@ -151,12 +151,12 @@ func (c *FakeControllerClient) FormationListActive() ([]*ct.ExpandedFormation, e
 			if !ok {
 				continue
 			}
-			artifact := c.artifacts[release.ArtifactID]
+			artifact := c.artifacts[release.ImageArtifactID()]
 			formations = append(formations, &ct.ExpandedFormation{
-				App:       app,
-				Release:   release,
-				Artifact:  artifact,
-				Processes: procs,
+				App:           app,
+				Release:       release,
+				ImageArtifact: artifact,
+				Processes:     procs,
 			})
 		}
 	}
@@ -214,9 +214,9 @@ func NewReleaseOmni(id string, artifact *ct.Artifact, processes map[string]int, 
 	}
 
 	return &ct.Release{
-		ID:         id,
-		ArtifactID: artifact.ID,
-		Processes:  processTypes,
+		ID:          id,
+		ArtifactIDs: []string{artifact.ID},
+		Processes:   processTypes,
 	}
 }
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -80,6 +80,10 @@ func (r *Release) FileArtifactIDs() []string {
 	return r.ArtifactIDs[1:len(r.ArtifactIDs)]
 }
 
+func (r *Release) IsGitDeploy() bool {
+	return r.Meta["git"] == "true"
+}
+
 type ProcessType struct {
 	Cmd         []string           `json:"cmd,omitempty"`
 	Entrypoint  []string           `json:"entrypoint,omitempty"`

--- a/controller/worker/domain_migration/domain_migration.go
+++ b/controller/worker/domain_migration/domain_migration.go
@@ -148,10 +148,10 @@ func (m *migration) generateTLSCert() (*tlscert.Cert, error) {
 
 func dupRelease(release *ct.Release) *ct.Release {
 	return &ct.Release{
-		ArtifactID: release.ArtifactID,
-		Env:        release.Env,
-		Meta:       release.Meta,
-		Processes:  release.Processes,
+		ArtifactIDs: release.ArtifactIDs,
+		Env:         release.Env,
+		Meta:        release.Meta,
+		Processes:   release.Processes,
 	}
 }
 

--- a/dashboard/app/lib/javascripts/dashboard/views/app-history.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/app-history.js.jsx
@@ -70,7 +70,7 @@ var AppHistory = React.createClass({
 				deployBtnDisabled = false;
 			}
 		} else if (selectedEvent && selectedEvent.object_type === 'app_release') {
-			if (this.props.release && this.props.release.id !== selectedEvent.object_id && selectedEvent.data.release.artifact) {
+			if (this.props.release && this.props.release.id !== selectedEvent.object_id && (selectedEvent.data.release.artifacts || []).length) {
 				deployBtnDisabled = false;
 			}
 		}

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -140,15 +140,15 @@ Options:
 
 	fmt.Printf("-----> Creating release...\n")
 
-	artifact := &ct.Artifact{Type: "docker", URI: os.Getenv("SLUGRUNNER_IMAGE_URI")}
+	artifact := &ct.Artifact{Type: host.ArtifactTypeDocker, URI: os.Getenv("SLUGRUNNER_IMAGE_URI")}
 	if err := client.CreateArtifact(artifact); err != nil {
 		log.Fatalln("Error creating artifact:", err)
 	}
 
 	release := &ct.Release{
-		ArtifactID: artifact.ID,
-		Env:        prevRelease.Env,
-		Meta:       prevRelease.Meta,
+		ArtifactIDs: []string{artifact.ID},
+		Env:         prevRelease.Env,
+		Meta:        prevRelease.Meta,
 	}
 	if release.Meta == nil {
 		release.Meta = make(map[string]string, len(meta))

--- a/gitreceive/server.go
+++ b/gitreceive/server.go
@@ -299,7 +299,7 @@ git-archive-all() {
 	tar --create --exclude-vcs .
 }
 while read oldrev newrev refname; do
-	[[ $refname = "refs/heads/master" ]] && git-archive-all $newrev | /bin/flynn-receiver "$RECEIVE_APP" "$newrev" | sed -u "s/^/"$'\e[1G\e[K'"/"
+	[[ $refname = "refs/heads/master" ]] && git-archive-all $newrev | /bin/flynn-receiver "$RECEIVE_APP" "$newrev" --meta git=true | sed -u "s/^/"$'\e[1G\e[K'"/"
 done
 `)
 

--- a/host/cli/run.go
+++ b/host/cli/run.go
@@ -29,7 +29,7 @@ Options:
 
 func runRun(args *docopt.Args, client *cluster.Client) error {
 	cmd := exec.Cmd{
-		Artifact: exec.DockerImage(args.String["<image>"]),
+		ImageArtifact: exec.DockerImage(args.String["<image>"]),
 		Job: &host.Job{
 			Config: host.ContainerConfig{
 				Entrypoint: []string{args.String["<command>"]},

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -353,7 +353,7 @@ func (l *LibvirtLXCBackend) SetDefaultEnv(k, v string) {
 
 func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error) {
 	g := grohl.NewContext(grohl.Data{"backend": "libvirt-lxc", "fn": "run", "job.id": job.ID})
-	g.Log(grohl.Data{"at": "start", "job.artifact.uri": job.Artifact.URI, "job.cmd": job.Config.Cmd})
+	g.Log(grohl.Data{"at": "start", "job.artifact.uri": job.ImageArtifact.URI, "job.cmd": job.Config.Cmd})
 
 	defer func() {
 		if err != nil {
@@ -398,12 +398,12 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 	}()
 
 	g.Log(grohl.Data{"at": "pull_image"})
-	layers, err := l.pinkertonPull(job.Artifact.URI)
+	layers, err := l.pinkertonPull(job.ImageArtifact.URI)
 	if err != nil {
 		g.Log(grohl.Data{"at": "pull_image", "status": "error", "err": err})
 		return err
 	}
-	imageID, err := pinkerton.ImageID(job.Artifact.URI)
+	imageID, err := pinkerton.ImageID(job.ImageArtifact.URI)
 	if err == pinkerton.ErrNoImageID && len(layers) > 0 {
 		imageID = layers[len(layers)-1].ID
 	} else if err != nil {

--- a/host/libvirt_lxc_backend.go
+++ b/host/libvirt_lxc_backend.go
@@ -528,10 +528,11 @@ func (l *LibvirtLXCBackend) Run(job *host.Job, runConfig *RunConfig) (err error)
 	}
 
 	config := &containerinit.Config{
-		TTY:       job.Config.TTY,
-		OpenStdin: job.Config.Stdin,
-		WorkDir:   job.Config.WorkingDir,
-		Resources: job.Resources,
+		TTY:           job.Config.TTY,
+		OpenStdin:     job.Config.Stdin,
+		WorkDir:       job.Config.WorkingDir,
+		Resources:     job.Resources,
+		FileArtifacts: job.FileArtifacts,
 	}
 	if !job.Config.HostNetwork {
 		config.IP = container.IP.String() + "/24"

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -15,9 +15,10 @@ type Job struct {
 
 	Metadata map[string]string `json:"metadata,omitempty"`
 
-	Artifact  Artifact           `json:"artifact,omitempty"`
-	Resources resource.Resources `json:"resources,omitempty"`
-	Partition string             `json:"partition,omitempty"`
+	ImageArtifact *Artifact          `json:"artifact,omitempty"`
+	FileArtifacts []*Artifact        `json:"file_artifacts,omitempty"`
+	Resources     resource.Resources `json:"resources,omitempty"`
+	Partition     string             `json:"partition,omitempty"`
 
 	Config ContainerConfig `json:"config,omitempty"`
 
@@ -180,9 +181,16 @@ type VolumeBinding struct {
 }
 
 type Artifact struct {
-	URI  string `json:"url,omitempty"`
-	Type string `json:"type,omitempty"`
+	URI  string       `json:"url,omitempty"`
+	Type ArtifactType `json:"type,omitempty"`
 }
+
+type ArtifactType string
+
+const (
+	ArtifactTypeDocker ArtifactType = "docker"
+	ArtifactTypeFile   ArtifactType = "file"
+)
 
 type Host struct {
 	ID string `json:"id,omitempty"`

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -85,15 +85,24 @@ func getApps(client *controller.Client) (map[string]*ct.ExpandedFormation, error
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s app formation: %s", name, err)
 		}
-		artifact, err := client.GetArtifact(release.ArtifactID)
+		imageArtifact, err := client.GetArtifact(release.ImageArtifactID())
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s app artifact: %s", name, err)
 		}
+		fileArtifacts := make([]*ct.Artifact, len(release.FileArtifactIDs()))
+		for i, artifactID := range release.FileArtifactIDs() {
+			fileArtifact, err := client.GetArtifact(artifactID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting %s app file artifact: %s", name, err)
+			}
+			fileArtifacts[i] = fileArtifact
+		}
 		data[name] = &ct.ExpandedFormation{
-			App:       app,
-			Release:   release,
-			Artifact:  artifact,
-			Processes: formation.Processes,
+			App:           app,
+			Release:       release,
+			ImageArtifact: imageArtifact,
+			FileArtifacts: fileArtifacts,
+			Processes:     formation.Processes,
 		}
 	}
 	return data, nil

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -22,7 +22,7 @@ type Cmd struct {
 
 	Entrypoint []string
 
-	Artifact host.Artifact
+	ImageArtifact host.Artifact
 
 	Cmd []string
 	Env map[string]string
@@ -82,15 +82,15 @@ type Cmd struct {
 }
 
 func DockerImage(uri string) host.Artifact {
-	return host.Artifact{Type: "docker", URI: uri}
+	return host.Artifact{Type: host.ArtifactTypeDocker, URI: uri}
 }
 
 func Command(artifact host.Artifact, cmd ...string) *Cmd {
-	return &Cmd{Artifact: artifact, Cmd: cmd}
+	return &Cmd{ImageArtifact: artifact, Cmd: cmd}
 }
 
 func Job(artifact host.Artifact, job *host.Job) *Cmd {
-	return &Cmd{Artifact: artifact, Job: job}
+	return &Cmd{ImageArtifact: artifact, Job: job}
 }
 
 type ClusterClient interface {
@@ -186,7 +186,7 @@ func (c *Cmd) Start() error {
 	// otherwise generate one from the fields on exec.Cmd that mirror stdlib's os.exec.
 	if c.Job == nil {
 		c.Job = &host.Job{
-			Artifact: c.Artifact,
+			ImageArtifact: &c.ImageArtifact,
 			Config: host.ContainerConfig{
 				Entrypoint: c.Entrypoint,
 				Cmd:        c.Cmd,
@@ -202,7 +202,7 @@ func (c *Cmd) Start() error {
 			c.Job.Config.DisableLog = true
 		}
 	} else {
-		c.Job.Artifact = c.Artifact
+		c.Job.ImageArtifact = &c.ImageArtifact
 	}
 	if c.Job.ID == "" {
 		c.Job.ID = cluster.GenerateJobID(c.HostID, "")

--- a/schema/controller/artifact.json
+++ b/schema/controller/artifact.json
@@ -18,12 +18,15 @@
     "type": {
       "description": "artifact type",
       "type": "string",
-      "enum": ["docker"]
+      "enum": ["docker", "file"]
     },
     "uri": {
       "description": "URI used to retrieve the artifact",
       "format": "uri",
       "type": "string"
+    },
+    "meta": {
+      "$ref": "/schema/controller/common#/definitions/meta"
     },
     "created_at": {
       "$ref": "/schema/controller/common#/definitions/created_at"

--- a/schema/controller/expanded_formation.json
+++ b/schema/controller/expanded_formation.json
@@ -21,6 +21,12 @@
     "artifact": {
       "$ref": "/schema/controller/artifact#"
     },
+    "file_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "/schema/controller/artifact#"
+      }
+    },
     "processes": {
       "description": "count of processes to run for each process type",
       "type": "object",

--- a/schema/controller/release.json
+++ b/schema/controller/release.json
@@ -19,7 +19,14 @@
       "$ref": "/schema/controller/common#/definitions/id"
     },
     "artifact": {
+      "description": "DEPRECATED: legacy artifact ID",
       "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "/schema/controller/common#/definitions/id"
+      }
     },
     "meta": {
       "$ref": "/schema/controller/common#/definitions/meta"

--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -1,5 +1,5 @@
 #!/bin/bash
-## Load slug from Bind Mount, URL or STDIN
+## Load slug from Bind Mount, Artifacts dir, URL or STDIN
 
 set -eo pipefail
 
@@ -8,6 +8,8 @@ mkdir -p "${HOME}"
 
 if [[ -n $(ls -A "${HOME}") ]]; then
   true
+elif [[ -s "/artifacts/slug.tgz" ]]; then
+  tar xzf "/artifacts/slug.tgz" -C "${HOME}"
 elif ! [[ -z "${SLUG_URL}" ]]; then
   curl --silent --location --noproxy "discoverd" --retry 5 --fail "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL

--- a/test/helper.go
+++ b/test/helper.go
@@ -136,11 +136,11 @@ func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {
 	t.Assert(client.CreateApp(app), c.IsNil)
 	debugf(t, "created app %s (%s)", app.Name, app.ID)
 
-	artifact := &ct.Artifact{Type: "docker", URI: imageURIs["test-apps"]}
+	artifact := &ct.Artifact{Type: host.ArtifactTypeDocker, URI: imageURIs["test-apps"]}
 	t.Assert(client.CreateArtifact(artifact), c.IsNil)
 
 	release := &ct.Release{
-		ArtifactID: artifact.ID,
+		ArtifactIDs: []string{artifact.ID},
 		Processes: map[string]ct.ProcessType{
 			"echoer": {
 				Cmd:     []string{"/bin/echoer"},

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -211,10 +211,10 @@ func (s *CLISuite) TestScaleAll(t *c.C) {
 
 	prevRelease := release
 	release = &ct.Release{
-		ArtifactID: release.ArtifactID,
-		Env:        release.Env,
-		Meta:       release.Meta,
-		Processes:  release.Processes,
+		ArtifactIDs: release.ArtifactIDs,
+		Env:         release.Env,
+		Meta:        release.Meta,
+		Processes:   release.Processes,
 	}
 	t.Assert(client.CreateRelease(release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.id, release.ID), c.IsNil)

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -561,7 +561,7 @@ func (s *ControllerSuite) TestBackup(t *c.C) {
 		t.Assert(ok, c.Equals, true)
 		t.Assert(ef.App, c.Not(c.IsNil))
 		t.Assert(ef.Release, c.Not(c.IsNil))
-		t.Assert(ef.Artifact, c.Not(c.IsNil))
+		t.Assert(ef.ImageArtifact, c.Not(c.IsNil))
 		t.Assert(ef.Processes, c.Not(c.IsNil))
 		t.Assert(ef.App.Name, c.Equals, name)
 	}

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -53,8 +53,11 @@ func (s *HostSuite) TestAddFailingJob(t *c.C) {
 
 	// add a job with a non existent artifact
 	job := &host.Job{
-		ID:       jobID,
-		Artifact: host.Artifact{Type: "docker", URI: "http://example.com?name=foo&id=bar"},
+		ID: jobID,
+		ImageArtifact: &host.Artifact{
+			Type: host.ArtifactTypeDocker,
+			URI:  "http://example.com?name=foo&id=bar",
+		},
 	}
 	t.Assert(h.AddJob(job), c.IsNil)
 

--- a/test/test_taffy_deploy.go
+++ b/test/test_taffy_deploy.go
@@ -119,7 +119,6 @@ func (s *TaffyDeploySuite) TestDeploys(t *c.C) {
 	newRelease, err := client.GetAppRelease(app.ID)
 	t.Assert(err, c.IsNil)
 	t.Assert(newRelease.ID, c.Not(c.Equals), release.ID)
-	env["SLUG_URL"] = newRelease.Env["SLUG_URL"] // SLUG_URL will be different
 	t.Assert(env, c.DeepEquals, newRelease.Env)
 	t.Assert(release.Processes, c.DeepEquals, newRelease.Processes)
 	t.Assert(newRelease, c.NotNil)

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -187,7 +187,7 @@ func deployApp(client *controller.Client, app *ct.App, uri string, updateFn upda
 		log.Error("error getting release", "err", err)
 		return err
 	}
-	artifact, err := client.GetArtifact(release.ArtifactID)
+	artifact, err := client.GetArtifact(release.ImageArtifactID())
 	if err != nil {
 		log.Error("error getting release artifact", "err", err)
 		return err
@@ -215,7 +215,7 @@ func deployApp(client *controller.Client, app *ct.App, uri string, updateFn upda
 		return err
 	}
 	release.ID = ""
-	release.ArtifactID = artifact.ID
+	release.SetImageArtifactID(artifact.ID)
 	if updateFn != nil {
 		updateFn(release)
 	}


### PR DESCRIPTION
Summary:

* Add a `tar` artifact type along with an `Attributes` field containing type specific attributes (compression and target path for `tar` artifacts)
* Rename `release.Artifact` to `release.ImageArtifact` (this is always required for a release to be runnable)
* Add `release.TarArtifacts` which is an optional list of `tar` artifacts
* Add `ExpandedFormation.TarArtifacts` and ensure it's always populated
* Add `Job.TarArtifacts` and extract them into the job's layer before starting the job
* Create tar artifacts for slugs

This is part of the changes proposed in #2422.