### PR TITLE
gitreceive: Cancel deploy if client git process disconnects

### DIFF
--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/exec"
 	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/version"
 )
 
@@ -119,6 +120,7 @@ Options:
 		}
 	}
 
+	shutdown.BeforeExit(func() { cmd.Kill() })
 	if err := cmd.Run(); err != nil {
 		log.Fatalln("Build failed:", err)
 	}

--- a/gitreceive/server.go
+++ b/gitreceive/server.go
@@ -192,7 +192,10 @@ func handlePostRPC(env gitEnv, rpc string, path string, w http.ResponseWriter, r
 		fail500(w, "handlePostRPC", err)
 		return
 	}
-	defer cleanUpProcessGroup(cmd) // Ensure brute force subprocess clean-up
+	go func(done <-chan bool) {
+		<-done
+		cleanUpProcessGroup(cmd) // Ensure brute force subprocess clean-up
+	}(w.(http.CloseNotifier).CloseNotify())
 
 	// Write the client request body to Git's standard input
 	if _, err := io.Copy(stdin, body); err != nil {


### PR DESCRIPTION
This allows using `Ctrl-C` to cancel the deploy while the build is running.

Closes #94