### PR TITLE
test/rootfs: Bump rootfs size to 50G

### DIFF
--- a/test/rootfs/build.sh
+++ b/test/rootfs/build.sh
@@ -4,7 +4,7 @@ set -e -x
 src_dir="$(cd "$(dirname "$0")" && pwd)"
 build_dir=${1:-.}
 
-truncate -s 32G ${build_dir}/rootfs.img
+truncate -s 50G ${build_dir}/rootfs.img
 mkfs.ext4 -FqL rootfs ${build_dir}/rootfs.img
 
 dir=$(mktemp -d)


### PR DESCRIPTION
CI jobs occasionally fail with `ENOSPC`, increase from 32G to 50G to fix.