### PR TITLE
host: Unblock the AddJob rate limit when waiting for discoverd / network

### DIFF
--- a/host/backend.go
+++ b/host/backend.go
@@ -23,7 +23,7 @@ type AttachRequest struct {
 }
 
 type Backend interface {
-	Run(*host.Job, *RunConfig) error
+	Run(*host.Job, *RunConfig, *RateLimitBucket) error
 	Stop(string) error
 	JobExists(id string) bool
 	Signal(string, int) error
@@ -52,17 +52,17 @@ type StateSaver interface {
 // MockBackend is used when testing flynn-host without the need to actually run jobs
 type MockBackend struct{}
 
-func (MockBackend) Run(*host.Job, *RunConfig) error                 { return nil }
-func (MockBackend) Stop(string) error                               { return nil }
-func (MockBackend) JobExists(string) bool                           { return false }
-func (MockBackend) Signal(string, int) error                        { return nil }
-func (MockBackend) ResizeTTY(id string, height, width uint16) error { return nil }
-func (MockBackend) Attach(*AttachRequest) error                     { return nil }
-func (MockBackend) Cleanup([]string) error                          { return nil }
-func (MockBackend) SetDefaultEnv(k, v string)                       {}
-func (MockBackend) ConfigureNetworking(*host.NetworkConfig) error   { return nil }
-func (MockBackend) OpenLogs(host.LogBuffers) error                  { return nil }
-func (MockBackend) CloseLogs() (host.LogBuffers, error)             { return nil, nil }
+func (MockBackend) Run(*host.Job, *RunConfig, *RateLimitBucket) error { return nil }
+func (MockBackend) Stop(string) error                                 { return nil }
+func (MockBackend) JobExists(string) bool                             { return false }
+func (MockBackend) Signal(string, int) error                          { return nil }
+func (MockBackend) ResizeTTY(id string, height, width uint16) error   { return nil }
+func (MockBackend) Attach(*AttachRequest) error                       { return nil }
+func (MockBackend) Cleanup([]string) error                            { return nil }
+func (MockBackend) SetDefaultEnv(k, v string)                         {}
+func (MockBackend) ConfigureNetworking(*host.NetworkConfig) error     { return nil }
+func (MockBackend) OpenLogs(host.LogBuffers) error                    { return nil }
+func (MockBackend) CloseLogs() (host.LogBuffers, error)               { return nil, nil }
 func (MockBackend) UnmarshalState(map[string]*host.ActiveJob, map[string][]byte, []byte, host.LogBuffers) error {
 	return nil
 }

--- a/host/state.go
+++ b/host/state.go
@@ -131,7 +131,7 @@ func (s *State) Restore(backend Backend, buffers host.LogBuffers) (func(), error
 				newJob.ID = cluster.GenerateJobID(s.id, "")
 				log.Printf("resurrecting %s as %s", job.ID, newJob.ID)
 				s.AddJob(newJob)
-				backend.Run(newJob, nil)
+				backend.Run(newJob, nil, nil)
 				wg.Done()
 			}(job)
 		}


### PR DESCRIPTION
This prevents jobs which require discoverd & networking which start before discoverd or flannel from blocking the rate limiter (and thus not allowing discoverd or flannel to be started).

Tested manually by reducing `maxJobConcurrency` to 1, adding a new host to a cluster and seeing that the discoverd job initially gets rate limited but then eventually is accepted:

```
t=2016-06-26T23:41:56+0000 lvl=info msg="request started" component=host req_id=1b85897b-42d8-4e6f-a569-c9dd514c40d3 method=PUT path=/host/jobs/host6-4829179d-a95e-4712-b01f-2c98759ec8ce client_ip=100.100.70.3
t=2016-06-26T23:41:56+0000 lvl=warn msg="maximum concurrent AddJob calls running" app=host pid=47620 host.id=host6 fn=AddJob job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
t=2016-06-26T23:41:57+0000 lvl=info msg="request started" req_id=0e579adc-070b-41be-b1f0-ab4584fa8272 component=host method=PUT path=/host/jobs/host6-4829179d-a95e-4712-b01f-2c98759ec8ce client_ip=100.100.70.3
t=2016-06-26T23:41:57+0000 lvl=warn msg="maximum concurrent AddJob calls running" app=host pid=47620 host.id=host6 fn=AddJob job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
...
t=2016-06-26T23:42:00+0000 lvl=info msg="request started" component=host req_id=cbf4859f-63ee-41b0-877a-992e0f29f9aa method=PUT path=/host/jobs/host6-4829179d-a95e-4712-b01f-2c98759ec8ce client_ip=100.100.70.3
t=2016-06-26T23:42:00+0000 lvl=info msg="decoding job" app=host pid=47620 host.id=host6 fn=AddJob job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
t=2016-06-26T23:42:00+0000 lvl=info msg="acquiring state database" app=host pid=47620 host.id=host6 fn=AddJob job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
t=2016-06-26T23:42:00+0000 lvl=info msg="running job" app=host pid=47620 host.id=host6 fn=AddJob job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
t=2016-06-26T23:42:00+0000 lvl=info msg="starting job" app=host pid=47620 host.id=host6 component=backend backend=libvirt-lxc fn=run job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce job.artifact.uri="https://dl.flynn.io/tuf?name=flynn/discoverd&id=4724177a9d09e51a1a3206c9a302815c962fb24512f00a46057928ba0e4ad6ba" job.cmd=[]
...
t=2016-06-26T23:42:02+0000 lvl=info msg="job started" app=host pid=47620 host.id=host6 component=backend backend=libvirt-lxc fn=run job.id=host6-4829179d-a95e-4712-b01f-2c98759ec8ce
```

Also see the scheduler job which was accepted _before_ `discoverd` (so obtained a rate limit token) but only actually started after discoverd:

```
t=2016-06-26T23:41:59+0000 lvl=info msg="starting job" app=host pid=47620 host.id=host6 component=backend backend=libvirt-lxc fn=run job.id=host6-9dccd9b6-b3d2-4f2d-b289-17e2881e72e7 job.artifact.uri="https://dl.flynn.io/tuf?name=flynn/controller&id=512852019e590ccd8633726d39c68829f45c8c346fc618ca9e1ded4790643b76" job.cmd=[scheduler]
...
t=2016-06-26T23:42:05+0000 lvl=info msg="job started" app=host pid=47620 host.id=host6 component=backend backend=libvirt-lxc fn=run job.id=host6-9dccd9b6-b3d2-4f2d-b289-17e2881e72e7

```

Fixes #2974.