### PR TITLE
scheduler: Include restarted jobs when counting host jobs

### DIFF
--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -202,7 +202,7 @@ func (s sortJobs) Sort()              { sort.Sort(s) }
 func (j Jobs) GetHostJobCounts(key utils.FormationKey, typ string) map[string]int {
 	counts := make(map[string]int)
 	for _, job := range j {
-		if job.IsInFormation(key) && job.Type == typ && job.restartTimer == nil {
+		if job.IsInFormation(key) && job.Type == typ && job.HostID != "" {
 			counts[job.HostID]++
 		}
 	}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1403,7 +1403,7 @@ func (s *Scheduler) restartJob(job *Job) {
 	// persist the job so that it appears as pending in the database
 	s.persistJob(newJob)
 
-	s.logger.Info("scheduling job restart", "fn", "restartJob", "job.id", newJob.ID, "attempts", newJob.restarts, "delay", backoff)
+	s.logger.Info("scheduling job restart", "fn", "restartJob", "old_job.id", job.ID, "new_job.id", newJob.ID, "attempts", newJob.restarts, "delay", backoff)
 	newJob.restartTimer = time.AfterFunc(backoff, func() { s.StartJob(newJob) })
 }
 


### PR DESCRIPTION
`job.restartTimer` is non-nil for any job that was a restart of another job, even when that job is running. This means that checking for a nil `job.restartTimer` causes `GetHostJobCounts` to ignore jobs which are restarts of others, regardless of whether those jobs are running or not, and thus can lead to too many jobs running on a single host.

This caused errors in a user's cluster because omni jobs were being placed unevenly, leading to the surplusOmniJobs routine stopping them, but then anti-entropy then placing the job unevenly again, leading to the omni job flapping indefinitely.

Fixes #2757.