### PR TITLE
router: Use a retry dialer in the client

### DIFF
--- a/router/client/client.go
+++ b/router/client/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
 	"github.com/flynn/flynn/pkg/stream"
 	"github.com/flynn/flynn/router/types"
@@ -36,7 +37,9 @@ func newRouterClient() *client {
 	return &client{Client: &httpclient.Client{
 		ErrNotFound: ErrNotFound,
 		URL:         "http://router-api.discoverd:5000",
-		HTTP:        http.DefaultClient,
+		HTTP: &http.Client{
+			Transport: &http.Transport{Dial: dialer.Retry.Dial},
+		},
 	}}
 }
 


### PR DESCRIPTION
This prevents errors in the controller when trying to create routes during a router deployment as seen in some domain migration jobs.