### PR TITLE
appliance/mongodb: Fix deletion of MongoDB resources

### DIFF
--- a/appliance/mongodb/cmd/flynn-mongodb-api/main.go
+++ b/appliance/mongodb/cmd/flynn-mongodb-api/main.go
@@ -71,7 +71,7 @@ func (a *API) createDatabase(w http.ResponseWriter, req *http.Request, _ httprou
 	defer session.Close()
 
 	// Create a user
-	if err := session.DB("admin").Run(bson.D{
+	if err := session.DB(database).Run(bson.D{
 		{"createUser", username},
 		{"pwd", password},
 		{"roles", []bson.M{
@@ -108,7 +108,7 @@ func (a *API) dropDatabase(w http.ResponseWriter, req *http.Request, _ httproute
 		Addrs:    []string{net.JoinHostPort(serviceHost, "27017")},
 		Username: "flynn",
 		Password: os.Getenv("MONGO_PWD"),
-		Database: database,
+		Database: "admin",
 	})
 	if err != nil {
 		httphelper.Error(w, err)

--- a/cli/mongodb.go
+++ b/cli/mongodb.go
@@ -99,7 +99,6 @@ func runMongo(args *docopt.Args, client controller.Client, config *runConfig) er
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],
-		"--authenticationDatabase", "admin",
 		config.Env["MONGO_DATABASE"],
 	}, args.All["<argument>"].([]string)...)
 
@@ -135,7 +134,6 @@ func configMongodbDump(config *runConfig) {
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],
-		"--authenticationDatabase", "admin",
 		"--db", config.Env["MONGO_DATABASE"],
 	}
 }
@@ -184,7 +182,6 @@ func mongodbRestore(client controller.Client, config *runConfig) error {
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],
-		"--authenticationDatabase", "admin",
 		"--db", config.Env["MONGO_DATABASE"],
 	}
 	err := runJob(client, *config)

--- a/test/test_mariadb.go
+++ b/test/test_mariadb.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/flynn/flynn/appliance/mariadb"
 	ct "github.com/flynn/flynn/controller/types"
@@ -80,7 +81,9 @@ func (s *MariaDBSuite) TestDumpRestore(t *c.C) {
 	r := s.newGitRepo(t, "empty")
 	t.Assert(r.flynn("create"), Succeeds)
 
-	t.Assert(r.flynn("resource", "add", "mysql"), Succeeds)
+	res := r.flynn("resource", "add", "mysql")
+	t.Assert(res, Succeeds)
+	id := strings.Split(res.Output, " ")[2]
 
 	t.Assert(r.flynn("mysql", "console", "--", "-e",
 		"CREATE TABLE T (F text); INSERT INTO T (F) VALUES ('abc')"), Succeeds)
@@ -93,4 +96,6 @@ func (s *MariaDBSuite) TestDumpRestore(t *c.C) {
 
 	query := r.flynn("mysql", "console", "--", "-e", "SELECT * FROM T")
 	t.Assert(query, SuccessfulOutputContains, "abc")
+
+	t.Assert(r.flynn("resource", "remove", "mysql", id), Succeeds)
 }

--- a/test/test_postgres.go
+++ b/test/test_postgres.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/pkg/postgres"
@@ -25,7 +26,9 @@ func (s *PostgresSuite) TestDumpRestore(t *c.C) {
 	r := s.newGitRepo(t, "empty")
 	t.Assert(r.flynn("create"), Succeeds)
 
-	t.Assert(r.flynn("resource", "add", "postgres"), Succeeds)
+	res := r.flynn("resource", "add", "postgres")
+	t.Assert(res, Succeeds)
+	id := strings.Split(res.Output, " ")[2]
 
 	t.Assert(r.flynn("pg", "psql", "--", "-c",
 		"CREATE table foos (data text); INSERT INTO foos (data) VALUES ('foobar')"), Succeeds)
@@ -38,6 +41,8 @@ func (s *PostgresSuite) TestDumpRestore(t *c.C) {
 
 	query := r.flynn("pg", "psql", "--", "-c", "SELECT * FROM foos")
 	t.Assert(query, SuccessfulOutputContains, "foobar")
+
+	t.Assert(r.flynn("resource", "remove", "postgres", id), Succeeds)
 }
 
 var sireniaPostgres = sireniaDatabase{

--- a/test/test_redis.go
+++ b/test/test_redis.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 
 	c "github.com/flynn/go-check"
 )
@@ -14,7 +15,10 @@ var _ = c.ConcurrentSuite(&RedisSuite{})
 
 func (s *RedisSuite) TestDumpRestore(t *c.C) {
 	a := s.newCliTestApp(t)
-	t.Assert(a.flynn("resource", "add", "redis"), Succeeds)
+
+	res := a.flynn("resource", "add", "redis")
+	t.Assert(res, Succeeds)
+	id := strings.Split(res.Output, " ")[2]
 
 	release, err := s.controllerClient(t).GetAppRelease(a.id)
 	t.Assert(err, c.IsNil)
@@ -32,4 +36,6 @@ func (s *RedisSuite) TestDumpRestore(t *c.C) {
 
 	query := a.flynn("redis", "redis-cli", "get", "foo")
 	t.Assert(query, SuccessfulOutputContains, "bar")
+
+	t.Assert(a.flynn("resource", "remove", "redis", id), Succeeds)
 }


### PR DESCRIPTION
Instead of creating users within the `admin` database create them within the resource databases.
This removes the need for user to authenticate using the `admin` database and is overall less surprising.