### PR TITLE
Release updates

### DIFF
--- a/script/lib/tuf.sh
+++ b/script/lib/tuf.sh
@@ -34,3 +34,14 @@ check_tuf_keys() {
     fi
   done
 }
+
+release_exists() {
+  local tuf_dir=$1
+  local version=$2
+
+  if jq --exit-status ".signed.targets.\"/${version}/flynn-host.gz\"" "${tuf_dir}/repository/targets.json" &>/dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/script/lib/ui.sh
+++ b/script/lib/ui.sh
@@ -22,6 +22,9 @@ say() {
       green)
         echo -e "\e[1;32m${msg}\e[0m"
         ;;
+      yellow)
+        echo -e "\e[1;33m${msg}\e[0m"
+        ;;
       *)
         echo "${msg}"
         ;;
@@ -35,6 +38,12 @@ info() {
   local msg=$1
   local timestamp=$(date +%H:%M:%S.%3N)
   say "===> ${timestamp} ${msg}" "green"
+}
+
+warn() {
+  local msg=$1
+  local timestamp=$(date +%H:%M:%S.%3N)
+  say "===> ${timestamp} WARN: ${msg}" "yellow" >&2
 }
 
 fail() {

--- a/script/release-channel
+++ b/script/release-channel
@@ -6,6 +6,7 @@
 #
 # - Install go-tuf
 #   go get github.com/flynn/go-tuf/cmd/tuf
+#   go get github.com/flynn/go-tuf/cmd/tuf-client
 #
 # - Set the TUF passphrases
 #   export TUF_TARGETS_PASSPHRASE=xxxxxx
@@ -27,6 +28,7 @@ OPTIONS:
   -h, --help            Show this message
   -b, --bucket BUCKET   The S3 bucket to sync with [default: flynn]
   -d, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
+  -e, --edit            Edit the changelog before committing the channel update
   --no-sync             Don't sync files with S3
 USAGE
 }
@@ -34,6 +36,7 @@ USAGE
 main() {
   local bucket="flynn"
   local tuf_dir="/etc/flynn/tuf"
+  local edit=false
   local sync=true
 
   while true; do
@@ -44,19 +47,21 @@ main() {
         ;;
       -b | --bucket)
         if [[ -z "$2" ]]; then
-          usage
-          exit 1
+          fail "$1 requires an argument"
         fi
         bucket="$2"
         shift 2
         ;;
       -d | --tuf-dir)
         if [[ -z "$2" ]]; then
-          usage
-          exit 1
+          fail "$1 requires an argument"
         fi
         tuf_dir="$2"
         shift 2
+        ;;
+      -e | --edit)
+        edit=true
+        shift
         ;;
       --no-sync)
         sync=false
