### PR TITLE
controller/client: Remove deploy stream timeout

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/julienschmidt/httprouter"
 	"github.com/flynn/flynn/Godeps/_workspace/src/gopkg.in/inconshreveable/log15.v2"
@@ -247,7 +248,9 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 	h.Logger.Info("formation", "formation", fmt.Sprintf("%#v", formation))
 
 	h.Logger.Info("deploying app release", "release.ID", release.ID)
-	if err := h.ControllerClient.DeployAppRelease(app.ID, release.ID); err != nil {
+	timeoutCh := make(chan struct{})
+	time.AfterFunc(5*time.Minute, func() { close(timeoutCh) })
+	if err := h.ControllerClient.DeployAppRelease(app.ID, release.ID, timeoutCh); err != nil {
 		h.Logger.Error("error deploying release", "err", err)
 		httphelper.Error(w, err)
 		return

--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"time"
+
 	ct "github.com/flynn/flynn/controller/types"
 )
 
@@ -104,5 +106,7 @@ func (a *DeployAppAction) Run(s *State) error {
 	}
 	as.Formation = formation
 
-	return client.DeployAppRelease(a.App.ID, a.Release.ID)
+	timeoutCh := make(chan struct{})
+	time.AfterFunc(5*time.Minute, func() { close(timeoutCh) })
+	return client.DeployAppRelease(a.App.ID, a.Release.ID, timeoutCh)
 }

--- a/cli/docker.go
+++ b/cli/docker.go
@@ -266,7 +266,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 	if err := client.CreateRelease(release); err != nil {
 		return err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 	log.Printf("flynn: image deployed, scale it with 'flynn scale app=N'")

--- a/cli/env.go
+++ b/cli/env.go
@@ -189,7 +189,7 @@ func setEnv(client controller.Client, proc string, env map[string]*string) (stri
 	if err := client.CreateRelease(release); err != nil {
 		return "", err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return "", err
 	}
 	return release.ID, nil

--- a/cli/limit.go
+++ b/cli/limit.go
@@ -134,7 +134,7 @@ func runLimitSet(args *docopt.Args, client controller.Client) error {
 	if err := client.CreateRelease(release); err != nil {
 		return err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 	fmt.Printf("Created release %s\n", release.ID)

--- a/cli/release.go
+++ b/cli/release.go
@@ -213,7 +213,7 @@ func runReleaseAddDocker(args *docopt.Args, client controller.Client) error {
 		return err
 	}
 
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 
@@ -302,7 +302,7 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 		return err
 	}
 
-	if err := client.DeployAppRelease(mustApp(), release.ID); err != nil {
+	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
 		return err
 	}
 

--- a/controller/app.go
+++ b/controller/app.go
@@ -197,7 +197,7 @@ func (r *AppRepo) Update(id string, data map[string]interface{}) (interface{}, e
 				return nil, fmt.Errorf("controller: expected json.Number, got %T", v)
 			}
 			t, err := timeout.Int64()
-			if !ok {
+			if err != nil {
 				tx.Rollback()
 				return nil, fmt.Errorf("controller: unable to decode json.Number: %s", err)
 			}

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -63,7 +63,7 @@ type Client interface {
 	CreateDeployment(appID, releaseID string) (*ct.Deployment, error)
 	DeploymentList(appID string) ([]*ct.Deployment, error)
 	StreamDeployment(d *ct.Deployment, output chan *ct.DeploymentEvent) (stream.Stream, error)
-	DeployAppRelease(appID, releaseID string) error
+	DeployAppRelease(appID, releaseID string, stopWait <-chan struct{}) error
 	StreamJobEvents(appID string, output chan *ct.Job) (stream.Stream, error)
 	WatchJobEvents(appID, releaseID string) (ct.JobWatcher, error)
 	StreamEvents(opts ct.StreamEventsOptions, output chan *ct.Event) (stream.Stream, error)

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -198,7 +198,7 @@ Options:
 	if err := client.CreateRelease(release); err != nil {
 		log.Fatalln("Error creating release:", err)
 	}
-	if err := client.DeployAppRelease(app.Name, release.ID); err != nil {
+	if err := client.DeployAppRelease(app.Name, release.ID, nil); err != nil {
 		log.Fatalln("Error deploying app release:", err)
 	}
 

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -1211,10 +1211,12 @@ func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
 	defer stream.Close()
 
 	// deploy a new release with the same slug as the last release
+	timeoutCh := make(chan struct{})
+	time.AfterFunc(5*time.Minute, func() { close(timeoutCh) })
 	newRelease := *lastRelease
 	newRelease.ID = ""
 	t.Assert(client.CreateRelease(&newRelease), c.IsNil)
-	t.Assert(client.DeployAppRelease(app.ID, newRelease.ID), c.IsNil)
+	t.Assert(client.DeployAppRelease(app.ID, newRelease.ID, timeoutCh), c.IsNil)
 
 	// wait for garbage collection
 	select {


### PR DESCRIPTION
The `deploy_timeout` field is already used to time out waiting for individual jobs to start. Using the same value for an overall timeout is unnecessary and confusing.

Closes #2159
Closes #2826