### PR TITLE
controller,worker: Add garbage collection to delete old slug releases

### DIFF
--- a/cli/release.go
+++ b/cli/release.go
@@ -318,10 +318,14 @@ func runReleaseDelete(args *docopt.Args, client controller.Client) error {
 			return nil
 		}
 	}
-	res, err := client.DeleteRelease(releaseID)
+	res, err := client.DeleteRelease(mustApp(), releaseID)
 	if err != nil {
 		return err
 	}
-	log.Printf("Deleted release %s (deleted %d files)", releaseID, len(res.DeletedFiles))
+	if len(res.RemainingApps) > 0 {
+		log.Printf("Release scaled down for app but not fully deleted (still associated with %d other apps)", len(res.RemainingApps))
+	} else {
+		log.Printf("Deleted release %s (deleted %d files)", releaseID, len(res.DeletedFiles))
+	}
 	return nil
 }

--- a/controller/app.go
+++ b/controller/app.go
@@ -303,6 +303,23 @@ func (c *controllerAPI) DeleteApp(ctx context.Context, w http.ResponseWriter, re
 	}
 }
 
+func (c *controllerAPI) ScheduleAppGarbageCollection(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	gc := &ct.AppGarbageCollection{AppID: c.getApp(ctx).ID}
+	args, err := json.Marshal(gc)
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	job := &que.Job{Type: "app_garbage_collection", Args: args}
+	if err := c.que.Enqueue(job); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	w.WriteHeader(200)
+}
+
 func (c *controllerAPI) AppLog(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -86,7 +86,7 @@ type Client interface {
 	ProviderList() ([]*ct.Provider, error)
 	Backup() (io.ReadCloser, error)
 	GetBackupMeta() (*ct.ClusterBackup, error)
-	DeleteRelease(releaseID string) (*ct.ReleaseDeletion, error)
+	DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error)
 }
 
 type Config struct {

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -87,6 +87,7 @@ type Client interface {
 	Backup() (io.ReadCloser, error)
 	GetBackupMeta() (*ct.ClusterBackup, error)
 	DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error)
+	ScheduleAppGarbageCollection(appID string) error
 }
 
 type Config struct {

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -778,6 +778,11 @@ func (c *Client) DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, er
 	}
 }
 
+// ScheduleAppGarbageCollection schedules a garbage collection cycle for the app
+func (c *Client) ScheduleAppGarbageCollection(appID string) error {
+	return c.Post(fmt.Sprintf("/apps/%s/gc", appID), nil, nil)
+}
+
 func (c *Client) Put(path string, in, out interface{}) error {
 	return c.send("PUT", path, in, out)
 }

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -744,9 +744,10 @@ func (c *Client) GetBackupMeta() (*ct.ClusterBackup, error) {
 }
 
 // DeleteRelease deletes a release and any associated file artifacts.
