### PR TITLE
scheduler: Don't try to start jobs which have already started

### DIFF
--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -668,7 +668,7 @@ func (TestSuite) TestJobPlacementTags(c *C) {
 		{typ: "clock", host: "host2"},
 		{typ: "clock", host: "host2"},
 	} {
-		job := s.jobs.Add(&Job{ID: fmt.Sprintf("job%d", i), Formation: formation, Type: t.typ})
+		job := s.jobs.Add(&Job{ID: fmt.Sprintf("job%d", i), Formation: formation, Type: t.typ, state: JobStatePending})
 		req := &PlacementRequest{Job: job, Err: make(chan error, 1)}
 		s.HandlePlacementRequest(req)
 		c.Assert(<-req.Err, IsNil, Commentf("placing job %d", i))

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -95,6 +95,7 @@ Options:
 		"flynn-controller.app":      app.ID,
 		"flynn-controller.app_name": app.Name,
 		"flynn-controller.release":  prevRelease.ID,
+		"flynn-controller.type":     "slugbuilder",
 	}
 	if len(prevRelease.Env) > 0 {
 		stdin, err := cmd.StdinPipe()

--- a/host/http.go
+++ b/host/http.go
@@ -300,7 +300,15 @@ func (h *jobAPI) AddJob(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		return
 	}
 
-	h.host.state.AddJob(job)
+	if err := h.host.state.AddJob(job); err != nil {
+		log.Error("error adding job to state database", "err", err)
+		if err == ErrJobExists {
+			httphelper.ConflictError(w, err.Error())
+		} else {
+			httphelper.Error(w, err)
+		}
+		return
+	}
 
 	go func() {
 		log.Info("running job")

--- a/host/state_test.go
+++ b/host/state_test.go
@@ -48,3 +48,14 @@ func (S) TestStatePersistRestore(c *C) {
 		c.Errorf("expected job.HostID to equal %s, got %s", hostID, job.HostID)
 	}
 }
+
+func (S) TestStateDuplicateID(c *C) {
+	workdir := c.MkDir()
+	hostID := "abc123"
+	state := NewState(hostID, filepath.Join(workdir, "host-state-db"))
+	c.Assert(state.OpenDB(), IsNil)
+	defer state.CloseDB()
+
+	c.Assert(state.AddJob(&host.Job{ID: "a"}), IsNil)
+	c.Assert(state.AddJob(&host.Job{ID: "a"}), Equals, ErrJobExists)
+}

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -214,6 +214,10 @@ func ObjectExistsError(w http.ResponseWriter, message string) {
 	Error(w, ObjectExistsErr(message))
 }
 
+func ConflictError(w http.ResponseWriter, message string) {
+	Error(w, JSONError{Code: ConflictErrorCode, Message: message})
+}
+
 func PreconditionFailedErr(message string) error {
 	return JSONError{Code: PreconditionFailedErrorCode, Message: message}
 }


### PR DESCRIPTION
This updates the scheduler to stop trying to add a job when it knows it has already started (regardless of whether AddJob continues to fail).

The host has also been updated to reject duplicate jobs, meaning the scheduler can continue to try starting a job with the same ID until it actually starts without leading to duplicate jobs.

I've also thrown in an update to the receiver to add `type=slugbuilder` to slugbuilder jobs as the scheduler now handles this correctly.

Closes #2545.