### PR TITLE
Implement Docker Receive App

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -463,6 +463,41 @@
     }
   },
   {
+    "id": "docker-receive",
+    "action": "deploy-app",
+    "app": {
+      "name": "docker-receive",
+      "meta": {"flynn-system-app": "true"}
+    },
+    "artifact": {
+      "type": "docker",
+      "uri": "$image_repository?name=flynn/docker-receive&id=$image_id[docker-receive]"
+    },
+    "release": {
+      "env": {
+        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}"
+      },
+      "processes": {
+        "app": {
+          "ports": [
+            {
+              "port": 80,
+              "proto": "tcp",
+              "service": {
+                "name": "docker-receive",
+                "create": true,
+                "check": {"type": "http", "path": "/v2/"}
+              }
+            }
+          ]
+        }
+      }
+    },
+    "processes": {
+      "app": 2
+    }
+  },
+  {
     "id": "router-wait",
     "action": "wait",
     "url": "http://router-api.discoverd",
@@ -476,6 +511,15 @@
     "type": "http",
     "service": "gitreceive",
     "domain": "git.{{ getenv \"CLUSTER_DOMAIN\" }}"
+  },
+  {
+    "id": "docker-receive-route",
+    "action": "add-route",
+    "app_step": "docker-receive",
+    "cert_step": "controller-cert",
+    "type": "http",
+    "service": "docker-receive",
+    "domain": "docker.{{ getenv \"CLUSTER_DOMAIN\" }}"
   },
   {
     "id": "controller-route",
@@ -653,6 +697,11 @@
     "id": "gitreceive-wait",
     "action": "wait",
     "url": "tcp://gitreceive.discoverd"
+  },
+  {
+    "id": "docker-receive-wait",
+    "action": "wait",
+    "url": "http://docker-receive.discoverd/v2/"
   },
   {
     "id": "status-check",

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -463,6 +463,10 @@
     }
   },
   {
+    "id": "docker-receive-secret",
+    "action": "gen-random"
+  },
+  {
     "id": "docker-receive",
     "action": "deploy-app",
     "app": {
@@ -475,7 +479,8 @@
     },
     "release": {
       "env": {
-        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}"
+        "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
+        "REGISTRY_HTTP_SECRET": "{{ (index .StepData \"docker-receive-secret\").Data }}"
       },
       "processes": {
         "app": {

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -479,6 +479,7 @@
     },
     "release": {
       "env": {
+        "AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
         "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}",
         "REGISTRY_HTTP_SECRET": "{{ (index .StepData \"docker-receive-secret\").Data }}"
       },
@@ -491,7 +492,7 @@
               "service": {
                 "name": "docker-receive",
                 "create": true,
-                "check": {"type": "http", "path": "/v2/"}
+                "check": {"type": "http", "path": "/v2/", "status": 401}
               }
             }
           ]
@@ -706,7 +707,8 @@
   {
     "id": "docker-receive-wait",
     "action": "wait",
-    "url": "http://docker-receive.discoverd/v2/"
+    "url": "http://docker-receive.discoverd/v2/",
+    "status": 401
   },
   {
     "id": "status-check",

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -24,7 +26,7 @@ import (
 func init() {
 	register("cluster", runCluster, `
 usage: flynn cluster
-       flynn cluster add [-f] [-d] [--git-url <giturl>] [--no-git] [-p <tlspin>] <cluster-name> <domain> <key>
+       flynn cluster add [-f] [-d] [--git-url <giturl>] [--no-git] [--docker-url <dockerurl>] [--docker] [-p <tlspin>] <cluster-name> <domain> <key>
        flynn cluster remove <cluster-name>
        flynn cluster default [<cluster-name>]
        flynn cluster migrate-domain <domain>
@@ -44,6 +46,8 @@ Commands:
             -d, --default             set as default cluster
             --git-url=<giturl>        git URL
             --no-git                  skip git configuration
+            --docker-url=<dockerurl>  Docker URL
+            --docker                  configure Docker to push to the cluster
             -p, --tls-pin=<tlspin>    SHA256 of the cluster's TLS cert
 
     remove
@@ -100,9 +104,17 @@ func runCluster(args *docopt.Args) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	listRec(w, "NAME", "CONTROLLER URL", "GIT URL")
+	listRec(w, "NAME", "CONTROLLER URL", "GIT URL", "DOCKER URL")
 	for _, s := range config.Clusters {
-		data := []interface{}{s.Name, s.ControllerURL, s.GitURL}
+		gitURL := s.GitURL
+		if gitURL == "" {
+			gitURL = "(none)"
+		}
+		dockerURL := s.DockerURL
+		if dockerURL == "" {
+			dockerURL = "(none)"
+		}
+		data := []interface{}{s.Name, s.ControllerURL, gitURL, dockerURL}
 		if s.Name == config.Default {
 			data = append(data, "(default)")
 		}
@@ -113,10 +125,11 @@ func runCluster(args *docopt.Args) error {
 
 func runClusterAdd(args *docopt.Args) error {
 	s := &cfg.Cluster{
-		Name:   args.String["<cluster-name>"],
-		Key:    args.String["<key>"],
-		GitURL: args.String["--git-url"],
-		TLSPin: args.String["--tls-pin"],
+		Name:      args.String["<cluster-name>"],
+		Key:       args.String["<key>"],
+		GitURL:    args.String["--git-url"],
+		DockerURL: args.String["--docker-url"],
+		TLSPin:    args.String["--tls-pin"],
 	}
 	domain := args.String["<domain>"]
 	if strings.HasPrefix(domain, "https://") {
@@ -124,8 +137,11 @@ func runClusterAdd(args *docopt.Args) error {
 	} else {
 		s.ControllerURL = "https://controller." + domain
 	}
-	if s.GitURL == "" {
+	if s.GitURL == "" && !args.Bool["--no-git"] {
 		s.GitURL = "https://git." + domain
+	}
+	if s.DockerURL == "" && args.Bool["--docker"] {
+		s.DockerURL = "https://docker." + domain
 	}
 
 	if err := config.Add(s, args.Bool["--force"]); err != nil {
@@ -138,22 +154,42 @@ func runClusterAdd(args *docopt.Args) error {
 		return errors.New(fmt.Sprintf("Cluster %q does not exist and cannot be set as default.", s.Name))
 	}
 
-	if !args.Bool["--no-git"] {
+	var caPath string
+	if s.GitURL != "" || s.DockerURL != "" {
+		client, err := s.Client()
+		if err != nil {
+			return err
+		}
+		caPath, err = writeCACert(client, s.Name)
+		if err != nil {
+			return fmt.Errorf("Error writing CA certificate: %s", err)
+		}
+	}
+
+	if s.GitURL != "" {
 		if _, err := exec.LookPath("git"); err != nil {
 			if serr, ok := err.(*exec.Error); ok && serr.Err == exec.ErrNotFound {
 				return errors.New("Executable 'git' was not found. Use --no-git to skip git configuration")
 			}
 			return err
 		}
-		client, err := s.Client()
+		if err := cfg.WriteGlobalGitConfig(s.GitURL, caPath); err != nil {
+			return err
+		}
+	}
+
+	if s.DockerURL != "" {
+		u, err := url.Parse(s.DockerURL)
 		if err != nil {
 			return err
 		}
-		caPath, err := writeCACert(client, s.Name)
-		if err != nil {
-			return fmt.Errorf("Error writing CA certificate: %s", err)
-		}
-		if err := cfg.WriteGlobalGitConfig(s.GitURL, caPath); err != nil {
+		if err := runDockerLogin(u.Host, s.Key); err != nil {
+			if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
+				err = errors.New("Executable 'docker' was not found.")
+			} else if err == ErrDockerTLSError {
+				printDockerTLSWarning(u.Host, caPath)
+				err = errors.New("Error configuring docker, follow the instructions above then try again")
+			}
 			return err
 		}
 	}
@@ -168,6 +204,35 @@ func runClusterAdd(args *docopt.Args) error {
 		log.Printf("Cluster %q added.", s.Name)
 	}
 	return nil
+}
+
+var ErrDockerTLSError = errors.New("docker TLS error")
+
+func runDockerLogin(host, key string) error {
+	var out bytes.Buffer
+	cmd := exec.Command("docker", "login", "--email=user@"+host, "--username=user", "--password="+key, host)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if strings.Contains(out.String(), "certificate signed by unknown authority") {
+		err = ErrDockerTLSError
+	}
+	return err
+}
+
+func runDockerLogout(host string) error {
+	return exec.Command("docker", "logout", host).Run()
+}
+
+func printDockerTLSWarning(host, caPath string) {
+	fmt.Printf(`
+WARN: docker configuration failed with a TLS error.
+WARN:
+WARN: Copy the TLS CA certificate %s
+WARN: to /etc/docker/certs.d/%s/ca.crt
+WARN: on the docker daemon's host and restart docker.
+
+`[1:], caPath, host)
 }
 
 func writeCACert(c controller.Client, name string) (string, error) {
@@ -201,6 +266,12 @@ func runClusterRemove(args *docopt.Args) error {
 		}
 
 		cfg.RemoveGlobalGitConfig(c.GitURL)
+
+		if c.DockerURL != "" {
+			if u, err := url.Parse(c.DockerURL); err == nil {
+				runDockerLogout(u.Host)
+			}
+		}
 
 		log.Print(msg)
 	}
@@ -298,6 +369,7 @@ func runClusterMigrateDomain(args *docopt.Args) error {
 				cluster.TLSPin = dm.TLSCert.Pin
 				cluster.ControllerURL = fmt.Sprintf("https://controller.%s", dm.Domain)
 				cluster.GitURL = fmt.Sprintf("https://git.%s", dm.Domain)
+				cluster.DockerURL = fmt.Sprintf("https://docker.%s", dm.Domain)
 				if err := config.SaveTo(configPath()); err != nil {
 					return fmt.Errorf("Error saving config: %s", err)
 				}
@@ -315,6 +387,14 @@ func runClusterMigrateDomain(args *docopt.Args) error {
 					return err
 				}
 				cfg.RemoveGlobalGitConfig(fmt.Sprintf("https://git.%s", dm.OldDomain))
+
+				// try to run "docker login" for the new domain, but just print a warning
+				// if it fails so the user can fix it later
+				u, _ := url.Parse(cluster.DockerURL)
+				if err := runDockerLogin(u.Host, cluster.Key); err == ErrDockerTLSError {
+					printDockerTLSWarning(u.Host, caFile.Name())
+				}
+				runDockerLogout(dm.OldDomain)
 
 				fmt.Println("Updated local CLI configuration")
 				return nil

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -21,7 +21,7 @@ type Cluster struct {
 	TLSPin        string `json:"tls_pin" toml:"TLSPin,omitempty"`
 	ControllerURL string `json:"controller_url"`
 	GitURL        string `json:"git_url"`
-	DockerURL     string `json:"docker_url"`
+	DockerPushURL string `json:"docker_push_url"`
 }
 
 func (c *Cluster) Client() (controller.Client, error) {
@@ -36,13 +36,13 @@ func (c *Cluster) Client() (controller.Client, error) {
 	return controller.NewClientWithConfig(c.ControllerURL, c.Key, controller.Config{Pin: pin})
 }
 
-func (c *Cluster) DockerHost() (string, error) {
-	if c.DockerURL == "" {
-		return "", errors.New("cluster: DockerURL not configured")
+func (c *Cluster) DockerPushHost() (string, error) {
+	if c.DockerPushURL == "" {
+		return "", errors.New("cluster: DockerPushURL not configured")
 	}
-	u, err := url.Parse(c.DockerURL)
+	u, err := url.Parse(c.DockerPushURL)
 	if err != nil {
-		return "", fmt.Errorf("cluster: could not parse DockerURL: %s", err)
+		return "", fmt.Errorf("cluster: could not parse DockerPushURL: %s", err)
 	}
 	return u.Host, nil
 }
@@ -106,8 +106,8 @@ func (c *Config) Add(s *Cluster, force bool) error {
 			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.GitURL)
 		case existing.ControllerURL == s.ControllerURL:
 			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.ControllerURL)
-		case existing.DockerURL != "" && existing.DockerURL == s.DockerURL:
-			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.DockerURL)
+		case existing.DockerPushURL != "" && existing.DockerPushURL == s.DockerPushURL:
+			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.DockerPushURL)
 		}
 		if m != "" {
 			if conflictIdx != -1 && conflictIdx != i {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -3,7 +3,9 @@ package config
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +34,17 @@ func (c *Cluster) Client() (controller.Client, error) {
 		}
 	}
 	return controller.NewClientWithConfig(c.ControllerURL, c.Key, controller.Config{Pin: pin})
+}
+
+func (c *Cluster) DockerHost() (string, error) {
+	if c.DockerURL == "" {
+		return "", errors.New("cluster: DockerURL not configured")
+	}
+	u, err := url.Parse(c.DockerURL)
+	if err != nil {
+		return "", fmt.Errorf("cluster: could not parse DockerURL: %s", err)
+	}
+	return u.Host, nil
 }
 
 type Config struct {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -93,6 +93,8 @@ func (c *Config) Add(s *Cluster, force bool) error {
 			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.GitURL)
 		case existing.ControllerURL == s.ControllerURL:
 			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.ControllerURL)
+		case existing.DockerURL != "" && existing.DockerURL == s.DockerURL:
+			m = fmt.Sprintf("A cluster with the URL %q already exists in ~/.flynnrc", s.DockerURL)
 		}
 		if m != "" {
 			if conflictIdx != -1 && conflictIdx != i {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/flynn/flynn/controller/client"
 )
 
+var ErrNoDockerPushURL = errors.New("ERROR: Docker push URL not configured, set it with 'flynn docker set-push-url'")
+
 type Cluster struct {
 	Name          string `json:"name"`
 	Key           string `json:"key"`
@@ -38,7 +40,7 @@ func (c *Cluster) Client() (controller.Client, error) {
 
 func (c *Cluster) DockerPushHost() (string, error) {
 	if c.DockerPushURL == "" {
-		return "", errors.New("cluster: DockerPushURL not configured")
+		return "", ErrNoDockerPushURL
 	}
 	u, err := url.Parse(c.DockerPushURL)
 	if err != nil {

--- a/cli/config/git.go
+++ b/cli/config/git.go
@@ -10,12 +10,16 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/kardianos/osext"
 )
 
+func CACertPath(name string) string {
+	return filepath.Join(Dir(), "ca-certs", name+".pem")
+}
+
 func CACertFile(name string) (*os.File, error) {
-	dir := filepath.Join(Dir(), "ca-certs")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	path := CACertPath(name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, err
 	}
-	return os.Create(filepath.Join(dir, name+".pem"))
+	return os.Create(path)
 }
 
 func gitConfig(args ...string) error {

--- a/cli/docker.go
+++ b/cli/docker.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
+)
+
+func init() {
+	register("docker", runDockerPush, `
+usage: flynn docker push <image>
+
+Deploy Docker images to a Flynn cluster.
+
+Example:
+
+	Assuming you have a Docker image tagged "my-custom-image:v2":
+
+	$ flynn docker push my-custom-image:v2
+	flynn: getting image config with "docker inspect -f {{ json .Config }} my-custom-image:v2"
+	flynn: tagging Docker image with "docker tag --force my-custom-image:v2 docker.1.localflynn.com/my-app:latest"
+	flynn: pushing Docker image with "docker push docker.1.localflynn.com/my-app:latest"
+	The push refers to a repository [docker.1.localflynn.com/my-app] (len: 1)
+	a8eb754d1a89: Pushed
+	...
+	3059b4820522: Pushed
+	latest: digest: sha256:1752ca12bbedb99734ca1ba3ec35720768a95ad83b7b6c371fc37a28b98ea351 size: 61216
+	flynn: image pushed, waiting for artifact creation
+	flynn: deploying release using artifact URI http://docker-receive.discoverd?name=my-app&id=sha256:1752ca12bbedb99734ca1ba3ec35720768a95ad83b7b6c371fc37a28b98ea351
+	flynn: image deployed, scale it with 'flynn scale app=N'
+`)
+}
+
+func runDockerPush(args *docopt.Args, client controller.Client) error {
+	image := args.String["<image>"]
+
+	prevRelease, err := client.GetAppRelease(mustApp())
+	if err == controller.ErrNotFound {
+		prevRelease = &ct.Release{}
+	} else if err != nil {
+		return fmt.Errorf("error getting current app release:", err)
+	}
+
+	// get the image config to determine Cmd, Entrypoint and Env
+	cmd := exec.Command("docker", "inspect", "-f", "{{ json .Config }}", image)
+	log.Printf("flynn: getting image config with %q", strings.Join(cmd.Args, " "))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	var config struct {
+		Cmd        []string `json:"Cmd"`
+		Entrypoint []string `json:"Entrypoint"`
+		Env        []string `json:"Env"`
+	}
+	if err := json.NewDecoder(stdout).Decode(&config); err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
+	// subscribe to artifact events
+	events := make(chan *ct.Event)
+	stream, err := client.StreamEvents(ct.StreamEventsOptions{
+		ObjectTypes: []ct.EventType{ct.EventTypeArtifact},
+	}, events)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	// push the Docker image to docker-receive
+	cluster, err := getCluster()
+	if err != nil {
+		return err
+	}
+	u, err := url.Parse(cluster.DockerURL)
+	if err != nil {
+		return err
+	}
+	tag := fmt.Sprintf("%s/%s:latest", u.Host, mustApp())
+	cmd = exec.Command("docker", "tag", "--force", image, tag)
+	log.Printf("flynn: tagging Docker image with %q", strings.Join(cmd.Args, " "))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("docker", "push", tag)
+	log.Printf("flynn: pushing Docker image with %q", strings.Join(cmd.Args, " "))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// wait for an artifact to be created
+	log.Printf("flynn: image pushed, waiting for artifact creation")
+	var artifact ct.Artifact
+loop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return fmt.Errorf("event stream closed unexpectedly: %s", stream.Err())
+			}
+			if err := json.Unmarshal(event.Data, &artifact); err != nil {
+				return err
+			}
+			if artifact.Meta["docker-receive.repository"] == mustApp() {
+				break loop
+			}
+		case <-time.After(30 * time.Second):
+			return fmt.Errorf("timed out waiting for artifact creation")
+		}
+	}
+
+	// create and deploy a release with the image config and created artifact
+	log.Printf("flynn: deploying release using artifact URI %s", artifact.URI)
+	release := &ct.Release{
+		ArtifactIDs: []string{artifact.ID},
+		Processes:   prevRelease.Processes,
+		Env:         prevRelease.Env,
+		Meta:        prevRelease.Meta,
+	}
+
+	proc, ok := release.Processes["app"]
+	if !ok {
+		proc = ct.ProcessType{}
+	}
+	proc.Cmd = config.Cmd
+	proc.Entrypoint = config.Entrypoint
+	if len(proc.Ports) == 0 {
+		proc.Ports = []ct.Port{{
+			Port:  8080,
+			Proto: "tcp",
+			Service: &host.Service{
+				Name:   mustApp(),
+				Create: true,
+			},
+		}}
+	}
+	if release.Processes == nil {
+		release.Processes = make(map[string]ct.ProcessType, 1)
+	}
+	release.Processes["app"] = proc
+
+	if len(config.Env) > 0 && release.Env == nil {
+		release.Env = make(map[string]string, len(config.Env))
+	}
+	for _, v := range config.Env {
+		keyVal := strings.SplitN(v, "=", 2)
+		if len(keyVal) != 2 {
+			continue
+		}
+		release.Env[keyVal[0]] = keyVal[1]
+	}
+
+	if release.Meta == nil {
+		release.Meta = make(map[string]string, 1)
+	}
+	release.Meta["docker-receive"] = "true"
+
+	if err := client.CreateRelease(release); err != nil {
+		return err
+	}
+	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+		return err
+	}
+	log.Printf("flynn: image deployed, scale it with 'flynn scale app=N'")
+	return nil
+}

--- a/cli/docker.go
+++ b/cli/docker.go
@@ -68,7 +68,7 @@ func runDockerLogin() error {
 	if err != nil {
 		return err
 	}
-	host, err := cluster.DockerHost()
+	host, err := cluster.DockerPushHost()
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func runDockerLogout() error {
 	if err != nil {
 		return err
 	}
-	host, err := cluster.DockerHost()
+	host, err := cluster.DockerPushHost()
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 	if err != nil {
 		return err
 	}
-	dockerHost, err := cluster.DockerHost()
+	dockerHost, err := cluster.DockerPushHost()
 	if err != nil {
 		return err
 	}

--- a/controller/artifact.go
+++ b/controller/artifact.go
@@ -48,7 +48,8 @@ func (r *ArtifactRepo) Add(data interface{}) error {
 			tx.Rollback()
 			return err
 		}
-	} else if err == nil {
+	}
+	if err == nil {
 		if err := createEvent(tx.Exec, &ct.Event{
 			ObjectID:   a.ID,
 			ObjectType: ct.EventTypeArtifact,
@@ -56,8 +57,7 @@ func (r *ArtifactRepo) Add(data interface{}) error {
 			tx.Rollback()
 			return err
 		}
-	}
-	if err != nil {
+	} else {
 		tx.Rollback()
 		return err
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -318,7 +318,7 @@ func muxHandler(main http.Handler, authKeys []string) http.Handler {
 			w.WriteHeader(200)
 			return
 		}
-		_, password, _ := utils.ParseBasicAuth(r.Header)
+		_, password, _ := r.BasicAuth()
 		if password == "" && r.URL.Path == "/ca-cert" {
 			main.ServeHTTP(w, r)
 			return

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -84,6 +84,10 @@ func (r *Release) IsGitDeploy() bool {
 	return r.Meta["git"] == "true"
 }
 
+func (r *Release) IsDockerReceiveDeploy() bool {
+	return r.Meta["docker-receive"] == "true"
+}
+
 type ProcessType struct {
 	Cmd         []string           `json:"cmd,omitempty"`
 	Entrypoint  []string           `json:"entrypoint,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -1,10 +1,7 @@
 package utils
 
 import (
-	"encoding/base64"
-	"errors"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -221,29 +218,6 @@ func (c clusterClientWrapper) StreamHostEvents(ch chan *discoverd.Event) (stream
 }
 
 var AppNamePattern = regexp.MustCompile(`^[a-z\d]+(-[a-z\d]+)*$`)
-
-func ParseBasicAuth(h http.Header) (username, password string, err error) {
-	s := strings.SplitN(h.Get("Authorization"), " ", 2)
-
-	if len(s) != 2 {
-		return "", "", errors.New("failed to parse authentication string")
-	}
-	if s[0] != "Basic" {
-		return "", "", fmt.Errorf("authorization scheme is %v, not Basic", s[0])
-	}
-
-	c, err := base64.StdEncoding.DecodeString(s[1])
-	if err != nil {
-		return "", "", errors.New("failed to parse base64 basic credentials")
-	}
-
-	s = strings.SplitN(string(c), ":", 2)
-	if len(s) != 2 {
-		return "", "", errors.New("failed to parse basic credentials")
-	}
-
-	return s[0], s[1], nil
-}
 
 func FormationTagsEqual(a, b map[string]map[string]string) bool {
 	if len(a) != len(b) {

--- a/docker-receive/Dockerfile
+++ b/docker-receive/Dockerfile
@@ -1,0 +1,5 @@
+FROM flynn/busybox:trusty-20160217
+
+ADD bin/docker-receive /bin/docker-receive
+
+CMD ["/bin/docker-receive"]

--- a/docker-receive/Tupfile
+++ b/docker-receive/Tupfile
@@ -1,0 +1,3 @@
+include_rules
+: |> !go |> bin/docker-receive
+: bin/docker-receive |> !docker-bootstrapped |>

--- a/docker-receive/auth.go
+++ b/docker-receive/auth.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/auth"
+)
+
+func init() {
+	auth.Register("flynn", auth.InitFunc(newAuth))
+}
+
+func newAuth(options map[string]interface{}) (auth.AccessController, error) {
+	return &Auth{key: options["auth_key"].(string)}, nil
+}
+
+type Auth struct {
+	key string
+}
+
+// Authorized implements the auth.AccessController interface and authorizes a
+// request if it includes the correct auth key
+func (a *Auth) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {
+	req, err := context.GetRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_, password, _ := req.BasicAuth()
+	if password == "" {
+		password = req.URL.Query().Get("key")
+	}
+	if subtle.ConstantTimeCompare([]byte(password), []byte(a.key)) != 1 {
+		return nil, Challenge{}
+	}
+	return ctx, nil
+}
+
+type Challenge struct{}
+
+func (Challenge) SetHeaders(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Basic realm=docker-receive")
+}
+
+func (Challenge) Error() string {
+	return "basic authentication failed"
+}

--- a/docker-receive/blobstore/blobstore.go
+++ b/docker-receive/blobstore/blobstore.go
@@ -1,0 +1,223 @@
+package blobstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/context"
+	storage "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver/base"
+	registry "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver/factory"
+)
+
+const (
+	DriverName = "blobstore"
+
+	blobstorePrefix = "/docker-receive"
+)
+
+func init() {
+	registry.Register(DriverName, factory{})
+}
+
+// factory implements the registry.StorageDriverFactory interface
+type factory struct{}
+
+func (factory) Create(_ map[string]interface{}) (storage.StorageDriver, error) {
+	return NewDriver(), nil
+}
+
+type baseEmbed struct {
+	base.Base
+}
+
+type Driver struct {
+	baseEmbed
+}
+
+func NewDriver() *Driver {
+	return &Driver{
+		baseEmbed: baseEmbed{
+			Base: base.Base{
+				StorageDriver: &driver{},
+			},
+		},
+	}
+}
+
+// driver implements the storage.StorageDriver interface using the blobstore
+// for storage
+type driver struct{}
+
+func (d *driver) Name() string {
+	return DriverName
+}
+
+func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
+	body, err := d.ReadStream(ctx, path, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+	return ioutil.ReadAll(body)
+}
+
+func (d *driver) PutContent(ctx context.Context, path string, content []byte) error {
+	_, err := d.WriteStream(ctx, path, 0, bytes.NewReader(content))
+	return err
+}
+
+func (d *driver) ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	req, err := http.NewRequest("GET", d.blobstoreURL(path), nil)
+	if err != nil {
+		return nil, err
+	}
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusPartialContent {
+		res.Body.Close()
+		if res.StatusCode == http.StatusNotFound {
+			return nil, storage.PathNotFoundError{Path: path}
+		}
+		return nil, fmt.Errorf("unexpected HTTP status from blobstore: %s", res.Status)
+	}
+	return res.Body, nil
+}
+
+// readCounter wraps an io.Reader and counts how many bytes are read
+type readCounter struct {
+	r io.Reader
+	n int64
+}
+
+func (r *readCounter) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	atomic.AddInt64(&r.n, int64(n))
+	return n, err
+}
+
+func (d *driver) WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (int64, error) {
+	// use a readCounter so we can return how many bytes were uploaded
+	// from the given reader
+	r := &readCounter{r: reader}
+	req, err := http.NewRequest("PUT", d.blobstoreURL(path), r)
+	if err != nil {
+		return 0, err
+	}
+	if offset > 0 {
+		req.Header.Set("Blobstore-Offset", fmt.Sprintf("%d", offset))
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected HTTP status from blobstore: %s", res.Status)
+	}
+	return r.n, nil
+}
+
+func (d *driver) Stat(ctx context.Context, path string) (storage.FileInfo, error) {
+	req, err := http.NewRequest("HEAD", d.blobstoreURL(path), nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, storage.PathNotFoundError{Path: path}
+	}
+	lastMod, err := time.Parse(time.RFC1123, res.Header.Get("Last-Modified"))
+	if err != nil {
+		return nil, err
+	}
+	f := storage.FileInfoFields{
+		Path:    path,
+		IsDir:   false,
+		Size:    res.ContentLength,
+		ModTime: lastMod,
+	}
+	return storage.FileInfoInternal{FileInfoFields: f}, nil
+}
+
+func (d *driver) List(ctx context.Context, path string) ([]string, error) {
+	res, err := http.Get("http://blobstore.discoverd/?dir=" + d.blobstorePath(path))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status from blobstore: %s", res.Status)
+	}
+	var fullPaths []string
+	if err := json.NewDecoder(res.Body).Decode(&fullPaths); err != nil {
+		return nil, err
+	}
+	paths := make([]string, len(fullPaths))
+	for i, path := range fullPaths {
+		paths[i] = strings.TrimPrefix(path, blobstorePrefix)
+	}
+	return paths, nil
+}
+
+func (d *driver) Move(ctx context.Context, src, dst string) error {
+	req, err := http.NewRequest("PUT", d.blobstoreURL(dst), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Blobstore-Copy-From", d.blobstorePath(src))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return storage.PathNotFoundError{Path: src}
+	} else if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status from blobstore: %s", res.Status)
+	}
+	return d.Delete(ctx, src)
+}
+
+func (d *driver) Delete(ctx context.Context, path string) error {
+	req, err := http.NewRequest("DELETE", d.blobstoreURL(path), nil)
+	if err != nil {
+		return err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status from blobstore: %s", res.Status)
+	}
+	return nil
+}
+
+func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	return "", storage.ErrUnsupportedMethod
+}
+
+func (d *driver) blobstoreURL(path string) string {
+	return "http://blobstore.discoverd" + d.blobstorePath(path)
+}
+
+func (d *driver) blobstorePath(path string) string {
+	return blobstorePrefix + path
+}

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -13,9 +13,9 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/manifest"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/middleware/repository"
-	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver/filesystem"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/docker-receive/blobstore"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/version"
 )
