### PR TITLE
scheduler: Reset HostID when placing jobs

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -690,6 +690,10 @@ func (s *Scheduler) HandlePlacementRequest(req *PlacementRequest) {
 		return
 	}
 
+	// reset the job's HostID in case we already placed it but it failed to
+	// start
+	req.Job.HostID = ""
+
 	formation := req.Job.Formation
 	counts := s.jobs.GetHostJobCounts(formation.key(), req.Job.Type)
 	var minCount int = math.MaxInt32


### PR DESCRIPTION
This is particularly problematic if we fail to place an omni job, because subsequent placements will treat all hosts as having the requested number of omni jobs, and a host will be picked at random, leading to stopSurplusOmniJobs stopping the job just placed and leading to flapping jobs.