### PR TITLE
Monotonic timeouts

### DIFF
--- a/bootstrap/wait_action.go
+++ b/bootstrap/wait_action.go
@@ -36,7 +36,7 @@ func (a *WaitAction) Run(s *State) error {
 		return err
 	}
 
-	start := time.Now()
+	timeout := time.After(waitMax)
 	for {
 		var result string
 
@@ -71,10 +71,11 @@ func (a *WaitAction) Run(s *State) error {
 			return fmt.Errorf("bootstrap: unknown protocol")
 		}
 	fail:
-		if time.Now().Sub(start) >= waitMax {
+		select {
+		case <-timeout:
 			return fmt.Errorf("bootstrap: timed out waiting for %s, last response %s", a.URL, result)
+		case <-time.After(waitInterval):
 		}
-		time.Sleep(waitInterval)
 	}
 }
 


### PR DESCRIPTION
If there is any time skew, subtracting absolute times is not reliable. The timers in Go use monotonic time, which does not have this problem.

I'm not certain that this is necessary, but I have seen a few weird things on CI with no good explanation, and this change is correct.