### PR TITLE
controller: Bump default deploy timeout to two minutes

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -196,7 +196,7 @@ type NewJob struct {
 	Resources  resource.Resources `json:"resources,omitempty"`
 }
 
-const DefaultDeployTimeout = 30 // seconds
+const DefaultDeployTimeout = 120 // seconds
 
 type Deployment struct {
 	ID            string         `json:"id,omitempty"`

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -56,7 +56,7 @@
       "type": "object"
     },
     "deploy_timeout": {
-      "description": "deployment timeout (default 30s)",
+      "description": "deployment timeout (default 120s)",
       "type": "integer"
     }
   }


### PR DESCRIPTION
This will allow deploying apps with larger slugs.