### PR TITLE
controller: Add status description

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flynn/go-docopt"
 )
 
+// TODO(jpg): Update example output with pending reason
 func init() {
 	register("ps", runPs, `
 usage: flynn ps [-a]
@@ -51,7 +52,7 @@ func runPs(args *docopt.Args, client controller.Client) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	listRec(w, "ID", "TYPE", "STATE", "CREATED", "RELEASE")
+	listRec(w, "ID", "TYPE", "STATE", "CREATED", "RELEASE", "DESCRIPTION")
 	for _, j := range jobs {
 		if j.Type == "" {
 			j.Type = "run"
@@ -67,7 +68,11 @@ func runPs(args *docopt.Args, client controller.Client) error {
 		if j.CreatedAt != nil {
 			created = units.HumanDuration(time.Now().UTC().Sub(*j.CreatedAt)) + " ago"
 		}
-		listRec(w, id, j.Type, j.State, created, j.ReleaseID)
+		var desc string
+		if j.StatusDescription != nil {
+			desc = *j.StatusDescription
+		}
+		listRec(w, id, j.Type, j.State, created, j.ReleaseID, desc)
 	}
 
 	return nil

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -58,6 +58,7 @@ func (r *JobRepo) Add(job *ct.Job) error {
 		job.HostError,
 		job.RunAt,
 		job.Restarts,
+		job.StatusDescription,
 	).Scan(&job.CreatedAt, &job.UpdatedAt)
 	if postgres.IsUniquenessError(err, "") {
 		err = r.db.QueryRow(
@@ -70,6 +71,7 @@ func (r *JobRepo) Add(job *ct.Job) error {
 			job.HostError,
 			job.RunAt,
 			job.Restarts,
+			job.StatusDescription,
 		).Scan(&job.CreatedAt, &job.UpdatedAt)
 		if postgres.IsPostgresCode(err, postgres.CheckViolation) {
 			return ct.ValidationError{Field: "state", Message: err.Error()}
@@ -104,6 +106,7 @@ func scanJob(s postgres.Scanner) (*ct.Job, error) {
 		&job.HostError,
 		&job.RunAt,
 		&job.Restarts,
+		&job.StatusDescription,
 		&job.CreatedAt,
 		&job.UpdatedAt,
 	)

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -87,6 +87,10 @@ type Job struct {
 	// referenced from within the main scheduler loop
 	State JobState `json:"state"`
 
+	// statusDescription is a human readable description of why a job
+	// is in a certain state
+	StatusDescription string
+
 	// metadata is the cluster job's metadata, assigned whenever a host
 	// event is received for the job, and is used when persisting the job
 	// to the controller
@@ -170,6 +174,9 @@ func (j *Job) ControllerJob() *ct.Job {
 	}
 	if j.Restarts > 0 {
 		job.Restarts = typeconv.Int32Ptr(int32(j.Restarts))
+	}
+	if j.StatusDescription != "" {
+		job.StatusDescription = &j.StatusDescription
 	}
 
 	return job

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -384,6 +384,9 @@ $$ LANGUAGE plpgsql`,
 	migrations.Add(18,
 		`INSERT INTO event_types (name) VALUES ('app_garbage_collection')`,
 	)
+	migrations.Add(19,
+		`ALTER TABLE job_cache ADD COLUMN status_description text`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -292,19 +292,19 @@ WHERE app_id = $1 AND release_id = $2 AND deleted_at IS NULL`
 UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now()
 WHERE app_id = $1 AND deleted_at IS NULL`
 	jobListQuery = `
-SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, status_description, created_at, updated_at
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
 	jobListActiveQuery = `
-SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, status_description, created_at, updated_at
 FROM job_cache WHERE state = 'starting' OR state = 'up' ORDER BY updated_at DESC`
 	jobSelectQuery = `
-SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
+SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, status_description, created_at, updated_at
 FROM job_cache WHERE job_id = $1`
 	jobInsertQuery = `
-INSERT INTO job_cache (cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING created_at, updated_at`
+INSERT INTO job_cache (cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, status_description)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING created_at, updated_at`
 	jobUpdateQuery = `
-UPDATE job_cache SET cluster_id = $2, host_id = $3, state = $4, exit_status = $5, host_error = $6, run_at = $7, restarts = $8, updated_at = now()
+UPDATE job_cache SET cluster_id = $2, host_id = $3, state = $4, exit_status = $5, host_error = $6, run_at = $7, restarts = $8, status_description = $9, updated_at = now()
 WHERE job_id = $1 RETURNING created_at, updated_at`
 	providerListQuery = `
 SELECT provider_id, name, url, created_at, updated_at

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -155,18 +155,19 @@ type Job struct {
 	// empty if the job is pending
 	HostID string `json:"host_id,omitempty"`
 
-	AppID      string            `json:"app,omitempty"`
-	ReleaseID  string            `json:"release,omitempty"`
-	Type       string            `json:"type,omitempty"`
-	State      JobState          `json:"state,omitempty"`
-	Cmd        []string          `json:"cmd,omitempty"`
-	Meta       map[string]string `json:"meta,omitempty"`
-	ExitStatus *int32            `json:"exit_status,omitempty"`
-	HostError  *string           `json:"host_error,omitempty"`
-	RunAt      *time.Time        `json:"run_at,omitempty"`
-	Restarts   *int32            `json:"restarts,omitempty"`
-	CreatedAt  *time.Time        `json:"created_at,omitempty"`
-	UpdatedAt  *time.Time        `json:"updated_at,omitempty"`
+	AppID             string            `json:"app,omitempty"`
+	ReleaseID         string            `json:"release,omitempty"`
+	Type              string            `json:"type,omitempty"`
+	State             JobState          `json:"state,omitempty"`
+	Cmd               []string          `json:"cmd,omitempty"`
+	Meta              map[string]string `json:"meta,omitempty"`
+	ExitStatus        *int32            `json:"exit_status,omitempty"`
+	HostError         *string           `json:"host_error,omitempty"`
+	RunAt             *time.Time        `json:"run_at,omitempty"`
+	Restarts          *int32            `json:"restarts,omitempty"`
+	StatusDescription *string           `json:"status_description,omitempty"`
+	CreatedAt         *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time        `json:"updated_at,omitempty"`
 }
 
 type JobState string

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -57,6 +57,10 @@
       "description": "time a pending job will be started",
       "format": "date-time"
     },
+    "status_description": {
+      "type": "string",
+      "description": "description of job status"
+    },
     "restarts": {
       "type": "integer",
       "description": "number of times this job has been restarted"


### PR DESCRIPTION
Stores the reason why the scheduler assigned the job a pending state in the controller database and displays it to users via `flynn ps`. ie:

```
$ flynn ps -a
ID                                          TYPE  STATE                              CREATED        RELEASE
host0-ae078f68-a515-4f5e-a838-d6b5e37c55ad  web   down                               5 minutes ago  bebb3189-7ef7-455d-b60e-8f1a641cc264
dcb82ff1-7b99-48f5-b3e4-d304b09a1ec3        web   pending (no hosts match job tags)  1 seconds ago  bebb3189-7ef7-455d-b60e-8f1a641cc264
```