@@ -98,6 +103,16 @@ main() {
   cd "${tuf_dir}"
   tuf clean
 
+  info "generating changelog"
+  local changelog="${tuf_dir}/staged/targets/channel/${channel}/${version}/CHANGELOG.md"
+  mkdir -p "$(dirname "${changelog}")"
+  generate_changelog
+
+  if $edit; then
+    info "starting vim to edit the changelog"
+    edit_changelog
+  fi
+
   info "staging updated channel file"
   mkdir -p "staged/targets/channels"
   echo "${version}" > "staged/targets/channels/${channel}"
@@ -117,6 +132,76 @@ main() {
   fi
 
   info "successfully set ${channel} release channel to ${version}"
+}
+
+# generate_changelog gets the current channel version from the TUF repository
+# then creates a changelog using the commit message of each merge commit (which
+# are expected to all be pull request merges) from the current version to the
+# version being released.
+#
+# Changelog entries are formatted like:
+#
+#   * DATE: MESSAGE (LINK TO PR)
+#
+# For example:
+#
+#   * 2016-06-27: script: Add --version and --channel flags to install-flynn ([#3003](https://github.com/flynn/flynn/pull/3003))
+generate_changelog() {
+  local repo_url="https://s3.amazonaws.com/${bucket}/tuf"
+  info "getting current ${channel} version from ${repo_url}"
+  local tmp="$(mktemp --directory)"
+  trap "rm -rf ${tmp}" EXIT
+  tuf-client init --store "${tmp}/tuf.db" "${repo_url}" <<< "$(tuf -d "${tuf_dir}" root-keys)"
+  local current="$(tuf-client get --store "${tmp}/tuf.db" "${repo_url}" "/channels/${channel}")"
+  if [[ -z "${current}" ]]; then
+    warn "could not determine current ${channel} version, using empty changelog"
+    echo "n/a" > "${changelog}"
+    return
+  fi
+
+  pushd "${ROOT}" >/dev/null
+
+  info "fetching git tags"
+  git fetch --tags
+
+  info "formatting changes between ${current} and ${version}"
+  git log \
+    --merges \
+    --reverse \
+    --date=short \
+    --pretty=format:'* %ad: %b %s%n' \
+    "${current}...${version}" \
+    | sed 's|Merge pull request #\([0-9]\+\) from \S\+|([#\1](https://github.com/flynn/flynn/pull/\1))|' \
+    > "${changelog}"
+
+  popd >/dev/null
+}
+
+edit_changelog() {
+  local tmpdir="$(mktemp --directory)"
+  trap "rm -rf ${tmpdir}" EXIT
+  local tmp="${tmpdir}/CHANGELOG.md"
+
+  cat <<EOF > "${tmp}"
+# You are currently editing the generated changelog for releasing the
+# ${channel} channel.
+#
+# Lines starting with '#' will be ignored, and an empty changelog aborts the
+# release.
+# -----------------------------------------------------------------------------
+EOF
+  cat "${changelog}" >> "${tmp}"
+
+  vim "${tmp}"
+
+  sed -i '/^#/d' "${tmp}"
+
+  if [[ ! -s "${tmp}" ]]; then
+    warn "aborting release due to empty changelog"
+    exit 0
+  fi
+
+  mv "${tmp}" "${changelog}"
 }
 
 main $@

--- a/script/release-channel
+++ b/script/release-channel
@@ -91,7 +91,7 @@ main() {
   fi
 
   info "checking version ${version} has been released"
-  if ! jq --exit-status ".signed.targets.\"/${version}/flynn-host.gz\"" "${tuf_dir}/repository/targets.json" &>/dev/null; then
+  if ! release_exists "${tuf_dir}" "${version}"; then
     fail "version ${version} has not been released"
   fi
 

--- a/script/release-components
+++ b/script/release-components
@@ -33,15 +33,17 @@ usage() {
 usage: $0 [options] COMMIT VERSION
 
 OPTIONS:
-  -h, --help            Show this message
-  -b, --bucket BUCKET   The S3 bucket to sync with [default: flynn]
-  -t, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
-  -k, --keep            Keep release directory
-  -r, --resume DIR      Resume the release using DIR
+  -h, --help              Show this message
+  -c, --channel CHANNEL   Point channel at VERSION once released
+  -b, --bucket BUCKET     The S3 bucket to sync with [default: flynn]
+  -t, --tuf-dir DIR       Path to the local TUF repository [default: /etc/flynn/tuf]
+  -k, --keep              Keep release directory
+  -r, --resume DIR        Resume the release using DIR
 USAGE
 }
 
 main() {
+  local channel=""
   local bucket="flynn"
   local tuf_dir="/etc/flynn/tuf"
   local dir=""
@@ -52,6 +54,13 @@ main() {
       -h | --help)
         usage
         exit 0
+        ;;
+      -c | --channel)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        fi
+        channel="$2"
+        shift 2
         ;;
       -b | --bucket)
         if [[ -z "$2" ]]; then
@@ -138,12 +147,14 @@ main() {
   info "adding components to the TUF repository"
   "${src}/script/export-components" "${tuf_dir}"
 
-  "${src}/script/release-channel" \
-    --bucket "${bucket}" \
-    --tuf-dir "${tuf_dir}" \
-    --no-sync \
-    "nightly" \
-    "${version}"
+  if [[ -n "${channel}" ]]; then
+    "${src}/script/release-channel" \
+      --bucket "${bucket}" \
+      --tuf-dir "${tuf_dir}" \
+      --no-sync \
+      "${channel}" \
+      "${version}"
+  fi
 
   info "uploading files to S3"
   mkdir -p "${dir}/upload"

--- a/script/release-components
+++ b/script/release-components
@@ -33,45 +33,60 @@ usage() {
 usage: $0 [options] COMMIT VERSION
 
 OPTIONS:
-  -h            Show this message
-  -k            Keep release directory
-  -b BUCKET     The S3 bucket to sync with [default: flynn]
-  -r DIR        Resume the release using DIR
-  -t DIR        Path to the local TUF repository [default: /etc/flynn/tuf]
+  -h, --help            Show this message
+  -b, --bucket BUCKET   The S3 bucket to sync with [default: flynn]
+  -t, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
+  -k, --keep            Keep release directory
+  -r, --resume DIR      Resume the release using DIR
 USAGE
 }
 
 main() {
-  local bucket dir tuf_dir
+  local bucket="flynn"
+  local tuf_dir="/etc/flynn/tuf"
+  local dir=""
   local keep=false
 
-  while getopts "hkb:r:t:" opt; do
-    case $opt in
-      h)
+  while true; do
+    case "$1" in
+      -h | --help)
         usage
-        exit 1
+        exit 0
         ;;
-      k) keep=true ;;
-      b) bucket=${OPTARG} ;;
-      r)
-        dir=${OPTARG}
-        if [[ ! -d "${dir}" ]]; then
-          fail "No such directory: ${dir}"
+      -b | --bucket)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
         fi
