### PR TITLE
host: Simplify Upstart start on stanza

### DIFF
--- a/host/upstart.conf
+++ b/host/upstart.conf
@@ -1,6 +1,6 @@
-description "Flynn layer 0"
+description "Flynn host daemon"
 
-start on (local-filesystems and net-device-up IFACE!=lo and mounted MOUNTPOINT=/sys/fs/cgroup)
+start on runlevel [2345]
 stop on runlevel [!2345]
 respawn
 respawn limit 100 60


### PR DESCRIPTION
The previous stanza was causing Upstart to hang on boot, perhaps some kind of circular dependency (I'm not sure).

The runlevel check has the same effect (see http://upstart.ubuntu.com/cookbook/#startup-process), and does not cause Upstart to hang.

Tested by installing Flynn in a VM, modifying `/etc/init/flynn-host.conf` and rebooting successfully multiple times.

Closes #3134