### PR TITLE
controller: Check rows.Err when listing/streaming formations

### DIFF
--- a/controller/formation.go
+++ b/controller/formation.go
@@ -199,7 +199,7 @@ func (r *FormationRepo) List(appID string) ([]*ct.Formation, error) {
 		}
 		formations = append(formations, formation)
 	}
-	return formations, nil
+	return formations, rows.Err()
 }
 
 func (r *FormationRepo) ListActive() ([]*ct.ExpandedFormation, error) {
@@ -216,7 +216,7 @@ func (r *FormationRepo) ListActive() ([]*ct.ExpandedFormation, error) {
 		}
 		formations = append(formations, formation)
 	}
-	return formations, nil
+	return formations, rows.Err()
 }
 
 func (r *FormationRepo) Remove(appID, releaseID string) error {


### PR DESCRIPTION
When reading back formations from the database it's possible some errors won't be returned on query and instead will be contained in `rows.Err()`.
For instance if the connection pool returns a dead connection.

It's likely this was the root cause of #2486