### PR TITLE
pkg/postgres: Fix connection leak when Listener errs out

### DIFF
--- a/pkg/postgres/listener.go
+++ b/pkg/postgres/listener.go
@@ -23,6 +23,7 @@ func (db *DB) Listen(channel string, log log15.Logger) (*Listener, error) {
 		conn:    conn,
 	}
 	if err := l.conn.Listen(channel); err != nil {
+		l.Close()
 		return nil, err
 	}
 	go l.listen()
@@ -56,6 +57,7 @@ func (l *Listener) listen() {
 		}
 		if err != nil {
 			l.Err = err
+			l.Close()
 			close(l.Notify)
 			return
 		}


### PR DESCRIPTION
Prevents leaking connections during reconnect phase of postgres failover.
This failure happened when reconnects happened fast enough that the pool would be fully consumed before the listener was re-established.
It always leaked connections but the effect was pronounced if multiple primary failovers happen as the connections are never reclaimed.

Closes #2439 

/cc @temujin9 @titanous 