### PR TITLE
test: Remove Sirenia deploy timeout

### DIFF
--- a/test/sirenia.go
+++ b/test/sirenia.go
@@ -316,8 +316,6 @@ loop:
 					newWebJobs++
 				}
 			}
-		case <-time.After(time.Duration(app.DeployTimeout) * time.Second):
-			t.Fatal("timed out waiting for deployment")
 		}
 	}
 


### PR DESCRIPTION
Instead we rely on the controller to do the right thing.
Worst case the test will be terminated if it hangs.