### PR TITLE
router: Re-enable upgrade path test

### DIFF
--- a/router/http_test.go
+++ b/router/http_test.go
@@ -1291,10 +1291,7 @@ func (s *S) TestClosedBackendRetriesAnotherBackend(c *C) {
 	tests := []ts{
 		{method: "GET", upgrade: false},
 		{method: "GET", upgrade: true},
-		// XXX(jpg): Something causing this to fail in Go 1.4.3 upgrade
-		// must investigate if this is an actual problem or a change in
-		// behavior that doesn't harm the actual function of the router
-		// {method: "POST", upgrade: false},
+		{method: "POST", upgrade: false},
 		{method: "POST", upgrade: true},
 	}
 


### PR DESCRIPTION
This test was broken by a bug in request smuggling protection in
Go 1.4.2. Re-enable the test that we have now upgraded to Go 1.6.2

Fixes #2358