### PR TITLE
host/cli: Use current MariaDB artifact URI when restoring from backup

### DIFF
--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -219,6 +219,7 @@ WHERE artifact_id = (SELECT artifact_id FROM releases
 	data.Discoverd.Artifact.URI = artifactURIs["discoverd"]
 	data.Discoverd.Release.Env["DISCOVERD_PEERS"] = "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1111,{{ end }}"
 	data.Postgres.Artifact.URI = artifactURIs["postgres"]
+	data.MariaDB.Artifact.URI = artifactURIs["mariadb"]
 	data.Flannel.Artifact.URI = artifactURIs["flannel"]
 	data.Controller.Artifact.URI = artifactURIs["controller"]
 


### PR DESCRIPTION
If this is not done, restores to a newer version of Flynn will fail with:

    run-app mariadb error: bootstrap: host error while launching job: "registry: unexpected status 403"'

/cc @josephglanville