### PR TITLE
cli: Fix exporting apps from legacy clusters

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -63,7 +63,7 @@ func (r *Release) ImageArtifactID() string {
 	if len(r.ArtifactIDs) > 0 {
 		return r.ArtifactIDs[0]
 	}
-	return ""
+	return r.LegacyArtifactID
 }
 
 func (r *Release) SetImageArtifactID(id string) {


### PR DESCRIPTION
Fixes #2777.

Tested manually by booting a `v20160327.0` cluster and using the latest CLI to export an app (and also run a cluster backup, but that is unaffected).