### PR TITLE
router: Store certificate SHA-256 as binary not hex

### DIFF
--- a/router/data_store.go
+++ b/router/data_store.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -183,9 +182,9 @@ func (d *pgDataStore) AddCert(c *router.Certificate) error {
 func (d *pgDataStore) addCertWithTx(tx *pgx.Tx, c *router.Certificate) error {
 	c.Cert = strings.Trim(c.Cert, " \n")
 	c.Key = strings.Trim(c.Key, " \n")
-	tlsCertSHA256 := hex.EncodeToString(sha256.New().Sum([]byte(c.Cert)))
-	if err := tx.QueryRow(sqlSelectCert, tlsCertSHA256).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
-		if err := tx.QueryRow(sqlAddCert, c.Cert, c.Key, tlsCertSHA256).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
+	tlsCertSHA256 := sha256.Sum256([]byte(c.Cert))
+	if err := tx.QueryRow(sqlSelectCert, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		if err := tx.QueryRow(sqlAddCert, c.Cert, c.Key, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return err
 		}
 	}

--- a/router/migrate_test.go
+++ b/router/migrate_test.go
@@ -107,7 +107,7 @@ func (MigrateSuite) TestMigrateTLSObject(c *C) {
 		fetchedCert := &router.Certificate{}
 		var fetchedCertSHA256 string
 		err := db.QueryRow(`
-			SELECT r.parent_ref, r.service, r.domain, c.cert, c.key, c.cert_sha256 FROM http_routes AS r
+			SELECT r.parent_ref, r.service, r.domain, c.cert, c.key, encode(c.cert_sha256, 'hex') FROM http_routes AS r
 			INNER JOIN route_certificates AS rc ON rc.http_route_id = r.id
 			INNER JOIN certificates AS c ON rc.certificate_id = c.id
 			WHERE r.id = $1

--- a/router/schema.go
+++ b/router/schema.go
@@ -157,7 +157,7 @@ CREATE TRIGGER check_http_route_update
 			id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
 			cert text NOT NULL,
 			key text NOT NULL,
-			cert_sha256 text NOT NULL,
+			cert_sha256 bytea NOT NULL,
 			created_at timestamptz NOT NULL DEFAULT now(),
 			updated_at timestamptz NOT NULL DEFAULT now(),
 			deleted_at timestamptz
@@ -174,10 +174,10 @@ CREATE TRIGGER check_http_route_update
 		DECLARE
 			http_route RECORD;
 			certificate_id uuid;
-			certsha256 text;
+			certsha256 bytea;
 		BEGIN
 			FOR http_route IN SELECT * FROM http_routes WHERE tls_key IS NOT NULL LOOP
-				SELECT INTO certsha256 trim(leading '\\x' from digest(ltrim(' \n', rtrim(' \n', http_route.tls_cert)), 'sha256')::varchar);
+				SELECT INTO certsha256 digest(ltrim(' \n', rtrim(' \n', http_route.tls_cert)), 'sha256');
 				SELECT INTO certificate_id id FROM certificates WHERE cert_sha256 = certsha256;
 
 				IF NOT FOUND THEN


### PR DESCRIPTION
The hex-encoded hash can be too wide for the index, it appears to be variable length before this patch. Store it as a shorter bytea field.

     ERROR: index row size 2792 exceeds maximum 2712 for index \"certificates_cert_sha256_idx\" (SQLSTATE 54000)