### PR TITLE
router: Fix hard-coded high port in tests

### DIFF
--- a/router/api_test.go
+++ b/router/api_test.go
@@ -249,7 +249,7 @@ func (s *S) TestStreamEvents(c *C) {
 		c.Fatal("Timed out waiting for remove event")
 	}
 
-	tcpr := addTCPRoute(c, tcpl, 46000)
+	tcpr := addTCPRoute(c, tcpl, allocatePort())
 	select {
 	case e, ok := <-events:
 		if !ok {


### PR DESCRIPTION
Use our low port allocator. High ports can conflict with ephemeral kernel usage.