### PR TITLE
appliance/mongodb: Stop peer before stopping heartbeater

### DIFF
--- a/appliance/mongodb/handler.go
+++ b/appliance/mongodb/handler.go
@@ -82,11 +82,11 @@ func (h *Handler) handleGetStatus(w http.ResponseWriter, req *http.Request, _ ht
 
 // handlePostStop handles request to POST /stop.
 func (h *Handler) handlePostStop(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	if err := h.Heartbeater.Close(); err != nil {
+	if err := h.Peer.Stop(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
-	if err := h.Peer.Stop(); err != nil {
+	if err := h.Heartbeater.Close(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}


### PR DESCRIPTION
Prevents the peer state machine from running `replSetReconfig` after it should have been stopped. Further work is required to ensure safety in some failure cases but this will stabilise the tests in CI.