### PR TITLE
controller: Add version endpoint

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -29,6 +29,7 @@ usage: flynn cluster
        flynn cluster default [<cluster-name>]
        flynn cluster migrate-domain <domain>
        flynn cluster backup [--file <file>]
+       flynn cluster version
 
 Manage Flynn clusters.
 
@@ -70,6 +71,9 @@ Commands:
         options:
             --file=<backup-file>  file to write backup to (defaults to stdout)
 
+    version
+        Reports the Flynn version the cluster is running.
+
 Examples:
 
 	$ flynn cluster add -p KGCENkp53YF5OvOKkZIry71+czFRkSw2ZdMszZ/0ljs= default dev.localflynn.com e09dc5301d72be755a3d666f617c4600
@@ -79,6 +83,9 @@ Examples:
 	Migrate cluster domain from "example.com" to "new.example.com"? (yes/no): yes
 	Migrating cluster domain (this can take up to 2m0s)...
 	Changed cluster domain from "example.com" to "new.example.com"
+
+	$ flynn cluster version
+	v20160609.0
 `)
 }
 
@@ -97,6 +104,8 @@ func runCluster(args *docopt.Args) error {
 		return runClusterMigrateDomain(args)
 	} else if args.Bool["backup"] {
 		return runClusterBackup(args)
+	} else if args.Bool["version"] {
+		return runGetClusterVersion(args)
 	}
 
 	w := tabWriter()
@@ -411,5 +420,18 @@ func runClusterBackup(args *docopt.Args) error {
 	}
 	fmt.Fprintln(os.Stderr, "Backup complete.")
 
+	return nil
+}
+
+func runGetClusterVersion(args *docopt.Args) error {
+	client, err := getClusterClient()
+	if err != nil {
+		return err
+	}
+	v, err := client.GetVersion()
+	if err != nil {
+		return err
+	}
+	fmt.Println(v)
 	return nil
 }

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -19,6 +19,7 @@ import (
 )
 
 type Client interface {
+	GetVersion() (string, error)
 	GetCACert() ([]byte, error)
 	StreamFormations(since *time.Time, output chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	PutDomain(dm *ct.DomainMigration) error

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -101,6 +101,20 @@ func jobEventsEqual(expected, actual ct.JobEvents) bool {
 	return true
 }
 
+// GetVersion returns the Flynn version running on the cluster
+func (c *Client) GetVersion() (string, error) {
+	var version bytes.Buffer
+	res, err := c.RawReq("GET", "/version", nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	if _, err := io.Copy(&version, res.Body); err != nil {
+		return "", err
+	}
+	return version.String(), nil
+}
+
 // GetCACert returns the CA cert for the controller
 func (c *Client) GetCACert() ([]byte, error) {
 	var cert bytes.Buffer

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/status"
+	"github.com/flynn/flynn/pkg/version"
 	routerc "github.com/flynn/flynn/router/client"
 	"github.com/flynn/flynn/router/types"
 )
@@ -241,6 +242,10 @@ func appHandler(c handlerConfig) http.Handler {
 	shutdown.BeforeExit(api.Shutdown)
 
 	httpRouter := httprouter.New()
+
+	httpRouter.Handler("GET", "/version", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(version.String()))
+	}))
 
 	crud(httpRouter, "apps", ct.App{}, appRepo)
 	crud(httpRouter, "releases", ct.Release{}, releaseRepo)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/testutils/postgres"
+	"github.com/flynn/flynn/pkg/version"
 )
 
 func init() {
@@ -105,6 +106,12 @@ func (s *S) SetUpSuite(c *C) {
 
 func (s *S) SetUpTest(c *C) {
 	s.cc.SetHosts(make(map[string]*tu.FakeHostClient))
+}
+
+func (s *S) TestGetVersion(c *C) {
+	v, err := s.c.GetVersion()
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, version.String())
 }
 
 func (s *S) TestBadAuth(c *C) {

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -28,6 +28,7 @@ import (
 	"github.com/flynn/flynn/pkg/attempt"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/tlscert"
+	"github.com/flynn/flynn/pkg/version"
 )
 
 type CLISuite struct {
@@ -1320,4 +1321,10 @@ func (s *CLISuite) TestDockerExportImport(t *c.C) {
 	// wait for it to start
 	_, err := s.discoverdClient(t).Instances(importApp, 10*time.Second)
 	t.Assert(err, c.IsNil)
+}
+
+func (s *CLISuite) TestClusterVersion(t *c.C) {
+	out := flynn(t, "cluster", "version")
+	t.Assert(out, Succeeds)
+	t.Assert(out.Output, c.Equals, version.String()+"\n")
 }


### PR DESCRIPTION
This will be used for determining which version of the controller client to use once there's more than one, and also for #2921.