### PR TITLE
logaggregator: Fix race in TestHostCursors

### DIFF
--- a/logaggregator/server.go
+++ b/logaggregator/server.go
@@ -30,6 +30,8 @@ type Server struct {
 
 	api      http.Handler
 	shutdown chan struct{}
+
+	testMessageHook chan struct{}
 }
 
 type ServerConfig struct {
@@ -186,6 +188,9 @@ func (s *Server) drainSyslogConn(conn net.Conn) {
 		} else {
 			s.Cursors.Update(string(msg.Hostname), cursor)
 			s.Aggregator.Feed(msg)
+		}
+		if s.testMessageHook != nil {
+			s.testMessageHook <- struct{}{}
 		}
 	}
 }

--- a/logaggregator/server_test.go
+++ b/logaggregator/server_test.go
@@ -57,6 +57,7 @@ func (s *ServerTestSuite) TestServerDurability(c *C) {
 
 func (s *ServerTestSuite) TestHostCursors(c *C) {
 	srv := testServer(c)
+	srv.testMessageHook = make(chan struct{}, 1)
 	c.Assert(srv.Start(), IsNil)
 	defer srv.Shutdown()
 	cl := testClient(c, srv)
@@ -72,6 +73,7 @@ func (s *ServerTestSuite) TestHostCursors(c *C) {
 	}
 	write := func(msg *rfc5424.Message) {
 		conn.Write(rfc6587.Bytes(msg))
+		<-srv.testMessageHook
 	}
 
 	// write some messages


### PR DESCRIPTION
Message processing happens in an independent goroutine, so we can’t just assume that they are processed after writing to the socket.