### PR TITLE
cli: Remove docker tag --force

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -204,7 +204,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 
 	// tag the docker image ready to be pushed
 	tag := fmt.Sprintf("%s/%s:latest", dockerHost, mustApp())
-	cmd = exec.Command("docker", "tag", "--force", image, tag)
+	cmd = exec.Command("docker", "tag", image, tag)
 	log.Printf("flynn: tagging Docker image with %q", strings.Join(cmd.Args, " "))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
It's been removed from Docker: https://docs.docker.com/engine/deprecated/

We (@mnaughto and I) can't push from our OSX machines running the latest Docker for Mac with this option in place, we just get:

````
flynn -a helloworld:latest docker push google/nodejs-hello
flynn: getting image config with "docker inspect -f {{ json .Config }} google/nodejs-hello"
flynn: tagging Docker image with "docker tag --force google/nodejs-hello docker.flynn.domain.com/helloworld:latest"
unknown flag: --force
See 'docker tag --help'.
exit status 1
```` 

Unsure if there are any side-effects of just removing this?

Fixes #3105.

Signed-off-by: Brett Neese <brett@neese.rocks>
