### PR TITLE
cli: Fix importing mysql databases

### DIFF
--- a/cli/mysql.go
+++ b/cli/mysql.go
@@ -138,8 +138,7 @@ func configMysqlDump(config *runConfig) {
 	config.Args = []string{
 		"-h", config.Env["MYSQL_HOST"],
 		"-u", config.Env["MYSQL_USER"],
-		"--databases", config.Env["MYSQL_DATABASE"],
-		"--no-create-db",
+		config.Env["MYSQL_DATABASE"],
 	}
 }
 


### PR DESCRIPTION
The mysqldump --databases flag leads to both CREATE DATABASE and USE statements to be included in the dump. We are setting the --no-create-db to avoid including the CREATE DATABASE statement (the new app will already have a database), but the USE statement remained leading to the following error on import:

```
ERROR 1044 (42000) at line 22: Access denied for user '04f365e0e25e2c63668876c771ff8cf1'@'%' to database 'dcc6f9d2b76880dde63f975c3637df7f'
```

Given we only export one database, and we use the -D flag on import to use a specific database, there seems to be no reason to use the --databases flag.

/cc @josephglanville 