### PR TITLE
discoverd: Don't error if DNS isn't running during promote/demote

### DIFF
--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -329,9 +329,6 @@ func (m *Main) Promote() error {
 	// Update the DNS server to use the local store.
 	if m.dnsServer != nil {
 		m.dnsServer.SetStore(m.store)
-	} else {
-		// This should never happen, we should always have a running DNS server at this point
-		return fmt.Errorf("No DNS server open during promotion")
 	}
 
 	// Update the HTTP server to use the local store.
@@ -366,9 +363,6 @@ func (m *Main) Demote() error {
 	// Update the dns server to use proxy store
 	if m.dnsServer != nil {
 		m.dnsServer.SetStore(&server.ProxyStore{Peers: m.peers})
-	} else {
-		// This should never happen, we should always have a running DNS server at this point
-		return fmt.Errorf("No DNS server open during promotion")
 	}
 
 	// Set handler into proxy mode


### PR DESCRIPTION
If the DNS server hasn't been started yet it's likely we are
are waiting on the host network to be configured.
Because we hold the lock after waitHostDNSConfig() unblocks the DNS
configuration will block on us releasing the lock.
Once this happens the DNS server will be properly configured taking into
account the state after promotion/demotion.

This basically fixes a race where if a new node is added and promote is called before Flannel has come up and notified the host + discoverd has recognized and configured it's DNS server.