### PR TITLE
all: Update base images

### DIFF
--- a/blobstore/Dockerfile
+++ b/blobstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD ./bin/flynn-blobstore /bin/flynn-blobstore
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD bin/flynn-controller /bin/flynn-controller
 ADD bin/flynn-scheduler /bin/flynn-scheduler

--- a/controller/examples/Dockerfile
+++ b/controller/examples/Dockerfile
@@ -1,3 +1,3 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD flynn-controller-examples /bin/flynn-controller-examples

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD bin/flynn-dashboard /bin/flynn-dashboard
 

--- a/discoverd/Dockerfile
+++ b/discoverd/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD ./bin/discoverd /bin/discoverd
 ADD start.sh /bin/start-discoverd

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD bin/flanneld /bin/flanneld
 ADD bin/flannel-wrapper /bin/flannel-wrapper

--- a/gitreceive/Dockerfile
+++ b/gitreceive/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM ubuntu:trusty-20160217
 
 RUN apt-get update && apt-get -qy install git && apt-get clean
 ADD start.sh /bin/start-flynn-receiver

--- a/logaggregator/Dockerfile
+++ b/logaggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD ./bin/logaggregator /bin/logaggregator
 

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD ./bin/flynn-router /bin/flynn-router
 

--- a/router/example-generator/Dockerfile
+++ b/router/example-generator/Dockerfile
@@ -1,3 +1,3 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD flynn-router-examples /bin/flynn-router-examples

--- a/status/Dockerfile
+++ b/status/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD ./bin/flynn-status /bin/flynn-status
 

--- a/taffy/Dockerfile
+++ b/taffy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM ubuntu:trusty-20160217
 
 RUN apt-get update && apt-get -qy install git && apt-get clean
 

--- a/test/apps/Dockerfile
+++ b/test/apps/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD bin/echoer /bin/echoer
 ADD bin/ping /bin/pingserv

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM flynn/busybox:trusty-20160217
 
 ADD updater /bin/updater
 

--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM ubuntu:trusty-20160217
 
 # Derived from https://github.com/heroku/stack-images/blob/master/Dockerfile
 


### PR DESCRIPTION
`flynn/busybox:trusty-20160217` was released after merging https://github.com/flynn/docker-busybox/pull/1.

I have not changed the slugrunner / slugbuilder base image references because they are [built after cedarish](https://github.com/flynn/flynn/blob/master/slugbuilder/Tupfile#L2), so will always use the latest cedarish as part of the build.