### PR TITLE
discoverd: Bump leader wait timeout at start

### DIFF
--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// LeaderTimeout is the amount of time discoverd will wait for a leader.
-	LeaderTimeout = 30 * time.Second
+	LeaderTimeout = 10 * time.Minute
 )
 
 func main() {


### PR DESCRIPTION
If the discoverd cluster doesn’t come up within this timeout, we can prematurely break the bootstrap process, bump it to a nice high ten minutes.