### PR TITLE
host/cli: Include artifact URIs in `flynn-host inspect` output

### DIFF
--- a/host/cli/inspect.go
+++ b/host/cli/inspect.go
@@ -68,6 +68,10 @@ func printJobDesc(job *host.ActiveJob, out io.Writer, env bool) {
 	listRec(w, "EndedAt", displayTime(job.EndedAt))
 	listRec(w, "ExitStatus", exitStatus)
 	listRec(w, "IP Address", job.InternalIP)
+	listRec(w, "ImageArtifact", job.Job.ImageArtifact.URI)
+	for i, artifact := range job.Job.FileArtifacts {
+		listRec(w, fmt.Sprintf("FileArtifact[%d]", i), artifact.URI)
+	}
 	for k, v := range job.Job.Metadata {
 		listRec(w, k, v)
 	}


### PR DESCRIPTION
This will help diagnose #2797 (i.e. is the image artifact set as the file artifact and vice versa, or does the job just have an image artifact and no file artifacts).