### PR TITLE
test,util/packer: Use latest Ubuntu xenial kernel

### DIFF
--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -94,8 +94,7 @@ echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
 # update packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-# install backported kernel, pin version to 3.19.0-39 to work around https://github.com/docker/docker/issues/18180 / https://github.com/flynn/flynn/issues/2365
-apt-get install --install-recommends linux-headers-3.19.0-39 linux-headers-3.19.0-39-generic linux-image-3.19.0-39-generic linux-image-extra-3.19.0-39-generic \
+apt-get install --install-recommends linux-generic-lts-xenial \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"

--- a/util/packer/ubuntu-14.04/scripts/upgrade.sh
+++ b/util/packer/ubuntu-14.04/scripts/upgrade.sh
@@ -35,8 +35,7 @@ if [[ "${PACKER_BUILDER_TYPE}" == "virtualbox-ovf" ]]; then
   apt-get remove --purge -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 fi
 
-# install backported kernel, pin version to 3.19.0-39 to work around https://github.com/docker/docker/issues/18180 / https://github.com/flynn/flynn/issues/2365
-apt-get install --install-recommends linux-headers-3.19.0-39 linux-headers-3.19.0-39-generic linux-image-3.19.0-39-generic linux-image-extra-3.19.0-39-generic \
+apt-get install --install-recommends linux-generic-lts-xenial \
   -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
The bug causing us to pin the kernel version (see #2366) has been fixed so we should be safe to upgrade, and we need a newer kernel version for the upcoming squashfs / overlayfs image changes.