### PR TITLE
scheduler: Use InternalState in tests

### DIFF
--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -334,7 +334,7 @@ func (TestSuite) TestMultipleHosts(c *C) {
 		// get a sorted list of scheduler jobs per host to compare
 		// against the expected list
 		actual := make(map[string]sortJobs)
-		for _, job := range s.Jobs() {
+		for _, job := range s.InternalState().Jobs {
 			actual[job.HostID] = append(actual[job.HostID], job)
 		}
 		for _, jobs := range actual {


### PR DESCRIPTION
This prevents data races when making assertions on Jobs which may be modified by the main scheduler loop.

Fixes #2980.