### PR TITLE
test: Add pkg-config to rootfs

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -153,7 +153,8 @@ apt-get install -y \
   inotify-tools \
   libsasl2-dev \
   libseccomp-dev \
-  squashfs-tools
+  squashfs-tools \
+  pkg-config
 
 # install flynn test dependencies: postgres, redis, mariadb
 # (normally these are used via appliances; install locally for unit tests)


### PR DESCRIPTION
This is required for building `libcontainer` and was previously pulled in when installing libvirt-bin.