### PR TITLE
pkg/cluster: Unlock mutex if attach wait fails

### DIFF
--- a/pkg/cluster/attach.go
+++ b/pkg/cluster/attach.go
@@ -143,6 +143,7 @@ func (c *attachClient) Wait() error {
 func (c *attachClient) Receive(stdout, stderr io.Writer) (int, error) {
 	if c.wait != nil {
 		if err := c.wait(); err != nil {
+			c.mtx.Unlock()
 			return -1, err
 		}
 		c.mtx.Unlock()


### PR DESCRIPTION
This prevents blocking other calls like Close and Write permanently.

Closes #1457