### PR TITLE
test/rootfs: Install libsasl2 in rootfs

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -152,7 +152,8 @@ apt-get install -y \
   btrfs-tools \
   libvirt-dev \
   libvirt-bin \
-  inotify-tools
+  inotify-tools \
+  libsasl2-dev
 
 # install flynn test dependencies: postgres, redis, mariadb
 # (normally these are used via appliances; install locally for unit tests)

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -181,6 +181,7 @@ install_packages() {
     "tup"
     "ubuntu-zfs"
     "vim-tiny"
+    "libsasl2-dev"
   )
 
   apt-get install -y ${packages[@]}


### PR DESCRIPTION
Required to build new `mgo` version with SASL authentication.