### PR TITLE
script: Move FLANNEL_BACKEND var back to bootstrap-flynn

### DIFF
--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -100,6 +100,9 @@ main() {
   local ips=()
   info "starting ${size} node cluster"
 
+  # don't create unnecessary vxlan devices
+  export FLANNEL_BACKEND="alloc"
+
   for index in $(seq 0 $((size - 1))); do
     # An RFC 5737 TEST-NET IP
     local ip="192.0.2.20$(($index))"

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -107,9 +107,6 @@ main() {
   # ensure log dir exists
   sudo mkdir -p $log_dir
 
-  # don't create unnecessary vxlan devices
-  export FLANNEL_BACKEND="alloc"
-
   sudo start-stop-daemon \
     --start \
     --background \


### PR DESCRIPTION
`FLANNEL_BACKEND` only affects bootstrap, not starting `flynn-host` (the variable was moved by accident in commit f5a2a23).