### PR TITLE
router: Remove useless mutex lock in TCP handler

### DIFF
--- a/router/tcp.go
+++ b/router/tcp.go
@@ -317,9 +317,7 @@ func (r *tcpRoute) Serve(started chan<- error) {
 		if err != nil {
 			break
 		}
-		r.mtx.RLock()
 		go r.ServeConn(conn)
-		r.mtx.RUnlock()
 	}
 }
 


### PR DESCRIPTION
A new route is built each time `Set` is called, and wrapping a go call in a mutex lock makes no sense in this case.

Closes #1034