### PR TITLE
util/packer,Vagrantfile: Only start Docker at boot in dev VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     grep ^cd ~/.bashrc || echo cd ~/go/src/github.com/flynn/flynn >> ~/.bashrc
     sudo chown -R vagrant:vagrant ~/go
+
+    # enable docker
+    sudo rm -f /etc/init/docker.override
+    sudo start docker
   SCRIPT
 
   if File.exists?("script/custom-vagrant")

--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -34,7 +34,7 @@ main() {
   add_apt_sources
   install_packages
   install_flynn
-  disable_docker_auto_restart
+  disable_docker_start
   bump_libvirt_start_timeout
   apt_cleanup
 
@@ -208,8 +208,8 @@ install_flynn() {
   sed -i 's/start on/#start on/' /etc/init/flynn-host.conf
 }
 
-disable_docker_auto_restart() {
-  sed -i 's/^#DOCKER_OPTS=.*/DOCKER_OPTS="-r=false"/' /etc/default/docker
+disable_docker_start() {
+  echo manual > /etc/init/docker.override
 }
 
 bump_libvirt_start_timeout() {


### PR DESCRIPTION
Before this change, it started in provisioned EC2 instances as well.