### PR TITLE
test/rootfs: Add MongoDB unit test dependencies

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -162,6 +162,7 @@ dpkg-reconfigure locales
 
 # add keys
 curl --fail --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 EA312927
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1C4CBDCDCD2EFD2A
 
@@ -169,12 +170,13 @@ apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1C4CBDCDCD2EFD
 echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
 echo "deb http://mirrors.syringanetworks.net/mariadb/repo/10.1/ubuntu trusty main" >> /etc/apt/sources.list.d/mariadb.list
 echo "deb http://repo.percona.com/apt trusty main" >> /etc/apt/sources.list.d/percona.list
+echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" >> /etc/apt/sources.list.d/mongo-org-3.2.list
 
 # update lists
 apt-get update
 
 # install packages
-apt-get install -y postgresql-9.4 postgresql-contrib-9.4 redis-server mariadb-server percona-xtrabackup
+apt-get install -y postgresql-9.4 postgresql-contrib-9.4 redis-server mariadb-server percona-xtrabackup mongodb-org
 
 # setup postgres
 service postgresql start
@@ -185,6 +187,10 @@ service postgresql stop
 # setup mariadb
 update-rc.d mysql disable
 service mysql stop
+
+# setup mongodb
+echo "manual" > /etc/init/mongod.override
+service mongod stop
 
 # make tup suid root so that we can build in chroots
 chmod ug+s /usr/bin/tup


### PR DESCRIPTION
Facilitates testing the MongoDB branch in CI before merging.