### PR TITLE
cli: Set deprecated newJob.Entrypoint / newJob.Cmd

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -90,6 +90,15 @@ func runJob(client controller.Client, config runConfig) error {
 		ReleaseEnv: config.ReleaseEnv,
 		DisableLog: config.DisableLog,
 	}
+
+	// set deprecated Entrypoint and Cmd for old clusters
+	if len(req.Args) > 0 {
+		req.DeprecatedEntrypoint = []string{req.Args[0]}
+	}
+	if len(req.Args) > 1 {
+		req.DeprecatedCmd = req.Args[1:]
+	}
+
 	if config.Stdin == nil {
 		config.Stdin = os.Stdin
 	}

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -248,6 +248,10 @@ type NewJob struct {
 	Lines      int                `json:"tty_lines,omitempty"`
 	DisableLog bool               `json:"disable_log,omitempty"`
 	Resources  resource.Resources `json:"resources,omitempty"`
+
+	// Entrypoint and Cmd are DEPRECATED: use Args instead
+	DeprecatedCmd        []string `json:"cmd,omitempty"`
+	DeprecatedEntrypoint []string `json:"entrypoint,omitempty"`
 }
 
 const DefaultDeployTimeout = 120 // seconds

--- a/pkg/backup/tar_writer.go
+++ b/pkg/backup/tar_writer.go
@@ -100,6 +100,14 @@ func (t *TarWriter) WriteCommandOutput(client controller.Client, name string, ap
 }
 
 func (t *TarWriter) runJob(client controller.Client, app string, req *ct.NewJob, out io.Writer) error {
+	// set deprecated Entrypoint and Cmd for old clusters
+	if len(req.Args) > 0 {
+		req.DeprecatedEntrypoint = []string{req.Args[0]}
+	}
+	if len(req.Args) > 1 {
+		req.DeprecatedCmd = req.Args[1:]
+	}
+
 	rwc, err := client.RunJobAttached(app, req)
 	if err != nil {
 		return err

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -15,6 +15,7 @@ OPTIONS:
   -n, --size=SIZE          Cluster size [default: 1]
   -f, --filter=FILTER      Regular expression selecting which tests and/or suites to run
   -s, --stream             Stream debug output
+  -v, --version=VERSION    Boot using the released VERSION (e.g. v20151104.1)
 USAGE
 }
 
@@ -22,6 +23,7 @@ main() {
   local size="1"
   local filter
   local stream=false
+  local version=""
 
   while true; do
     case "$1" in
@@ -31,16 +33,14 @@ main() {
         ;;
       -n | --size)
         if [[ -z "$2" ]]; then
-          usage
-          exit 1
+          fail "--size flag requires an argument"
         fi
         size="$2"
         shift 2
         ;;
       -f | --filter)
         if [[ -z "$2" ]]; then
-          usage
-          exit 1
+          fail "--filter flag requires an argument"
         fi
         filter="$2"
         shift 2
@@ -48,6 +48,13 @@ main() {
       -s | --stream)
         stream=true
         shift
+        ;;
+      -v | --version)
+        if [[ -z "$2" ]]; then
+          fail "--version flag requires an argument"
+        fi
+        version="$2"
+        shift 2
         ;;
       *)
         break
@@ -69,7 +76,13 @@ main() {
 
   export BACKOFF_PERIOD="5s"
 
-  cluster_add=$("${ROOT}/script/bootstrap-flynn" --size "${size}" &> >(tee /dev/stderr) | tail -3 | head -1)
+  local boot_flags=(
+    "--size" "${size}"
+  )
+  if [[ -n "${version}" ]]; then
+    boot_flags+=("--version" "${version}")
+  fi
+  cluster_add=$("${ROOT}/script/bootstrap-flynn" ${boot_flags[@]} &> >(tee /dev/stderr) | tail -3 | head -1)
 
   if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then
     echo Bootstrap failed >&2


### PR DESCRIPTION
The CLI may be communicating with a cluster which still uses the deprecated fields.

Tested manually with:

```
$ script/run-integration-tests --version "v20160624.1" --filter "TestDumpRestore"
$ script/run-integration-tests --version "v20160624.1" --filter "CLISuite.TestExportImport"
```

which exercises most of the "run job" paths (e.g. `flynn pg` / `flynn redis` etc.).

Fixes #3146.