### PR TITLE
all: Replace Entrypoint / Cmd with Args

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -206,7 +206,7 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 					{Port: 6380, Proto: "tcp"},
 				},
 				Data:    true,
-				Cmd:     []string{"redis"},
+				Args:    []string{"/bin/start-flynn-redis", "redis"},
 				Service: "redis",
 			},
 		},

--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -32,9 +32,6 @@ func interpolateRelease(s *State, r *ct.Release) {
 				delete(proc.Env, k)
 			}
 		}
-		for i, v := range proc.Cmd {
-			proc.Cmd[i] = interpolate(s, v)
-		}
 	}
 }
 

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -107,7 +107,7 @@
         "postgres": {
           "ports": [{"port": 5432, "proto": "tcp"}],
           "data": true,
-          "cmd": ["postgres"],
+          "args": ["/bin/start-flynn-postgres", "postgres"],
           "service": "postgres",
           "env": {
             "SINGLETON": "{{ .Singleton }}"
@@ -115,7 +115,7 @@
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"]
+          "args": ["/bin/start-flynn-postgres", "api"]
         }
       }
     },
@@ -186,17 +186,17 @@
       "processes": {
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["controller"],
+          "args": ["/bin/start-flynn-controller", "controller"],
           "service": "controller"
         },
         "scheduler": {
-          "cmd": ["scheduler"],
+          "args": ["/bin/start-flynn-controller", "scheduler"],
           "omni": true,
           "service": "controller-scheduler",
           "ports": [{ "proto": "tcp" }]
         },
         "worker": {
-          "cmd": ["worker"],
+          "args": ["/bin/start-flynn-controller", "worker"],
           "ports": [{ "proto": "tcp" }]
         }
       }
@@ -299,7 +299,7 @@
       "processes": {
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"]
+          "args": ["/bin/start-flynn-redis", "api"]
         }
       }
     },
