### PR TITLE
router: Don't allow malformed certificates/keys

### DIFF
--- a/router/data_store.go
+++ b/router/data_store.go
@@ -209,7 +209,7 @@ func (d *pgDataStore) addRouteCertWithTx(tx *pgx.Tx, r *router.Route) error {
 	} else {
 		cert = r.Certificate
 	}
-	if cert == nil {
+	if cert == nil || (len(cert.Cert) == 0 && len(cert.Key) == 0) {
 		return nil
 	}
 	cert.Routes = []string{r.ID}

--- a/router/data_store.go
+++ b/router/data_store.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"crypto/sha256"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/postgres"
 	"github.com/flynn/flynn/router/types"
 	"github.com/jackc/pgx"
@@ -182,6 +184,14 @@ func (d *pgDataStore) AddCert(c *router.Certificate) error {
 func (d *pgDataStore) addCertWithTx(tx *pgx.Tx, c *router.Certificate) error {
 	c.Cert = strings.Trim(c.Cert, " \n")
 	c.Key = strings.Trim(c.Key, " \n")
+
+	if _, err := tls.X509KeyPair([]byte(c.Cert), []byte(c.Key)); err != nil {
+		return httphelper.JSONError{
+			Code:    httphelper.ValidationErrorCode,
+			Message: "Certificate invalid: " + err.Error(),
+		}
+	}
+
 	tlsCertSHA256 := sha256.Sum256([]byte(c.Cert))
 	if err := tx.QueryRow(sqlSelectCert, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
 		if err := tx.QueryRow(sqlAddCert, c.Cert, c.Key, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -40,7 +40,7 @@ var tlsCerts = map[string]*tlscert.Cert{
 		// of ASN.1 time).
 		// generated from src/pkg/crypto/tls:
 		// go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com,*.example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
-		CACert: `-----BEGIN CERTIFICATE-----
+		Cert: `-----BEGIN CERTIFICATE-----
 MIIBmjCCAUagAwIBAgIRAP5DRqWA/pgvAnbC6gnl82kwCwYJKoZIhvcNAQELMBIx
 EDAOBgNVBAoTB0FjbWUgQ28wIBcNNzAwMTAxMDAwMDAwWhgPMjA4NDAxMjkxNjAw
 MDBaMBIxEDAOBgNVBAoTB0FjbWUgQ28wXDANBgkqhkiG9w0BAQEFAANLADBIAkEA
@@ -125,7 +125,11 @@ func httpTestHandler(id string) http.Handler {
 func newHTTPClient(serverName string) *http.Client {
 	cert := tlsConfigForDomain(serverName)
 	pool := x509.NewCertPool()
-	pool.AppendCertsFromPEM([]byte(cert.CACert))
+	if len(cert.CACert) > 0 {
+		pool.AppendCertsFromPEM([]byte(cert.CACert))
+	} else {
+		pool.AppendCertsFromPEM([]byte(cert.Cert))
+	}
 
 	if strings.Contains(serverName, ":") {
 		serverName, _, _ = net.SplitHostPort(serverName)
@@ -141,7 +145,11 @@ func newHTTPClient(serverName string) *http.Client {
 func newHTTP2Client(serverName string) *http.Client {
 	cert := tlsConfigForDomain(serverName)
 	pool := x509.NewCertPool()
-	pool.AppendCertsFromPEM([]byte(cert.CACert))
+	if len(cert.CACert) > 0 {
+		pool.AppendCertsFromPEM([]byte(cert.CACert))
+	} else {
+		pool.AppendCertsFromPEM([]byte(cert.Cert))
+	}
 
 	if strings.Contains(serverName, ":") {
 		serverName, _, _ = net.SplitHostPort(serverName)
@@ -155,7 +163,7 @@ func newHTTP2Client(serverName string) *http.Client {
 
 func (s *S) newHTTPListener(t testutil.TestingT) *HTTPListener {
 	cert := tlsConfigForDomain("example.com")
-	pair, err := tls.X509KeyPair([]byte(cert.CACert), []byte(cert.PrivateKey))
+	pair, err := tls.X509KeyPair([]byte(cert.Cert), []byte(cert.PrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -268,6 +268,24 @@ func (s *S) TestAddHTTPRouteWithCert(c *C) {
 	unregister()
 }
 
+func (s *S) TestAddHTTPRouteWithInvalidCert(c *C) {
+	l := s.newHTTPListener(c)
+	defer l.Close()
+
+	c1, _ := tlscert.Generate([]string{"1.example.com"})
+	c2, _ := tlscert.Generate([]string{"2.example.com"})
+
+	err := l.AddRoute(router.HTTPRoute{
+		Domain:  "example.com",
+		Service: "test",
+		Certificate: &router.Certificate{
+			Cert: c1.Cert,
+			Key:  c2.PrivateKey,
+		},
+	}.ToRoute())
+	c.Assert(err, Not(IsNil))
+}
+
 func (s *S) TestAddHTTPRouteWithExistingCert(c *C) {
 	srv1 := httptest.NewServer(httpTestHandler("1"))
 	srv2 := httptest.NewServer(httpTestHandler("2"))

--- a/router/migrate_test.go
+++ b/router/migrate_test.go
@@ -63,7 +63,7 @@ func (MigrateSuite) TestMigrateTLSObject(c *C) {
 			ParentRef:     fmt.Sprintf("some/parent/ref/%d", i),
 			Service:       fmt.Sprintf("migrationtest%d.example.org", i),
 			Domain:        fmt.Sprintf("migrationtest%d.example.org", i),
-			LegacyTLSCert: cert.CACert,
+			LegacyTLSCert: cert.Cert,
 			LegacyTLSKey:  cert.PrivateKey,
 		}
 		err := db.QueryRow(`
@@ -87,7 +87,7 @@ func (MigrateSuite) TestMigrateTLSObject(c *C) {
 			ParentRef:     fmt.Sprintf("some/parent/ref/%d", i),
 			Service:       fmt.Sprintf("migrationtest%d.example.org", i),
 			Domain:        fmt.Sprintf("migrationtest%d.example.org", i),
-			LegacyTLSCert: "  \n\n  \n " + cert.CACert + "   \n   \n   ",
+			LegacyTLSCert: "  \n\n  \n " + cert.Cert + "   \n   \n   ",
 			LegacyTLSKey:  "    \n   " + cert.PrivateKey + "   \n   \n  ",
 		}
 		err := db.QueryRow(`
@@ -125,7 +125,7 @@ func (MigrateSuite) TestMigrateTLSObject(c *C) {
 		if i == 0 || i >= len(certs)-2 {
 			continue
 		}
-		c.Assert(cert.CACert, Not(Equals), certs[i-1].CACert)
+		c.Assert(cert.Cert, Not(Equals), certs[i-1].Cert)
 	}
 
 	// run TLS object migration
@@ -155,12 +155,12 @@ func (MigrateSuite) TestMigrateTLSObject(c *C) {
 			c.Assert(fetchedCertKey, IsNil)
 			c.Assert(fetchedCertSHA256, IsNil)
 		} else {
-			sum := sha256.Sum256([]byte(strings.TrimSpace(cert.CACert)))
+			sum := sha256.Sum256([]byte(strings.TrimSpace(cert.Cert)))
 			certSHA256 := hex.EncodeToString(sum[:])
 			c.Assert(fetchedCert, Not(IsNil))
 			c.Assert(fetchedCertKey, Not(IsNil))
 			c.Assert(fetchedCertSHA256, Not(IsNil))
-			c.Assert(strings.TrimSpace(*fetchedCert), Equals, strings.TrimSpace(cert.CACert))
+			c.Assert(strings.TrimSpace(*fetchedCert), Equals, strings.TrimSpace(cert.Cert))
 			c.Assert(strings.TrimSpace(*fetchedCertKey), Equals, strings.TrimSpace(cert.PrivateKey))
 			c.Assert(*fetchedCertSHA256, Equals, certSHA256)
 		}


### PR DESCRIPTION
Before this patch the router would happily add broken and mismatched keys/certs to the database, which would result in sync breaking after a restart.
