### PR TITLE
controller: Fix domain migration route creation

### DIFF
--- a/controller/worker/domain_migration/domain_migration.go
+++ b/controller/worker/domain_migration/domain_migration.go
@@ -345,7 +345,7 @@ func (m *migration) appCreateMissingRoutes(appID string, routes []*router.Route)
 		if route.Type != "http" {
 			continue
 		}
-		if strings.HasSuffix(route.Domain, m.dm.OldDomain) && route.TLSCert == m.dm.OldTLSCert.Cert {
+		if strings.HasSuffix(route.Domain, m.dm.OldDomain) {
 			if err := m.appMaybeCreateRoute(appID, route, routes); err != nil {
 				return err
 			}


### PR DESCRIPTION
Create new routes for apps where old route doesn't have a TLSCert.

Closes #2616 

- [x] Add test