### PR TITLE
test: Log domain migration stream error

### DIFF
--- a/test/test_z_domain_migration.go
+++ b/test/test_z_domain_migration.go
@@ -44,7 +44,7 @@ func (s *ZDomainMigrationSuite) migrateDomain(t *c.C, dm *ct.DomainMigration) {
 		select {
 		case e, ok = <-events:
 			if !ok {
-				t.Fatal("event stream closed unexpectedly")
+				t.Fatalf("event stream closed unexpectedly: %s", stream.Err())
 			}
 			debugf(t, "got %s domain migration event", typ)
 		case <-time.After(timeout):


### PR DESCRIPTION
This will help debug an intermittent failure of the test.