### PR TITLE
test: Trigger a more reliable error in TestAddFailingJob

### DIFF
--- a/test/test_host.go
+++ b/test/test_host.go
@@ -51,13 +51,14 @@ func (s *HostSuite) TestAddFailingJob(t *c.C) {
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 
-	// add a job with a non existent artifact
+	// add a job with a non existent partition
 	job := &host.Job{
 		ID: jobID,
 		ImageArtifact: &host.Artifact{
 			Type: host.ArtifactTypeDocker,
 			URI:  "http://example.com?name=foo&id=bar",
 		},
+		Partition: "nonexistent",
 	}
 	t.Assert(h.AddJob(job), c.IsNil)
 
@@ -83,7 +84,7 @@ loop:
 	t.Assert(actual[1].Event, c.Equals, host.JobEventError)
 	jobErr := actual[1].Job.Error
 	t.Assert(jobErr, c.NotNil)
-	t.Assert(*jobErr, c.Equals, "registry: repo not found")
+	t.Assert(*jobErr, c.Equals, `host: invalid job partition "nonexistent"`)
 }
 
 func (s *HostSuite) TestAttachNonExistentJob(t *c.C) {


### PR DESCRIPTION
We were previously relying on the artifact pull from example.com to return a 404, thus generating a "repo not found" error, but example.com recently starting returning a 500 instead. We probably shouldn't be relying on the reliability of example.com :wink: