### PR TITLE
discoverd: Improvements to promotion/demotion

### DIFF
--- a/discoverd/server/store.go
+++ b/discoverd/server/store.go
@@ -316,6 +316,8 @@ func (s *Store) AddPeer(peer string) error {
 	err := s.raft.AddPeer(peer).Error()
 	if err == raft.ErrNotLeader {
 		err = ErrNotLeader
+	} else if err == raft.ErrKnownPeer {
+		return nil
 	}
 	return err
 }
@@ -325,6 +327,8 @@ func (s *Store) RemovePeer(peer string) error {
 	err := s.raft.RemovePeer(peer).Error()
 	if err == raft.ErrNotLeader {
 		err = ErrNotLeader
+	} else if err == raft.ErrUnknownPeer {
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
This aims to make promotion and demotion requests idempotent.
Firstly by making requests to add/remove peers from the cluster idempotent and further by altering the promotion/demotion logic to be tolerant of being requested to demote/promote oneself when it appears it should already be in that state.