### PR TITLE
router: Fix shutdown after startup error

### DIFF
--- a/router/server.go
+++ b/router/server.go
@@ -55,6 +55,7 @@ func (s *Router) Start() error {
 	log.Info("starting TCP listener")
 	if err := s.TCP.Start(); err != nil {
 		log.Error("error starting TCP listener", "err", err)
+		s.HTTP.Close()
 		return err
 	}
 	return nil

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -126,6 +126,7 @@ func (l *TCPListener) Start() error {
 	// TODO(benburkert): the sync API cannot handle routes deleted while the
 	// listen/notify connection is disconnected
 	if err := l.startSync(ctx); err != nil {
+		l.Close()
 		return err
 	}
 
@@ -173,6 +174,9 @@ func (l *TCPListener) doSync(ctx context.Context, errc chan<- error) <-chan stru
 func (l *TCPListener) Close() error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
+	if l.closed {
+		return nil
+	}
 	l.stopSync()
 	for _, s := range l.routes {
 		s.Close()


### PR DESCRIPTION
Ensure that everything gets closed down before we close the database pool, otherwise we’ll deadlock.

Closes #2649
Refs #2784