### PR TITLE
Discoverd deployment fixes

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -263,7 +263,7 @@
         "flynn-system-critical": "true"
       },
       "strategy": "discoverd-meta",
-      "deploy_timeout": 120
+      "deploy_timeout": 300
     }
   },
   {

--- a/controller/worker/deployment/discoverd_meta.go
+++ b/controller/worker/deployment/discoverd_meta.go
@@ -27,7 +27,7 @@ func (d *DeployJob) deployDiscoverdMeta() (err error) {
 			return err
 		}
 		discDeploys[typ] = discDeploy
-		if err := discDeploy.Reset(); err != nil {
+		if err := discDeploy.Create(d.ID); err != nil {
 			return err
 		}
 		defer discDeploy.Close()
@@ -37,7 +37,7 @@ func (d *DeployJob) deployDiscoverdMeta() (err error) {
 		for typ, events := range expected {
 			if count, ok := events[ct.JobStateUp]; ok && count > 0 {
 				if discDeploy, ok := discDeploys[typ]; ok {
-					if err := discDeploy.Wait(count, 120, log); err != nil {
+					if err := discDeploy.Wait(d.ID, count, 120, log); err != nil {
 						return err
 					}
 					// clear up events for this type so we can safely

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -34,6 +34,7 @@ func main() {
 
 	// Initialize main program and execute.
 	m := NewMain()
+	shutdown.BeforeExit(func() { fmt.Fprintln(m.Stderr, "discoverd is exiting") })
 	if err := m.Run(os.Args[1:]...); err != nil {
 		fmt.Fprintln(m.Stderr, err.Error())
 		os.Exit(1)

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -249,6 +249,7 @@ func waitHostDNSConfig() (addr string, resolvers []string) {
 
 // Close shuts down all open servers.
 func (m *Main) Close() (info dt.ShutdownInfo, err error) {
+	m.logger.Println("discoverd shutting down")
 	if m.httpServer != nil {
 		// Disable keep alives so that persistent connections will close
 		m.httpServer.SetKeepAlivesEnabled(false)


### PR DESCRIPTION
These are some preliminary fixes to issues that can occur during discoverd deployments.
The main one is the addition of the deployment ID to the discoverd metadata as it fixes stale reads of service meta.