### PR TITLE
test/runner: Bump test timeout to 35 minutes

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -311,7 +311,7 @@ cmd="bin/flynn-test \
   --router-ip {{ .Cluster.RouterIP }} \
   --debug"
 
-timeout --signal=QUIT --kill-after=10 25m $cmd
+timeout --signal=QUIT --kill-after=10 35m $cmd
 `[1:]))
 
 func formatDuration(d time.Duration) string {


### PR DESCRIPTION
Test runs on the new infrastructure appear to take a bit longer.