+        bucket="$2"
+        shift 2
         ;;
-      t)
-        tuf_dir=${OPTARG}
-        if [[ ! -d "${tuf_dir}" ]]; then
-          fail "No such directory: ${tuf_dir}"
+      -t | --tuf-dir)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        elif [[ ! -d "$2" ]]; then
+          fail "No such directory: $2"
         fi
+        tuf_dir="$2"
+        shift 2
         ;;
-      ?)
-        usage
-        exit 1
+      -k | --keep)
+        keep=true
+        shift
+        ;;
+      -r | --resume)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        elif [[ ! -d "$2" ]]; then
+          fail "No such directory: $2"
+        fi
+        dir="$2"
+        shift 2
+        ;;
+      *)
+        break
         ;;
     esac
   done
-  shift $((${OPTIND} - 1))
 
   if [[ $# -ne 2 ]]; then
     usage
@@ -87,9 +102,7 @@ main() {
     fail "commit has not passed CI"
   fi
 
-  bucket="${bucket:-"flynn"}"
-  dir="${dir:-$(mktemp -d)}"
-  tuf_dir="${tuf_dir:="/etc/flynn/tuf"}"
+  dir="${dir:-$(mktemp --directory)}"
   info "using base dir: ${dir}"
 
   check_tuf_keys "${tuf_dir}"
@@ -113,7 +126,7 @@ main() {
     | xargs -L 1 docker pull
 
   info "building flynn"
-  git checkout --force --quiet $commit
+  git checkout --force --quiet "${commit}"
 
   make release
 

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -21,7 +21,8 @@ usage: $0 [options]
 
 OPTIONS:
   -h, --help            Show this message
-  -c, --commit COMMIT   The git commit to build [default: the master branch of https://github.com/flynn/flynn.git]
+  -c, --commit COMMIT   The git commit to build (takes precedence over the --branch flag)
+  -b, --branch BRANCH   The git branch to build [default: master]
   -b, --bucket BUCKET   The S3 bucket to upload packages to [default: flynn]
   -d, --domain DOMAIN   The CloudFront domain [default: dl.flynn.io]
   -t, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
@@ -33,6 +34,7 @@ USAGE
 
 main() {
   local commit=""
+  local branch="master"
   local bucket="flynn"
   local domain="dl.flynn.io"
   local tuf_dir="/etc/flynn/tuf"
@@ -51,7 +53,14 @@ main() {
         commit="$2"
         shift 2
         ;;
-      -b | --bucket)
+      -b | --branch)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        fi
+        branch="$2"
+        shift 2
+        ;;
+      -k | --bucket)
         if [[ -z "$2" ]]; then
           fail "$1 requires an argument"
         fi
@@ -100,11 +109,12 @@ main() {
   dir="${dir:-$(mktemp --directory)}"
 
   if [[ -z "${commit}" ]]; then
-    info "determining commit"
-    commit=$(curl --fail --silent https://api.github.com/repos/flynn/flynn/git/refs/heads/master | jq --raw-output .object.sha)
+    info "determining commit of ${branch} branch"
+    commit="$(curl --fail --silent "https://api.github.com/repos/flynn/flynn/git/refs/heads/${branch}" | jq --raw-output .object.sha)"
     if [[ -z "${commit}" ]]; then
       fail "could not determine commit"
     fi
+    info "using commit ${commit}"
   fi
 
   info "checking script is from commit being released"

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -14,19 +14,21 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "${ROOT}/script/lib/ui.sh"
 source "${ROOT}/script/lib/aws.sh"
 source "${ROOT}/script/lib/release.sh"
+source "${ROOT}/script/lib/tuf.sh"
 
 usage() {
   cat <<USAGE >&2
 usage: $0 [options]
 
 OPTIONS:
-  -h, --help            Show this message
-  -c, --commit COMMIT   The git commit to build (takes precedence over the --branch flag)
-  -b, --branch BRANCH   The git branch to build [default: master]
-  -b, --bucket BUCKET   The S3 bucket to upload packages to [default: flynn]
-  -d, --domain DOMAIN   The CloudFront domain [default: dl.flynn.io]
-  -t, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
-  --resume DIR          Resume the release using DIR
+  -h, --help              Show this message
+  -c, --commit COMMIT     The git commit to build (takes precedence over the --branch flag)
+  -b, --branch BRANCH     The git branch to build [default: master]
+  -v, --version VERSION   Version to use [default: vYYYYMMDD.N]
+  -b, --bucket BUCKET     The S3 bucket to upload packages to [default: flynn]
+  -d, --domain DOMAIN     The CloudFront domain [default: dl.flynn.io]
+  -t, --tuf-dir DIR       Path to the local TUF repository [default: /etc/flynn/tuf]
+  --resume DIR            Resume the release using DIR
 
 Requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and GITHUB_TOKEN to be set.
 USAGE
@@ -35,6 +37,7 @@ USAGE
 main() {
   local commit=""
   local branch="master"
+  local version=""
   local bucket="flynn"
   local domain="dl.flynn.io"
   local tuf_dir="/etc/flynn/tuf"
@@ -58,6 +61,13 @@ main() {
           fail "$1 requires an argument"
         fi
         branch="$2"
+        shift 2
+        ;;
+      -v | --version)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        fi
+        version="$2"
         shift 2
         ;;
       -k | --bucket)
@@ -135,10 +145,18 @@ main() {
 
     exec "${src}/script/release-flynn" \
       --commit  "${commit}" \
+      --version "${version}" \
       --bucket  "${bucket}" \
       --domain  "${domain}" \
       --tuf-dir "${tuf_dir}" \
       --resume  "${dir}"
+  fi
+
+  if [[ -n "${version}" ]]; then
+    info "verifying that version ${version} does not already exist"
+    if release_exists "${tuf_dir}" "${version}"; then
+      fail "version ${version} already exists"
+    fi
   fi
 
   info "checking status of commit ${commit}"
@@ -148,11 +166,13 @@ main() {
 
   info "starting release of commit ${commit}"
 
-  info "getting previous release tag"
-  local previous=$(git tag --list "v*" --sort "v:refname" | tail -n 1)
+  if [[ -z "${version}" ]]; then
+    info "getting previous release tag"
+    local previous=$(git tag --list "v*" --sort "v:refname" | tail -n 1)
 
-  info "determining version"
-  local version="$(next_release_version ${previous})"
+    info "determining version"
+    version="$(next_release_version ${previous})"
+  fi
   info "using version ${version}"
 
   info "tagging release"

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -158,14 +158,17 @@ main() {
   info "tagging release"
   tag_release "${commit}" "${version}"
 
+  local flags=(
+    "--bucket"  "${bucket}"
+    "--tuf-dir" "${tuf_dir}"
+    "--resume"  "${dir}"
+    "--keep"
+  )
+  if [[ "${branch}" = "master" ]]; then
+    flags+=("--channel" "nightly")
+  fi
   info "releasing components"
-  "${ROOT}/script/release-components" \
-    --bucket  "${bucket}" \
-    --tuf-dir "${tuf_dir}" \
-    --resume  "${dir}" \
-    --keep \
-    "${commit}" \
-    "${version}"
+  "${ROOT}/script/release-components" ${flags[@]} "${commit}" "${version}"
 
   info "successfully released Flynn version ${version}"
 

--- a/script/release-flynn
+++ b/script/release-flynn
@@ -20,48 +20,74 @@ usage() {
 usage: $0 [options]
 
 OPTIONS:
-  -h            Show this message
-  -b BUCKET     The S3 bucket to upload packages to [default: flynn]
-  -c COMMIT     The commit to build [default: the master branch of https://github.com/flynn/flynn.git]
-  -d DOMAIN     The CloudFront domain [default: dl.flynn.io]
-  -r DIR        Resume the release using DIR
-  -t DIR        Path to the local TUF repository [default: /etc/flynn/tuf]
+  -h, --help            Show this message
+  -c, --commit COMMIT   The git commit to build [default: the master branch of https://github.com/flynn/flynn.git]
+  -b, --bucket BUCKET   The S3 bucket to upload packages to [default: flynn]
+  -d, --domain DOMAIN   The CloudFront domain [default: dl.flynn.io]
+  -t, --tuf-dir DIR     Path to the local TUF repository [default: /etc/flynn/tuf]
+  --resume DIR          Resume the release using DIR
 
-Requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and GITHUB_TOKEN to be set
+Requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and GITHUB_TOKEN to be set.
 USAGE
 }
 
 main() {
-  local bucket commit dir domain tuf_dir
+  local commit=""
+  local bucket="flynn"
+  local domain="dl.flynn.io"
+  local tuf_dir="/etc/flynn/tuf"
+  local dir=""
 
-  while getopts "hb:c:d:r:t:" opt; do
-    case $opt in
-      h)
+  while true; do
+    case "$1" in
+      -h | --help)
         usage
-        exit 1
+        exit 0
         ;;
-      b) bucket=${OPTARG} ;;
-      c) commit=${OPTARG} ;;
-      d) domain=${OPTARG} ;;
-      r)
-        dir=${OPTARG}
-        if [[ ! -d "${dir}" ]]; then
-          fail "No such directory: ${dir}"
+      -c | --commit)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
         fi
+        commit="$2"
+        shift 2
         ;;
-      t)
-        tuf_dir=${OPTARG}
-        if [[ ! -d "${tuf_dir}" ]]; then
-          fail "No such directory: ${tuf_dir}"
+      -b | --bucket)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
         fi
+        bucket="$2"
+        shift 2
         ;;
-      ?)
-        usage
-        exit 1
+      -d | --domain)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        fi
+        domain="$2"
+        shift 2
+        ;;
+      -t | --tuf-dir)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        elif [[ ! -d "$2" ]]; then
+          fail "No such directory: $2"
+        fi
+        tuf_dir="$2"
+        shift 2
+        ;;
+      --resume)
+        if [[ -z "$2" ]]; then
+          fail "$1 requires an argument"
+        elif [[ ! -d "$2" ]]; then
+          fail "No such directory: $2"
+        fi
+        dir="$2"
+        shift 2
+        ;;
+      *)
+        break
         ;;
     esac
   done
