### PR TITLE
appliance/mariadb: Add apt-transport-https package

### DIFF
--- a/appliance/mariadb/Dockerfile
+++ b/appliance/mariadb/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu-debootstrap:14.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y software-properties-common &&\
+    apt-get install -y software-properties-common apt-transport-https &&\
     apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db &&\
     add-apt-repository 'deb http://mirrors.syringanetworks.net/mariadb/repo/10.1/ubuntu trusty main' &&\
     apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1C4CBDCDCD2EFD2A &&\


### PR DESCRIPTION
The percona apt repo now redirects to HTTPS.