### PR TITLE
controller: Log formation expansion error

### DIFF
--- a/controller/formation_test.go
+++ b/controller/formation_test.go
@@ -196,7 +196,7 @@ func (s *S) TestFormationStreamingInterrupted(c *C) {
 	ch := make(chan *ct.ExpandedFormation)
 	updated := make(chan struct{})
 
-	_, err := formationRepo.Subscribe(ch, before, updated)
+	_, err := formationRepo.Subscribe(nil, ch, before, updated)
 	c.Assert(err, IsNil)
 
 	// simulate scenario where we have not completed `sendUpdatedSince` but the channel for a subscription


### PR DESCRIPTION
Instead of closing the connection with an error, log it and move on.

This avoids bricking the streaming endpoint permanently if there is an issue with referential integrity or decoding a specific field.