### PR TITLE
controller: Shutdown fixes

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -314,6 +314,11 @@ func appHandler(c handlerConfig) http.Handler {
 
 func muxHandler(main http.Handler, authKeys []string) http.Handler {
 	return httphelper.CORSAllowAll.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if shutdown.IsActive() {
+			httphelper.ServiceUnavailableError(w, ErrShutdown.Error())
+			return
+		}
+
 		if r.URL.Path == "/ping" {
 			w.WriteHeader(200)
 			return

--- a/controller/events.go
+++ b/controller/events.go
@@ -465,6 +465,7 @@ func (e *EventListener) Listen() error {
 				e.Notify(event)
 			case <-e.doneCh:
 				listener.Close()
+				return
 			}
 		}
 	}()

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -366,11 +366,11 @@ func (r *FormationRepo) startListener() error {
 		return err
 	}
 	go func() {
+		defer r.unsubscribeAll()
 		for {
 			select {
 			case n, ok := <-listener.Notify:
 				if !ok {
-					r.unsubscribeAll()
 					return
 				}
 				ids := strings.SplitN(n.Payload, ":", 2)

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -225,7 +225,7 @@ func PreconditionFailedErr(message string) error {
 }
 
 func ServiceUnavailableError(w http.ResponseWriter, message string) {
-	Error(w, JSONError{Code: ServiceUnavailableErrorCode, Message: message})
+	Error(w, JSONError{Code: ServiceUnavailableErrorCode, Message: message, Retry: true})
 }
 
 func ValidationError(w http.ResponseWriter, field, message string) {


### PR DESCRIPTION
A bunch of fixes which make controller shutdown cleaner and also quicker (it currently takes 10s before being forcibly killed, increasing the time of all controller deployments in CI).