### PR TITLE
discoverd/server: Fix mutex that doesn’t get unlocked in error path

### DIFF
--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -896,6 +896,7 @@ func (s *Store) applyExpireInstancesCommand(cmd []byte) error {
 func (s *Store) raftApply(typ byte, cmd []byte) (uint64, error) {
 	s.mu.RLock()
 	if s.raft == nil {
+		s.mu.RUnlock()
 		return 0, ErrShutdown
 	}
 	s.mu.RUnlock()


### PR DESCRIPTION
Not unlocking the mutex can result in a deadlock at startup.