### PR TITLE
controller/client: Convert time to UTC when streaming formations

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -181,7 +181,7 @@ func (c *Client) StreamFormations(since *time.Time, output chan<- *ct.ExpandedFo
 		s := time.Unix(0, 0)
 		since = &s
 	}
-	t := since.Format(time.RFC3339)
+	t := since.UTC().Format(time.RFC3339)
 	return c.Stream("GET", "/formations?since="+t, nil, output)
 }
 


### PR DESCRIPTION
This ensures the controller client will work on systems not configured for UTC.