### PR TITLE
controller/types: Fallback to `LegacyArtifactID` in `ImageArtifactID()`

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -63,7 +63,7 @@ func (r *Release) ImageArtifactID() string {
 	if len(r.ArtifactIDs) > 0 {
 		return r.ArtifactIDs[0]
 	}
-	return ""
+	return r.LegacyArtifactID
 }
 
 func (r *Release) SetImageArtifactID(id string) {


### PR DESCRIPTION
Closes #2777 
Bug introduced in #2448