### PR TITLE
Fix host crash due to race and recovery

### DIFF
--- a/host/backend.go
+++ b/host/backend.go
@@ -32,7 +32,10 @@ type Backend interface {
 	Cleanup([]string) error
 	UnmarshalState(map[string]*host.ActiveJob, map[string][]byte, []byte, host.LogBuffers) error
 	ConfigureNetworking(config *host.NetworkConfig) error
+	SetHost(*Host)
 	SetDefaultEnv(k, v string)
+	SetDiscoverdConfig(*host.DiscoverdConfig)
+	SetNetworkConfig(*host.NetworkConfig)
 	OpenLogs(host.LogBuffers) error
 	CloseLogs() (host.LogBuffers, error)
 }
@@ -63,6 +66,9 @@ func (MockBackend) SetDefaultEnv(k, v string)                         {}
 func (MockBackend) ConfigureNetworking(*host.NetworkConfig) error     { return nil }
 func (MockBackend) OpenLogs(host.LogBuffers) error                    { return nil }
 func (MockBackend) CloseLogs() (host.LogBuffers, error)               { return nil, nil }
+func (MockBackend) SetDiscoverdConfig(*host.DiscoverdConfig)          {}
+func (MockBackend) SetNetworkConfig(*host.NetworkConfig)              {}
+func (MockBackend) SetHost(*Host)                                     {}
 func (MockBackend) UnmarshalState(map[string]*host.ActiveJob, map[string][]byte, []byte, host.LogBuffers) error {
 	return nil
 }

--- a/host/state.go
+++ b/host/state.go
@@ -225,6 +225,12 @@ func (s *State) Release() {
 	}
 }
 
+func (s *State) PersistBackendGlobalState(data []byte) error {
+	return s.stateDB.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("backend-global")).Put([]byte("backend"), data)
+	})
+}
+
 func (s *State) persist(jobID string) {
 	// s.mtx.RLock() should already be covered by caller
 

--- a/pinkerton/context.go
+++ b/pinkerton/context.go
@@ -42,6 +42,7 @@ type Context struct {
 	store  *graph.TagStore
 	graph  *graph.Graph
 	driver graphdriver.Driver
+	mtx    sync.Mutex
 }
 
 func BuildContext(driver, root string) (*Context, error) {
@@ -76,6 +77,9 @@ func NewContext(store *graph.TagStore, graph *graph.Graph, driver graphdriver.Dr
 }
 
 func (c *Context) PullDocker(url string, out io.Writer) (string, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
 	ref, err := NewRef(url)
 	if err != nil {
 		return "", err
@@ -109,6 +113,9 @@ func (c *Context) PullDocker(url string, out io.Writer) (string, error) {
 }
 
 func (c *Context) PullTUF(url string, client *tuf.Client, progress chan<- layer.PullInfo) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
 	ref, err := NewRef(url)
 	if err != nil {
 		return err
@@ -169,6 +176,9 @@ func (c *Context) PullTUF(url string, client *tuf.Client, progress chan<- layer.
 }
 
 func (c *Context) Checkout(id, imageID string) (string, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
 	id = "tmp-" + id
 	if err := c.driver.Create(id, imageID); err != nil {
 		return "", err
@@ -181,6 +191,9 @@ func (c *Context) Checkout(id, imageID string) (string, error) {
 }
 
 func (c *Context) Cleanup(id string) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
 	id = "tmp-" + id
 	if err := c.driver.Put(id); err != nil {
 		return err


### PR DESCRIPTION
This PR fixes two distinct issues, the first triggered the second.

#### flynn-host crash

Calls from pinkerton into the graph layer are not thread-safe, causing this flynn-host panic:

    fatal error: concurrent map writes


    goroutine 747 [running]:
    runtime.throw(0xf00770, 0x15)
        go/src/runtime/panic.go:547 +0x90 fp=0xc820a772a8 sp=0xc820a77290
    runtime.mapassign1(0xbb70a0, 0xc820236690, 0xc820a77490, 0xc820a773c0)
        go/src/runtime/hashmap.go:445 +0xb1 fp=0xc820a77350 sp=0xc820a772a8
    github.com/flynn/flynn/vendor/github.com/docker/docker/daemon/graphdriver/aufs.(*Driver).Create(0xc82024e140, 0xc8208b4000, 0x31, 0xc820b48831, 0x40, 0x0, 0x0)
        vendor/github.com/docker/docker/daemon/graphdriver/aufs/aufs.go:230 +0x6f3 fp=0xc820a77530 sp=0xc820a77350
    github.com/flynn/flynn/pinkerton.(*Context).Checkout(0xc820382d80, 0xc8208b4000, 0x31, 0xc820b48831, 0x40, 0x0, 0x0, 0x0, 0x0)
        pinkerton/context.go:173 +0xda fp=0xc820a775a0 sp=0xc820a77530
    main.(*LibcontainerBackend).Run(0xc8203fd680, 0xc8205ff800, 0xc820a77c10, 0xc8201807d8, 0x0, 0x0)
        host/libcontainer_backend.go:419 +0x17fd fp=0xc820a77ee0 sp=0xc820a775a0
    main.(*jobAPI).AddJob.func1(0x7f8be2685738, 0xc820492c40, 0xc8202389f0, 0xc8205ff800)
        host/http.go:323 +0xaf fp=0xc820a77f70 sp=0xc820a77ee0
    runtime.goexit()
        go/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc820a77f78 sp=0xc820a77f70
    created by main.(*jobAPI).AddJob
        host/http.go:330 +0xd85

#### flynn-host crash recovery failure

If flynn-host terminates without stopping jobs, when it reconnects it needs to load the discoverd and network configuration back in so that new jobs can be started.

Before this patch, newly added jobs would block forever waiting for networking to come up.

The details are persisted in the global backend state storage system, and a set of functions are set up to ensure it is kept up to date when the relevant job IDs change and so on.

This also resulted in a cleanup of state restoration on updates, the same code path is now used.

To test, I did the following:

1. Sent a SIGKILL to flynn-host and then started it back up, and
   confirmed that new jobs could be scheduled and the appropriate
   log messages were printed.
2. Sent a POST /host/update to simulate an in-place upgrade and
   confirmed that new jobs could be scheduled and the appropriate
   log messages were printed.
3. Stopped flynn-host cleanly and then started it back up and
   confirmed that the old config was not used, the appropriate log
   messages were printed, and the cluster resurrected.

Closes #3129 
Closes #3125 
Closes #3124