### PR TITLE
bootstrap: Wait up to 10 minutes for cluster restored from backup

### DIFF
--- a/bootstrap/status_check_action.go
+++ b/bootstrap/status_check_action.go
@@ -9,9 +9,10 @@ import (
 )
 
 type StatusCheckAction struct {
-	ID     string `json:"id"`
-	URL    string `json:"url"`
-	Output string `json:"output"`
+	ID      string `json:"id"`
+	URL     string `json:"url"`
+	Output  string `json:"output"`
+	Timeout int    `json:"timeout"` // in seconds
 }
 
 type StatusResponse struct {
@@ -32,7 +33,10 @@ func init() {
 }
 
 func (a *StatusCheckAction) Run(s *State) error {
-	const waitMax = time.Minute
+	waitMax := time.Minute
+	if a.Timeout > 0 {
+		waitMax = time.Duration(a.Timeout) * time.Second
+	}
 	const waitInterval = 500 * time.Millisecond
 
 	u, err := url.Parse(interpolate(s, a.URL))

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -440,7 +440,8 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 			ExpandedFormation: data.Controller,
 		}),
 		step("status", "status-check", &bootstrap.StatusCheckAction{
-			URL: "http://status-web.discoverd",
+			URL:     "http://status-web.discoverd",
+			Timeout: 600,
 		}),
 		step("cluster-monitor", "cluster-monitor", &bootstrap.ClusterMonitorAction{
 			Enabled: true,


### PR DESCRIPTION
It can take a bit for all of the components to get started by the scheduler.

Closes #2802