@@ -39,9 +39,7 @@ func main() {
 	config := configuration.Configuration{
 		Version: configuration.CurrentVersion,
 		Storage: configuration.Storage{
-			"filesystem": configuration.Parameters{
-				"rootdirectory": "/data",
-			},
+			blobstore.DriverName: configuration.Parameters{},
 		},
 		Middleware: map[string][]configuration.Middleware{
 			"repository": {

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/configuration"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/digest"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/manifest"
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/middleware/repository"
 	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver/filesystem"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/version"
 )
 
@@ -21,11 +29,23 @@ func main() {
 	ctx = context.WithValue(ctx, "version", version.String())
 	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "version"))
 
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
+	if err != nil {
+		context.GetLogger(ctx).Fatalln(err)
+	}
+
+	middleware.Register("flynn", repositoryMiddleware(client))
+
 	config := configuration.Configuration{
 		Version: configuration.CurrentVersion,
 		Storage: configuration.Storage{
 			"filesystem": configuration.Parameters{
 				"rootdirectory": "/data",
+			},
+		},
+		Middleware: map[string][]configuration.Middleware{
+			"repository": {
+				{Name: "flynn"},
 			},
 		},
 	}
@@ -38,4 +58,73 @@ func main() {
 	if err := http.ListenAndServe(addr, app); err != nil {
 		context.GetLogger(app).Fatalln(err)
 	}
+}
+
+func repositoryMiddleware(client controller.Client) middleware.InitFunc {
+	return func(ctx context.Context, r distribution.Repository, _ map[string]interface{}) (distribution.Repository, error) {
+		return &repository{
+			Repository: r,
+			client:     client,
+		}, nil
+	}
+}
+
+// repository is a repository middleware which returns a custom ManifestService
+// in order to create Flynn artifacts when image manifests are pushed
+type repository struct {
+	distribution.Repository
+
+	client controller.Client
+}
+
+func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	m, err := r.Repository.Manifests(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestService{
+		ManifestService: m,
+		repository:      r,
+		client:          r.client,
+	}, nil
+}
+
+type manifestService struct {
+	distribution.ManifestService
+
+	repository distribution.Repository
+	client     controller.Client
+}
+
+func (m *manifestService) Put(manifest *manifest.SignedManifest) error {
+	if err := m.ManifestService.Put(manifest); err != nil {
+		return err
+	}
+
+	dgst, err := digestManifest(manifest)
+	if err != nil {
+		return err
+	}
+
+	return m.createArtifact(dgst)
+}
+
+func (m *manifestService) createArtifact(dgst digest.Digest) error {
+	return m.client.CreateArtifact(&ct.Artifact{
+		Type: host.ArtifactTypeDocker,
+		URI:  fmt.Sprintf("http://docker-receive.discoverd?name=%s&id=%s", m.repository.Name(), dgst),
+		Meta: map[string]string{
+			"docker-receive.repository": m.repository.Name(),
+		},
+	})
+}
+
+// digestManifest is a modified version of:
+// https://github.com/docker/distribution/blob/6ba799b/registry/handlers/images.go#L228-L251
+func digestManifest(manifest *manifest.SignedManifest) (digest.Digest, error) {
+	p, err := manifest.Payload()
+	if err != nil {
+		return "", err
+	}
+	return digest.FromBytes(p)
 }

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/configuration"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/context"
+	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers"
+	_ "github.com/flynn/flynn/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/driver/filesystem"
+	"github.com/flynn/flynn/pkg/version"
+)
+
+// main is a modified version of the registry main function:
+// https://github.com/docker/distribution/blob/6ba799b/cmd/registry/main.go
+func main() {
+	logrus.SetLevel(logrus.InfoLevel)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "version", version.String())
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "version"))
+
+	config := configuration.Configuration{
+		Version: configuration.CurrentVersion,
+		Storage: configuration.Storage{
+			"filesystem": configuration.Parameters{
+				"rootdirectory": "/data",
+			},
+		},
+	}
+
+	app := handlers.NewApp(ctx, config)
+	// TODO: add status handler
+
+	addr := ":" + os.Getenv("PORT")
+	context.GetLogger(app).Infof("listening on %s", addr)
+	if err := http.ListenAndServe(addr, app); err != nil {
+		context.GetLogger(app).Fatalln(err)
+	}
+}

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -47,6 +47,7 @@ func main() {
 			},
 		},
 	}
