### PR TITLE
status: Make the docker-receive app optional

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -152,7 +152,7 @@ var services = []Service{
 	{Name: "discoverd"},
 	{Name: "flannel"},
 	{Name: "gitreceive", ReqFn: RandomReqFn("gitreceive")},
-	{Name: "docker-receive", ReqFn: RandomReqFn("docker-receive")},
+	{Name: "docker-receive", ReqFn: RandomReqFn("docker-receive"), Optional: true},
 	{Name: "logaggregator", ReqFn: LeaderReqFn("logaggregator", "80")},
 	{Name: "postgres", ReqFn: LeaderReqFn("postgres", "5433")},
 	{Name: "mariadb", ReqFn: LeaderReqFn("mariadb", "3307"), Optional: true},


### PR DESCRIPTION
Users restoring from a cluster backup may not have a docker-receive release, so docker-receive will not start as part of bootstrap, causing the final status check to fail.

Given not all users will be using docker-receive, we should just make it optional and have a mechanism to create a release and scale it up when pushing an image.