### PR TITLE
cli: Fix service name for Docker processes

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -236,7 +236,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 			Port:  8080,
 			Proto: "tcp",
 			Service: &host.Service{
-				Name:   mustApp(),
+				Name:   mustApp() + "-web",
 				Create: true,
 			},
 		}}

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -1337,7 +1337,7 @@ func (s *CLISuite) TestDockerPush(t *c.C) {
 	t.Assert(flynn(t, "/", "-a", app.Name, "scale", "app=1"), Succeeds)
 
 	// check the job is reachable with the app's name in discoverd
-	instances, err := s.discoverdClient(t).Instances(app.Name, 10*time.Second)
+	instances, err := s.discoverdClient(t).Instances(app.Name+"-web", 10*time.Second)
 	t.Assert(err, c.IsNil)
 	res, err := http.Get("http://" + instances[0].Addr)
 	t.Assert(err, c.IsNil)
@@ -1383,6 +1383,6 @@ func (s *CLISuite) TestDockerExportImport(t *c.C) {
 	defer flynn(t, "/", "-a", importApp, "scale", "app=0")
 
 	// wait for it to start
-	_, err = s.discoverdClient(t).Instances(importApp, 10*time.Second)
+	_, err = s.discoverdClient(t).Instances(importApp+"-web", 10*time.Second)
 	t.Assert(err, c.IsNil)
 }


### PR DESCRIPTION
The convention `APPNAME-web` is used for routes by default in the CLI, use that convention when naming the service registration configured for a process type in a release based on a Docker image.

Closes #3097