+	config.HTTP.Secret = os.Getenv("REGISTRY_HTTP_SECRET")
 
 	app := handlers.NewApp(ctx, config)
 	// TODO: add status handler

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -17,6 +17,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/docker-receive/blobstore"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/version"
 )
 
@@ -49,12 +50,14 @@ func main() {
 	}
 	config.HTTP.Secret = os.Getenv("REGISTRY_HTTP_SECRET")
 
+	status.AddHandler(status.HealthyHandler)
+
 	app := handlers.NewApp(ctx, config)
-	// TODO: add status handler
+	http.Handle("/", app)
 
 	addr := ":" + os.Getenv("PORT")
 	context.GetLogger(app).Infof("listening on %s", addr)
-	if err := http.ListenAndServe(addr, app); err != nil {
+	if err := http.ListenAndServe(addr, nil); err != nil {
 		context.GetLogger(app).Fatalln(err)
 	}
 }

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -128,6 +128,7 @@ func (m *manifestService) createArtifact(dgst digest.Digest) error {
 		URI:  fmt.Sprintf("http://flynn:%s@docker-receive.discoverd?name=%s&id=%s", m.authKey, m.repository.Name(), dgst),
 		Meta: map[string]string{
 			"docker-receive.repository": m.repository.Name(),
+			"docker-receive.digest":     string(dgst),
 		},
 	})
 }

