### PR TITLE
util/packer: Pin docker version

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -93,13 +93,15 @@ EOF
 
 # install docker
 # apparmor is required - see https://github.com/dotcloud/docker/issues/4734
+# pin docker version due to https://github.com/flynn/flynn/issues/2459
 apt-key adv \
   --keyserver hkp://p80.pool.sks-keyservers.net:80 \
   --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo deb https://apt.dockerproject.org/repo ubuntu-trusty main \
   > /etc/apt/sources.list.d/docker.list
 apt-get update
-apt-get install -y docker-engine aufs-tools apparmor
+apt-get install -y "docker-engine=1.9.1-0~trusty" "aufs-tools" "apparmor"
+apt-mark hold docker-engine
 
 # install flynn build dependencies: tup
 apt-get install -y software-properties-common

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -176,7 +176,7 @@ install_packages() {
     "libvirt-bin"
     "libvirt-dev"
     "linux-image-extra-$(uname -r)"
-    "docker-engine"
+    "docker-engine=1.9.1-0~trusty"
     "make"
     "mercurial"
     "tup"
@@ -185,6 +185,9 @@ install_packages() {
   )
 
   apt-get install -y ${packages[@]}
+
+  # hold back docker upgrades to prevent breaking pinkerton see gh issue #2459
+  apt-mark hold docker-engine
 
   # make tup suid root so that we can build in chroots
   chmod ug+s /usr/bin/tup


### PR DESCRIPTION
Pinkerton isn't currently compatible with more recent Docker
versions so we must pin it for now.

Refs: #2459 