### PR TITLE
scheduler: Prevent completely scaling down critical apps

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -18,7 +18,10 @@
     "id": "discoverd",
     "app": {
       "name": "discoverd",
-      "meta": {"flynn-system-app": "true"}
+      "meta": {
+        "flynn-system-app": "true",
+        "flynn-system-critical": "true"
+      }
     },
     "action": "run-app",
     "release": {
@@ -85,7 +88,10 @@
     "id": "postgres",
     "app": {
       "name": "postgres",
-      "meta": {"flynn-system-app": "true"}
+      "meta": {
+        "flynn-system-app": "true",
+        "flynn-system-critical": "true"
+      }
     },
     "action": "run-app",
     "release": {
@@ -165,7 +171,10 @@
     "action": "run-app",
     "app": {
       "name": "controller",
-      "meta": {"flynn-system-app": "true"}
+      "meta": {
+        "flynn-system-app": "true",
+        "flynn-system-critical": "true"
+      }
     },
     "release": {
       "env": {
@@ -225,7 +234,10 @@
     "from_step": "postgres",
     "app": {
       "name": "postgres",
-      "meta": {"flynn-system-app": "true"},
+      "meta": {
+        "flynn-system-app": "true",
+        "flynn-system-critical": "true"
+      },
       "strategy": "sirenia",
       "deploy_timeout": 120
     }
@@ -246,7 +258,10 @@
     "from_step": "discoverd",
     "app": {
       "name": "discoverd",
-      "meta": {"flynn-system-app": "true"},
+      "meta": {
+        "flynn-system-app": "true",
+        "flynn-system-critical": "true"
+      },
       "strategy": "discoverd-meta",
       "deploy_timeout": 120
     }

--- a/controller/scheduler/discoverd.go
+++ b/controller/scheduler/discoverd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	discoverd "github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/stream"
@@ -17,16 +18,20 @@ type Discoverd interface {
 	LeaderCh() chan bool
 }
 
-func newDiscoverdWrapper() *discoverdWrapper {
-	return &discoverdWrapper{leader: make(chan bool)}
+func newDiscoverdWrapper(l log15.Logger) *discoverdWrapper {
+	return &discoverdWrapper{
+		leader: make(chan bool),
+		logger: l,
+	}
 }
 
 type discoverdWrapper struct {
 	leader chan bool
+	logger log15.Logger
 }
 
 func (d *discoverdWrapper) Register() (bool, error) {
-	log := logger.New("fn", "discoverd.Register")
+	log := d.logger.New("fn", "discoverd.Register")
 
 	log.Info("registering with service discovery")
 	hb, err := discoverd.AddServiceAndRegister(serviceName, ":"+os.Getenv("PORT"))

--- a/controller/scheduler/formation.go
+++ b/controller/scheduler/formation.go
@@ -21,18 +21,28 @@ func (fs Formations) Add(f *Formation) *Formation {
 
 type Processes map[string]int
 
-func (p Processes) Equals(other Processes) bool {
+func (p Processes) Diff(other Processes) Processes {
+	diff := make(map[string]int)
 	for typ, count := range p {
-		if other[typ] != count {
-			return false
+		if typ == "" {
+			continue
 		}
+		diff[typ] = count - other[typ]
 	}
+
 	for typ, count := range other {
-		if p[typ] != count {
-			return false
+		if typ == "" {
+			continue
+		}
+		if _, ok := p[typ]; !ok {
+			diff[typ] = -count
 		}
 	}
-	return true
+	return diff
+}
+
+func (p Processes) Equals(other Processes) bool {
+	return p.Diff(other).IsEmpty()
 }
 
 func (p Processes) IsEmpty() bool {
@@ -98,26 +108,8 @@ func (f *Formation) key() utils.FormationKey {
 	return utils.FormationKey{AppID: f.App.ID, ReleaseID: f.Release.ID}
 }
 
-// Update stores the new processes and returns the diff from the previous
-// processes.
-func (f *Formation) Update(procs Processes) Processes {
-	diff := make(map[string]int)
-	for typ, requested := range procs {
-		if typ == "" {
-			continue
-		}
-		current := f.Processes[typ]
-		diff[typ] = requested - current
-	}
-
-	for typ, current := range f.Processes {
-		if typ == "" {
-			continue
-		}
-		if _, ok := procs[typ]; !ok {
-			diff[typ] = -current
-		}
-	}
-	f.Processes = procs
-	return diff
+// Diff returns the diff between the given running processes and what is
+// expected to be running for the formation
+func (f *Formation) Diff(running Processes) Processes {
+	return Processes(f.Processes).Diff(running)
 }

--- a/controller/scheduler/formation.go
+++ b/controller/scheduler/formation.go
@@ -54,9 +54,11 @@ func (p Processes) IsEmpty() bool {
 	return true
 }
 
-func (p Processes) IsScaleDown() bool {
-	for _, count := range p {
-		if count < 0 {
+// IsScaleDownOf returns whether a diff is the complete scale down of any
+// process types in the given processes
+func (p Processes) IsScaleDownOf(proc Processes) bool {
+	for typ, count := range p {
+		if count <= -proc[typ] {
 			return true
 		}
 	}

--- a/controller/scheduler/formation.go
+++ b/controller/scheduler/formation.go
@@ -54,6 +54,15 @@ func (p Processes) IsEmpty() bool {
 	return true
 }
 
+func (p Processes) IsScaleDown() bool {
+	for _, count := range p {
+		if count < 0 {
+			return true
+		}
+	}
+	return false
+}
+
 type Formation struct {
 	*ct.ExpandedFormation
 

--- a/controller/scheduler/formation_test.go
+++ b/controller/scheduler/formation_test.go
@@ -98,3 +98,67 @@ func (TestSuite) TestFormationRectifyOmni(c *C) {
 	assertRectify(2, true, map[string]int{"web": 4, "omni": 4})
 	assertRectify(2, false, map[string]int{"web": 4, "omni": 4})
 }
+
+func (TestSuite) TestDiffScaleDownOf(c *C) {
+	type test struct {
+		diff     Processes
+		procs    Processes
+		expected bool
+	}
+
+	for _, t := range []test{
+		{
+			diff:     nil,
+			procs:    nil,
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": 1},
+			procs:    Processes{"web": 0},
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": 1},
+			procs:    Processes{"web": 1},
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": -1},
+			procs:    Processes{"web": 1},
+			expected: true,
+		},
+		{
+			diff:     Processes{"web": 0},
+			procs:    Processes{"web": 1},
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": -1},
+			procs:    Processes{"web": 2},
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": -2},
+			procs:    Processes{"web": 2},
+			expected: true,
+		},
+		{
+			diff:     Processes{"web": -1, "worker": -1},
+			procs:    Processes{"web": 2, "worker": 2},
+			expected: false,
+		},
+		{
+			diff:     Processes{"web": -2, "worker": -1},
+			procs:    Processes{"web": 2, "worker": 2},
+			expected: true,
+		},
+		{
+			diff:     Processes{"web": -2, "worker": -2},
+			procs:    Processes{"web": 2, "worker": 2},
+			expected: true,
+		},
+	} {
+		diff := Processes(t.diff)
+		c.Assert(diff.IsScaleDownOf(Processes(t.procs)), Equals, t.expected)
+	}
+}

--- a/controller/scheduler/formation_test.go
+++ b/controller/scheduler/formation_test.go
@@ -5,67 +5,66 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 )
 
-func (TestSuite) TestFormationUpdate(c *C) {
+func (TestSuite) TestFormationDiff(c *C) {
 	type test struct {
-		desc      string
-		initial   Processes
-		requested Processes
-		diff      Processes
+		desc     string
+		running  Processes
+		expected Processes
+		diff     Processes
 	}
 	for _, t := range []test{
 		{
-			desc:      "+1 web proc",
-			initial:   Processes{"web": 1},
-			requested: Processes{"web": 2},
-			diff:      Processes{"web": 1},
+			desc:     "+1 web proc",
+			running:  Processes{"web": 1},
+			expected: Processes{"web": 2},
+			diff:     Processes{"web": 1},
 		},
 		{
-			desc:      "+3 web proc",
-			initial:   Processes{"web": 1},
-			requested: Processes{"web": 4},
-			diff:      Processes{"web": 3},
+			desc:     "+3 web proc",
+			running:  Processes{"web": 1},
+			expected: Processes{"web": 4},
+			diff:     Processes{"web": 3},
 		},
 		{
-			desc:      "-1 web proc",
-			initial:   Processes{"web": 2},
-			requested: Processes{"web": 1},
-			diff:      Processes{"web": -1},
+			desc:     "-1 web proc",
+			running:  Processes{"web": 2},
+			expected: Processes{"web": 1},
+			diff:     Processes{"web": -1},
 		},
 		{
-			desc:      "-3 web proc",
-			initial:   Processes{"web": 4},
-			requested: Processes{"web": 1},
-			diff:      Processes{"web": -3},
+			desc:     "-3 web proc",
+			running:  Processes{"web": 4},
+			expected: Processes{"web": 1},
+			diff:     Processes{"web": -3},
 		},
 		{
-			desc:      "no change",
-			initial:   Processes{"web": 1},
-			requested: Processes{"web": 1},
-			diff:      Processes{"web": 0},
+			desc:     "no change",
+			running:  Processes{"web": 1},
+			expected: Processes{"web": 1},
+			diff:     Processes{"web": 0},
 		},
 		{
-			desc:      "missing type",
-			initial:   Processes{"web": 1, "worker": 1},
-			requested: Processes{"web": 1},
-			diff:      Processes{"web": 0, "worker": -1},
+			desc:     "missing type",
+			running:  Processes{"web": 1, "worker": 1},
+			expected: Processes{"web": 1},
+			diff:     Processes{"web": 0, "worker": -1},
 		},
 		{
-			desc:      "nil request",
-			initial:   Processes{"web": 1, "worker": 1},
-			requested: nil,
-			diff:      Processes{"web": -1, "worker": -1},
+			desc:     "nil request",
+			running:  Processes{"web": 1, "worker": 1},
+			expected: nil,
+			diff:     Processes{"web": -1, "worker": -1},
 		},
 		{
-			desc:      "multiple type changes",
-			initial:   Processes{"web": 3, "worker": 1},
-			requested: Processes{"web": 1, "clock": 2},
-			diff:      Processes{"web": -2, "worker": -1, "clock": 2},
+			desc:     "multiple type changes",
+			running:  Processes{"web": 3, "worker": 1},
+			expected: Processes{"web": 1, "clock": 2},
+			diff:     Processes{"web": -2, "worker": -1, "clock": 2},
 		},
 	} {
-		formation := NewFormation(&ct.ExpandedFormation{Processes: t.initial})
-		diff := formation.Update(t.requested)
+		formation := NewFormation(&ct.ExpandedFormation{Processes: t.expected})
+		diff := formation.Diff(t.running)
 		c.Assert(diff, DeepEquals, t.diff, Commentf(t.desc))
-		c.Assert(formation.GetProcesses(), DeepEquals, t.requested, Commentf(t.desc))
 	}
 }
 

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -148,6 +148,10 @@ func (j *Job) IsInFormation(key utils.FormationKey) bool {
 	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key && j.HasTypeFromRelease()
 }
 
+func (j *Job) IsInApp(appID string) bool {
+	return j.Formation != nil && j.Formation.key().AppID == appID && j.HasTypeFromRelease()
+}
+
 func (j *Job) ControllerJob() *ct.Job {
 	job := &ct.Job{
 		ID:        j.JobID,

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1223,9 +1223,9 @@ func (s *Scheduler) handleFormation(ef *ct.ExpandedFormation) (formation *Format
 			return
 		}
 
-		// do not scale down critical apps for which this is the only active formation
+		// do not completely scale down critical apps for which this is the only active formation
 		// (this prevents for example scaling down discoverd which breaks the cluster)
-		if diff.IsScaleDown() && formation.App.Critical() && s.activeFormationCount(formation.App.ID) < 2 {
+		if diff.IsScaleDownOf(formation.OriginalProcesses) && formation.App.Critical() && s.activeFormationCount(formation.App.ID) < 2 {
 			log.Info("refusing to scale down critical app")
 			return
 		}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -654,15 +654,12 @@ func (s *Scheduler) formationDiff(formation *Formation) Processes {
 		return nil
 	}
 	key := formation.key()
-	expected := formation.GetProcesses()
 	actual := s.jobs.GetProcesses(key)
-	if expected.Equals(actual) {
-		return nil
+	diff := formation.Diff(actual)
+	if !diff.IsEmpty() {
+		log := s.logger.New("fn", "formationDiff", "app.id", key.AppID, "release.id", key.ReleaseID)
+		log.Info("expected different from actual", "expected", formation.Processes, "actual", actual, "diff", diff)
 	}
-	formation.Processes = actual
-	diff := formation.Update(expected)
-	log := s.logger.New("fn", "formationDiff", "app.id", key.AppID, "release.id", key.ReleaseID)
-	log.Info("expected different from actual", "expected", expected, "actual", actual, "diff", diff)
 	return diff
 }
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -39,6 +39,12 @@ func (a *App) System() bool {
 	return ok && v == "true"
 }
 
+// Critical apps cannot be completely scaled down by the scheduler
+func (a *App) Critical() bool {
+	v, ok := a.Meta["flynn-system-critical"]
+	return ok && v == "true"
+}
+
 type Release struct {
 	ID         string                 `json:"id,omitempty"`
 	ArtifactID string                 `json:"artifact,omitempty"`


### PR DESCRIPTION
This adds a sanity check to make sure we do not scale down "critical" apps such as discoverd, because if we do then clusters break hard.

We should not actually ever be getting these critical apps being scaled down like this, but it happened in #2610, and I suspect it was the controller not handling an error and returning empty formations rather than some agent actively scaling things down.

I have also updated the scheduler tests to use log messages for synchronisation (rather than the make shift events we had previously) which feels a little cleaner.

Fixes #2613.