### PR TITLE
discoverd: Use AppliedIndex instead of LastIndex

### DIFF
--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -217,7 +217,7 @@ func (s *Store) LastIndex() uint64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.raft != nil {
-		return s.raft.LastIndex()
+		return s.raft.AppliedIndex()
 	}
 	return 0
 }


### PR DESCRIPTION
Newer versions of the Raft library update LastIndex differently
as such it's not as good for our usecase. However they also
added a new function AppliedIndex which returns the index of the
last log successfully applied to the FSM.
This is even better than what we had previously as the other did
have a possibility of returning an index of a log entry that was
yet to be applied on the leader.