### PR TITLE
Blobstore enhancements

### DIFF
--- a/blobstore/README.md
+++ b/blobstore/README.md
@@ -7,12 +7,51 @@ files. It is like a simpler S3. All operations fall under these three HTTP
 verbs:
 
  * PUT: write a file: `curl -X PUT -T /path/to/local/file
-   http://blobstorehost/path/to/remote/file`
- * GET: read a file: `curl http://blobstorehost/path/to/remote/file`
+   http://blobstore.discoverd/path/to/remote/file`
+ * GET: read a file: `curl http://blobstore.discoverd/path/to/remote/file`
  * DELETE: delete a file: `curl -X DELETE
-   http://blobstorehost/path/to/remote/file`
+   http://blobstore.discoverd/path/to/remote/file`
 
-There are no directory indexes. Parent directories are automatically created.
+Files can be copied by setting the `Blobstore-Copy-From` header in a PUT
+request:
+
+```shell
+# create /file1.txt
+echo data | curl -X PUT --data-binary @- http://blobstore.discoverd/file1.txt
+
+# copy it to /file2.txt
+curl -X PUT --header "Blobstore-Copy-From: /file1.txt" http://blobstore.discoverd/file2.txt
+
+# read /file2.txt
+curl http://blobstore.discoverd/file2.txt
+data
+
+```
+
+
+Parent directories are automatically created, and directory indexes can be
+accessed with a GET request to the root path with the `dir` query param:
+
+```shell
+# create 4 files in different directories
+curl -X PUT --data-binary "data" http://blobstore.discoverd/foo.txt
+curl -X PUT --data-binary "data" http://blobstore.discoverd/dir1/foo.txt
+curl -X PUT --data-binary "data" http://blobstore.discoverd/dir2/foo.txt
+curl -X PUT --data-binary "data" http://blobstore.discoverd/dir3/foo.txt
+
+# list all top-level files and directories
+curl http://blobstore.discoverd/
+["/dir1/","/dir2/","/dir3/","/foo.txt"]
+
+# list files in /dir1
+curl http://blobstore.discoverd/?dir=/dir1
+["/dir1/foo.txt"]
+
+# list files in /dir2
+curl http://blobstore.discoverd/?dir=/dir2
+["/dir2/foo.txt"]
+```
+
 Right now, the files are stored as large objects in PostgreSQL or on the local
 filesystem, but it's intended to provide a simple, pre-authenticated gateway to
 S3 and maybe other file storage systems in the near future.

--- a/blobstore/blobstore_test.go
+++ b/blobstore/blobstore_test.go
@@ -191,6 +191,36 @@ func testFilesystem(fs Filesystem, testMeta bool, t *testing.T) {
 				}
 			}
 
+			newPath := srv.URL + "/foo/bar/" + random.Hex(16)
+			req, err = http.NewRequest("PUT", newPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Blobstore-Copy-From", strings.TrimPrefix(path, srv.URL))
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res.Body.Close()
+			if res.StatusCode != 200 {
+				t.Errorf("Expected 200 for copy PUT, got %d", res.StatusCode)
+			}
+			res, err = http.Get(newPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resData, err = ioutil.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.StatusCode != 200 {
+				t.Errorf("Expected 200 for copy GET, got %d", res.StatusCode)
+			}
+			if string(resData) != data {
+				t.Errorf("Expected copied data to be %q, got %q", data, string(resData))
+			}
+
 			newData := random.Hex(32)
 			req, err = http.NewRequest("PUT", path, strings.NewReader(newData))
 			if err != nil {

--- a/blobstore/os_filesystem.go
+++ b/blobstore/os_filesystem.go
@@ -51,6 +51,17 @@ func (s *OSFilesystem) Put(name string, r io.Reader, typ string) error {
 	return err
 }
 
+func (s *OSFilesystem) Copy(dstPath, srcPath string) error {
+	src, err := s.Open(srcPath)
+	if err != nil {
+		return err
+	} else if src.(*osFile).IsDir() {
+		return ErrNotFound
+	}
+	defer src.Close()
+	return s.Put(dstPath, src, "")
+}
+
 func (s *OSFilesystem) Delete(name string) error {
 	return os.RemoveAll(s.path(name))
 }

--- a/blobstore/os_filesystem.go
+++ b/blobstore/os_filesystem.go
@@ -24,6 +24,30 @@ type OSFilesystem struct {
 	root string
 }
 
+func (s *OSFilesystem) List(dir string) ([]string, error) {
+	f, err := s.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if !f.(*osFile).IsDir() {
+		return nil, ErrNotFound
+	}
+	entries, err := f.(*osFile).Readdir(0)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, len(entries))
+	for i, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		if entry.IsDir() {
+			path = path + "/"
+		}
+		paths[i] = path
+	}
+	return paths, nil
+}
+
 func (s *OSFilesystem) Open(name string) (File, error) {
 	f, err := os.Open(s.path(name))
 	if err != nil {

--- a/blobstore/postgres_filesystem.go
+++ b/blobstore/postgres_filesystem.go
@@ -106,8 +106,11 @@ create:
 }
 
 func (p *PostgresFilesystem) Delete(name string) error {
-	err := p.db.Exec("DELETE FROM files WHERE name = $1", name)
-	return err
+	// use a regular expression so that either a file with the name is
+	// deleted, or any file prefixed with "{name}/" is deleted (so in other
+	// words, mimic either deleting a file or recursively deleting a
+	// directory)
+	return p.db.Exec("DELETE FROM files WHERE name ~ ('^' || $1 || '(/.*)?$')", name)
 }
 
 func (p *PostgresFilesystem) Open(name string) (File, error) {

--- a/blobstore/postgres_filesystem.go
+++ b/blobstore/postgres_filesystem.go
@@ -105,6 +105,15 @@ create:
 	return tx.Commit()
 }
 
+func (p *PostgresFilesystem) Copy(dstPath, srcPath string) error {
+	src, err := p.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	return p.Put(dstPath, src, "")
+}
+
 func (p *PostgresFilesystem) Delete(name string) error {
 	// use a regular expression so that either a file with the name is
 	// deleted, or any file prefixed with "{name}/" is deleted (so in other

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -647,7 +647,7 @@
     "id": "blobstore-wait",
     "action": "wait",
     "url": "http://blobstore.discoverd",
-    "status": 404
+    "status": 200
   },
   {
     "id": "gitreceive-wait",


### PR DESCRIPTION
A number of enhancements to the blobstore to aid in supporting a blobstore backend for a Docker registry (see #2763).

The directory indexes (which are GET requests to `/` with a `dir` param) are simpler versions of listing objects with a prefix from S3 (see [here](http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html#v2-RESTBucketGET-responses-examples-ex3)), and copying files (using the `X-Blobstore-Copy-From` header) is similar to [copying an object in S3](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html), which means we should still be able to make the blobstore an S3 gateway.