@@ -341,7 +341,7 @@
       "processes": {
         "mariadb": {
           "ports": [{"port": 3306, "proto": "tcp"}],
-          "cmd": ["mariadb"],
+          "args": ["/bin/start-flynn-mariadb", "mariadb"],
           "service": "mariadb",
           "env": {
             "SINGLETON": "{{ .Singleton }}"
@@ -350,7 +350,7 @@
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"],
+          "args": ["/bin/start-flynn-mariadb", "api"],
           "env": {
             "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}"
           }
@@ -396,7 +396,7 @@
       "processes": {
         "mongodb": {
           "ports": [{"port": 27017, "proto": "tcp"}],
-          "cmd": ["mongodb"],
+          "args": ["/bin/start-flynn-mongodb", "mongodb"],
           "service": "mongodb",
           "env": {
             "SINGLETON": "{{ .Singleton }}"
@@ -405,7 +405,7 @@
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
-          "cmd": ["api"],
+          "args": ["/bin/start-flynn-mongodb", "api"],
           "env": {
             "CONTROLLER_KEY": "{{ (index .StepData \"controller-key\").Data }}"
           }
@@ -471,7 +471,7 @@
       "processes": {
         "app": {
           "host_network": true,
-          "cmd": ["-http-port", "80", "-https-port", "443", "-tcp-range-start", "3000", "-tcp-range-end", "3500"],
+          "args": ["/bin/flynn-router", "-http-port", "80", "-https-port", "443", "-tcp-range-start", "3000", "-tcp-range-end", "3500"],
           "omni": true,
           "service": "router-api"
         }
@@ -612,7 +612,7 @@
     "release": {
       "processes": {
         "app": {
-          "cmd": ["-logaddr", ":514", "-apiaddr", ":80"],
+          "args": ["/bin/logaggregator", "-logaddr", ":514", "-apiaddr", ":80"],
           "ports": [
             {"port": 80, "proto": "tcp"},
             {"port": 514, "proto": "tcp"}

--- a/cli/docker.go
+++ b/cli/docker.go
@@ -230,8 +230,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 	if !ok {
 		proc = ct.ProcessType{}
 	}
-	proc.Cmd = config.Cmd
-	proc.Entrypoint = config.Entrypoint
+	proc.Args = append(config.Entrypoint, config.Cmd...)
 	if len(proc.Ports) == 0 {
 		proc.Ports = []ct.Port{{
 			Port:  8080,

--- a/cli/export.go
+++ b/cli/export.go
@@ -209,8 +209,7 @@ func runExport(args *docopt.Args, client controller.Client) error {
 			App:        mustApp(),
 			Release:    release.ID,
 			DisableLog: true,
-			Entrypoint: []string{"curl"},
-			Args:       []string{"--include", "--location", "--raw", slugURL},
+			Args:       []string{"curl", "--include", "--location", "--raw", slugURL},
 			Stdout:     reqW,
 			Stderr:     ioutil.Discard,
 		}
@@ -255,8 +254,7 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		configPgDump(pgConfig)
 		if err := tw.WriteCommandOutput(client, "postgres.dump", pgConfig.App, &ct.NewJob{
 			ReleaseID:  pgConfig.Release,
-			Entrypoint: pgConfig.Entrypoint,
-			Cmd:        pgConfig.Args,
+			Args:       pgConfig.Args,
 			Env:        pgConfig.Env,
 			DisableLog: pgConfig.DisableLog,
 		}); err != nil {
@@ -268,8 +266,7 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		configMysqlDump(mysqlConfig)
 		if err := tw.WriteCommandOutput(client, "mysql.dump", mysqlConfig.App, &ct.NewJob{
 			ReleaseID:  mysqlConfig.Release,
-			Entrypoint: mysqlConfig.Entrypoint,
-			Cmd:        mysqlConfig.Args,
+			Args:       mysqlConfig.Args,
 			Env:        mysqlConfig.Env,
 			DisableLog: mysqlConfig.DisableLog,
 		}); err != nil {
@@ -600,8 +597,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			App:        app.ID,
 			Release:    release.ID,
 			DisableLog: true,
-			Entrypoint: []string{"curl"},
-			Args:       []string{"--request", "PUT", "--upload-file", "-", slugURI},
+			Args:       []string{"curl", "--request", "PUT", "--upload-file", "-", slugURI},
 			Stdin:      slug,
 			Stdout:     ioutil.Discard,
 			Stderr:     ioutil.Discard,

--- a/cli/mongodb.go
+++ b/cli/mongodb.go
@@ -92,10 +92,10 @@ func getMongodbRunConfig(client controller.Client, app string, appRelease *ct.Re
 }
 
 func runMongo(args *docopt.Args, client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"mongo"}
 	config.Env["PAGER"] = "less"
 	config.Env["LESS"] = "--ignore-case --LONG-PROMPT --SILENT --tabs=4 --quit-if-one-screen --no-init --quit-at-eof"
 	config.Args = append([]string{
+		"mongo",
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],
@@ -129,8 +129,8 @@ func runMongodbDump(args *docopt.Args, client controller.Client, config *runConf
 }
 
 func configMongodbDump(config *runConfig) {
-	config.Entrypoint = []string{"/bin/dump-flynn-mongodb"}
 	config.Args = []string{
+		"/bin/dump-flynn-mongodb",
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],
@@ -177,8 +177,8 @@ func runMongodbRestore(args *docopt.Args, client controller.Client, config *runC
 }
 
 func mongodbRestore(client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"/bin/restore-flynn-mongodb"}
 	config.Args = []string{
+		"/bin/restore-flynn-mongodb",
 		"--host", config.Env["MONGO_HOST"],
 		"-u", config.Env["MONGO_USER"],
 		"-p", config.Env["MONGO_PWD"],

--- a/cli/mysql.go
+++ b/cli/mysql.go
@@ -98,10 +98,10 @@ func getMysqlRunConfig(client controller.Client, appName string, appRelease *ct.
 }
 
 func runMysqlMysql(args *docopt.Args, client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"mysql"}
 	config.Env["PAGER"] = "less"
 	config.Env["LESS"] = "--ignore-case --LONG-PROMPT --SILENT --tabs=4 --quit-if-one-screen --no-init --quit-at-eof"
 	config.Args = append([]string{
+		"mysql",
 		"-u", config.Env["MYSQL_USER"],
 		"-D", config.Env["MYSQL_DATABASE"],
 	}, args.All["<argument>"].([]string)...)
@@ -134,8 +134,8 @@ func runMysqlDump(args *docopt.Args, client controller.Client, config *runConfig
 }
 
 func configMysqlDump(config *runConfig) {
-	config.Entrypoint = []string{"mysqldump"}
 	config.Args = []string{
+		"mysqldump",
 		"-h", config.Env["MYSQL_HOST"],
 		"-u", config.Env["MYSQL_USER"],
 		config.Env["MYSQL_DATABASE"],
@@ -176,8 +176,7 @@ func runMysqlRestore(args *docopt.Args, client controller.Client, config *runCon
 }
 
 func mysqlRestore(client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"mysql"}
-	config.Args = []string{"-u", config.Env["MYSQL_USER"], "-D", config.Env["MYSQL_DATABASE"]}
+	config.Args = []string{"mysql", "-u", config.Env["MYSQL_USER"], "-D", config.Env["MYSQL_DATABASE"]}
 	err := runJob(client, *config)
 	if exit, ok := err.(RunExitError); ok && exit == 1 {
 		return nil

--- a/cli/pg.go
+++ b/cli/pg.go
@@ -92,10 +92,9 @@ func getPgRunConfig(client controller.Client, app string, appRelease *ct.Release
 }
 
 func runPsql(args *docopt.Args, client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"psql"}
 	config.Env["PAGER"] = "less"
 	config.Env["LESS"] = "--ignore-case --LONG-PROMPT --SILENT --tabs=4 --quit-if-one-screen --no-init --quit-at-eof"
-	config.Args = args.All["<argument>"].([]string)
+	config.Args = append([]string{"psql"}, args.All["<argument>"].([]string)...)
 	return runJob(client, *config)
 }
 
@@ -123,8 +122,7 @@ func runPgDump(args *docopt.Args, client controller.Client, config *runConfig) e
 }
 
 func configPgDump(config *runConfig) {
-	config.Entrypoint = []string{"pg_dump"}
-	config.Args = []string{"--format=custom", "--no-owner", "--no-acl"}
+	config.Args = []string{"pg_dump", "--format=custom", "--no-owner", "--no-acl"}
 }
 
 func pgDump(client controller.Client, config *runConfig) error {
@@ -166,8 +164,7 @@ func runPgRestore(args *docopt.Args, client controller.Client, config *runConfig
 }
 
 func pgRestore(client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"pg_restore"}
-	config.Args = []string{"-d", config.Env["PGDATABASE"], "--clean", "--if-exists", "--no-owner", "--no-acl"}
+	config.Args = []string{"pg_restore", "-d", config.Env["PGDATABASE"], "--clean", "--if-exists", "--no-owner", "--no-acl"}
 	err := runJob(client, *config)
 	if exit, ok := err.(RunExitError); ok && exit == 1 {
 		// pg_restore exits with zero if there are warnings

--- a/cli/redis.go
+++ b/cli/redis.go
@@ -76,7 +76,7 @@ func getRedisRunConfig(client controller.Client, app string, appRelease *ct.Rele
 		App:        app,
 		Release:    redisRelease.ID,
 		Env:        make(map[string]string),
-		Args:       []string{"-h", redisApp + ".discoverd", "-a", appRelease.Env["REDIS_PASSWORD"]},
+		Args:       []string{"redis-cli", "-h", redisApp + ".discoverd", "-a", appRelease.Env["REDIS_PASSWORD"]},
 		DisableLog: true,
 		Exit:       true,
 	}
@@ -85,7 +85,6 @@ func getRedisRunConfig(client controller.Client, app string, appRelease *ct.Rele
 }
 
 func runRedisCLI(args *docopt.Args, client controller.Client, config *runConfig) error {
-	config.Entrypoint = []string{"redis-cli"}
 	config.Env["PAGER"] = "less"
 	config.Env["LESS"] = "--ignore-case --LONG-PROMPT --SILENT --tabs=4 --quit-if-one-screen --no-init --quit-at-eof"
 	config.Args = append(config.Args, args.All["<argument>"].([]string)...)
@@ -114,7 +113,7 @@ func runRedisDump(args *docopt.Args, client controller.Client, config *runConfig
 		config.Stdout = io.MultiWriter(config.Stdout, bar)
 	}
 
-	config.Entrypoint = []string{"/bin/dump-flynn-redis"}
+	config.Args[0] = "/bin/dump-flynn-redis"
 	return runJob(client, *config)
 }
 
@@ -150,6 +149,6 @@ func runRedisRestore(args *docopt.Args, client controller.Client, config *runCon
 		config.Stdin = bar.NewProxyReader(config.Stdin)
 	}
 
-	config.Entrypoint = []string{"/bin/restore-flynn-redis"}
+	config.Args[0] = "/bin/restore-flynn-redis"
 	return runJob(client, *config)
 }

--- a/cli/release.go
+++ b/cli/release.go
@@ -74,8 +74,7 @@ Examples:
 		"env": {"MY_VAR": "Hello World, this will be available in all process types."},
 		"processes": {
 			"echo": {
-				"cmd": ["socat -v tcp-l:$PORT,fork exec:/bin/cat"],
-				"entrypoint": ["sh", "-c"],
+				"args": ["sh", "-c", "socat -v tcp-l:$PORT,fork exec:/bin/cat"],
 				"env": {"ECHO": "This var is specific to the echo process type."},
 				"ports": [{"proto": "tcp"}]
 			}
@@ -271,11 +270,8 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 				continue
 			}
 
-			if len(procUpdate.Cmd) > 0 {
-				procRelease.Cmd = procUpdate.Cmd
-			}
-			if len(procUpdate.Entrypoint) > 0 {
-				procRelease.Entrypoint = procUpdate.Entrypoint
+			if len(procUpdate.Args) > 0 {
+				procRelease.Args = procUpdate.Args
 			}
 			for key, value := range procUpdate.Env {
 				procRelease.Env[key] = value

--- a/cli/run.go
+++ b/cli/run.go
@@ -61,7 +61,7 @@ func runRun(args *docopt.Args, client controller.Client) error {
 		config.Release = release.ID
 	}
 	if e := args.String["-e"]; e != "" {
-		fmt.Println("WARN: The -e flag is deprecated and will be removed in future versions, use <command> as the entrypoint")
+		fmt.Fprintln(os.Stderr, "WARN: The -e flag is deprecated and will be removed in future versions, use <command> as the entrypoint")
 		config.Args = append([]string{e}, config.Args...)
 	}
 	return runJob(client, config)

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -305,7 +305,7 @@ func (e *generator) createRelease() {
 		},
 		Processes: map[string]ct.ProcessType{
 			"foo": {
-				Cmd: []string{"ls", "-l"},
+				Args: []string{"ls", "-l"},
 				Env: map[string]string{
 					"BAR": "baz",
 				},
@@ -386,7 +386,7 @@ func (e *generator) runJob() {
 		Env: map[string]string{
 			"BODY": "Hello!",
 		},
-		Cmd: []string{"echo", "$BODY"},
+		Args: []string{"echo", "$BODY"},
 	}
 	job, err := e.client.RunJobDetached(e.resourceIds["app"], new_job)
 	if err == nil {

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -275,7 +275,6 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 		ID:       id,
 		Metadata: metadata,
 		Config: host.ContainerConfig{
-			Cmd:        newJob.Cmd,
 			Env:        env,
 			TTY:        newJob.TTY,
 			Stdin:      attach,
@@ -284,8 +283,8 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 		Resources: newJob.Resources,
 	}
 	resource.SetDefaults(&job.Resources)
-	if len(newJob.Entrypoint) > 0 {
-		job.Config.Entrypoint = newJob.Entrypoint
+	if len(newJob.Args) > 0 {
+		job.Config.Args = newJob.Args
 	}
 	if len(release.ArtifactIDs) > 0 {
 		artifacts, err := c.artifactRepo.ListIDs(release.ArtifactIDs...)
@@ -352,7 +351,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 			UUID:      uuid,
 			HostID:    hostID,
 			ReleaseID: newJob.ReleaseID,
-			Cmd:       newJob.Cmd,
+			Args:      newJob.Args,
 		})
 	}
 }

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -299,6 +299,11 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 		}
 	}
 
+	// ensure slug apps use /runner/init
+	if release.IsGitDeploy() && (len(job.Config.Args) == 0 || job.Config.Args[0] != "/runner/init") {
+		job.Config.Args = append([]string{"/runner/init"}, job.Config.Args...)
+	}
+
 	var attachClient cluster.AttachClient
 	if attach {
 		attachReq := &host.AttachReq{

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -162,11 +162,11 @@ func (s *S) TestRunJobDetached(c *C) {
 		Env:         map[string]string{"RELEASE": "true", "FOO": "bar"},
 	})
 
-	cmd := []string{"foo", "bar"}
+	args := []string{"foo", "bar"}
 	req := &ct.NewJob{
 		ReleaseID:  release.ID,
 		ReleaseEnv: true,
-		Cmd:        cmd,
+		Args:       args,
 		Env:        map[string]string{"JOB": "true", "FOO": "baz"},
 		Meta:       map[string]string{"foo": "baz"},
 	}
@@ -175,7 +175,7 @@ func (s *S) TestRunJobDetached(c *C) {
 	c.Assert(res.ID, Not(Equals), "")
 	c.Assert(res.ReleaseID, Equals, release.ID)
 	c.Assert(res.Type, Equals, "")
-	c.Assert(res.Cmd, DeepEquals, cmd)
+	c.Assert(res.Args, DeepEquals, args)
 
 	jobs, err := host.ListJobs()
 	c.Assert(err, IsNil)
@@ -188,7 +188,7 @@ func (s *S) TestRunJobDetached(c *C) {
 			"flynn-controller.release":  release.ID,
 			"foo": "baz",
 		})
-		c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
+		c.Assert(job.Config.Args, DeepEquals, []string{"foo", "bar"})
 		c.Assert(job.Config.Env, DeepEquals, map[string]string{
 			"FLYNN_APP_ID":       app.ID,
 			"FLYNN_RELEASE_ID":   release.ID,
@@ -242,7 +242,7 @@ func (s *S) TestRunJobAttached(c *C) {
 	data := &ct.NewJob{
 		ReleaseID:  release.ID,
 		ReleaseEnv: true,
-		Cmd:        []string{"foo", "bar"},
+		Args:       []string{"foo", "bar"},
 		Env:        map[string]string{"JOB": "true", "FOO": "baz"},
 		Meta:       map[string]string{"foo": "baz"},
 		TTY:        true,
@@ -271,7 +271,7 @@ func (s *S) TestRunJobAttached(c *C) {
 			"flynn-controller.release":  release.ID,
 			"foo": "baz",
 		})
-		c.Assert(job.Config.Cmd, DeepEquals, []string{"foo", "bar"})
+		c.Assert(job.Config.Args, DeepEquals, []string{"foo", "bar"})
 		c.Assert(job.Config.Env, DeepEquals, map[string]string{
 			"FLYNN_APP_ID":       app.ID,
 			"FLYNN_RELEASE_ID":   release.ID,

--- a/controller/release.go
+++ b/controller/release.go
@@ -52,6 +52,13 @@ func (r *ReleaseRepo) Add(data interface{}) error {
 	release := data.(*ct.Release)
 
 	for typ, proc := range release.Processes {
+		// handle deprecated Entrypoint and Cmd
+		if len(proc.DeprecatedEntrypoint) > 0 {
+			proc.Args = proc.DeprecatedEntrypoint
+		}
+		if len(proc.DeprecatedCmd) > 0 {
+			proc.Args = append(proc.Args, proc.DeprecatedCmd...)
+		}
 		resource.SetDefaults(&proc.Resources)
 		release.Processes[typ] = proc
 	}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -807,10 +807,9 @@ func (s *Scheduler) HandleInternalStateRequest(req *InternalStateRequest) {
 		}
 		for name, proc := range formation.Release.Processes {
 			f.Release.Processes[name] = ct.ProcessType{
-				Cmd:        proc.Cmd,
-				Entrypoint: proc.Entrypoint,
-				Data:       proc.Data,
-				Omni:       proc.Omni,
+				Args: proc.Args,
+				Data: proc.Data,
+				Omni: proc.Omni,
 			}
 		}
 		req.State.Formations[key.String()] = &f

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -260,7 +260,7 @@ func NewReleaseOmni(id string, artifact *ct.Artifact, processes map[string]int, 
 	processTypes := make(map[string]ct.ProcessType, len(processes))
 	for t := range processes {
 		processTypes[t] = ct.ProcessType{
-			Cmd:  []string{"start", t},
+			Args: []string{"start", t},
 			Omni: omni,
 		}
 	}

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -89,8 +89,7 @@ func (r *Release) IsDockerReceiveDeploy() bool {
 }
 
 type ProcessType struct {
-	Cmd         []string           `json:"cmd,omitempty"`
-	Entrypoint  []string           `json:"entrypoint,omitempty"`
+	Args        []string           `json:"args,omitempty"`
 	Env         map[string]string  `json:"env,omitempty"`
 	Ports       []Port             `json:"ports,omitempty"`
 	Data        bool               `json:"data,omitempty"`
@@ -99,6 +98,10 @@ type ProcessType struct {
 	Service     string             `json:"service,omitempty"`
 	Resurrect   bool               `json:"resurrect,omitempty"`
 	Resources   resource.Resources `json:"resources,omitempty"`
+
+	// Entrypoint and Cmd are DEPRECATED: use Args instead
+	DeprecatedCmd        []string `json:"cmd,omitempty"`
+	DeprecatedEntrypoint []string `json:"entrypoint,omitempty"`
 }
 
 type Port struct {
@@ -159,7 +162,7 @@ type Job struct {
 	ReleaseID  string            `json:"release,omitempty"`
 	Type       string            `json:"type,omitempty"`
 	State      JobState          `json:"state,omitempty"`
-	Cmd        []string          `json:"cmd,omitempty"`
+	Args       []string          `json:"args,omitempty"`
 	Meta       map[string]string `json:"meta,omitempty"`
 	ExitStatus *int32            `json:"exit_status,omitempty"`
 	HostError  *string           `json:"host_error,omitempty"`
@@ -237,8 +240,7 @@ func JobDownEvents(count int) map[JobState]int {
 type NewJob struct {
 	ReleaseID  string             `json:"release,omitempty"`
 	ReleaseEnv bool               `json:"release_env,omitempty"`
-	Cmd        []string           `json:"cmd,omitempty"`
-	Entrypoint []string           `json:"entrypoint,omitempty"`
+	Args       []string           `json:"args,omitempty"`
 	Env        map[string]string  `json:"env,omitempty"`
 	Meta       map[string]string  `json:"meta,omitempty"`
 	TTY        bool               `json:"tty,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -42,18 +42,22 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 		ID:       id,
 		Metadata: metadata,
 		Config: host.ContainerConfig{
-			Cmd:         t.Cmd,
+			Args:        t.Args,
 			Env:         env,
 			HostNetwork: t.HostNetwork,
 		},
 		Resurrect: t.Resurrect,
 		Resources: t.Resources,
 	}
+
+	// job.Config.Args may be empty if restoring from an old backup which
+	// still uses the deprecated Entrypoint / Cmd fields
+	if len(job.Config.Args) == 0 {
+		job.Config.Args = append(t.DeprecatedEntrypoint, t.DeprecatedCmd...)
+	}
+
 	if f.App.Meta["flynn-system-app"] == "true" {
 		job.Partition = "system"
-	}
-	if len(t.Entrypoint) > 0 {
-		job.Config.Entrypoint = t.Entrypoint
 	}
 	if f.ImageArtifact != nil {
 		job.ImageArtifact = f.ImageArtifact.HostArtifact()

--- a/dashboard/app/lib/javascripts/dashboard/actions/deploy.js
+++ b/dashboard/app/lib/javascripts/dashboard/actions/deploy.js
@@ -4,7 +4,7 @@ import Config from 'dashboard/config';
 
 var createTaffyJob = function (taffyReleaseId, appID, appName, meta, env) {
 	env = env || {};
-	var args = [appName, meta.clone_url, meta.branch, meta.rev];
+	var args = ["/bin/taffy", appName, meta.clone_url, meta.branch, meta.rev];
 	[{ arg: '--meta', data: meta }, { arg: '--env', data: env }].forEach(function (item) {
 		Object.keys(item.data).forEach(function (k) {
 			var v = item.data[k];
@@ -15,7 +15,7 @@ var createTaffyJob = function (taffyReleaseId, appID, appName, meta, env) {
 	return Config.client.createTaffyJob({
 		release: taffyReleaseId,
 		release_env: true,
-		cmd: args,
+		args: args,
 		meta: extend({}, meta, {
 			app: appID
 		})

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -110,7 +110,7 @@ Options:
 
 	job := &host.Job{
 		Config: host.ContainerConfig{
-			Cmd:        []string{slugURL},
+			Args:       []string{"/tmp/builder/build.sh", slugURL},
 			Env:        jobEnv,
 			Stdin:      true,
 			DisableLog: true,
@@ -192,7 +192,7 @@ Options:
 	procs := make(map[string]ct.ProcessType)
 	for _, t := range types {
 		proc := prevRelease.Processes[t]
-		proc.Cmd = []string{"start", t}
+		proc.Args = []string{"/runner/init", "start", t}
 		if t == "web" || strings.HasSuffix(t, "-web") {
 			proc.Service = app.Name + "-" + t
 			proc.Ports = []ct.Port{{

--- a/host/cli/inspect.go
+++ b/host/cli/inspect.go
@@ -66,8 +66,7 @@ func printJobDesc(job *host.ActiveJob, out io.Writer, env bool, redactEnv []stri
 	}
 
 	listRec(w, "ID", job.Job.ID)
-	listRec(w, "Entrypoint", strings.Join(job.Job.Config.Entrypoint, " "))
-	listRec(w, "Cmd", strings.Join(job.Job.Config.Cmd, " "))
+	listRec(w, "Args", strings.Join(job.Job.Config.Args, " "))
 	listRec(w, "Status", job.Status)
 	listRec(w, "CreatedAt", job.CreatedAt)
 	listRec(w, "StartedAt", job.StartedAt)

--- a/host/cli/run.go
+++ b/host/cli/run.go
@@ -32,8 +32,7 @@ func runRun(args *docopt.Args, client *cluster.Client) error {
 		ImageArtifact: exec.DockerImage(args.String["<image>"]),
 		Job: &host.Job{
 			Config: host.ContainerConfig{
-				Entrypoint: []string{args.String["<command>"]},
-				Cmd:        args.All["<argument>"].([]string),
+				Args:       append([]string{args.String["<command>"]}, args.All["<argument>"].([]string)...),
 				TTY:        term.IsTerminal(os.Stdin.Fd()) && term.IsTerminal(os.Stdout.Fd()),
 				Stdin:      true,
 				DisableLog: true,

--- a/host/cli/update.go
+++ b/host/cli/update.go
@@ -220,7 +220,7 @@ func runUpdate(args *docopt.Args) error {
 
 	// use a flag to determine whether to use a TTY log formatter because actually
 	// assigning a TTY to the job causes reading images via stdin to fail.
-	cmd := exec.Command(exec.DockerImage(updaterImage), fmt.Sprintf("--tty=%t", term.IsTerminal(os.Stdout.Fd())))
+	cmd := exec.Command(exec.DockerImage(updaterImage), "/bin/updater", fmt.Sprintf("--tty=%t", term.IsTerminal(os.Stdout.Fd())))
 	cmd.Stdin = bytes.NewReader(imageJSON)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -343,7 +343,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		return nil
 	}
 
-	log.Info("starting job", "job.artifact.uri", job.ImageArtifact.URI, "job.cmd", job.Config.Cmd)
+	log.Info("starting job", "job.artifact.uri", job.ImageArtifact.URI, "job.args", job.Config.Args)
 
 	defer func() {
 		if err != nil {
@@ -588,6 +588,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	l.state.mtx.Unlock()
 
 	initConfig := &containerinit.Config{
+		Args:          job.Config.Args,
 		TTY:           job.Config.TTY,
 		OpenStdin:     job.Config.Stdin,
 		WorkDir:       job.Config.WorkingDir,
@@ -606,16 +607,8 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	} else if imageConfig.User != "" {
 		// TODO: check and lookup user from image config
 	}
-	if len(job.Config.Entrypoint) > 0 {
-		initConfig.Args = job.Config.Entrypoint
-		initConfig.Args = append(initConfig.Args, job.Config.Cmd...)
-	} else {
-		initConfig.Args = imageConfig.Entrypoint
-		if len(job.Config.Cmd) > 0 {
-			initConfig.Args = append(initConfig.Args, job.Config.Cmd...)
-		} else {
-			initConfig.Args = append(initConfig.Args, imageConfig.Cmd...)
-		}
+	if len(job.Config.Args) == 0 {
+		initConfig.Args = append(imageConfig.Entrypoint, imageConfig.Cmd...)
 	}
 	for _, port := range job.Config.Ports {
 		initConfig.Ports = append(initConfig.Ports, port)

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -49,8 +49,7 @@ func (j *Job) Dup() *Job {
 		return res
 	}
 	job.Metadata = dupMap(j.Metadata)
-	job.Config.Entrypoint = dupSlice(j.Config.Entrypoint)
-	job.Config.Cmd = dupSlice(j.Config.Cmd)
+	job.Config.Args = dupSlice(j.Config.Args)
 	job.Config.Env = dupMap(j.Config.Env)
 	if j.Config.Ports != nil {
 		job.Config.Ports = make([]Port, len(j.Config.Ports))
@@ -73,11 +72,10 @@ type JobResources struct {
 }
 
 type ContainerConfig struct {
+	Args        []string          `json:"args,omitempty"`
 	TTY         bool              `json:"tty,omitempty"`
 	Stdin       bool              `json:"stdin,omitempty"`
 	Data        bool              `json:"data,omitempty"`
-	Entrypoint  []string          `json:"entry_point,omitempty"`
-	Cmd         []string          `json:"cmd,omitempty"`
 	Env         map[string]string `json:"env,omitempty"`
 	Mounts      []Mount           `json:"mounts,omitempty"`
 	Volumes     []VolumeBinding   `json:"volumes,omitempty"`
@@ -93,11 +91,8 @@ func (x ContainerConfig) Merge(y ContainerConfig) ContainerConfig {
 	x.TTY = x.TTY || y.TTY
 	x.Stdin = x.Stdin || y.Stdin
 	x.Data = x.Data || y.Data
-	if y.Entrypoint != nil {
-		x.Entrypoint = y.Entrypoint
-	}
-	if y.Cmd != nil {
-		x.Cmd = y.Cmd
+	if y.Args != nil {
+		x.Args = y.Args
 	}
 	env := make(map[string]string, len(x.Env)+len(y.Env))
 	for k, v := range x.Env {

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -24,9 +24,8 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 
 	pgRelease := data["postgres"].Release
 	pgJob := &ct.NewJob{
-		ReleaseID:  pgRelease.ID,
-		Entrypoint: []string{"bash"},
-		Cmd:        []string{"-c", "set -o pipefail; pg_dumpall --clean --if-exists | gzip -9"},
+		ReleaseID: pgRelease.ID,
+		Args:      []string{"bash", "-c", "set -o pipefail; pg_dumpall --clean --if-exists | gzip -9"},
 		Env: map[string]string{
 			"PGHOST":     pgRelease.Env["PGHOST"],
 			"PGUSER":     pgRelease.Env["PGUSER"],
@@ -42,9 +41,12 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 	if mariadb, ok := data["mariadb"]; ok && mariadb.Processes["mariadb"] > 0 {
 		mysqlRelease := mariadb.Release
 		mysqlJob := &ct.NewJob{
-			ReleaseID:  mysqlRelease.ID,
-			Entrypoint: []string{"bash"},
-			Cmd:        []string{"-c", fmt.Sprintf("set -o pipefail; /usr/bin/mysqldump -h %s -u %s --all-databases | gzip -9", mysqlRelease.Env["MYSQL_HOST"], mysqlRelease.Env["MYSQL_USER"])},
+			ReleaseID: mysqlRelease.ID,
+			Args: []string{
+				"bash",
+				"-c",
+				fmt.Sprintf("set -o pipefail; /usr/bin/mysqldump -h %s -u %s --all-databases | gzip -9", mysqlRelease.Env["MYSQL_HOST"], mysqlRelease.Env["MYSQL_USER"]),
+			},
 			Env: map[string]string{
 				"MYSQL_PWD": mysqlRelease.Env["MYSQL_PWD"],
 			},
@@ -59,9 +61,12 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 	if mongodb, ok := data["mongodb"]; ok && mongodb.Processes["mongodb"] > 0 {
 		mongodbRelease := mongodb.Release
 		mongodbJob := &ct.NewJob{
-			ReleaseID:  mongodbRelease.ID,
-			Entrypoint: []string{"bash"},
-			Cmd:        []string{"-c", fmt.Sprintf("set -o pipefail; /usr/bin/mongodump --host %s -u %s -p $MONGO_PWD --authenticationDatabase admin --archive | gzip -9", mongodbRelease.Env["MONGO_HOST"], mongodbRelease.Env["MONGO_USER"])},
+			ReleaseID: mongodbRelease.ID,
+			Args: []string{
+				"bash",
+				"-c",
+				fmt.Sprintf("set -o pipefail; /usr/bin/mongodump --host %s -u %s -p $MONGO_PWD --authenticationDatabase admin --archive | gzip -9", mongodbRelease.Env["MONGO_HOST"], mongodbRelease.Env["MONGO_USER"]),
+			},
 			Env: map[string]string{
 				"MONGO_PWD": mongodbRelease.Env["MONGO_PWD"],
 			},

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -20,11 +20,10 @@ type Cmd struct {
 	TTY    bool
 	Meta   map[string]string
 
-	Entrypoint []string
+	Args []string
 
 	ImageArtifact host.Artifact
 
-	Cmd []string
 	Env map[string]string
 
 	Stdin io.Reader
@@ -85,8 +84,8 @@ func DockerImage(uri string) host.Artifact {
 	return host.Artifact{Type: host.ArtifactTypeDocker, URI: uri}
 }
 
-func Command(artifact host.Artifact, cmd ...string) *Cmd {
-	return &Cmd{ImageArtifact: artifact, Cmd: cmd}
+func Command(artifact host.Artifact, args ...string) *Cmd {
+	return &Cmd{ImageArtifact: artifact, Args: args}
 }
 
 func Job(artifact host.Artifact, job *host.Job) *Cmd {
@@ -98,8 +97,8 @@ type ClusterClient interface {
 	Host(string) (*cluster.Host, error)
 }
 
-func CommandUsingCluster(c ClusterClient, artifact host.Artifact, cmd ...string) *Cmd {
-	command := Command(artifact, cmd...)
+func CommandUsingCluster(c ClusterClient, artifact host.Artifact, args ...string) *Cmd {
+	command := Command(artifact, args...)
 	command.cluster = c
 	return command
 }
@@ -188,11 +187,10 @@ func (c *Cmd) Start() error {
 		c.Job = &host.Job{
 			ImageArtifact: &c.ImageArtifact,
 			Config: host.ContainerConfig{
-				Entrypoint: c.Entrypoint,
-				Cmd:        c.Cmd,
-				TTY:        c.TTY,
-				Env:        c.Env,
-				Stdin:      c.Stdin != nil || c.stdinPipe != nil,
+				Args:  c.Args,
+				TTY:   c.TTY,
+				Env:   c.Env,
+				Stdin: c.Stdin != nil || c.stdinPipe != nil,
 			},
 			Metadata: c.Meta,
 		}

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -21,13 +21,21 @@
       }
     },
     "cmd": {
-      "description": "shell command",
+      "description": "DEPRECATED (use args instead): shell command",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "entrypoint": {
+      "description": "DEPRECATED (use args instead)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "args": {
+      "description": "command line arguments",
       "type": "array",
       "items": {
         "type": "string"

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -41,6 +41,9 @@
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"
     },
+    "args": {
+      "$ref": "/schema/controller/common#/definitions/args"
+    },
     "meta": {
       "$ref": "/schema/controller/common#/definitions/meta"
     },

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -20,6 +20,9 @@
     "entrypoint": {
       "$ref": "/schema/controller/common#/definitions/entrypoint"
     },
+    "args": {
+      "$ref": "/schema/controller/common#/definitions/args"
+    },
     "env": {
       "$ref": "/schema/controller/common#/definitions/env"
     },

--- a/schema/controller/process_type.json
+++ b/schema/controller/process_type.json
@@ -7,6 +7,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "args": {
+      "$ref": "/schema/controller/common#/definitions/args"
+    },
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"
     },

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -27,9 +27,8 @@ USAGE
 
 main() {
   local size="1"
-  local destroy_vols=true
   local version=""
-  local host_flags=""
+  local host_flags=()
   local backup=""
 
   while true; do
@@ -47,8 +46,7 @@ main() {
         shift 2
         ;;
       -z | --no-destroy-vols)
-        destroy_vols=false
-        host_flags+="-z"
+        host_flags+=("--no-destroy-vols")
         shift
         ;;
       -v | --version)
@@ -91,6 +89,7 @@ main() {
     flynn_host="${dir}/flynn-host"
     bin_dir="${dir}"
     manifest="${dir}/bootstrap-manifest.json"
+    host_flags+=("--bin-dir" "${bin_dir}")
   fi
 
   # kill flynn first
@@ -107,7 +106,7 @@ main() {
     # An RFC 5737 TEST-NET IP
     local ip="192.0.2.20$(($index))"
     ips+=("${ip}")
-    "${ROOT}/script/start-flynn-host" "${host_flags}" "${index}"
+    "${ROOT}/script/start-flynn-host" ${host_flags[@]} "${index}"
   done
 
   info "bootstrapping Flynn"

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -21,7 +21,7 @@ OPTIONS:
   -s, --size=SIZE          Cluster size [default: 1]
   -z, --no-destroy-vols    Don't destroy volumes
   -v, --version=VERSION    Boot using the released VERSION (e.g. v20151104.1)
-  --from-backup=FILE       Bootstrap from backup file
+  --from-backup=FILE       Bootstrap from backup file or URL (e.g. https://s3.amazonaws.com/flynn-test/backups/nodejs-v20160624.1.tar)
 USAGE
 }
 
@@ -30,6 +30,7 @@ main() {
   local version=""
   local host_flags=()
   local backup=""
+  local backup_url=""
 
   while true; do
     case "$1" in
@@ -62,7 +63,11 @@ main() {
           usage
           exit 1
         fi
-        backup="--from-backup=$2"
+        if [[ "${2:0:8}" = "https://" ]]; then
+          backup_url="$2"
+        else
+          backup="$2"
+        fi
         shift 2
         ;;
       *)
@@ -79,6 +84,15 @@ main() {
   local bin_dir="${ROOT}/host/bin"
   local flynn_host="${bin_dir}/flynn-host"
   local manifest="${ROOT}/bootstrap/bin/manifest.json"
+
+  if [[ -n "${backup_url}" ]]; then
+    info "using backup URL ${backup_url}"
+    backup="${ROOT}/tmp/backups/$(basename "${backup_url}")"
+    if [[ ! -s "${backup}" ]]; then
+      mkdir -p "${ROOT}/tmp/backups"
+      curl --fail --location --output "${backup}" "${backup_url}"
+    fi
+  fi
 
   if [[ -n "${version}" ]]; then
     local dir="${ROOT}/tmp/${version}"
@@ -112,12 +126,14 @@ main() {
   info "bootstrapping Flynn"
   export CLUSTER_DOMAIN="${size}.localflynn.com"
   export DISCOVERD="$(join "," ${ips[@]/%/:1111})"
-  "${flynn_host}" \
-    bootstrap \
-    ${backup} \
-    --min-hosts="${size}" \
-    --peer-ips="$(join "," ${ips[@]})" \
-    "${manifest}"
+  local flags=(
+    "--min-hosts=${size}"
+    "--peer-ips=$(join "," ${ips[@]})"
+  )
+  if [[ -n "${backup}" ]]; then
+    flags+=("--from-backup=${backup}")
+  fi
+  "${flynn_host}" bootstrap ${flags[@]} "${manifest}"
 }
 
 main $@

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -14,6 +14,8 @@ Start a flynn node with specific binary, ip and index.
 
 Options:
 
+  -b, --bin-dir=DIR        Host binary dir [default: ROOT/host/bin]
+
   -k, --no-destroy-state   Don't destroy job state
 
   -z, --no-destroy-vols    Don't destroy volumes
@@ -26,6 +28,7 @@ USAGE
 }
 
 main() {
+  local bin_dir="${ROOT}/host/bin"
   local destroy_vols=true
   local destroy_state=true
   local peers=()
@@ -35,6 +38,15 @@ main() {
       -h | --help)
         usage
         exit
+        ;;
+      -b | --bin-dir)
+        if [[ -z "$2" ]]; then
+          fail "--bin-dir requires an argument"
+        elif [[ ! -d "$2" ]]; then
+          fail "no such directory: ${bin_dir}"
+        fi
+        bin_dir="$2"
+        shift 2
         ;;
       -k | --no-destroy-state)
         destroy_state=false
@@ -67,8 +79,6 @@ main() {
 
   # An RFC 5737 TEST-NET IP
   local ip="192.0.2.20$(($index))"
-
-  local bin_dir="${ROOT}/host/bin"
   local flynn_host="${bin_dir}/flynn-host"
 
   local id="host${index}"

--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -1,5 +1,5 @@
 #!/bin/bash
-## Load slug from Bind Mount, Artifacts dir, URL or STDIN
+## Load slug from Bind Mount, Artifacts dir or URL
 
 set -eo pipefail
 
@@ -13,8 +13,6 @@ elif [[ -s "/artifacts/slug.tgz" ]]; then
 elif ! [[ -z "${SLUG_URL}" ]]; then
   curl --silent --location --noproxy "discoverd" --retry 5 --fail "${SLUG_URL}" | tar -xzC "${HOME}"
   unset SLUG_URL
-else
-  cat | tar -xzC "${HOME}"
 fi
 cd "${HOME}"
 

--- a/test/helper.go
+++ b/test/helper.go
@@ -145,7 +145,7 @@ func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {
 		ArtifactIDs: []string{artifact.ID},
 		Processes: map[string]ct.ProcessType{
 			"echoer": {
-				Cmd:     []string{"/bin/echoer"},
+				Args:    []string{"/bin/echoer"},
 				Service: "echo-service",
 				Ports: []ct.Port{{
 					Proto: "tcp",
@@ -156,25 +156,25 @@ func (h *Helper) createApp(t *c.C) (*ct.App, *ct.Release) {
 				}},
 			},
 			"ping": {
-				Cmd:   []string{"/bin/pingserv"},
+				Args:  []string{"/bin/pingserv"},
 				Ports: []ct.Port{{Proto: "tcp"}},
 			},
 			"printer": {
-				Cmd: []string{"sh", "-c", "while true; do echo I like to print; sleep 1; done"},
+				Args: []string{"sh", "-c", "while true; do echo I like to print; sleep 1; done"},
 			},
 			"crasher": {
-				Cmd: []string{"sh", "-c", "trap 'exit 1' SIGTERM; while true; do echo I like to crash; sleep 1; done"},
+				Args: []string{"sh", "-c", "trap 'exit 1' SIGTERM; while true; do echo I like to crash; sleep 1; done"},
 			},
 			"omni": {
-				Cmd:  []string{"sh", "-c", "while true; do echo I am everywhere; sleep 1; done"},
+				Args: []string{"sh", "-c", "while true; do echo I am everywhere; sleep 1; done"},
 				Omni: true,
 			},
 			"resources": {
-				Cmd:       []string{"sh", "-c", resourceCmd},
+				Args:      []string{"sh", "-c", resourceCmd},
 				Resources: testResources(),
 			},
 			"ish": {
-				Cmd:   []string{"/bin/ish"},
+				Args:  []string{"/bin/ish"},
 				Ports: []ct.Port{{Proto: "tcp"}},
 				Env: map[string]string{
 					"NAME": app.Name,

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -826,11 +826,11 @@ func (s *CLISuite) TestRelease(t *c.C) {
 		"env": {"GLOBAL": "FOO"},
 		"processes": {
 			"echoer": {
-				"cmd": ["/bin/echoer"],
+				"args": ["/bin/echoer"],
 				"env": {"ECHOER_ONLY": "BAR"}
 			},
 			"env": {
-				"cmd": ["sh", "-c", "env; while true; do sleep 60; done"],
+				"args": ["sh", "-c", "env; while true; do sleep 60; done"],
 				"env": {"ENV_ONLY": "BAZ"}
 			}
 		}
@@ -849,13 +849,13 @@ func (s *CLISuite) TestRelease(t *c.C) {
 		"env": {"GLOBAL": "FOO"},
 		"processes": {
 			"echoer": {
-				"cmd": ["/bin/echoer"],
+				"args": ["/bin/echoer"],
 				"env": {
 					"ECHOER_ONLY": "BAT"
 				}
 			},
 			"env": {
-				"cmd": ["sh", "-c", "env; while true; do sleep 60; done"],
+				"args": ["sh", "-c", "env; while true; do sleep 60; done"],
 				"env": {
 					"ENV_ONLY": "BAZ",
 					"ENV_UPDATE": "QUUX"
@@ -1207,7 +1207,7 @@ func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
 		release := &ct.Release{
 			ArtifactIDs: []string{imageArtifact.ID, r.slug.ID},
 			Processes: map[string]ct.ProcessType{
-				"app": {Cmd: []string{"/bin/pingserv"}, Ports: []ct.Port{{Proto: "tcp"}}},
+				"app": {Args: []string{"/bin/pingserv"}, Ports: []ct.Port{{Proto: "tcp"}}},
 			},
 		}
 		t.Assert(client.CreateRelease(release), c.IsNil)
@@ -1331,7 +1331,7 @@ func (s *CLISuite) TestDockerPush(t *c.C) {
 	if !ok {
 		t.Fatal(`release missing "app" process type`)
 	}
-	t.Assert(proc.Cmd, c.DeepEquals, []string{"/bin/pingserv"})
+	t.Assert(proc.Args, c.DeepEquals, []string{"/bin/pingserv"})
 
 	// check the release can be scaled up
 	t.Assert(flynn(t, "/", "-a", app.Name, "scale", "app=1"), Succeeds)

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -213,7 +213,7 @@ func (s *ControllerSuite) TestResourceLimitsOneOffJob(t *c.C) {
 
 	rwc, err := s.controllerClient(t).RunJobAttached(app.ID, &ct.NewJob{
 		ReleaseID: release.ID,
-		Cmd:       []string{"sh", "-c", resourceCmd},
+		Args:      []string{"sh", "-c", resourceCmd},
 		Resources: testResources(),
 	})
 	t.Assert(err, c.IsNil)
@@ -501,7 +501,7 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 	runJob := func(appID, releaseID string) {
 		rwc, err := client.RunJobAttached(appID, &ct.NewJob{
 			ReleaseID:  releaseID,
-			Cmd:        []string{"/bin/true"},
+			Args:       []string{"/bin/true"},
 			DisableLog: true,
 		})
 		t.Assert(err, c.IsNil)

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -210,7 +210,7 @@ func (s *DeployerSuite) TestRollbackFailedJob(t *c.C) {
 	client := s.controllerClient(t)
 	release.ID = ""
 	printer := release.Processes["printer"]
-	printer.Cmd = []string{"this-is-gonna-fail"}
+	printer.Args = []string{"this-is-gonna-fail"}
 	release.Processes["printer"] = printer
 	t.Assert(client.CreateRelease(release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -159,7 +159,7 @@ func makeIshApp(cluster *cluster.Client, h *cluster.Host, dc *discoverd.Client, 
 	// run a job that accepts tcp connections and performs tasks we ask of it in its container
 	cmd := exec.JobUsingCluster(cluster, exec.DockerImage(imageURIs["test-apps"]), &host.Job{
 		Config: host.ContainerConfig{
-			Cmd:   []string{"/bin/ish"},
+			Args:  []string{"/bin/ish"},
 			Ports: []host.Port{{Proto: "tcp"}},
 			Env: map[string]string{
 				"NAME": serviceName,
@@ -290,7 +290,7 @@ func (s *HostSuite) TestSignalJob(t *c.C) {
 	// start a signal-service job
 	cmd := exec.JobUsingCluster(cluster, exec.DockerImage(imageURIs["test-apps"]), &host.Job{
 		Config: host.ContainerConfig{
-			Cmd:        []string{"/bin/signal"},
+			Args:       []string{"/bin/signal"},
 			DisableLog: true,
 		},
 	})
@@ -325,7 +325,7 @@ func (s *HostSuite) TestResourceLimits(t *c.C) {
 		s.clusterClient(t),
 		exec.DockerImage(imageURIs["test-apps"]),
 		&host.Job{
-			Config:    host.ContainerConfig{Cmd: []string{"sh", "-c", resourceCmd}},
+			Config:    host.ContainerConfig{Args: []string{"sh", "-c", resourceCmd}},
 			Resources: testResources(),
 		},
 	)

--- a/test/test_host_update.go
+++ b/test/test_host_update.go
@@ -36,7 +36,7 @@ func (s *HostUpdateSuite) TestUpdateLogs(t *c.C) {
 		client,
 		exec.DockerImage(imageURIs["test-apps"]),
 		&host.Job{
-			Config: host.ContainerConfig{Cmd: []string{"/bin/partial-logger"}},
+			Config: host.ContainerConfig{Args: []string{"/bin/partial-logger"}},
 			Metadata: map[string]string{
 				"flynn-controller.app": "partial-logger",
 			},

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -177,7 +177,7 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	t.Assert(client.CreateArtifact(slugArtifact), c.IsNil)
 	release := &ct.Release{
 		ArtifactIDs: []string{imageArtifact.ID, slugArtifact.ID},
-		Processes:   map[string]ct.ProcessType{"web": {Cmd: []string{"bin/http"}}},
+		Processes:   map[string]ct.ProcessType{"web": {Args: []string{"bin/http"}}},
 	}
 	t.Assert(client.CreateRelease(release), c.IsNil)
 	t.Assert(client.SetAppRelease(slugApp.ID, release.ID), c.IsNil)

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -177,7 +177,8 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	t.Assert(client.CreateArtifact(slugArtifact), c.IsNil)
 	release := &ct.Release{
 		ArtifactIDs: []string{imageArtifact.ID, slugArtifact.ID},
-		Processes:   map[string]ct.ProcessType{"web": {Args: []string{"bin/http"}}},
+		Processes:   map[string]ct.ProcessType{"web": {Args: []string{"/runner/init", "bin/http"}}},
+		Meta:        map[string]string{"git": "true"},
 	}
 	t.Assert(client.CreateRelease(release), c.IsNil)
 	t.Assert(client.SetAppRelease(slugApp.ID, release.ID), c.IsNil)

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -344,7 +344,7 @@ func (s *SchedulerSuite) TestJobMeta(t *c.C) {
 	// start 1 one-off job
 	_, err = s.controllerClient(t).RunJobDetached(app.ID, &ct.NewJob{
 		ReleaseID: release.ID,
-		Cmd:       []string{"sh", "-c", "while true; do echo one-off-job; sleep 1; done"},
+		Args:      []string{"sh", "-c", "while true; do echo one-off-job; sleep 1; done"},
 		Meta: map[string]string{
 			"foo": "baz",
 		},
@@ -376,7 +376,7 @@ func (s *SchedulerSuite) TestJobStatus(t *c.C) {
 	}), c.IsNil)
 	_, err = s.controllerClient(t).RunJobDetached(app.ID, &ct.NewJob{
 		ReleaseID: release.ID,
-		Cmd:       []string{"sh", "-c", "while true; do echo one-off-job; sleep 1; done"},
+		Args:      []string{"sh", "-c", "while true; do echo one-off-job; sleep 1; done"},
 	})
 	t.Assert(err, c.IsNil)
 	err = watcher.WaitFor(ct.JobEvents{"printer": {ct.JobStateUp: 1}, "crasher": {ct.JobStateUp: 1}, "": {ct.JobStateUp: 1}}, scaleTimeout, nil)
@@ -568,7 +568,7 @@ func (s *SchedulerSuite) TestRollbackController(t *c.C) {
 	// create a controller deployment that will fail
 	release.ID = ""
 	worker := release.Processes["worker"]
-	worker.Entrypoint = []string{"/i/dont/exist"}
+	worker.Args = []string{"/i/dont/exist"}
 	release.Processes["worker"] = worker
 	t.Assert(client.CreateRelease(release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)

--- a/test/test_taffy_deploy.go
+++ b/test/test_taffy_deploy.go
@@ -22,6 +22,7 @@ func (s *TaffyDeploySuite) deployWithTaffy(t *c.C, app *ct.App, env, meta, githu
 	t.Assert(err, c.IsNil)
 
 	args := []string{
+		"/bin/taffy",
 		app.Name,
 		github["clone_url"],
 		github["branch"],
@@ -38,7 +39,7 @@ func (s *TaffyDeploySuite) deployWithTaffy(t *c.C, app *ct.App, env, meta, githu
 	rwc, err := client.RunJobAttached("taffy", &ct.NewJob{
 		ReleaseID:  taffyRelease.ID,
 		ReleaseEnv: true,
-		Cmd:        args,
+		Args:       args,
 		Meta: map[string]string{
 			"github":      "true",
 			"github_user": github["user"],


### PR DESCRIPTION
This consolidates the `Entrypoint` and `Cmd` fields into a single `Args` field, which is simpler and more compatible with the changes proposed in #3100.

The `Entrypoint` in Dockerfiles is now largely redundant (except when used as a fallback when a job has no explicit `Args`, e.g. blobstore), and is now explicitly set in the bootstrap manifest, with a migration added to update the releases in the database.

I have also included a change to the scripts to support bootstrapping from a backup URL, and I have uploaded a backup of `v20160624.1` (which includes the NodeJS example app) at https://s3.amazonaws.com/flynn-test/backups/nodejs-v20160624.1.tar.

Using the above, I manually tested restoring from a backup:

```
$ script/bootstrap-flynn --from-backup https://s3.amazonaws.com/flynn-test/backups/nodejs-v20160624.1.tar
===> 12:34:29.787 using backup URL https://s3.amazonaws.com/flynn-test/backups/nodejs-v20160624.1.tar
...
12:34:30.328530 check online-hosts
12:34:31.329800 run-app discoverd
12:34:31.440595 run-app flannel
12:34:31.502869 wait-hosts wait-hosts
12:34:33.505763 run-app postgres
12:34:33.815807 wait postgres-wait
12:34:35.829652 restore-postgres restore
12:34:38.320593 run-app controller
12:34:38.442225 wait-controller wait-controller
12:34:39.004028 run-app blobstore
12:34:39.106169 wait blobstore-wait
12:34:39.120159 run-app controller-scheduler
12:34:39.223460 status-check status
12:34:41.153589 cluster-monitor cluster-monitor

$ flynn -a nodejs ps
ID                                          TYPE  STATE  CREATED        RELEASE
host0-1c6b8b48-0e05-49b5-8c95-e33b5c18a78f  web   up     8 seconds ago  52ffe7cb-7b4c-4461-8c5d-17503448dd1d
```