### PR TITLE
appliance/postgres: Tune WAL checkpoint settings

### DIFF
--- a/appliance/postgresql/postgres.go
+++ b/appliance/postgresql/postgres.go
@@ -902,6 +902,8 @@ wal_level = hot_standby
 fsync = on
 max_wal_senders = 15
 wal_keep_segments = 1000
+checkpoint_completion_target = 0.9
+checkpoint_segments = 64
 synchronous_commit = remote_write
 synchronous_standby_names = '{{.Sync}}'
 {{if .ReadOnly}}


### PR DESCRIPTION
Improves performance when database is doing a large amount of writes by allowing postgres more time to complete snapshots and to perform them less frequently.