### PR TITLE
Add CPU limits and resource partitions

### DIFF
--- a/cli/limit.go
+++ b/cli/limit.go
@@ -31,22 +31,22 @@ Commands:
 Examples:
 
 	$ flynn limit
-	web:     max_fd=10000  memory=1GB
-	worker:  max_fd=10000  memory=1GB
+	web:     cpu=1000  max_fd=10000  memory=1GB
+	worker:  cpu=1000  max_fd=10000  memory=1GB
 
-	$ flynn limit set web memory=512MB max_fd=12000
+	$ flynn limit set web memory=512MB max_fd=12000 cpu=500
 	Created release 5058ae7964f74c399a240bdd6e7d1bcb
 
 	$ flynn limit
-	web:     max_fd=12000  memory=512MB
-	worker:  max_fd=10000  memory=1GB
+	web:     cpu=500   max_fd=12000  memory=512MB
+	worker:  cpu=1000  max_fd=10000  memory=1GB
 
 	$ flynn limit set web memory=256MB
 	Created release b39fe25d0ea344b6b2af5cf4d6542a80
 
 	$ flynn limit
-	web:     max_fd=12000  memory=256MB
-	worker:  max_fd=10000  memory=1GB
+	web:     cpu=500   max_fd=12000  memory=256MB
+	worker:  cpu=1000  max_fd=10000  memory=1GB
 `)
 }
 

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -151,6 +151,7 @@ func scanExpandedFormation(s postgres.Scanner) (*ct.ExpandedFormation, error) {
 	err := s.Scan(
 		&f.App.ID,
 		&f.App.Name,
+		&f.App.Meta,
 		&f.Release.ID,
 		&artifactID,
 		&f.Release.Meta,

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -182,7 +182,7 @@ FROM formations WHERE app_id = $1 AND deleted_at IS NULL ORDER BY created_at DES
 	`
 	formationListActiveQuery = `
 SELECT
-  apps.app_id, apps.name,
+  apps.app_id, apps.name, apps.meta,
   releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
   artifacts.artifact_id, artifacts.type, artifacts.uri,
   formations.processes, formations.tags, formations.updated_at
@@ -207,7 +207,7 @@ SELECT app_id, release_id, processes, tags, created_at, updated_at
 FROM formations WHERE app_id = $1 AND release_id = $2 AND deleted_at IS NULL`
 	formationSelectExpandedQuery = `
 SELECT
-  apps.app_id, apps.name,
+  apps.app_id, apps.name, apps.meta,
   releases.release_id, releases.artifact_id, releases.meta, releases.env, releases.processes,
   artifacts.artifact_id, artifacts.type, artifacts.uri,
   formations.processes, formations.tags, formations.updated_at

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -55,6 +55,9 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 		Resurrect: t.Resurrect,
 		Resources: t.Resources,
 	}
+	if f.App.Meta["flynn-system-app"] == "true" {
+		job.Partition = "system"
+	}
 	if len(t.Entrypoint) > 0 {
 		job.Config.Entrypoint = t.Entrypoint
 	}

--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -16,6 +16,7 @@ type Domain struct {
 	Memory UnitInt `xml:"memory"`
 
 	CPUTune  *CPUTune  `xml:"cputune,omitempty"`
+	Resource *Resource `xml:"resource,omitempty"`
 
 	OnPoweroff string `xml:"on_poweroff,omitempty"`
 	OnReboot   string `xml:"on_reboot,omitempty"`
@@ -141,4 +142,8 @@ type MAC struct {
 
 type CPUTune struct {
 	Shares int64 `xml:"shares"`
+}
+
+type Resource struct {
+	Partition string `xml:"partition"`
 }

--- a/host/libvirt/types.go
+++ b/host/libvirt/types.go
@@ -15,6 +15,8 @@ type Domain struct {
 
 	Memory UnitInt `xml:"memory"`
 
+	CPUTune  *CPUTune  `xml:"cputune,omitempty"`
+
 	OnPoweroff string `xml:"on_poweroff,omitempty"`
 	OnReboot   string `xml:"on_reboot,omitempty"`
 	OnCrash    string `xml:"on_crash,omitempty"`
@@ -135,4 +137,8 @@ type IP struct {
 
 type MAC struct {
 	Address string `xml:"address,attr"`
+}
+
+type CPUTune struct {
+	Shares int64 `xml:"shares"`
 }

--- a/host/resource/resource.go
+++ b/host/resource/resource.go
@@ -28,6 +28,11 @@ const (
 	// TypeMemory specifies the available memory in bytes inside a container.
 	TypeMemory Type = "memory"
 
+	// TypeCPU specifies the amount of milliCPU requested. A milliCPU is
+	// conceptually 1/1000 of a CPU core (eg 500m is half of a CPU core). In
+	// practice, a 1000 milliCPU limit is equivalent to 1024 CPU shares.
+	TypeCPU Type = "cpu"
+
 	// TypeMaxFD specifies a value one greater than the maximum file
 	// descriptor number that can be opened inside a container.
 	TypeMaxFD Type = "max_fd"
@@ -39,6 +44,7 @@ const (
 
 var defaults = Resources{
 	TypeMemory: {Request: typeconv.Int64Ptr(1 * units.GiB), Limit: typeconv.Int64Ptr(1 * units.GiB)},
+	TypeCPU:    {Limit: typeconv.Int64Ptr(1000)}, // results in Linux default of 1024 shares
 	TypeMaxFD:  {Request: typeconv.Int64Ptr(10000), Limit: typeconv.Int64Ptr(10000)},
 }
 

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -17,6 +17,7 @@ type Job struct {
 
 	Artifact  Artifact           `json:"artifact,omitempty"`
 	Resources resource.Resources `json:"resources,omitempty"`
+	Partition string             `json:"partition,omitempty"`
 
 	Config ContainerConfig `json:"config,omitempty"`
 

--- a/test/helper.go
+++ b/test/helper.go
@@ -108,12 +108,13 @@ func (h *Helper) anyHostClient(t *c.C) *cluster.Host {
 const (
 	resourceMem   int64 = 256 * units.MiB
 	resourceMaxFD int64 = 1024
-	resourceCmd         = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes; ulimit -n"
+	resourceCmd         = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes; cat /sys/fs/cgroup/cpu/cpu.shares; ulimit -n"
 )
 
 func testResources() resource.Resources {
 	r := resource.Resources{
 		resource.TypeMemory: resource.Spec{Limit: typeconv.Int64Ptr(resourceMem)},
+		resource.TypeCPU:    resource.Spec{Limit: typeconv.Int64Ptr(750)},
 		resource.TypeMaxFD:  resource.Spec{Limit: typeconv.Int64Ptr(resourceMaxFD)},
 	}
 	resource.SetDefaults(&r)
@@ -122,9 +123,10 @@ func testResources() resource.Resources {
 
 func assertResourceLimits(t *c.C, out string) {
 	limits := strings.Split(strings.TrimSpace(out), "\n")
-	t.Assert(limits, c.HasLen, 2)
+	t.Assert(limits, c.HasLen, 3)
 	t.Assert(limits[0], c.Equals, strconv.FormatInt(resourceMem, 10))
-	t.Assert(limits[1], c.Equals, strconv.FormatInt(resourceMaxFD, 10))
+	t.Assert(limits[1], c.Equals, strconv.FormatInt(768, 10))
+	t.Assert(limits[2], c.Equals, strconv.FormatInt(resourceMaxFD, 10))
 }
 
 func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -901,7 +901,7 @@ func (s *CLISuite) TestRelease(t *c.C) {
 func (s *CLISuite) TestLimits(t *c.C) {
 	app := s.newCliTestApp(t)
 	defer app.cleanup()
-	t.Assert(app.flynn("limit", "set", "resources", "memory=512MB", "max_fd=12k"), Succeeds)
+	t.Assert(app.flynn("limit", "set", "resources", "memory=512MB", "max_fd=12k", "cpu=2000"), Succeeds)
 
 	release, err := s.controller.GetAppRelease(app.name)
 	t.Assert(err, c.IsNil)
@@ -911,11 +911,13 @@ func (s *CLISuite) TestLimits(t *c.C) {
 	}
 	r := proc.Resources
 	t.Assert(*r[resource.TypeMemory].Limit, c.Equals, int64(536870912))
+	t.Assert(*r[resource.TypeCPU].Limit, c.Equals, int64(2000))
 	t.Assert(*r[resource.TypeMaxFD].Limit, c.Equals, int64(12000))
 
 	cmd := app.flynn("limit", "-t", "resources")
 	t.Assert(cmd, Succeeds)
 	t.Assert(cmd, OutputContains, "memory=512MB")
+	t.Assert(cmd, OutputContains, "cpu=2000")
 	t.Assert(cmd, OutputContains, "max_fd=12000")
 }
 
@@ -926,9 +928,10 @@ func (s *CLISuite) TestRunLimits(t *c.C) {
 	t.Assert(cmd, Succeeds)
 	defaults := resource.Defaults()
 	limits := strings.Split(strings.TrimSpace(cmd.Output), "\n")
-	t.Assert(limits, c.HasLen, 2)
+	t.Assert(limits, c.HasLen, 3)
 	t.Assert(limits[0], c.Equals, strconv.FormatInt(*defaults[resource.TypeMemory].Limit, 10))
-	t.Assert(limits[1], c.Equals, strconv.FormatInt(*defaults[resource.TypeMaxFD].Limit, 10))
+	t.Assert(limits[1], c.Equals, strconv.FormatInt(1024, 10))
+	t.Assert(limits[2], c.Equals, strconv.FormatInt(*defaults[resource.TypeMaxFD].Limit, 10))
 }
 
 func (s *CLISuite) TestExportImport(t *c.C) {


### PR DESCRIPTION
### CPU limits

CPU limits are implemented as a resource denominated in “milliCPUs”, a concept from Google. When doing placement, a request for 1000 milliCPUs will be equivalent to a single CPU core.

A limit of 1000 milliCPUs results in the Linux default of 1024 CPU shares, and the request portion of the resource spec can be used for scheduling in the future.

CPU shares are relative, the more shares a process has, the higher priority it is. When a host is under load, a job with 2000 milliCPUs will get twice the CPU time as a job with the default of 1000.

Limits can be specified on a per-process basis with:

```text
flynn limit set web cpu=1500
```

### Resource Partitions

Resource partitions complement CPU limits in order to isolate system apps from user apps. A top-level set of cgroups is added that all jobs are nested under. Currently these cgroups just provide CPU share allocations, but in the future they can be used for any other cgroup control. The partitions are only throttled when all partitions are under equal load, full bursting is allowed, unused shares are given to the other partitions on a proportional basis. With that in mind, the default allocations are:

- `system`, all Flynn-managed system apps, with 25% of available CPU time
- `user`, all user app processes, with 50% of available CPU time
- `background`, slugbuilder builds, with 25% of available CPU time

Allocations can be modified by passing the `--partitions` flag to `flynn-host daemon` like this:

```text
flynn-host daemon --partitions "system=cpu_shares:4096 background=cpu_shares:4096 user=cpu_shares:8192"
```

Refs #1496