### PR TITLE
host/cli: collect-debug-info improvements

### DIFF
--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -138,6 +138,9 @@ func captureJobs(gist *Gist, env bool, lines int) error {
 
 	for _, job := range jobs {
 		var name string
+		if system, ok := job.Job.Metadata["flynn-system-app"]; !ok || system != "true" {
+			continue // Skip non-system applications
+		}
 		if app, ok := job.Job.Metadata["flynn-controller.app_name"]; ok {
 			name += app + "-"
 		}

--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -88,7 +88,11 @@ func runCollectDebugInfo(args *docopt.Args) error {
 	}
 	gist.AddFile("0-debug-output.log", debugOutput)
 
-	if args.Bool["--tarball"] {
+	if gist.Size > GistMaxSize {
+		log.Info(fmt.Sprintf("Total size of %d bytes exceeds gist limit, falling back to tarball.", gist.Size))
+	}
+
+	if args.Bool["--tarball"] || gist.Size > GistMaxSize {
 		path, err := gist.CreateTarball()
 		if err != nil {
 			log.Error("error creating tarball", "err", err)

--- a/host/cli/collect-debug-info.go
+++ b/host/cli/collect-debug-info.go
@@ -3,10 +3,8 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/flynn/go-docopt"
@@ -46,18 +44,12 @@ usage: flynn-host collect-debug-info [options]
 Options:
   --tarball          Create a tarball instead of uploading to a gist
   --include-env      Include sensitive environment variables
-  --job-lines=<num>  Maximum number of lines to fetch from each job [default: 1000]
 
 Collect debug information into an anonymous gist or tarball`)
 }
 
 func runCollectDebugInfo(args *docopt.Args) error {
 	log := log15.New()
-	lines, err := strconv.Atoi(args.String["--job-lines"])
-	if err != nil {
-		return err
-	}
-
 	if args.Bool["--tarball"] {
 		log.Info("creating a tarball containing logs and debug information")
 	} else {
@@ -79,9 +71,9 @@ func runCollectDebugInfo(args *docopt.Args) error {
 	}
 
 	log.Info("getting job logs")
-	if err := captureJobs(gist, args.Bool["--include-env"], lines); err != nil {
+	if err := captureJobs(gist, args.Bool["--include-env"]); err != nil {
 		log.Error("error getting job logs, falling back to on-disk logs", "err", err)
-		debugCmds = append(debugCmds, []string{"bash", "-c", fmt.Sprintf("tail -n %d /var/log/flynn/*.log", lines)})
+		debugCmds = append(debugCmds, []string{"bash", "-c", "tail -n+1 /var/log/flynn/*.log"})
 	}
 
 	log.Info("getting system information")
@@ -124,7 +116,7 @@ func captureCmd(name string, arg ...string) (string, error) {
 	return buf.String(), nil
 }
 
-func captureJobs(gist *Gist, env bool, lines int) error {
+func captureJobs(gist *Gist, env bool) error {
 	client := cluster.NewClient()
 
 	jobs, err := jobList(client, true)
@@ -152,15 +144,7 @@ func captureJobs(gist *Gist, env bool, lines int) error {
 		var content bytes.Buffer
 		printJobDesc(&job, &content, env)
 		fmt.Fprint(&content, "\n\n***** ***** ***** ***** ***** ***** ***** ***** ***** *****\n\n")
-		stdoutR, stdoutW := io.Pipe()
-		stderrR, stderrW := io.Pipe()
-		go func() {
-			getLog(job.HostID, job.Job.ID, client, false, true, stdoutW, stderrW)
-			stdoutW.Close()
-			stderrW.Close()
-		}()
-		tailLogs(stdoutR, stderrR, lines, &content, &content)
-
+		getLog(job.HostID, job.Job.ID, client, false, true, &content, &content)
 		gist.AddFile(name, content.String())
 	}
 

--- a/host/cli/gist.go
+++ b/host/cli/gist.go
@@ -19,11 +19,15 @@ import (
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
 )
 
+// Actual limit is likely ~200mb.
+const GistMaxSize = 195 * 1024 * 1024
+
 type Gist struct {
 	URL         string          `json:"html_url,omitempty"`
 	Description string          `json:"description"`
 	Public      bool            `json:"public"`
 	Files       map[string]File `json:"files"`
+	Size        int
 }
 
 func (g *Gist) AddLocalFile(name, filepath string) error {
@@ -37,6 +41,7 @@ func (g *Gist) AddLocalFile(name, filepath string) error {
 
 func (g *Gist) AddFile(name, content string) {
 	g.Files[name] = File{Content: content}
+	g.Size = g.Size + len(content)
 }
 
 func (g *Gist) Upload(log log15.Logger) error {


### PR DESCRIPTION
Namely always collects full log files now.
Unless it needs to switch to fallback it will only collect system logs.
If the total file size exceeds the gist limit then it will automatically fallback to tarball.