### PR TITLE
Fix containerinit hang

### DIFF
--- a/discoverd/client/client.go
+++ b/discoverd/client/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	dt "github.com/flynn/flynn/discoverd/types"
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
@@ -29,8 +30,18 @@ type Service interface {
 
 var ErrTimedOut = errors.New("discoverd: timed out waiting for instances")
 
+var defaultLogger = log15.New("component", "discoverd")
+
+func init() {
+	defaultLogger.SetHandler(log15.StreamHandler(os.Stderr, log15.LogfmtFormat()))
+}
+
 type Client struct {
 	c *httpclient.Client
+
+	// Logger is used to log messages from Heartbeaters, it must not be changed
+	// after the first API request made with the Client.
+	Logger log15.Logger
 }
 
 func NewClient() *Client {
@@ -53,6 +64,7 @@ func NewClientWithURL(url string) *Client {
 				CheckRedirect: redirectPreserveHeaders,
 			},
 		},
+		Logger: defaultLogger,
 	}
 }
 
@@ -65,6 +77,7 @@ func NewClientWithHTTP(url string, hc *http.Client) *Client {
 			URL:  url,
 			HTTP: hc,
 		},
+		Logger: defaultLogger,
 	}
 }
 

--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -2,7 +2,6 @@ package discoverd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -153,7 +152,7 @@ func (h *heartbeater) run(firstErr chan<- error) {
 		select {
 		case <-timer.C:
 			if err := register(); err != nil {
-				log.Printf("discoverd: heartbeat %s (%s) failed: %s", h.service, h.inst.Addr, err)
+				h.client().Logger.Error("heartbeat failed", "service", h.service, "addr", h.inst.Addr, "err", err)
 				timer.Reset(heartbeatFailingInterval)
 				break
 			}

--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -448,6 +448,7 @@ func getCmdPath(c *Config) (string, error) {
 func monitor(port host.Port, container *ContainerInit, env map[string]string, log log15.Logger) (discoverd.Heartbeater, error) {
 	config := port.Service
 	client := discoverd.NewClientWithURL(env["DISCOVERD"])
+	client.Logger = logger.New("component", "discoverd")
 
 	if config.Create {
 		// TODO: maybe reuse maybeAddService() from the client


### PR DESCRIPTION
Before this patch, the discoverd heartbeater would attempt to log errors to `os.Stderr`, which for reasons that have not been fully investigated would hang permanently. The process would never restart heartbeating when discoverd came back and all RPC operations would also become wedged. This prevented the process from being killed and resulted in the fd exhaustion reported in #2461.

Logging to the fd we use for all other log messages from containerinit solves this problem.