### PR TITLE
Fix containerinit registeration on error

### DIFF
--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -74,7 +74,10 @@ func (c *Client) RegisterInstance(service string, inst *Instance) (Heartbeater, 
 	h := newHeartbeater(c, service, inst)
 	firstErr := make(chan error)
 	go h.run(firstErr)
-	return h, <-firstErr
+	if err := <-firstErr; err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 func newHeartbeater(c *Client, service string, inst *Instance) *heartbeater {

--- a/discoverd/health/register.go
+++ b/discoverd/health/register.go
@@ -91,6 +91,9 @@ func (h *heartbeater) register(stop chan struct{}) {
 				return
 			}
 			h.hb, err = h.Registrar.RegisterInstance(h.Service, h.Instance)
+			if err != nil {
+				h.hb = nil
+			}
 		}()
 		if err == nil {
 			if h.l != nil {

--- a/discoverd/health/register.go
+++ b/discoverd/health/register.go
@@ -99,7 +99,7 @@ func (h *heartbeater) register(stop chan struct{}) {
 			return
 		}
 		if h.l != nil {
-			h.l.Error("error creating heartbeater")
+			h.l.Error("error creating heartbeater", "err", err)
 		}
 		time.Sleep(registerErrWait)
 	}


### PR DESCRIPTION
This fixes a bug in the discoverd registrar where the first registration fails and then there is no subsequent tries because a struct field (`h.hb`) that is supposed to be nil is not nil.