### PR TITLE
script: Add --peers to start-flynn-host

### DIFF
--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -4,6 +4,7 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "${ROOT}/script/lib/ui.sh"
+source "${ROOT}/script/lib/util.sh"
 
 usage() {
   cat <<USAGE >&2
@@ -95,6 +96,7 @@ main() {
   # kill flynn first
   "${ROOT}/script/kill-flynn"
 
+  # populate IP list for bootstrap
   local ips=()
   info "starting ${size} node cluster"
 
@@ -105,10 +107,7 @@ main() {
     # An RFC 5737 TEST-NET IP
     local ip="192.0.2.20$(($index))"
     ips+=("${ip}")
-
-    info "starting flynn-host using IP ${ip}"
-    sudo ifconfig "eth0:${index}" "${ip}"
-    "${ROOT}/script/start-flynn-host" "${host_flags}" "${ip}" "${index}"
+    "${ROOT}/script/start-flynn-host" "${host_flags}" "${index}"
   done
 
   info "bootstrapping Flynn"
@@ -120,12 +119,6 @@ main() {
     --min-hosts="${size}" \
     --peer-ips="$(join "," ${ips[@]})" \
     "${manifest}"
-}
-
-join() {
-  local IFS="$1"
-  shift
-  echo "$*"
 }
 
 main $@

--- a/script/lib/util.sh
+++ b/script/lib/util.sh
@@ -4,3 +4,9 @@ sha256() {
   local file=$1
   sha256sum "${file}" | cut -d " " -f 1
 }
+
+join() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -4,10 +4,11 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "${ROOT}/script/lib/ui.sh"
+source "${ROOT}/script/lib/util.sh"
 
 usage() {
   cat <<USAGE >&2
-usage: $0 IP INDEX
+usage: $0 INDEX
 
 Start a flynn node with specific binary, ip and index
 USAGE
@@ -16,6 +17,7 @@ USAGE
 main() {
   local destroy_vols=true
   local destroy_state=true
+  local peers=()
 
   while true; do
     case "$1" in
@@ -27,19 +29,26 @@ main() {
         destroy_vols=false
         shift
         ;;
+      -p | --peers)
+        # Initialises array by replacing , with whitespace
+        peers=(${2//,/ })
+        shift 2
+        ;;
       *)
         break
         ;;
     esac
   done
 
-  if [[ $# -ne 2 ]]; then
+  if [[ $# -ne 1 ]]; then
     usage
     exit 1
   fi
 
-  local ip=$1
-  local index=$2
+  local index=$1
+
+  # An RFC 5737 TEST-NET IP
+  local ip="192.0.2.20$(($index))"
 
   local bin_dir="${ROOT}/host/bin"
   local flynn_host="${bin_dir}/flynn-host"
@@ -51,6 +60,7 @@ main() {
   local vol_path="/var/lib/flynn/volumes-${index}"
   local log_dir="/var/log/flynn/host-${index}"
   local log="/tmp/flynn-host-${index}-$(date +%Y-%m-%dT%H-%M-%S.%N).log"
+  local peer_ips=""
   ln -nfs "${log}" "/tmp/flynn-host-${index}.log"
 
   # delete the old state
@@ -60,6 +70,20 @@ main() {
 
   if $destroy_vols; then
     sudo "${flynn_host}" destroy-volumes --volpath="${vol_path}" --include-data
+  fi
+
+  # create IP on eth0 interface
+  info "starting flynn-host using IP ${ip}"
+  sudo ifconfig "eth0:${index}" "$ip"
+
+  # if the number of peers given is > 0 then join existing cluster
+  if [[ ${#peers[@]} -gt 0 ]]; then
+    local ips=()
+    for i in ${peers[@]}; do
+      ips+=("192.0.2.20$(($i))")
+    done
+    info "joining to existing cluster"
+    peer_ips="--peer-ips=$(join "," ${ips[@]})"
   fi
 
   # ensure log dir exists
@@ -83,6 +107,7 @@ main() {
     --log-dir "${log_dir}" \
     --flynn-init "${bin_dir}/flynn-init" \
     --nsumount "${bin_dir}/flynn-nsumount" \
+    ${peer_ips} \
     &>"${log}"
 
 }


### PR DESCRIPTION
This makes it easier to test scenarios that require adding/removing
hosts from the cluster manually.

After bootstrapping a cluster with `bootstrap-flynn --size $SIZE` you can then add a new peer by providing it with the indices of the peers you want it to connect to. i.e `start-flynn-host --peers 0,1,2 3`.
This will start the new host at index 3 (`192.0.2.203`) connecting to the existing peers.