### PR TITLE
Enable TCP keepalive

### DIFF
--- a/appliance/redis/cmd/flynn-redis/main.go
+++ b/appliance/redis/cmd/flynn-redis/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flynn/flynn/appliance/redis"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -153,7 +154,7 @@ func (m *Main) Run() error {
 		m.Logger.Error("error opening port", "err", err)
 		return err
 	}
-	m.ln = ln
+	m.ln = keepalive.Listener(ln)
 
 	// Initialize and server handler.
 	m.Logger.Info("serving http api")

--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -21,6 +21,7 @@ import (
 	dt "github.com/flynn/flynn/discoverd/types"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/mux"
 	"github.com/flynn/flynn/pkg/shutdown"
 )
@@ -156,7 +157,7 @@ func (m *Main) Run(args ...string) error {
 	if err != nil {
 		return err
 	}
-	m.ln = ln
+	m.ln = keepalive.Listener(ln)
 
 	// Open mux
 	m.mux = mux.New(m.ln)

--- a/discoverd/server/dns.go
+++ b/discoverd/server/dns.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/miekg/dns"
 	"github.com/vanillahsu/go_reuseport"
@@ -79,7 +80,7 @@ func (srv *DNSServer) ListenAndServe() error {
 	}
 
 	if srv.TCPAddr != "" {
-		l, err := reuseport.NewReusablePortListener("tcp4", srv.TCPAddr)
+		l, err := keepalive.ReusableListen("tcp4", srv.TCPAddr)
 		if err != nil {
 			return err
 		}

--- a/flannel/main.go
+++ b/flannel/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flynn/flynn/flannel/pkg/ip"
 	"github.com/flynn/flynn/flannel/pkg/task"
 	"github.com/flynn/flynn/flannel/subnet"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/version"
 	log "github.com/golang/glog"
@@ -221,8 +222,8 @@ func httpServer(sn *subnet.SubnetManager, publicIP, port string) error {
 	status.AddHandler(status.SimpleHandler(func() error {
 		return pingLeases(sn.Leases())
 	}))
-	go http.Serve(overlayListener, nil)
-	go http.Serve(publicListener, nil)
+	go http.Serve(keepalive.Listener(overlayListener), nil)
+	go http.Serve(keepalive.Listener(publicListener), nil)
 	return nil
 }
 

--- a/host/http.go
+++ b/host/http.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flynn/flynn/pinkerton/layer"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/sse"
 	"github.com/flynn/flynn/pkg/version"
@@ -575,7 +576,11 @@ func (h *Host) Close() error {
 func newHTTPListener(addr string) (net.Listener, error) {
 	fdEnv := os.Getenv("FLYNN_HTTP_FD")
 	if fdEnv == "" {
-		return net.Listen("tcp", addr)
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return keepalive.Listener(l), nil
 	}
 	fd, err := strconv.Atoi(fdEnv)
 	if err != nil {

--- a/host/update.go
+++ b/host/update.go
@@ -66,7 +66,9 @@ func (h *Host) Update(cmd *host.Command) error {
 	// able continue serving requests if the child exits by using the dup'd
 	// listener.
 	log.Info("duplicating HTTP listener")
-	file, err := h.listener.(*net.TCPListener).File()
+	file, err := h.listener.(interface {
+		File() (*os.File, error)
+	}).File()
 	if err != nil {
 		log.Error("error duplicating HTTP listener", "err", err)
 		return err

--- a/pkg/keepalive/keepalive.go
+++ b/pkg/keepalive/keepalive.go
@@ -1,0 +1,33 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package keepalive provides a listener that enables TCP keepalives.
+package keepalive
+
+import (
+	"net"
+	"time"
+)
+
+// Listener returns a net.Listener that enables TCP keep-alive timeouts on
+// accepted connections. It allows detection of dead TCP connections (e.g.
+// closing laptop mid-download) to eventually go away. Derived from the Go
+// net/http package.
+func Listener(l net.Listener) net.Listener {
+	return keepaliveListener{l.(*net.TCPListener)}
+}
+
+type keepaliveListener struct {
+	*net.TCPListener
+}
+
+func (l keepaliveListener) Accept() (c net.Conn, err error) {
+	tc, err := l.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/pkg/keepalive/reuseport.go
+++ b/pkg/keepalive/reuseport.go
@@ -1,0 +1,107 @@
+package keepalive
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var backlog int
+var backlogOnce = &sync.Once{}
+
+// ReusableListen returns a TCP listener with SO_REUSEPORT and keepalives
+// enabled.
+func ReusableListen(proto, addr string) (net.Listener, error) {
+	backlogOnce.Do(func() {
+		backlog = maxListenerBacklog()
+	})
+
+	saddr, typ, err := sockaddr(proto, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	fd, err := syscall.Socket(typ, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setSockopt(fd); err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Bind(fd, saddr); err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Listen(fd, backlog); err != nil {
+		return nil, err
+	}
+
+	f := os.NewFile(uintptr(fd), proto+":"+addr)
+	l, err := net.FileListener(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := f.Close(); err != nil {
+		l.Close()
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func sockaddr(proto, addr string) (syscall.Sockaddr, int, error) {
+	a, err := net.ResolveTCPAddr(proto, addr)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	switch proto {
+	case "tcp4":
+		var ip [4]byte
+		copy(ip[:], a.IP.To4())
+		return &syscall.SockaddrInet4{Port: a.Port, Addr: ip}, syscall.AF_INET, nil
+	case "tcp6":
+		var ip [16]byte
+		copy(ip[:], a.IP.To16())
+		// TODO: this does not set the zone
+		return &syscall.SockaddrInet6{Port: a.Port, Addr: ip}, syscall.AF_INET6, nil
+	default:
+		return nil, -1, errors.New("reuseport: only tcp4 and tcp6 are supported")
+	}
+}
+
+func maxListenerBacklog() int {
+	f, err := os.Open("/proc/sys/net/core/somaxconn")
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	defer f.Close()
+	r := bufio.NewReader(f)
+	l, err := r.ReadString('\n')
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	fs := strings.Fields(l)
+	if len(fs) < 1 {
+		return syscall.SOMAXCONN
+	}
+	n, err := strconv.Atoi(fs[0])
+	if err != nil || n == 0 {
+		return syscall.SOMAXCONN
+	}
+	// Linux stores the backlog in a uint16.
+	// Truncate number to avoid wrapping.
+	// See Go issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return n
+}

--- a/pkg/keepalive/sockopt_linux.go
+++ b/pkg/keepalive/sockopt_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+package keepalive
+
+import (
+	"os"
+	"syscall"
+)
+
+const reusePort = 0x0F
+const keepaliveSecs = 180 // three minutes
+
+func setSockopt(fd int) error {
+	if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, reusePort, 1); err != nil {
+		return os.NewSyscallError("setsockopt", err)
+	}
+	if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
+		return os.NewSyscallError("setsockopt", err)
+	}
+	if err := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, keepaliveSecs); err != nil {
+		return os.NewSyscallError("setsockopt", err)
+	}
+	if err := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, keepaliveSecs); err != nil {
+		return os.NewSyscallError("setsockopt", err)
+	}
+	return nil
+}

--- a/pkg/keepalive/sockopt_stub.go
+++ b/pkg/keepalive/sockopt_stub.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package keepalive
+
+func setSockopt(fd int) error {
+	return nil
+}

--- a/router/server.go
+++ b/router/server.go
@@ -10,10 +10,10 @@ import (
 	"os"
 
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/keepalive"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/router/types"
-	"github.com/vanillahsu/go_reuseport"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -66,7 +66,7 @@ func (s *Router) Close() {
 	s.TCP.Close()
 }
 
-var listenFunc = reuseport.NewReusablePortListener
+var listenFunc = keepalive.ReusableListen
 
 func main() {
 	defer shutdown.Exit()


### PR DESCRIPTION
By default on Linux, TCP connections in the `ESTABLISHED` state do not get reaped for 5 days:

    $ sysctl net.netfilter.nf_conntrack_tcp_timeout_established
    net.netfilter.nf_conntrack_tcp_timeout_established = 43200

This means that if a `FIN` or `RST` packet is not received, for example if a user closes their laptop instead of shutting down their browser cleanly, the server will keep blocking on the fd for a very long time, resulting in what appears to be a slow fd leak.

The solution is to enable TCP keepalive on the socket which will tell the kernel ping the client periodically and if no response is received, will move the connection into the `CLOSE_WAIT` state, freeing the fd and server resources that were serving it.

The creator of the socket has to opt-in to this. By default `net/http` does this when listening, but there are a variety of places where we don't rely on `net/http` to set up the socket. This patch wraps the listener in each of those cases so that keepalive is enabled.

Closes #2684