### PR TITLE
Add dev script to compile/run the installer

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,2 @@
-bindata.go
+/bindata.go
+/cli

--- a/installer/app/.gitignore
+++ b/installer/app/.gitignore
@@ -6,3 +6,5 @@
 /erb.rb
 /scss.js
 /transformer.js
+/.bundle
+/vendor/bundle

--- a/installer/http.go
+++ b/installer/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -100,7 +101,13 @@ func ServeHTTP() error {
 	httpRouter.GET("/regions", api.GetCloudRegions)
 	httpRouter.GET("/azure/subscriptions", api.GetAzureSubscriptions)
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	port := os.Getenv("PORT")
+	if port == "" {
+		// if no port is given, use a random one
+		port = "0"
+	}
+
+	l, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		return err
 	}

--- a/script/installer-dev
+++ b/script/installer-dev
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/ui.sh"
+
+usage() {
+  cat <<USAGE >&2
+usage: $0 [-h|--help] <command>
+
+COMMANDS:
+  compile       Compile the installer assets
+
+  run           Build and run the installer
+
+OPTIONS:
+  -h, --help    Show this message
+USAGE
+}
+
+main() {
+  if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
+    usage
+    exit
+  fi
+
+  case "$1" in
+    compile)
+      compile
+      ;;
+    run)
+      run
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+compile() {
+  docker run \
+    --volume "${ROOT}/installer/app:/build" \
+    --workdir /build \
+    flynn/installer-builder \
+    bash -c "cp --recursive /app/.bundle . && cp --recursive /app/vendor/bundle vendor/ && cp --recursive /app/node_modules . && ./compiler && chown -R $(id -u):$(id -g) ."
+}
+
+run() {
+  cd "${ROOT}/installer"
+
+  info "updating installer to read assets from the filesystem"
+  cat <<BINDATA > bindata.go
+package installer
+
+import (
+  "bytes"
+  "io"
+  "os"
+)
+
+func Asset(path string) ([]byte, error) {
+  file, err := os.Open(path)
+  if err != nil {
+    return nil, err
+  }
+  var buf bytes.Buffer
+  _, err = io.Copy(&buf, file)
+  return buf.Bytes(), err
+}
+BINDATA
+
+  info "building installer"
+  go build ../cli
+
+  info "setting environment variables"
+  export PORT="4455"
+
+  info "running installer on installer.1.localflynn.com:${PORT}"
+  ./cli install
+}
+
+main $@


### PR DESCRIPTION
Similar to the existing script for the dashboard (#3024).

Refs #1624

Workflow:

- `script/installer-dev compile` compiles the assets into `installer/app`
- `script/installer-dev run` updates `installer/bindata.go`, then builds and runs the installer on port 4455
- re-run the first step after each asset code change, and the second after changes to the Go code