### PR TITLE
host: Always resurrect jobs

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -445,9 +445,11 @@ func runDaemon(args *docopt.Args) {
 	}
 	log.Info("connecting to cluster peers")
 	if err := discoverdManager.ConnectPeer(peerIPs); err != nil && !args.Bool["--no-resurrect"] {
-		log.Info("no cluster peers available, resurrecting jobs")
-		resurrect()
+		log.Info("no cluster peers available")
 	}
+
+	log.Info("resurrecting jobs")
+	resurrect()
 
 	monitor := NewMonitor(host.discMan, externalIP)
 	shutdown.BeforeExit(func() { monitor.Shutdown() })


### PR DESCRIPTION
Being able to connect to discoverd nodes on other peers doesn't necessarily mean the scheduler is healthy. We should resurrect our own jobs regardless so that if the cluster is damaged then the cluster-monitor will be able to fix it.