### PR TITLE
WIP: Cause ReleaseSuite.TestReleaseImages to fail

### DIFF
--- a/test/test_release.go
+++ b/test/test_release.go
@@ -250,4 +250,6 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	imageArtifact, err = client.GetArtifact(release.ImageArtifactID())
 	t.Assert(err, c.IsNil)
 	assertImage(imageArtifact.URI, "flynn/slugrunner")
+
+	t.Fatal("WIP: Error to see what is taking so long in this test")
 }


### PR DESCRIPTION
This is a dummy PR to trigger `ReleaseSuite.TestReleaseImages` to fail so we can see why it is taking so long in CI (when I run it manually it takes ~5mins, but it is currently double that in CI).