### PR TITLE
Fix host-wait timeout

### DIFF
--- a/bootstrap/wait_hosts_action.go
+++ b/bootstrap/wait_hosts_action.go
@@ -14,7 +14,6 @@ func init() {
 }
 
 func (a *WaitHostsAction) Run(s *State) error {
-	const waitMax = time.Minute
 	const waitInterval = 500 * time.Millisecond
 
 	hosts := make(map[*cluster.Host]struct{}, len(s.Hosts))
@@ -40,7 +39,7 @@ outer:
 			break outer
 		}
 
-		if time.Now().Sub(start) >= waitMax {
+		if time.Now().Sub(start) >= s.HostTimeout {
 			msg := "bootstrap: timed out waiting for hosts to come up\n\nThe following hosts were unreachable:\n"
 			for host := range hosts {
 				msg += "\t" + host.Addr() + "\n"

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -28,7 +28,7 @@ usage: flynn-host bootstrap [options] [<manifest>]
 
 Options:
   -n, --min-hosts=MIN  minimum number of hosts required to be online
-  -t, --timeout=SECS   seconds to wait for hosts to come online [default: 30]
+  -t, --timeout=SECS   seconds to wait for hosts to come online [default: 120]
   --json               format log output as json
   --from-backup=FILE   bootstrap from backup file
   --discovery=TOKEN    use discovery token to connect to cluster


### PR DESCRIPTION
This was previously hard-coded. Also, bump the default to a less aggressive two minutes.