### PR TITLE
Godeps: Bump asset-matrix-go

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -500,7 +500,7 @@
 		},
 		{
 			"ImportPath": "github.com/jvatic/asset-matrix-go",
-			"Rev": "f5fcb3012298314fa20c03f60812c08c04307cbf"
+			"Rev": "2cb2227cdc3d81cfae144cfc1c5b50e0e407da8f"
 		},
 		{
 			"ImportPath": "github.com/kardianos/osext",

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/asset.go
@@ -10,6 +10,7 @@ import (
 type Asset interface {
 	Open() (*os.File, error)
 	Initialize() error
+	Checksum() string
 	Path() string
 	RelPath() (string, error)
 	SetIndexKey(string)

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/cache.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/cache.go
@@ -1,0 +1,143 @@
+package assetmatrix
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type Cache struct {
+	Dir            string
+	cacheHits      []string
+	cacheHitsMutex sync.Mutex
+}
+
+func (c *Cache) FindCachedAsset(a Asset) (Asset, error) {
+	checksum := a.Checksum()
+	if checksum == "" {
+		return a, nil
+	}
+	p := filepath.Join(c.Dir, checksum)
+	if _, err := os.Lstat(p); err != nil {
+		return nil, err
+	}
+	c.cacheHitsMutex.Lock()
+	c.cacheHits = append(c.cacheHits, p)
+	c.cacheHitsMutex.Unlock()
+	return &CachedAsset{input: a, p: p}, nil
+}
+
+func (c *Cache) CacheAsset(ar io.Reader, checksum string) io.Reader {
+	if checksum == "" {
+		return ar
+	}
+	p := filepath.Join(c.Dir, checksum)
+	if err := os.MkdirAll(c.Dir, 0755); err != nil {
+		// abort
+		log.Println(err)
+		return ar
+	}
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		// abort
+		log.Println(err)
+		return ar
+	}
+	c.cacheHitsMutex.Lock()
+	c.cacheHits = append(c.cacheHits, p)
+	c.cacheHitsMutex.Unlock()
+	cr, w := io.Pipe()
+	r := io.TeeReader(ar, w)
+	go func() {
+		defer f.Close()
+		defer w.Close()
+		if _, err := io.Copy(f, cr); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	return r
+}
+
+func (c *Cache) CleanupCacheDir() error {
+	c.cacheHitsMutex.Lock()
+	defer c.cacheHitsMutex.Unlock()
+	return filepath.Walk(c.Dir, func(path string, info os.FileInfo, err error) error {
+		if path == c.Dir {
+			return nil
+		}
+		found := false
+		for _, p := range c.cacheHits {
+			if p == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return os.Remove(path)
+		}
+		return nil
+	})
+}
+
+type CachedAsset struct {
+	p     string
+	input Asset
+}
+
+func (a *CachedAsset) Open() (*os.File, error) {
+	return os.Open(a.p)
+}
+
+func (a *CachedAsset) Initialize() error {
+	return nil
+}
+
+func (a *CachedAsset) Checksum() string {
+	return a.input.Checksum()
+}
+
+func (a *CachedAsset) Path() string {
+	return a.input.Path()
+}
+
+func (a *CachedAsset) RelPath() (string, error) {
+	return a.input.RelPath()
+}
+
+func (a *CachedAsset) SetIndexKey(key string) {
+	a.input.SetIndexKey(key)
+}
+
+func (a *CachedAsset) IndexKey() string {
+	return a.input.IndexKey()
+}
+
+func (a *CachedAsset) ImportPaths() []string {
+	return a.input.ImportPaths()
+}
+
+func (a *CachedAsset) Compile() (io.Reader, error) {
+	file, err := os.Open(a.p)
+	if err != nil {
+		return nil, err
+	}
+	r, w := io.Pipe()
+	go func() {
+		defer file.Close()
+		defer w.Close()
+		if _, err := io.Copy(w, file); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	return r, nil
+}
+
+func (a *CachedAsset) OutputExt() string {
+	return a.input.OutputExt()
+}
+
+func (a *CachedAsset) OutputPath() string {
+	return a.input.OutputPath()
+}

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/erb-asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/erb-asset.go
@@ -40,6 +40,10 @@ func (a *ERBAsset) Initialize() error {
 	return nil
 }
 
+func (a *ERBAsset) Checksum() string {
+	return ""
+}
+
 func (a *ERBAsset) Path() string {
 	return a.p
 }

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/eslint_asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/eslint_asset.go
@@ -35,6 +35,10 @@ func (a *ESLintAsset) Initialize() error {
 	return nil
 }
 
+func (a *ESLintAsset) Checksum() string {
+	return a.input.Checksum()
+}
+
 func (a *ESLintAsset) Path() string {
 	return a.p
 }

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/generic-asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/generic-asset.go
@@ -1,6 +1,8 @@
 package assetmatrix
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"io"
 	"log"
 	"os"
@@ -11,6 +13,7 @@ type GenericAsset struct {
 	r        *AssetRoot
 	p        string
 	indexKey string
+	checkSum string
 }
 
 func (a *GenericAsset) OutputExt() string {
@@ -31,6 +34,24 @@ func (a *GenericAsset) Open() (*os.File, error) {
 
 func (a *GenericAsset) Initialize() error {
 	return nil
+}
+
+func (a *GenericAsset) Checksum() string {
+	if a.checkSum != "" {
+		return a.checkSum
+	}
+	file, err := a.Open()
+	defer file.Close()
+	if err != nil {
+		return ""
+	}
+	h := md5.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return ""
+	}
+	h.Write([]byte(a.p))
+	a.checkSum = hex.EncodeToString(h.Sum(nil))
+	return a.checkSum
 }
 
 func (a *GenericAsset) Path() string {

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/javascript-asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/javascript-asset.go
@@ -94,6 +94,10 @@ func (a *JavaScriptAsset) Initialize() error {
 	return nil
 }
 
+func (a *JavaScriptAsset) Checksum() string {
+	return a.input.Checksum()
+}
+
 var jsImportParseRegex = regexp.MustCompile("from[^'\"]+(['\"])([^'\"]+)['\"]")
 var jsImportRegex = regexp.MustCompile("^import .*$")
 var jsExportRegex = regexp.MustCompile("^export .*$")

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/jsx-asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/jsx-asset.go
@@ -43,6 +43,10 @@ func (a *JSXAsset) Initialize() error {
 	return nil
 }
 
+func (a *JSXAsset) Checksum() string {
+	return a.input.Checksum()
+}
+
 func (a *JSXAsset) Path() string {
 	return a.p
 }

--- a/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/scss-asset.go
+++ b/Godeps/_workspace/src/github.com/jvatic/asset-matrix-go/scss-asset.go
@@ -48,6 +48,10 @@ func (a *SCSSAsset) Initialize() error {
 	return nil
 }
 
+func (a *SCSSAsset) Checksum() string {
+	return ""
+}
+
 func (a *SCSSAsset) Path() string {
 	return a.p
 }


### PR DESCRIPTION
This greatly speeds up asset build times in development for dashboard and installer by adding build caching.

See https://github.com/jvatic/asset-matrix-go/commit/2cb2227cdc3d81cfae144cfc1c5b50e0e407da8f

\\cc @titanous 