### PR TITLE
slugbuilder: Don't checkout origin/HEAD when cloning buildpacks

### DIFF
--- a/slugbuilder/builder/install-buildpack
+++ b/slugbuilder/builder/install-buildpack
@@ -33,7 +33,7 @@ IFS='#' read url treeish <<< "${buildpack_url}"
 if [[ "${treeish}" == "" ]]; then
   git clone --recursive --depth=1 "${url}" "${buildpack_name}"
 else
-  git clone --recursive "${url}" "${buildpack_name}"
+  git clone --recursive --no-checkout "${url}" "${buildpack_name}"
   pushd ${buildpack_name} > /dev/null
   git checkout -q "${treeish}"
   rm -rf .git


### PR DESCRIPTION
The Go buildpack is currently failing to clone due to a missing .gitmodules file (see https://github.com/heroku/heroku-buildpack-go/pull/134).

Given we checkout an explicit version, there is no need to checkout origin/HEAD first.