### PR TITLE
appliance/postgresql: Don’t log transaction errors

### DIFF
--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -916,6 +916,7 @@ log_destination = 'stderr'
 logging_collector = false
 log_line_prefix = '{{.ID}} %m '
 log_timezone = 'UTC'
+log_min_messages = 'LOG'
 log_connections = on
 log_disconnections = on
 datestyle = 'iso, mdy'


### PR DESCRIPTION
The default log level is `ERROR` which logs transaction errors to the pg log. These errors are also provided to the client, which can log them if they are relevant. Log messages that admins care about will have level of `LOG` or higher.

Closes #2739