### PR TITLE
host: Make max job concurrency configurable

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -56,6 +56,7 @@ options:
   --peer-ips=IPLIST      join existing cluster using IPs
   --bridge-name=NAME     network bridge name [default: flynnbr0]
   --no-resurrect         disable cluster resurrection
+  --max-job-concurrency  maximum number of jobs to start concurrently
 	`)
 }
 
@@ -166,6 +167,11 @@ func runDaemon(args *docopt.Args) {
 
 	if hostID == "" {
 		hostID = strings.Replace(hostname, "-", "", -1)
+	}
+
+	var maxJobConcurrency uint64 = 4
+	if m, err := strconv.ParseUint(args.String["--max-job-concurrency"], 10, 64); err == nil {
+		maxJobConcurrency = m
 	}
 
 	log := logger.New("fn", "runDaemon", "host.id", hostID)
@@ -279,6 +285,8 @@ func runDaemon(args *docopt.Args) {
 		vman:    vman,
 		discMan: discoverdManager,
 		log:     logger.New("host.id", hostID),
+
+		maxJobConcurrency: maxJobConcurrency,
 	}
 
 	// restore the host status if set in the environment

--- a/host/http.go
+++ b/host/http.go
@@ -47,6 +47,8 @@ type Host struct {
 
 	listener net.Listener
 
+	maxJobConcurrency uint64
+
 	log log15.Logger
 }
 
@@ -509,8 +511,6 @@ func (h *jobAPI) RegisterRoutes(r *httprouter.Router) error {
 	return nil
 }
 
-const maxParallelAddJob = 4
-
 func (h *Host) ServeHTTP() {
 	r := httprouter.New()
 
@@ -518,7 +518,7 @@ func (h *Host) ServeHTTP() {
 
 	jobAPI := &jobAPI{
 		host: h,
-		addJobRatelimitBucket: make(chan struct{}, maxParallelAddJob),
+		addJobRatelimitBucket: make(chan struct{}, h.maxJobConcurrency),
 	}
 	jobAPI.RegisterRoutes(r)
 

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -491,6 +491,7 @@ sudo start-stop-daemon \
   --force \
   --backend libvirt-lxc \
   --peer-ips {{ .Peers }} \
+  --max-job-concurrency 8 \
   &>/tmp/flynn-host.log
 `[1:])),
 }


### PR DESCRIPTION
Allow configuring the maximum number of jobs the API will allow to be started concurrently from the command line.