-func (c *Client) DeleteRelease(releaseID string) (*ct.ReleaseDeletion, error) {
+func (c *Client) DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error) {
 	events := make(chan *ct.Event)
 	stream, err := c.StreamEvents(ct.StreamEventsOptions{
+		AppID:       appID,
 		ObjectID:    releaseID,
 		ObjectTypes: []ct.EventType{ct.EventTypeReleaseDeletion},
 	}, events)
@@ -755,7 +756,7 @@ func (c *Client) DeleteRelease(releaseID string) (*ct.ReleaseDeletion, error) {
 	}
 	defer stream.Close()
 
-	if err := c.Delete(fmt.Sprintf("/releases/%s", releaseID), nil); err != nil {
+	if err := c.Delete(fmt.Sprintf("/apps/%s/releases/%s", appID, releaseID), nil); err != nil {
 		return nil, err
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -213,6 +213,7 @@ func appHandler(c handlerConfig) http.Handler {
 	releaseRepo := NewReleaseRepo(c.db, artifactRepo, q)
 	jobRepo := NewJobRepo(c.db)
 	formationRepo := NewFormationRepo(c.db, appRepo, releaseRepo, artifactRepo)
+	releaseRepo.formations = formationRepo
 	deploymentRepo := NewDeploymentRepo(c.db)
 	eventRepo := NewEventRepo(c.db)
 	backupRepo := NewBackupRepo(c.db)
@@ -262,6 +263,7 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.POST("/apps/:apps_id", httphelper.WrapHandler(api.UpdateApp))
 	httpRouter.GET("/apps/:apps_id/log", httphelper.WrapHandler(api.appLookup(api.AppLog)))
 	httpRouter.DELETE("/apps/:apps_id", httphelper.WrapHandler(api.appLookup(api.DeleteApp)))
+	httpRouter.DELETE("/apps/:apps_id/releases/:releases_id", httphelper.WrapHandler(api.appLookup(api.DeleteRelease)))
 
 	httpRouter.PUT("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.PutFormation)))
 	httpRouter.GET("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.GetFormation)))
@@ -283,8 +285,6 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.PUT("/apps/:apps_id/release", httphelper.WrapHandler(api.appLookup(api.SetAppRelease)))
 	httpRouter.GET("/apps/:apps_id/release", httphelper.WrapHandler(api.appLookup(api.GetAppRelease)))
 	httpRouter.GET("/apps/:apps_id/releases", httphelper.WrapHandler(api.appLookup(api.GetAppReleases)))
-
-	httpRouter.DELETE("/releases/:releases_id", httphelper.WrapHandler(api.DeleteRelease))
 
 	httpRouter.GET("/resources", httphelper.WrapHandler(api.GetResources))
 	httpRouter.POST("/providers/:providers_id/resources", httphelper.WrapHandler(api.ProvisionResource))

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -264,6 +264,7 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.GET("/apps/:apps_id/log", httphelper.WrapHandler(api.appLookup(api.AppLog)))
 	httpRouter.DELETE("/apps/:apps_id", httphelper.WrapHandler(api.appLookup(api.DeleteApp)))
 	httpRouter.DELETE("/apps/:apps_id/releases/:releases_id", httphelper.WrapHandler(api.appLookup(api.DeleteRelease)))
+	httpRouter.POST("/apps/:apps_id/gc", httphelper.WrapHandler(api.appLookup(api.ScheduleAppGarbageCollection)))
 
 	httpRouter.PUT("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.PutFormation)))
 	httpRouter.GET("/apps/:apps_id/formations/:releases_id", httphelper.WrapHandler(api.appLookup(api.GetFormation)))

--- a/controller/release.go
+++ b/controller/release.go
@@ -17,13 +17,18 @@ import (
 )
 
 type ReleaseRepo struct {
-	db        *postgres.DB
-	artifacts *ArtifactRepo
-	que       *que.Client
+	db         *postgres.DB
+	artifacts  *ArtifactRepo
+	formations *FormationRepo
+	que        *que.Client
 }
 
 func NewReleaseRepo(db *postgres.DB, artifacts *ArtifactRepo, que *que.Client) *ReleaseRepo {
-	return &ReleaseRepo{db, artifacts, que}
+	return &ReleaseRepo{
+		db:        db,
+		artifacts: artifacts,
+		que:       que,
+	}
 }
 
 func scanRelease(s postgres.Scanner) (*ct.Release, error) {
@@ -127,25 +132,61 @@ func (r *ReleaseRepo) AppList(appID string) ([]*ct.Release, error) {
 	return releaseList(rows)
 }
 
-// Delete deletes the release and any associated formations and file artifacts,
-// and enqueues a worker job to delete any files stored in the blobstore
-func (r *ReleaseRepo) Delete(release *ct.Release) error {
-	fileArtifacts, err := r.artifacts.ListIDs(release.FileArtifactIDs()...)
-	if err != nil {
-		return err
-	}
-
+// Delete deletes any formations for the given app and release, then deletes
+// the release and any associated file artifacts if there are no remaining
+// formations for the release, enqueueing a worker job to delete any files
+// stored in the blobstore
+func (r *ReleaseRepo) Delete(app *ct.App, release *ct.Release) error {
 	tx, err := r.db.Begin()
 	if err != nil {
 		return err
 	}
 
-	if err := tx.Exec("release_delete", release.ID); err != nil {
+	if err := tx.Exec("formation_delete", app.ID, release.ID); err != nil {
 		tx.Rollback()
 		return err
 	}
 
-	if err := tx.Exec("formation_delete_by_release", release.ID); err != nil {
+	// if the release still has formations, don't remove it entirely, just
+	// save a release deletion event and return
+	rows, err := tx.Query("formation_list_by_release", release.ID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	formations, err := scanFormations(rows)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	if len(formations) > 0 {
+		apps := make([]string, len(formations))
+		for i, f := range formations {
+			apps[i] = f.AppID
+		}
+		event := ct.ReleaseDeletionEvent{
+			ReleaseDeletion: &ct.ReleaseDeletion{
+				RemainingApps: apps,
+				ReleaseID:     release.ID,
+			},
+		}
+		if err := createEvent(tx.Exec, &ct.Event{
+			AppID:      app.ID,
+			ObjectID:   release.ID,
+			ObjectType: ct.EventTypeReleaseDeletion,
+		}, event); err != nil {
+			tx.Rollback()
+			return err
+		}
+		return tx.Commit()
+	}
+
+	fileArtifacts, err := r.artifacts.ListIDs(release.FileArtifactIDs()...)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Exec("release_delete", release.ID); err != nil {
 		tx.Rollback()
 		return err
 	}
@@ -170,6 +211,7 @@ func (r *ReleaseRepo) Delete(release *ct.Release) error {
 			},
 		}
 		if err := createEvent(tx.Exec, &ct.Event{
+			AppID:      app.ID,
 			ObjectID:   release.ID,
 			ObjectType: ct.EventTypeReleaseDeletion,
 		}, event); err != nil {
@@ -181,9 +223,11 @@ func (r *ReleaseRepo) Delete(release *ct.Release) error {
 
 	// enqueue a job to delete the blobstore files
 	args, err := json.Marshal(struct {
+		AppID     string
 		ReleaseID string
 		FileURIs  []string
 	}{
+		app.ID,
 		release.ID,
 		blobstoreFiles,
 	})
@@ -255,12 +299,13 @@ func (c *controllerAPI) GetAppRelease(ctx context.Context, w http.ResponseWriter
 }
 
 func (c *controllerAPI) DeleteRelease(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	app := c.getApp(ctx)
 	release, err := c.getRelease(ctx)
 	if err != nil {
 		respondWithError(w, err)
 		return
 	}
-	if err := c.releaseRepo.Delete(release); err != nil {
+	if err := c.releaseRepo.Delete(app, release); err != nil {
 		if postgres.IsPostgresCode(err, postgres.CheckViolation) {
 			err = ct.ValidationError{
 				Message: "cannot delete current app release",

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -381,6 +381,9 @@ $$ LANGUAGE plpgsql`,
 		END $$`,
 		`ALTER TABLE release_artifacts ALTER COLUMN index SET NOT NULL`,
 	)
+	migrations.Add(18,
+		`INSERT INTO event_types (name) VALUES ('app_garbage_collection')`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -24,6 +24,7 @@ var preparedStatements = map[string]string{
 	"release_insert":                        releaseInsertQuery,
 	"release_app_list":                      releaseAppListQuery,
 	"release_artifacts_insert":              releaseArtifactsInsertQuery,
+	"release_artifacts_delete":              releaseArtifactsDeleteQuery,
 	"release_delete":                        releaseDeleteQuery,
 	"artifact_list":                         artifactListQuery,
 	"artifact_list_ids":                     artifactListIDsQuery,
@@ -31,6 +32,7 @@ var preparedStatements = map[string]string{
 	"artifact_select_by_type_and_uri":       artifactSelectByTypeAndURIQuery,
 	"artifact_insert":                       artifactInsertQuery,
 	"artifact_delete":                       artifactDeleteQuery,
+	"artifact_release_count":                artifactReleaseCountQuery,
 	"deployment_list":                       deploymentListQuery,
 	"deployment_select":                     deploymentSelectQuery,
 	"deployment_insert":                     deploymentInsertQuery,
@@ -161,6 +163,8 @@ FROM releases r JOIN formations f USING (release_id)
 WHERE f.app_id = $1 AND r.deleted_at IS NULL ORDER BY r.created_at DESC`
 	releaseArtifactsInsertQuery = `
 INSERT INTO release_artifacts (release_id, artifact_id, index) VALUES ($1, $2, $3)`
+	releaseArtifactsDeleteQuery = `
+UPDATE release_artifacts SET deleted_at = now() WHERE release_id = $1 AND artifact_id = $2 AND deleted_at IS NULL`
 	releaseDeleteQuery = `
 UPDATE releases SET deleted_at = now() WHERE release_id = $1 AND deleted_at IS NULL`
 	artifactListQuery = `
@@ -178,6 +182,8 @@ SELECT artifact_id, meta, created_at FROM artifacts WHERE type = $1 AND uri = $2
 INSERT INTO artifacts (artifact_id, type, uri, meta) VALUES ($1, $2, $3, $4) RETURNING created_at`
 	artifactDeleteQuery = `
 UPDATE artifacts SET deleted_at = now() WHERE artifact_id = $1 AND deleted_at IS NULL`
+	artifactReleaseCountQuery = `
+SELECT COUNT(*) FROM release_artifacts WHERE artifact_id = $1 AND deleted_at IS NULL`
 	deploymentInsertQuery = `
 INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes, deploy_timeout)
 VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING created_at`

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -41,6 +41,7 @@ var preparedStatements = map[string]string{
 	"event_insert":                          eventInsertQuery,
 	"event_insert_unique":                   eventInsertUniqueQuery,
 	"formation_list_by_app":                 formationListByAppQuery,
+	"formation_list_by_release":             formationListByReleaseQuery,
 	"formation_list_active":                 formationListActiveQuery,
 	"formation_list_since":                  formationListSinceQuery,
 	"formation_select":                      formationSelectQuery,
@@ -49,7 +50,6 @@ var preparedStatements = map[string]string{
 	"formation_update":                      formationUpdateQuery,
 	"formation_delete":                      formationDeleteQuery,
 	"formation_delete_by_app":               formationDeleteByAppQuery,
-	"formation_delete_by_release":           formationDeleteByReleaseQuery,
 	"job_list":                              jobListQuery,
 	"job_list_active":                       jobListActiveQuery,
 	"job_select":                            jobSelectQuery,
@@ -220,8 +220,10 @@ INSERT INTO events (app_id, object_id, unique_id, object_type, data)
 VALUES ($1, $2, $3, $4, $5)`
 	formationListByAppQuery = `
 SELECT app_id, release_id, processes, tags, created_at, updated_at
-FROM formations WHERE app_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC
-	`
+FROM formations WHERE app_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC`
+	formationListByReleaseQuery = `
+SELECT app_id, release_id, processes, tags, created_at, updated_at
+FROM formations WHERE release_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC`
 	formationListActiveQuery = `
 SELECT
   apps.app_id, apps.name, apps.meta,
@@ -280,9 +282,6 @@ WHERE app_id = $1 AND release_id = $2`
 	formationDeleteByAppQuery = `
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
 WHERE app_id = $1 AND deleted_at IS NULL`
-	formationDeleteByReleaseQuery = `
-UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
-WHERE release_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
 SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -336,25 +336,26 @@ type LogOpts struct {
 type EventType string
 
 const (
-	EventTypeApp                 EventType = "app"
-	EventTypeAppDeletion         EventType = "app_deletion"
-	EventTypeAppRelease          EventType = "app_release"
-	EventTypeDeployment          EventType = "deployment"
-	EventTypeJob                 EventType = "job"
-	EventTypeScale               EventType = "scale"
-	EventTypeRelease             EventType = "release"
-	EventTypeReleaseDeletion     EventType = "release_deletion"
-	EventTypeArtifact            EventType = "artifact"
-	EventTypeProvider            EventType = "provider"
-	EventTypeResource            EventType = "resource"
-	EventTypeResourceDeletion    EventType = "resource_deletion"
-	EventTypeResourceAppDeletion EventType = "resource_app_deletion"
-	EventTypeKey                 EventType = "key"
-	EventTypeKeyDeletion         EventType = "key_deletion"
-	EventTypeRoute               EventType = "route"
-	EventTypeRouteDeletion       EventType = "route_deletion"
-	EventTypeDomainMigration     EventType = "domain_migration"
-	EventTypeClusterBackup       EventType = "cluster_backup"
+	EventTypeApp                  EventType = "app"
+	EventTypeAppDeletion          EventType = "app_deletion"
+	EventTypeAppRelease           EventType = "app_release"
+	EventTypeDeployment           EventType = "deployment"
+	EventTypeJob                  EventType = "job"
+	EventTypeScale                EventType = "scale"
+	EventTypeRelease              EventType = "release"
+	EventTypeReleaseDeletion      EventType = "release_deletion"
+	EventTypeArtifact             EventType = "artifact"
+	EventTypeProvider             EventType = "provider"
+	EventTypeResource             EventType = "resource"
+	EventTypeResourceDeletion     EventType = "resource_deletion"
+	EventTypeResourceAppDeletion  EventType = "resource_app_deletion"
+	EventTypeKey                  EventType = "key"
+	EventTypeKeyDeletion          EventType = "key_deletion"
+	EventTypeRoute                EventType = "route"
+	EventTypeRouteDeletion        EventType = "route_deletion"
+	EventTypeDomainMigration      EventType = "domain_migration"
+	EventTypeClusterBackup        EventType = "cluster_backup"
+	EventTypeAppGarbageCollection EventType = "app_garbage_collection"
 )
 
 type Event struct {
@@ -443,4 +444,14 @@ type StreamEventsOptions struct {
 	ObjectID    string
 	Past        bool
 	Count       int
+}
+
+type AppGarbageCollection struct {
+	AppID           string   `json:"app_id"`
+	DeletedReleases []string `json:"deleted_releases"`
+}
+
+type AppGarbageCollectionEvent struct {
+	AppGarbageCollection *AppGarbageCollection `json:"app_garbage_collection"`
+	Error                string                `json:"error"`
 }

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -412,8 +412,10 @@ type ClusterBackup struct {
 }
 
 type ReleaseDeletion struct {
-	ReleaseID    string   `json:"release"`
-	DeletedFiles []string `json:"deleted_files"`
+	AppID         string   `json:"app"`
+	ReleaseID     string   `json:"release"`
+	RemainingApps []string `json:"remaining_apps"`
+	DeletedFiles  []string `json:"deleted_files"`
 }
 
 type ReleaseDeletionEvent struct {

--- a/controller/worker/app_garbage_collection/handler.go
+++ b/controller/worker/app_garbage_collection/handler.go
@@ -1,0 +1,143 @@
+package app_garbage_collection
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/que-go"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/postgres"
+)
+
+type context struct {
+	db     *postgres.DB
+	client controller.Client
+	logger log15.Logger
+}
+
+func JobHandler(db *postgres.DB, client controller.Client, logger log15.Logger) func(*que.Job) error {
+	return (&context{db, client, logger}).HandleAppGarbageCollection
+}
+
+func (c *context) HandleAppGarbageCollection(job *que.Job) (err error) {
+	log := c.logger.New("fn", "HandleAppGarbageCollection")
+	log.Info("handling garbage collection", "job_id", job.ID, "error_count", job.ErrorCount)
+
+	var gc ct.AppGarbageCollection
+	if err := json.Unmarshal(job.Args, &gc); err != nil {
+		log.Error("error unmarshaling job", "err", err)
+		return err
+	}
+
+	log = log.New("app.id", gc.AppID)
+	defer func() {
+		if err := c.createEvent(&gc, err); err != nil {
+			log.Error("error creating garbage collection event", "err", err)
+		}
+		log.Info("garbage collection finished")
+	}()
+
+	log.Info("getting app")
+	app, err := c.client.GetApp(gc.AppID)
+	if err != nil {
+		log.Error("error getting app", "err", err)
+		return err
+	}
+
+	log.Info("deleting old slug releases")
+	meta, ok := app.Meta["gc.max_inactive_slug_releases"]
+	if !ok || meta == "false" {
+		log.Info(fmt.Sprintf("skipping old slug release deletion since gc.max_inactive_slug_releases=%q", meta))
+		return nil
+	}
+	maxInactiveSlugReleases, err := strconv.Atoi(meta)
+	if err != nil {
+		log.Error("error parsing gc.max_inactive_slug_releases", "err", err)
+		return err
+	}
+	log.Info(fmt.Sprintf("gc.max_inactive_slug_releases is set to %d", maxInactiveSlugReleases))
+
+	log.Info("getting app releases")
+	releases, err := c.client.AppReleaseList(app.ID)
+	if err != nil {
+		log.Error("error getting app releases", "err", err)
+		return err
+	}
+	log.Info("getting app formations")
+	formations, err := c.client.FormationList(app.ID)
+	if err != nil {
+		log.Error("error getting app formations", "err", err)
+		return err
+	}
+
+	// determine which releases are active so we don't delete them
+	activeReleases := make(map[string]struct{}, len(formations))
+outer:
+	for _, formation := range formations {
+		for _, n := range formation.Processes {
+			if n > 0 {
+				activeReleases[formation.ReleaseID] = struct{}{}
+				continue outer
+			}
+		}
+	}
+
+	// iterate over the releases (which are in reverse chronological order)
+	// and mark them for deletion once we have seen more than the
+	// configured maximum count of slugs with distinct URIs
+	oldReleases := make([]*ct.Release, 0, len(releases))
+	distinctSlugs := make(map[string]struct{}, len(releases))
+	for _, release := range releases {
+		// ignore active releases
+		if _, ok := activeReleases[release.ID]; ok {
+			continue
+		}
+
+		if len(distinctSlugs) >= maxInactiveSlugReleases {
+			oldReleases = append(oldReleases, release)
+		}
+
+		for _, id := range release.FileArtifactIDs() {
+			artifact, err := c.client.GetArtifact(id)
+			if err != nil {
+				log.Error("error getting file artifact for release", "release.id", release.ID, "artifact.id", id, "err", err)
+				return err
+			}
+			if artifact.Blobstore() {
+				distinctSlugs[artifact.URI] = struct{}{}
+			}
+		}
+	}
+	log.Info(fmt.Sprintf("app has %d releases (%d with distinct slugs)", len(releases), len(distinctSlugs)))
+
+	if len(oldReleases) == 0 {
+		log.Info("no old releases to delete")
+		return nil
+	}
+
+	log.Info(fmt.Sprintf("deleting %d old releases", len(oldReleases)))
+	gc.DeletedReleases = make([]string, 0, len(oldReleases))
+	for _, release := range oldReleases {
+		log.Info("deleting release", "release.id", release.ID)
+		if _, err := c.client.DeleteRelease(app.ID, release.ID); err != nil {
+			// ignore releases which fail to delete, the next gc cycle
+			// will try again
+			log.Error("error deleting release", "release.id", release.ID, "err", err)
+			continue
+		}
+		gc.DeletedReleases = append(gc.DeletedReleases, release.ID)
+	}
+
+	return nil
+}
+
+func (c *context) createEvent(gc *ct.AppGarbageCollection, err error) error {
+	e := ct.AppGarbageCollectionEvent{AppGarbageCollection: gc}
+	if err != nil {
+		e.Error = err.Error()
+	}
+	return c.db.Exec("event_insert", gc.AppID, gc.AppID, string(ct.EventTypeAppGarbageCollection), e)
+}

--- a/controller/worker/deployment/context.go
+++ b/controller/worker/deployment/context.go
@@ -122,6 +122,13 @@ func (c *context) HandleDeployment(job *que.Job) (e error) {
 		Status:    "complete",
 	}
 	log.Info("deployment complete")
+
+	log.Info("scheduling app garbage collection")
+	if err := c.client.ScheduleAppGarbageCollection(deployment.AppID); err != nil {
+		// just log the error, no need to rollback the deploy
+		log.Error("error scheduling app garbage collection", "err", err)
+	}
+
 	return nil
 }
 

--- a/controller/worker/main.go
+++ b/controller/worker/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	"github.com/flynn/flynn/controller/schema"
 	"github.com/flynn/flynn/controller/worker/app_deletion"
+	"github.com/flynn/flynn/controller/worker/app_garbage_collection"
 	"github.com/flynn/flynn/controller/worker/deployment"
 	"github.com/flynn/flynn/controller/worker/domain_migration"
 	"github.com/flynn/flynn/controller/worker/release_cleanup"
@@ -58,10 +59,11 @@ func main() {
 	workers := que.NewWorkerPool(
 		que.NewClient(db.ConnPool),
 		que.WorkMap{
-			"deployment":       deployment.JobHandler(db, client, logger),
-			"app_deletion":     app_deletion.JobHandler(db, client, logger),
-			"domain_migration": domain_migration.JobHandler(db, client, logger),
-			"release_cleanup":  release_cleanup.JobHandler(db, client, logger),
+			"deployment":             deployment.JobHandler(db, client, logger),
+			"app_deletion":           app_deletion.JobHandler(db, client, logger),
+			"domain_migration":       domain_migration.JobHandler(db, client, logger),
+			"release_cleanup":        release_cleanup.JobHandler(db, client, logger),
+			"app_garbage_collection": app_garbage_collection.JobHandler(db, client, logger),
 		},
 		workerCount,
 	)

--- a/controller/worker/release_cleanup/handler.go
+++ b/controller/worker/release_cleanup/handler.go
@@ -27,6 +27,7 @@ func (c *context) HandleReleaseCleanup(job *que.Job) (err error) {
 	log.Info("handling release cleanup", "job_id", job.ID, "error_count", job.ErrorCount)
 
 	var data struct {
+		AppID     string
 		ReleaseID string
 		FileURIs  []string
 	}
@@ -36,7 +37,7 @@ func (c *context) HandleReleaseCleanup(job *que.Job) (err error) {
 	}
 	log = log.New("release_id", data.ReleaseID)
 
-	r := ct.ReleaseDeletion{ReleaseID: data.ReleaseID}
+	r := ct.ReleaseDeletion{AppID: data.AppID, ReleaseID: data.ReleaseID}
 	defer func() { c.createEvent(&r, err) }()
 
 	for _, uri := range data.FileURIs {
@@ -73,5 +74,5 @@ func (c *context) createEvent(r *ct.ReleaseDeletion, err error) error {
 	if err != nil {
 		e.Error = err.Error()
 	}
-	return c.db.Exec("event_insert", nil, r.ReleaseID, string(ct.EventTypeReleaseDeletion), e)
+	return c.db.Exec("event_insert", r.AppID, r.ReleaseID, string(ct.EventTypeReleaseDeletion), e)
 }

--- a/test/helper.go
+++ b/test/helper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -257,6 +258,15 @@ func (h *Helper) removeHosts(t *c.C, hosts []*tc.Instance, service string) {
 		t.Assert(testCluster.RemoveHost(events, host), c.IsNil)
 		debugf(t, "host removed: %s", host.ID)
 	}
+}
+
+func (h *Helper) assertURI(t *c.C, uri string, status int) {
+	req, err := http.NewRequest("HEAD", uri, nil)
+	t.Assert(err, c.IsNil)
+	res, err := http.DefaultClient.Do(req)
+	t.Assert(err, c.IsNil)
+	res.Body.Close()
+	t.Assert(res.StatusCode, c.Equals, status)
 }
 
 type gitRepo struct {

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"archive/tar"
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +24,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/host/resource"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/tlscert"
@@ -1054,17 +1057,9 @@ func (s *CLISuite) TestReleaseDelete(t *c.C) {
 	t.Assert(res.Output, c.Equals, "Release scaled down for app but not fully deleted (still associated with 1 other apps)\n")
 
 	// check the slug artifact still exists
-	assertURI := func(uri string, status int) {
-		req, err := http.NewRequest("HEAD", uri, nil)
-		t.Assert(err, c.IsNil)
-		res, err := http.DefaultClient.Do(req)
-		t.Assert(err, c.IsNil)
-		res.Body.Close()
-		t.Assert(res.StatusCode, c.Equals, status)
-	}
 	slugArtifact, err := client.GetArtifact(releases[1].FileArtifactIDs()[0])
 	t.Assert(err, c.IsNil)
-	assertURI(slugArtifact.URI, http.StatusOK)
+	s.assertURI(t, slugArtifact.URI, http.StatusOK)
 
 	// check the inital release can now be deleted
 	res = r.flynn("-a", otherApp.ID, "release", "delete", "--yes", releases[1].ID)
@@ -1074,9 +1069,163 @@ func (s *CLISuite) TestReleaseDelete(t *c.C) {
 	// check the slug artifact was deleted
 	_, err = client.GetArtifact(slugArtifact.ID)
 	t.Assert(err, c.Equals, controller.ErrNotFound)
-	assertURI(slugArtifact.URI, http.StatusNotFound)
+	s.assertURI(t, slugArtifact.URI, http.StatusNotFound)
 
 	// check the image artifact was not deleted (since it is shared between both releases)
 	_, err = client.GetArtifact(releases[1].ImageArtifactID())
 	t.Assert(err, c.IsNil)
+}
+
+func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
+	client := s.controllerClient(t)
+
+	// create app with gc.max_inactive_slug_releases=3
+	maxInactiveSlugReleases := 3
+	app := &ct.App{Meta: map[string]string{"gc.max_inactive_slug_releases": strconv.Itoa(maxInactiveSlugReleases)}}
+	t.Assert(client.CreateApp(app), c.IsNil)
+
+	// create an image artifact
+	imageArtifact := &ct.Artifact{Type: host.ArtifactTypeDocker, URI: imageURIs["test-apps"]}
+	t.Assert(client.CreateArtifact(imageArtifact), c.IsNil)
+
+	// create 5 slug artifacts
+	var slug bytes.Buffer
+	gz := gzip.NewWriter(&slug)
+	t.Assert(tar.NewWriter(gz).Close(), c.IsNil)
+	t.Assert(gz.Close(), c.IsNil)
+	slugs := []string{
+		"http://blobstore.discoverd/1/slug.tgz",
+		"http://blobstore.discoverd/2/slug.tgz",
+		"http://blobstore.discoverd/3/slug.tgz",
+		"http://blobstore.discoverd/4/slug.tgz",
+		"http://blobstore.discoverd/5/slug.tgz",
+	}
+	slugArtifacts := make([]*ct.Artifact, len(slugs))
+	for i, uri := range slugs {
+		req, err := http.NewRequest("PUT", uri, bytes.NewReader(slug.Bytes()))
+		t.Assert(err, c.IsNil)
+		res, err := http.DefaultClient.Do(req)
+		t.Assert(err, c.IsNil)
+		res.Body.Close()
+		t.Assert(res.StatusCode, c.Equals, http.StatusOK)
+		artifact := &ct.Artifact{
+			Type: host.ArtifactTypeFile,
+			URI:  uri,
+			Meta: map[string]string{"blobstore": "true"},
+		}
+		t.Assert(client.CreateArtifact(artifact), c.IsNil)
+		slugArtifacts[i] = artifact
+	}
+
+	// create 6 releases, the second being scaled up and having the
+	// same slug as the third (so prevents the slug being deleted)
+	releases := make([]*ct.Release, 6)
+	for i, r := range []struct {
+		slug   *ct.Artifact
+		active bool
+	}{
+		{slugArtifacts[0], false},
+		{slugArtifacts[1], true},
+		{slugArtifacts[1], false},
+		{slugArtifacts[2], false},
+		{slugArtifacts[3], false},
+		{slugArtifacts[4], false},
+	} {
+		release := &ct.Release{
+			ArtifactIDs: []string{imageArtifact.ID, r.slug.ID},
+			Processes: map[string]ct.ProcessType{
+				"app": {Cmd: []string{"/bin/pingserv"}, Ports: []ct.Port{{Proto: "tcp"}}},
+			},
+		}
+		t.Assert(client.CreateRelease(release), c.IsNil)
+		procs := map[string]int{"app": 0}
+		if r.active {
+			procs["app"] = 1
+		}
+		t.Assert(client.PutFormation(&ct.Formation{
+			AppID:     app.ID,
+			ReleaseID: release.ID,
+			Processes: procs,
+		}), c.IsNil)
+		releases[i] = release
+	}
+
+	// scale the last release so we can deploy it
+	lastRelease := releases[len(releases)-1]
+	watcher, err := client.WatchJobEvents(app.ID, lastRelease.ID)
+	t.Assert(err, c.IsNil)
+	defer watcher.Close()
+	t.Assert(client.PutFormation(&ct.Formation{
+		AppID:     app.ID,
+		ReleaseID: lastRelease.ID,
+		Processes: map[string]int{"app": 1},
+	}), c.IsNil)
+	t.Assert(watcher.WaitFor(ct.JobEvents{"app": ct.JobUpEvents(1)}, scaleTimeout, nil), c.IsNil)
+	t.Assert(client.SetAppRelease(app.ID, lastRelease.ID), c.IsNil)
+
+	// subscribe to garbage collection events
+	gcEvents := make(chan *ct.Event)
+	stream, err := client.StreamEvents(ct.StreamEventsOptions{
+		AppID:       app.ID,
+		ObjectTypes: []ct.EventType{ct.EventTypeAppGarbageCollection},
+	}, gcEvents)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+	// deploy a new release with the same slug as the last release
+	newRelease := *lastRelease
+	newRelease.ID = ""
+	t.Assert(client.CreateRelease(&newRelease), c.IsNil)
+	t.Assert(client.DeployAppRelease(app.ID, newRelease.ID), c.IsNil)
+
+	// wait for garbage collection
+	select {
+	case event, ok := <-gcEvents:
+		if !ok {
+			t.Fatalf("event stream closed unexpectedly: %s", stream.Err())
+		}
+		var e ct.AppGarbageCollectionEvent
+		t.Assert(json.Unmarshal(event.Data, &e), c.IsNil)
+		if e.Error != "" {
+			t.Fatalf("garbage collection failed: %s", e.Error)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("timed out waiting for garbage collection")
+	}
+
+	// check we have 4 distinct slug releases (so 5 in total, only 3 are
+	// inactive)
+	list, err := client.AppReleaseList(app.ID)
+	t.Assert(err, c.IsNil)
+	t.Assert(list, c.HasLen, maxInactiveSlugReleases+2)
+	distinctSlugs := make(map[string]struct{}, len(list))
+	for _, release := range list {
+		files := release.FileArtifactIDs()
+		t.Assert(files, c.HasLen, 1)
+		distinctSlugs[files[0]] = struct{}{}
+	}
+	t.Assert(distinctSlugs, c.HasLen, maxInactiveSlugReleases+1)
+
+	// check the first and third releases got deleted, but the rest remain
+	assertDeleted := func(release *ct.Release, deleted bool) {
+		_, err := client.GetRelease(release.ID)
+		if deleted {
+			t.Assert(err, c.Equals, controller.ErrNotFound)
+		} else {
+			t.Assert(err, c.IsNil)
+		}
+	}
+	assertDeleted(releases[0], true)
+	assertDeleted(releases[1], false)
+	assertDeleted(releases[2], true)
+	assertDeleted(releases[3], false)
+	assertDeleted(releases[4], false)
+	assertDeleted(releases[5], false)
+	assertDeleted(&newRelease, false)
+
+	// check the first slug got deleted, but the rest remain
+	s.assertURI(t, slugs[0], http.StatusNotFound)
+	for i := 1; i < len(slugs); i++ {
+		s.assertURI(t, slugs[i], http.StatusOK)
+	}
 }


### PR DESCRIPTION
This adds app garbage collection to remove old slug releases based on the value of `app.Meta["gc.max_inactive_slug_releases"]`:

* if not set or set to `false` then do nothing
* if set to an integer, ensure the app only has that many releases with distinct slugs

Garbage collection cycles are scheduled after every deployment.

For now I have left it as opt in so we can test it out in the real world and then potentially make it the default in the future.

To opt in, run:

```
$ flynn meta set gc.max_inactive_slug_releases=N
```

where `N` is a positive integer.

Ref #2750.