### PR TITLE
host/cli: Include /var/log/flynn/bootstrap.log in collect-debug-info

### DIFF
--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -15,8 +15,9 @@ import (
 )
 
 var flynnHostLogs = map[string]string{
-	"upstart-flynn-host.log": "/var/log/upstart/flynn-host.log",
-	"tmp-flynn-host.log":     "/tmp/flynn-host.log",
+	"upstart-flynn-host.log":   "/var/log/upstart/flynn-host.log",
+	"flynn-host-bootstrap.log": "/var/log/flynn/bootstrap.log",
+	"tmp-flynn-host.log":       "/tmp/flynn-host.log",
 }
 
 var debugCmds = [][]string{


### PR DESCRIPTION
This allows users with automation to include the bootstrap log easily.

Note that the file will need to be written to with `tee` or other mechanisms.