### PR TITLE
cli: Don't wait for job events if expected count is 0

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -219,6 +219,11 @@ func scaleToZero(appName string, client controller.Client) error {
 	}
 	processes := make(map[string]int)
 	expected := client.ExpectedScalingEvents(formation.Processes, processes, release.Processes, 1)
+
+	if expected.Count() == 0 {
+		return nil
+	}
+
 	watcher, err := client.WatchJobEvents(appName, release.ID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes deleting apps that have been scaled to 0.

Fixes #2901