### PR TITLE
controller/client: Log deployment stream errors

### DIFF
--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -519,7 +519,7 @@ outer:
 		select {
 		case e, ok := <-events:
 			if !ok {
-				return errors.New("unexpected close of deployment event stream")
+				return fmt.Errorf("unexpected close of deployment event stream: %s", stream.Err())
 			}
 			switch e.Status {
 			case "complete":


### PR DESCRIPTION
This is to assist in tracking down why issues like #1689 occur.