### PR TITLE
script: Add script to configure Docker with a cluster's TLS CA certificate

### DIFF
--- a/script/configure-docker
+++ b/script/configure-docker
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/ui.sh"
+
+usage() {
+  cat <<USAGE >&2
+usage: $0 CLUSTER_DOMAIN
+
+Configure the local Docker daemon to trust a cluster's TLS CA certificate.
+USAGE
+}
+
+main() {
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  CLUSTER_DOMAIN=$1
+
+  local docker_cert_path="/etc/docker/certs.d/docker.${CLUSTER_DOMAIN}/ca.crt"
+  sudo mkdir -p "$(dirname "${docker_cert_path}")"
+  sudo curl --silent --output "${docker_cert_path}" "http://controller.${CLUSTER_DOMAIN}/ca-cert"
+  sudo restart docker
+}
+
+main $@

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -79,6 +79,9 @@ main() {
   sudo mv /etc/resolv.conf{,.backup}
   trap 'sudo mv /etc/resolv.conf{.backup,}' EXIT
   echo "nameserver $(ifconfig flynnbr0 | grep -oP 'inet addr:\S+' | cut -d: -f2)" | sudo tee /etc/resolv.conf
+
+  "${ROOT}/script/configure-docker" "${CLUSTER_DOMAIN:-"${size}.localflynn.com"}"
+
   export FLYNNRC=/tmp/flynnrc
   "${flynn}" cluster remove default
   "${flynn}" ${cluster_add:6}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -296,7 +296,7 @@ var testRunScript = template.Must(template.New("test-run").Parse(`
 #!/bin/bash
 set -e -x -o pipefail
 
-echo {{ .Cluster.RouterIP }} {{ .Cluster.ClusterDomain }} {{ .Cluster.ControllerDomain }} {{ .Cluster.GitDomain }} dashboard.{{ .Cluster.ClusterDomain }} | sudo tee -a /etc/hosts
+echo {{ .Cluster.RouterIP }} {{ .Cluster.ClusterDomain }} {{ .Cluster.ControllerDomain }} {{ .Cluster.GitDomain }} dashboard.{{ .Cluster.ClusterDomain }} docker.{{ .Cluster.ClusterDomain }} | sudo tee -a /etc/hosts
 
 # Wait for the Flynn bridge interface to show up so we can use it as the
 # nameserver to resolve discoverd domains
@@ -316,6 +316,8 @@ done
 echo "nameserver ${ip}" | sudo tee /etc/resolv.conf
 
 cd ~/go/src/github.com/flynn/flynn
+
+script/configure-docker "{{ .Cluster.ClusterDomain }}
 
 cli/bin/flynn cluster add \
   --tls-pin "{{ .Config.TLSPin }}" \


### PR DESCRIPTION
Part of the docker-receive changes (#2763) but opening as a separate PR so we can get the tests to pass in CI.