-  shift $((${OPTIND} - 1))
 
   if [[ $# -ne 0 ]]; then
     usage
@@ -71,10 +97,7 @@ main() {
   check_aws_keys
   check_github_token
 
-  bucket="${bucket:-"flynn"}"
-  dir="${dir:-$(mktemp -d)}"
-  tuf_dir="${tuf_dir:="/etc/flynn/tuf"}"
-  domain="${domain:-"dl.flynn.io"}"
+  dir="${dir:-$(mktemp --directory)}"
 
   if [[ -z "${commit}" ]]; then
     info "determining commit"
@@ -89,7 +112,7 @@ main() {
   if [[ "${src_commit}" != "${commit}" ]]; then
     info "re-executing using scripts from commit ${commit}"
 
-    export GOPATH="$(mktemp -d)"
+    export GOPATH="$(mktemp --directory)"
     trap "rm -rf ${GOPATH}" EXIT
     local src="${GOPATH}/src/github.com/flynn/flynn"
 
@@ -100,17 +123,16 @@ main() {
     info "building flynn-release binary"
     go build -o util/release/flynn-release ./util/release
 
-    "${src}/script/release-flynn" \
-      -b "${bucket}" \
-      -c "${commit}" \
-      -d "${domain}" \
-      -r "${dir}"
-
-    exit 0
+    exec "${src}/script/release-flynn" \
+      --commit  "${commit}" \
+      --bucket  "${bucket}" \
+      --domain  "${domain}" \
+      --tuf-dir "${tuf_dir}" \
+      --resume  "${dir}"
   fi
 
   info "checking status of commit ${commit}"
-  if ! "${ROOT}/util/release/flynn-release" status ${commit}; then
+  if ! "${ROOT}/util/release/flynn-release" status "${commit}"; then
     fail "commit has not passed CI"
   fi
 
@@ -128,10 +150,10 @@ main() {
 
   info "releasing components"
   "${ROOT}/script/release-components" \
-    -k \
-    -b "${bucket}" \
-    -r "${dir}" \
-    -t "${tuf_dir}" \
+    --bucket  "${bucket}" \
+    --tuf-dir "${tuf_dir}" \
+    --resume  "${dir}" \
+    --keep \
     "${commit}" \
     "${version}"
 


### PR DESCRIPTION
Summary:

* Support releasing an explicit branch (e.g. `script/release-flynn --branch v20160624.1-hotfix`)
* Support using an explicit version string (e.g. `script/release-flynn --version v20160624.1p1`)
* Only release the nightly channel if releasing the master branch
* Generate a changelog when releasing a channel using merge commit messages (there is a `--edit` flag so we can edit them in `vim` before releasing)

Closes #3040.