### PR TITLE
blobstore: Fix parsing of double space in backend config

### DIFF
--- a/blobstore/blobstore_test.go
+++ b/blobstore/blobstore_test.go
@@ -69,6 +69,9 @@ func TestPostgresFilesystem(t *testing.T) {
 func parseBackendEnv(s string) map[string]string {
 	info := make(map[string]string)
 	for _, token := range strings.Split(s, " ") {
+		if token == "" {
+			continue
+		}
 		kv := strings.SplitN(token, "=", 2)
 		info[kv[0]] = kv[1]
 	}

--- a/blobstore/data/file_repo.go
+++ b/blobstore/data/file_repo.go
@@ -60,6 +60,9 @@ func NewFileRepoFromEnv(db *postgres.DB) (*FileRepo, error) {
 func parseBackendInfo(s string) (map[string]string, error) {
 	info := make(map[string]string)
 	for _, token := range strings.Split(s, " ") {
+		if token == "" {
+			continue
+		}
 		kv := strings.SplitN(token, "=", 2)
 		if len(kv) < 2 {
 			return nil, fmt.Errorf("blobstore: error parsing backend kv pair %q", token)


### PR DESCRIPTION
This fixes a case where the parser will error if there are two spaces in a row.