### PR TITLE
bootstrap: Improve logging when waiting for hosts

### DIFF
--- a/bootstrap/wait_hosts_action.go
+++ b/bootstrap/wait_hosts_action.go
@@ -41,7 +41,12 @@ outer:
 		}
 
 		if time.Now().Sub(start) >= waitMax {
-			return fmt.Errorf("bootstrap: timed out waiting for hosts to come up")
+			msg := "bootstrap: timed out waiting for hosts to come up\n\nThe following hosts were unreachable:\n"
+			for host := range hosts {
+				msg += "\t" + host.Addr() + "\n"
+			}
+			msg += "\n"
+			return fmt.Errorf(msg)
 		}
 		time.Sleep(waitInterval)
 	}


### PR DESCRIPTION
Improves logging when bootstrapping cluster and hosts are unreachable.

When checking for online hosts for example the new output will tell you which URLs it is still waiting on, including those found via discovery:

```
01:49:57.158452 check online-hosts
01:50:47.214339 check online-hosts error: timed out waiting for 3 hosts to come online (currently 2 online)

The following hosts were discovered but remained unreachable:

http://192.0.2.202:1113
```

Refs: #2454 