### PR TITLE
Sirenia stop peer heartbeater

### DIFF
--- a/appliance/mariadb/handler.go
+++ b/appliance/mariadb/handler.go
@@ -121,11 +121,11 @@ func (h *Handler) handleGetBackup(w http.ResponseWriter, req *http.Request, _ ht
 
 // handlePostStop handles request to POST /stop.
 func (h *Handler) handlePostStop(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	if err := h.Heartbeater.Close(); err != nil {
+	if err := h.Peer.Stop(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
-	if err := h.Peer.Stop(); err != nil {
+	if err := h.Heartbeater.Close(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}

--- a/appliance/postgresql/http.go
+++ b/appliance/postgresql/http.go
@@ -70,11 +70,11 @@ func (h *HTTP) GetStatus(w http.ResponseWriter, req *http.Request, _ httprouter.
 }
 
 func (h *HTTP) Stop(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	if err := h.hb.Close(); err != nil {
+	if err := h.peer.Stop(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}
-	if err := h.peer.Stop(); err != nil {
+	if err := h.hb.Close(); err != nil {
 		httphelper.Error(w, err)
 		return
 	}


### PR DESCRIPTION
Mirrors the change made to the MongoDB appliance, this is more correct and may potentially close small windows where clients remain connected to the old primary for longer than necessary.