### PR TITLE
host: Always use logfmt output when logging

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -31,6 +31,10 @@ const configFile = "/etc/flynn/host.json"
 var logger = log15.New("app", "host", "pid", os.Getpid())
 
 func init() {
+	// always use logfmt output, even when attached to a TTY (e.g.
+	// when run as an Upstart job)
+	logger.SetHandler(log15.StreamHandler(os.Stdout, log15.LogfmtFormat()))
+
 	cli.Register("daemon", runDaemon, `
 usage: flynn-host daemon [options]
 


### PR DESCRIPTION
When run as an Upstart job, stdout is connected to a pty which ultimately gets logged to a file, which means color codes and escape characters end up being logged to the file (e.g. see [this host log](https://gist.githubusercontent.com/anonymous/5da86fa3300212c642e1/raw/0dceef9f4483588819b893ff1e82929bf5f92327/upstart-flynn-host.log)).