### PR TITLE
test: Temporarily skip TestReleaseImages until new stable release

### DIFF
--- a/test/test_release.go
+++ b/test/test_release.go
@@ -106,6 +106,9 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	if testCluster == nil {
 		t.Skip("cannot boot release cluster")
 	}
+	//XXX(jpg): Temporarily skip this test until a new stable is released
+	// that ships 9.5.
+	t.Skip("requires new stable release with postgres 9.5")
 
 	// stream script output to t.Log
 	logReader, logWriter := io.Pipe()


### PR DESCRIPTION
Postgres 9.5 isn't backwards compatible to 9.4 so we have a check in `flynn-host update` to prevent updating from releases with 9.4. Until a new stable is released this will break `TestReleaseImages`.
Temporarily skip the test until we ship a new stable release with 9.5.