### PR TITLE
controller/scheduler: Simplify crash restart backoff algorithm

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -179,7 +179,6 @@
     "release": {
       "env": {
         "AUTH_KEY": "{{ (index .StepData \"controller-key\").Data }}",
-        "BACKOFF_PERIOD": "{{ getenv \"BACKOFF_PERIOD\" }}",
         "DEFAULT_ROUTE_DOMAIN": "{{ getenv \"CLUSTER_DOMAIN\" }}",
         "NAME_SEED": "{{ (index .StepData \"name-seed\").Data }}",
         "CA_CERT": "{{ (index .StepData \"controller-cert\").CACert }}"

--- a/test/cluster/client/client.go
+++ b/test/cluster/client/client.go
@@ -48,10 +48,6 @@ func (c *Client) Size() int {
 	return c.size
 }
 
-func (c *Client) BackoffPeriod() time.Duration {
-	return c.cluster.BackoffPeriod
-}
-
 func (c *Client) AddHost(ch chan *discoverd.Event, vanilla bool) (*tc.Instance, error) {
 	path := ""
 	if vanilla {

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -36,13 +36,12 @@ type BootConfig struct {
 }
 
 type Cluster struct {
-	ID            string        `json:"id"`
-	Instances     instances     `json:"instances"`
-	BackoffPeriod time.Duration `json:"backoff_period"`
-	ClusterDomain string        `json:"cluster_domain"`
-	ControllerPin string        `json:"controller_pin"`
-	ControllerKey string        `json:"controller_key"`
-	RouterIP      string        `json:"router_ip"`
+	ID            string    `json:"id"`
+	Instances     instances `json:"instances"`
+	ClusterDomain string    `json:"cluster_domain"`
+	ControllerPin string    `json:"controller_pin"`
+	ControllerKey string    `json:"controller_key"`
+	RouterIP      string    `json:"router_ip"`
 
 	defaultInstances []*Instance
 	releaseInstances []*Instance
@@ -499,7 +498,6 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	inst := instances[0]
 	c.ClusterDomain = fmt.Sprintf("flynn-%s.local", random.String(16))
 	c.ControllerKey = random.String(16)
-	c.BackoffPeriod = 5 * time.Second
 	rd, wr := io.Pipe()
 
 	ips := make([]string, len(instances))
@@ -510,8 +508,8 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	var cmdErr error
 	go func() {
 		command := fmt.Sprintf(
-			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s BACKOFF_PERIOD=%fs flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s /etc/flynn-bootstrap.json",
-			c.ClusterDomain, c.ControllerKey, c.BackoffPeriod.Seconds(), len(instances), strings.Join(ips, ","),
+			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s /etc/flynn-bootstrap.json",
+			c.ClusterDomain, c.ControllerKey, len(instances), strings.Join(ips, ","),
 		)
 		cmdErr = inst.Run(command, &Streams{Stdout: wr, Stderr: c.out})
 		wr.Close()

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -435,19 +434,7 @@ func (s *SchedulerSuite) TestOmniJobs(t *c.C) {
 }
 
 func (s *SchedulerSuite) TestJobRestartBackoffPolicy(t *c.C) {
-	// To run this test on local, set BACKOFF_PERIOD on the flynn host machine
-	var backoffPeriod time.Duration
-	var err error
-	if testCluster == nil {
-		backoffPeriod, err = time.ParseDuration(os.Getenv("BACKOFF_PERIOD"))
-		if err != nil {
-			t.Skip("cannot determine backoff period")
-		}
-	} else {
-		backoffPeriod = testCluster.BackoffPeriod()
-	}
 	startTimeout := 20 * time.Second
-	debugf(t, "job restart backoff period: %s", backoffPeriod)
 
 	app, release := s.createApp(t)
 
@@ -482,10 +469,8 @@ func (s *SchedulerSuite) TestJobRestartBackoffPolicy(t *c.C) {
 	}
 
 	waitForRestart(0)
-	waitForRestart(backoffPeriod)
-	waitForRestart(2 * backoffPeriod)
-	debug(t, "waiting for backoff period to expire")
-	time.Sleep(backoffPeriod)
+	waitForRestart(0)
+	waitForRestart(0)
 	waitForRestart(0)
 }
 


### PR DESCRIPTION
The first five times a job crashes, restart it right away.
The next ten times, wait ten seconds before retrying.
After that, continue trying every thirty seconds.

Closes #2915