### PR TITLE
controller: Migrate Args for redis apps

### DIFF
--- a/controller/schema.go
+++ b/controller/schema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flynn/flynn/pkg/postgres"
 )
@@ -454,7 +455,11 @@ func migrateProcessArgs(tx *postgres.DBTx) error {
 				case "logaggregator":
 					proc["entrypoint"] = []interface{}{"/bin/logaggregator"}
 				default:
-					panic(fmt.Sprintf("migration failed to set entrypoint for system app %s", *release.AppName))
+					if strings.HasPrefix(*release.AppName, "redis-") {
+						proc["entrypoint"] = []interface{}{"/bin/start-flynn-redis"}
+					} else {
+						panic(fmt.Sprintf("migration failed to set entrypoint for system app %s", *release.AppName))
+					}
 				}
 			}
 


### PR DESCRIPTION
Tested manually:

```
$ script/bootstrap-flynn --from-backup https://s3.amazonaws.com/flynn-test/backups/nodejs-v20160624.1-redis.tar

$ flynn -a nodejs redis redis-cli ping
PONG
```

Fixes #3148.