### PR TITLE
controller/worker/deployment: Use configured deploy timeout when waiting for events

### DIFF
--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -366,7 +366,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 			case JobEventTypeError:
 				return e.Error
 			}
-		case <-time.After(60 * time.Second):
+		case <-time.After(time.Duration(d.DeployTimeout) * time.Second):
 			return fmt.Errorf("timed out waiting for job events: %v", expected)
 		}
 	}


### PR DESCRIPTION
This hard-coded timeout is too tight for many larger apps.

Closes #2604.

@lmars I think it makes more sense to use this timeout as the amount of time to wait for a single process to start. We should probably just completely drop some of the other timeouts related to watching the deployment stream.