### PR TITLE
scheduler: Formation stream fixes

### DIFF
--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -121,17 +121,6 @@ func (j *Job) needsVolume() bool {
 	return j.Formation.Release.Processes[j.Type].Data
 }
 
-// HasTypeFromRelease indicates whether the job has a type which is present
-// in the release
-func (j *Job) HasTypeFromRelease() bool {
-	for typ := range j.Formation.Release.Processes {
-		if j.Type == typ {
-			return true
-		}
-	}
-	return false
-}
-
 func (j *Job) IsStopped() bool {
 	return j.state == JobStateStopping || j.state == JobStateStopped
 }
@@ -145,11 +134,11 @@ func (j *Job) IsSchedulable() bool {
 }
 
 func (j *Job) IsInFormation(key utils.FormationKey) bool {
-	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key && j.HasTypeFromRelease()
+	return !j.IsStopped() && j.Formation != nil && j.Formation.key() == key
 }
 
 func (j *Job) IsInApp(appID string) bool {
-	return j.Formation != nil && j.Formation.key().AppID == appID && j.HasTypeFromRelease()
+	return j.Formation != nil && j.Formation.key().AppID == appID
 }
 
 func (j *Job) ControllerJob() *ct.Job {

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -296,16 +296,16 @@ func (s *Scheduler) Run() error {
 		return err
 	}
 
+	if err := s.streamFormationEvents(); err != nil {
+		return err
+	}
+
 	isLeader, err := s.discoverd.Register()
 	if err != nil {
 		return err
 	}
 	s.HandleLeaderChange(isLeader)
 	leaderCh := s.discoverd.LeaderCh()
-
-	if err := s.streamFormationEvents(); err != nil {
-		return err
-	}
 
 	s.tickSyncJobs(30 * time.Second)
 	s.tickSyncFormations(time.Minute)

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1127,8 +1127,8 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 		s.persistJob(job)
 	}
 
-	// ensure the job has a known formation
-	if job.Formation == nil {
+	// ensure jobs started as part of a formation change have a known formation
+	if job.metadata["flynn-controller.formation"] == "true" && job.Formation == nil {
 		formation := s.formations.Get(job.AppID, job.ReleaseID)
 		if formation == nil {
 			ef, err := s.GetExpandedFormation(job.AppID, job.ReleaseID)
@@ -1156,9 +1156,8 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 		job.Formation = formation
 	}
 
-	// if the job has no type, or has a type which is not part of the
-	// release (e.g. a slugbuilder job), then we are done
-	if job.Type == "" || !job.HasTypeFromRelease() {
+	// if the job was not started as part of a formation, then we are done
+	if job.Formation == nil {
 		return
 	}
 

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -39,6 +39,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 	metadata["flynn-controller.app"] = f.App.ID
 	metadata["flynn-controller.app_name"] = f.App.Name
 	metadata["flynn-controller.release"] = f.Release.ID
+	metadata["flynn-controller.formation"] = "true"
 	metadata["flynn-controller.type"] = name
 	job := &host.Job{
 		ID:       id,


### PR DESCRIPTION
In [this CI failure](https://ci.flynn.io/builds/20160423202834-61474f73), the cluster fell over during a controller deployment because new schedulers were started, old ones were killed but the new schedulers all crashed with:

```
20:47:41.968254 scheduler.go:159: timed out waiting for current formation list
```

Whilst I am unsure why the scheduler was not getting the current event from the formation stream, I've made two patches which will improve the situation:

* Only register in service discovery once the current formation event has been received. This means that if there is the above error, the old schedulers will still be around and the deployment will just fail (rather than the old schedulers already being killed, and then the new schedulers also crashing, leaving no running schedulers)
* Return an error to the client if `sendUpdatedSince` encounters an error (and therefore does not send the current event)

I've also added a slightly unrelated patch so that the scheduler explicitly identifies jobs for which it needs to look up a formation, because I was seeing lots of errors looking up formations for one-off jobs.