### PR TITLE
host: Remove unnecessary CAP_AUDIT_{READ,WRITE}

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -58,8 +58,6 @@ const (
 var defaultCapabilities = []string{
 	"CAP_NET_RAW",
 	"CAP_NET_BIND_SERVICE",
-	"CAP_AUDIT_READ",
-	"CAP_AUDIT_WRITE",
 	"CAP_DAC_OVERRIDE",
 	"CAP_SETFCAP",
 	"CAP_SETPCAP",


### PR DESCRIPTION
`CAP_AUDIT_READ` does not exist in kernel 3.13, and we don’t need/want these capabilities.

Refs #3095