### PR TITLE
test: Use the default flynn-host backend

### DIFF
--- a/test/arg/arg.go
+++ b/test/arg/arg.go
@@ -37,7 +37,6 @@ func Parse() *Args {
 	flag.StringVar(&args.BootConfig.Kernel, "kernel", "rootfs/vmlinuz", "path to the Linux binary")
 	flag.StringVar(&args.BootConfig.Network, "network", "10.52.0.1/24", "the network to use for vms")
 	flag.StringVar(&args.BootConfig.NatIface, "nat", "eth0", "the interface to provide NAT to vms")
-	flag.StringVar(&args.BootConfig.Backend, "backend", "libvirt-lxc", "the host backend to use")
 	flag.StringVar(&args.RootFS, "rootfs", "rootfs/rootfs.img", "filesystem image to use with QEMU")
 	flag.StringVar(&args.CLI, "cli", "flynn", "path to flynn-cli binary")
 	flag.StringVar(&args.FlynnHost, "flynn-host", "../host/bin/flynn-host", "path to flynn-host binary")


### PR DESCRIPTION
This allows us to test changing the default backend (for example to libcontainer) without needing to modify the test runner.