### PR TITLE
MariaDB: Scale up on first resource request

### DIFF
--- a/appliance/mariadb/cmd/flynn-mariadb-api/main.go
+++ b/appliance/mariadb/cmd/flynn-mariadb-api/main.go
@@ -2,20 +2,26 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 	"github.com/flynn/flynn/appliance/mariadb"
+	"github.com/flynn/flynn/controller/client"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/resource"
 	"github.com/flynn/flynn/pkg/shutdown"
+	sirenia "github.com/flynn/flynn/pkg/sirenia/client"
 )
 
 var serviceName = os.Getenv("FLYNN_MYSQL")
@@ -31,14 +37,7 @@ func init() {
 func main() {
 	defer shutdown.Exit()
 
-	dsn := &mariadb.DSN{
-		Host:     serviceHost + ":3306",
-		User:     "flynn",
-		Password: os.Getenv("MYSQL_PWD"),
-		Database: "mysql",
-	}
-	db, err := sql.Open("mysql", dsn.String())
-	api := &API{db}
+	api := &API{}
 
 	router := httprouter.New()
 	router.POST("/databases", httphelper.WrapHandler(api.createDatabase))
@@ -62,24 +61,37 @@ func main() {
 }
 
 type API struct {
-	db *sql.DB
+	mtx      sync.Mutex
+	scaledUp bool
 }
 
 func (a *API) createDatabase(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	username, password, database := random.Hex(16), random.Hex(16), random.Hex(16)
+	// Ensure the cluster has been scaled up before attempting to create a database.
+	if err := a.scaleUp(); err != nil {
+		httphelper.Error(w, err)
+		return
+	}
 
-	if _, err := a.db.Exec(fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", username, password)); err != nil {
+	db, err := a.connect()
+	if err != nil {
 		httphelper.Error(w, err)
 		return
 	}
-	if _, err := a.db.Exec(fmt.Sprintf("CREATE DATABASE `%s`", database)); err != nil {
-		a.db.Exec(fmt.Sprintf("DROP USER '%s'", username))
+	defer db.Close()
+
+	username, password, database := random.Hex(16), random.Hex(16), random.Hex(16)
+	if _, err := db.Exec(fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", username, password)); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
-	if _, err := a.db.Exec(fmt.Sprintf("GRANT ALL ON `%s`.* TO '%s'@'%%'", database, username)); err != nil {
-		a.db.Exec(fmt.Sprintf("DROP DATABASE `%s`", database))
-		a.db.Exec(fmt.Sprintf("DROP USER '%s'", username))
+	if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE `%s`", database)); err != nil {
+		db.Exec(fmt.Sprintf("DROP USER '%s'", username))
+		httphelper.Error(w, err)
+		return
+	}
+	if _, err := db.Exec(fmt.Sprintf("GRANT ALL ON `%s`.* TO '%s'@'%%'", database, username)); err != nil {
+		db.Exec(fmt.Sprintf("DROP DATABASE `%s`", database))
+		db.Exec(fmt.Sprintf("DROP USER '%s'", username))
 		httphelper.Error(w, err)
 		return
 	}
@@ -105,12 +117,19 @@ func (a *API) dropDatabase(ctx context.Context, w http.ResponseWriter, req *http
 		return
 	}
 
-	if _, err := a.db.Exec(fmt.Sprintf("DROP DATABASE `%s`", id[1])); err != nil {
+	db, err := a.connect()
+	if err != nil {
+		httphelper.Error(w, err)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(fmt.Sprintf("DROP DATABASE `%s`", id[1])); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
 
-	if _, err := a.db.Exec(fmt.Sprintf("DROP USER '%s'", id[0])); err != nil {
+	if _, err := db.Exec(fmt.Sprintf("DROP USER '%s'", id[0])); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
@@ -119,9 +138,155 @@ func (a *API) dropDatabase(ctx context.Context, w http.ResponseWriter, req *http
 }
 
 func (a *API) ping(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-	if _, err := a.db.Exec("SELECT 1"); err != nil {
+	app := os.Getenv("FLYNN_APP_ID")
+	logger := a.logger().New("fn", "ping")
+
+	// Connect to controller.
+	logger.Info("connecting to controller")
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
+	if err != nil {
+		logger.Error("controller client error", "err", err)
+		httphelper.Error(w, err)
+		return
+	}
+
+	// Retrieve mariadb release.
+	logger.Info("retrieving app release", "app", app)
+	release, err := client.GetAppRelease(app)
+	if err == controller.ErrNotFound {
+		logger.Error("release not found", "app", app)
+		httphelper.Error(w, err)
+		return
+	} else if err != nil {
+		logger.Error("get release error", "app", app, "err", err)
+		httphelper.Error(w, err)
+		return
+	}
+
+	// Retrieve current formation.
+	logger.Info("retrieving formation", "app", app, "release_id", release.ID)
+	formation, err := client.GetFormation(app, release.ID)
+	if err == controller.ErrNotFound {
+		logger.Error("formation not found", "app", app, "release_id", release.ID)
+		httphelper.Error(w, err)
+		return
+	} else if err != nil {
+		logger.Error("formation error", "app", app, "release_id", release.ID, "err", err)
+		httphelper.Error(w, err)
+		return
+	}
+
+	// MariaDB isn't running, just return healthy
+	if formation.Processes["mariadb"] == 0 {
+		w.WriteHeader(200)
+		return
+	}
+
+	db, err := a.connect()
+	if err != nil {
+		httphelper.Error(w, err)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("SELECT 1"); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
 	w.WriteHeader(200)
+}
+
+func (a *API) connect() (*sql.DB, error) {
+	dsn := &mariadb.DSN{
+		Host:     serviceHost + ":3306",
+		User:     "flynn",
+		Password: os.Getenv("MYSQL_PWD"),
+		Database: "mysql",
+	}
+	return sql.Open("mysql", dsn.String())
+}
+
+func (a *API) scaleUp() error {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	// Ignore if already scaled up.
+	if a.scaledUp {
+		return nil
+	}
+
+	app := os.Getenv("FLYNN_APP_ID")
+	logger := a.logger().New("fn", "scaleUp")
+
+	// Connect to controller.
+	logger.Info("connecting to controller")
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
+	if err != nil {
+		logger.Error("controller client error", "err", err)
+		return err
+	}
+
+	// Retrieve mariadb release.
+	logger.Info("retrieving app release", "app", app)
+	release, err := client.GetAppRelease(app)
+	if err == controller.ErrNotFound {
+		logger.Error("release not found", "app", app)
+		return errors.New("mariadb release not found")
+	} else if err != nil {
+		logger.Error("get release error", "app", app, "err", err)
+		return err
+	}
+
+	// Retrieve current formation.
+	logger.Info("retrieving formation", "app", app, "release_id", release.ID)
+	formation, err := client.GetFormation(app, release.ID)
+	if err == controller.ErrNotFound {
+		logger.Error("formation not found", "app", app, "release_id", release.ID)
+		return errors.New("mariadb formation not found")
+	} else if err != nil {
+		logger.Error("formation error", "app", app, "release_id", release.ID, "err", err)
+		return err
+	}
+
+	// If mariadb is running then exit.
+	if formation.Processes["mariadb"] > 0 {
+		logger.Info("database is running, scaling not necessary")
+		return nil
+	}
+
+	// Copy processes and increase database processes.
+	processes := make(map[string]int, len(formation.Processes))
+	for k, v := range formation.Processes {
+		processes[k] = v
+	}
+
+	if os.Getenv("SINGLETON") == "true" {
+		processes["mariadb"] = 1
+	} else {
+		processes["mariadb"] = 3
+	}
+
+	// Update formation.
+	logger.Info("updating formation", "app", app, "release_id", release.ID)
+	formation.Processes = processes
+	if err := client.PutFormation(formation); err != nil {
+		logger.Error("put formation error", "app", app, "release_id", release.ID, "err", err)
+		return err
+	}
+
+	if err := sirenia.NewClient(serviceHost + ":3306").WaitForReadWrite(5 * time.Minute); err != nil {
+		logger.Error("wait for read write", "err", err)
+		return errors.New("timed out while starting mariadb cluster")
+	}
+
+	logger.Info("scaling complete")
+
+	// Mark as successfully scaled up.
+	a.scaledUp = true
+
+	return nil
+}
+
+func (a *API) logger() log15.Logger {
+	return log15.New("app", "mariadb-web")
 }

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -351,7 +351,10 @@
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"]
+          "cmd": ["api"],
+          "env": {
+            "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}"
+          }
         }
       }
     },
@@ -360,7 +363,7 @@
       "uri": "$image_repository?name=flynn/mariadb&id=$image_id[mariadb]"
     },
     "processes": {
-      "mariadb": 3,
+      "mariadb": 0,
       "web": 2
     }
   },

--- a/test/sirenia.go
+++ b/test/sirenia.go
@@ -91,10 +91,10 @@ func testSireniaDeploy(client controller.Client, disc *discoverd.Client, t *c.C,
 	t.Assert(err, c.IsNil)
 	release.ID = ""
 	release.Env[d.db.hostKey] = fmt.Sprintf("leader.%s.discoverd", d.name)
+	release.Env[d.db.serviceKey] = d.name
 	procName := release.Env["SIRENIA_PROCESS"]
 	proc := release.Processes[procName]
 	delete(proc.Env, "SINGLETON")
-	proc.Env[d.db.serviceKey] = d.name
 	proc.Service = d.name
 	release.Processes[procName] = proc
 	t.Assert(client.CreateRelease(release), c.IsNil)

--- a/test/test_healthcheck.go
+++ b/test/test_healthcheck.go
@@ -131,7 +131,10 @@ func (s *HealthcheckSuite) TestStatus(t *c.C) {
 
 	t.Assert(data.Data.Status, c.Equals, status.CodeHealthy)
 	t.Assert(data.Data.Detail, c.HasLen, 12)
+	optional := map[string]bool{"mariadb": true}
 	for name, s := range data.Data.Detail {
-		t.Assert(s.Status, c.Equals, status.CodeHealthy, c.Commentf("name = %s", name))
+		if !optional[name] {
+			t.Assert(s.Status, c.Equals, status.CodeHealthy, c.Commentf("name = %s", name))
+		}
 	}
 }


### PR DESCRIPTION
This changes the MariaDB appliance to scale up the database formation only after the first resource is requested. This saves cluster resources in the case MariaDB goes unutilized.

Fixes #2595