--- a/gitreceive/server.go
+++ b/gitreceive/server.go
@@ -95,7 +95,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, password, _ := utils.ParseBasicAuth(r.Header)
+	_, password, _ := r.BasicAuth()
 	if !hmac.Equal([]byte(password), h.authKey) {
 		w.Header().Set("WWW-Authenticate", "Basic")
 		http.Error(w, "Authentication required", 401)

--- a/pinkerton/context.go
+++ b/pinkerton/context.go
@@ -28,7 +28,10 @@ import (
 	"github.com/flynn/flynn/pkg/version"
 )
 
-const dockerReceiveEndpoint = "docker-receive.discoverd"
+var internalDockerEndpoints = []string{
+	"docker-receive.discoverd",
+	"100.100.0.0/16",
+}
 
 func init() {
 	// This will run docker-untar and docker-applyLayer in a chroot
@@ -57,7 +60,7 @@ func BuildContext(driver, root string) (*Context, error) {
 		Events: events.New(),
 		Registry: registry.NewService(&registry.Options{
 			Mirrors:            opts.NewListOpts(nil),
-			InsecureRegistries: *opts.NewListOptsRef(&[]string{dockerReceiveEndpoint}, nil),
+			InsecureRegistries: *opts.NewListOptsRef(&internalDockerEndpoints, nil),
 		}),
 	}
 	store, err := graph.NewTagStore(filepath.Join(root, "repositories-"+d.String()), config)

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -84,7 +84,7 @@ main() {
 
   export FLYNNRC=/tmp/flynnrc
   "${flynn}" cluster remove default
-  "${flynn}" ${cluster_add:6}
+  "${flynn}" cluster add --docker ${cluster_add:18}
 
   cd "${ROOT}/test"
 

--- a/status/status.go
+++ b/status/status.go
@@ -14,7 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/cache"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/status"
@@ -80,7 +79,7 @@ func (s *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !authed {
-			_, password, _ := utils.ParseBasicAuth(r.Header)
+			_, password, _ := r.BasicAuth()
 			if password == "" {
 				password = r.URL.Query().Get("key")
 			}

--- a/status/status.go
+++ b/status/status.go
@@ -153,6 +153,7 @@ var services = []Service{
 	{Name: "discoverd"},
 	{Name: "flannel"},
 	{Name: "gitreceive", ReqFn: RandomReqFn("gitreceive")},
+	{Name: "docker-receive", ReqFn: RandomReqFn("docker-receive")},
 	{Name: "logaggregator", ReqFn: LeaderReqFn("logaggregator", "80")},
 	{Name: "postgres", ReqFn: LeaderReqFn("postgres", "5433")},
 	{Name: "mariadb", ReqFn: LeaderReqFn("mariadb", "3307"), Optional: true},

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -367,6 +367,7 @@ func (c *Cluster) CLIConfig() (*config.Config, error) {
 		Name:          "default",
 		ControllerURL: "https://controller." + c.ClusterDomain,
 		GitURL:        "https://git." + c.ClusterDomain,
+		DockerURL:     "https://docker." + c.ClusterDomain,
 		Key:           c.ControllerKey,
 		TLSPin:        c.ControllerPin,
 	}

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -367,7 +367,7 @@ func (c *Cluster) CLIConfig() (*config.Config, error) {
 		Name:          "default",
 		ControllerURL: "https://controller." + c.ClusterDomain,
 		GitURL:        "https://git." + c.ClusterDomain,
-		DockerURL:     "https://docker." + c.ClusterDomain,
+		DockerPushURL: "https://docker." + c.ClusterDomain,
 		Key:           c.ControllerKey,
 		TLSPin:        c.ControllerPin,
 	}

--- a/test/helper.go
+++ b/test/helper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -267,6 +268,12 @@ func (h *Helper) assertURI(t *c.C, uri string, status int) {
 	t.Assert(err, c.IsNil)
 	res.Body.Close()
 	t.Assert(res.StatusCode, c.Equals, status)
+}
+
+func (h *Helper) buildDockerImage(t *c.C, repo string, lines ...string) {
+	cmd := exec.Command("docker", "build", "--tag", repo, "-")
+	cmd.Stdin = bytes.NewReader([]byte(fmt.Sprintf("FROM flynn/test-apps\n%s\n", strings.Join(lines, "\n"))))
+	t.Assert(run(t, cmd), Succeeds)
 }
 
 type gitRepo struct {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -322,7 +322,7 @@ script/configure-docker "{{ .Cluster.ClusterDomain }}"
 cli/bin/flynn cluster add \
   --tls-pin "{{ .Config.TLSPin }}" \
   --git-url "{{ .Config.GitURL }}" \
-  {{ if .Config.DockerURL }}--docker-url "{{ .Config.DockerURL }}"{{ end }} \
+  --docker-url "{{ .Config.DockerURL }}" \
   default \
   {{ .Config.ControllerURL }} \
   {{ .Config.Key }}

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -322,7 +322,7 @@ script/configure-docker "{{ .Cluster.ClusterDomain }}"
 cli/bin/flynn cluster add \
   --tls-pin "{{ .Config.TLSPin }}" \
   --git-url "{{ .Config.GitURL }}" \
-  --docker-url "{{ .Config.DockerURL }}" \
+  --docker-push-url "{{ .Config.DockerPushURL }}" \
   default \
   {{ .Config.ControllerURL }} \
   {{ .Config.Key }}

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -182,7 +182,7 @@ func (s *ControllerSuite) TestKeyRotation(t *c.C) {
 	t.Assert(set, Succeeds)
 
 	// reconfigure components to use new key
-	for _, app := range []string{"gitreceive", "taffy", "dashboard"} {
+	for _, app := range []string{"gitreceive", "docker-receive", "taffy", "dashboard"} {
 		set := flynn(t, "/", "-a", app, "env", "set", "CONTROLLER_KEY="+newKey)
 		t.Assert(set, Succeeds)
 	}

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"time"
+
+	c "github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-check"
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+type DockerReceiveSuite struct {
+	Helper
+}
+
+var _ = c.Suite(&DockerReceiveSuite{})
+
+func (s *DockerReceiveSuite) TestPushImage(t *c.C) {
+	// build a Docker image
+	u, err := url.Parse(s.clusterConf(t).DockerURL)
+	t.Assert(err, c.IsNil)
+	name := fmt.Sprintf("%s/test:latest", u.Host)
+	cmd := exec.Command("docker", "build", "--tag", name, "-")
+	cmd.Stdin = bytes.NewReader([]byte(`
+	FROM flynn/test-apps
+	RUN echo foo > /foo.txt
+	`))
+	t.Assert(run(t, cmd), Succeeds)
+
+	// subscribe to artifact events
+	client := s.controllerClient(t)
+	events := make(chan *ct.Event)
+	stream, err := client.StreamEvents(ct.StreamEventsOptions{
+		ObjectTypes: []ct.EventType{ct.EventTypeArtifact},
+	}, events)
+	t.Assert(err, c.IsNil)
+	defer stream.Close()
+
+	// push the Docker image to docker-receive
+	t.Assert(run(t, exec.Command("docker", "push", name)), Succeeds)
+
+	// wait for an artifact to be created
+	var artifact ct.Artifact
+loop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatalf("event stream closed unexpectedly: %s", stream.Err())
+			}
+			t.Assert(json.Unmarshal(event.Data, &artifact), c.IsNil)
+			if artifact.Meta["docker-receive.repository"] == "test" {
+				break loop
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for artifact")
+		}
+	}
+
+	// create a release with the Docker artifact
+	app := &ct.App{}
+	t.Assert(client.CreateApp(app), c.IsNil)
+	release := &ct.Release{ArtifactIDs: []string{artifact.ID}}
+	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.SetAppRelease(app.ID, release.ID), c.IsNil)
+
+	// check running a job uses the image
+	t.Assert(flynn(t, "/", "-a", app.ID, "run", "cat", "/foo.txt"), SuccessfulOutputContains, "foo")
+}

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -32,7 +32,7 @@ func (s *DockerReceiveSuite) TestPushImage(t *c.C) {
 	defer stream.Close()
 
 	// push the Docker image to docker-receive
-	u, err := url.Parse(s.clusterConf(t).DockerURL)
+	u, err := url.Parse(s.clusterConf(t).DockerPushURL)
 	t.Assert(err, c.IsNil)
 	tag := fmt.Sprintf("%s/%s:latest", u.Host, repo)
 	t.Assert(run(t, exec.Command("docker", "tag", "--force", repo, tag)), Succeeds)

--- a/test/test_healthcheck.go
+++ b/test/test_healthcheck.go
@@ -130,7 +130,7 @@ func (s *HealthcheckSuite) TestStatus(t *c.C) {
 	t.Assert(err, c.IsNil)
 
 	t.Assert(data.Data.Status, c.Equals, status.CodeHealthy)
-	t.Assert(data.Data.Detail, c.HasLen, 12)
+	t.Assert(data.Data.Detail, c.HasLen, 13)
 	optional := map[string]bool{"mariadb": true}
 	for name, s := range data.Data.Detail {
 		if !optional[name] {

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -27,6 +27,7 @@ var SystemApps = []SystemApp{
 	{Name: "dashboard"},
 	{Name: "router"},
 	{Name: "gitreceive"},
+	{Name: "docker-receive"},
 	{Name: "controller"},
 	{Name: "logaggregator"},
 	{

--- a/util/release/version_template.json
+++ b/util/release/version_template.json
@@ -14,5 +14,6 @@
   "flynn/logaggregator": "$image_id[logaggregator]",
   "flynn/status": "$image_id[status]",
   "flynn/redis": "$image_id[redis]",
-  "flynn/mariadb": "$image_id[mariadb]"
+  "flynn/mariadb": "$image_id[mariadb]",
+  "flynn/docker-receive": "$image_id[docker-receive]"
 }


### PR DESCRIPTION
This adds a `docker-receive` app which receives Docker images from `docker push` and creates corresponding artifacts, and `flynn docker push` which also deploys them to the cluster.

Running `flynn cluster add ...` will attempt to configure the local Docker client using `docker login`, but this can fail if the Docker daemon does not trust the Flynn cluster's CA certificate, in which case a warning is printed like:

```
WARN: docker configuration failed with a TLS error.
WARN:
WARN: Copy the TLS CA certificate /home/ubuntu/.flynn/ca-certs/default.pem
WARN: to /etc/docker/certs.d/docker.1.localflynn.com/ca.crt
WARN: on the docker daemon's host and restart docker.
```

Following the instructions then re-running the `flynn cluster add ...` command (or `flynn docker login`) should work.

Assuming things are configured, here is an example of deploying elasticsearch:

```
$ docker pull elasticsearch:2.3.3

$ flynn create --remote "" elasticsearch
Created elasticsearch

$ flynn -a elasticsearch docker push elasticsearch:2.3.3
flynn: getting image config with "docker inspect -f {{ json .Config }} elasticsearch:2.3.3"
flynn: tagging Docker image with "docker tag --force elasticsearch:2.3.3 docker.1.localflynn.com/elasticsearch:latest"
flynn: pushing Docker image with "docker push docker.1.localflynn.com/elasticsearch:latest"
The push refers to a repository [docker.1.localflynn.com/elasticsearch] (len: 1)
a8eb754d1a89: Pushed 
6162aa7ca453: Pushed 
...
4e59e6df754e: Pushed 
3059b4820522: Pushed 
latest: digest: sha256:1752ca12bbedb99734ca1ba3ec35720768a95ad83b7b6c371fc37a28b98ea351 size: 61216
flynn: image pushed, waiting for artifact creation
flynn: deploying release using artifact URI http://docker-receive.discoverd?name=elasticsearch&id=sha256:1752ca12bbedb99734ca1ba3ec35720768a95ad83b7b6c371fc37a28b98ea351
flynn: image deployed, scale it with 'flynn scale app=N'

$ flynn -a elasticsearch scale app=1
scaling app: 0=>1

18:05:38.308 ==> app fd8266b1-453d-4733-9417-2ad9ac33a418 pending
18:05:38.308 ==> app host0-fd8266b1-453d-4733-9417-2ad9ac33a418 starting
18:05:41.018 ==> app host0-fd8266b1-453d-4733-9417-2ad9ac33a418 up

scale completed in 2.728163927s

$ flynn -a elasticsearch run curl http://elasticsearch.discoverd:9200
{
  "name" : "Hate-Monger",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "2.3.3",
    "build_hash" : "218bdf10790eef486ff2c41a3df5cfa32dadcfde",
    "build_timestamp" : "2016-05-17T15:40:04Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.0"
  },
  "tagline" : "You Know, for Search"
}
```

Closes #2763.