### PR TITLE
cli: Add Docker for Mac instructions to docker TLS warning

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -156,8 +156,12 @@ WARN:
 WARN: Copy the TLS CA certificate %s
 WARN: to /etc/docker/certs.d/%s/ca.crt
 WARN: on the docker daemon's host and restart docker.
+WARN:
+WARN: If using Docker for Mac, go to Docker -> Preferences
+WARN: -> Advanced, add %q as an
+WARN: Insecure Registry and hit "Apply & Restart".
 
-`[1:], caPath, host)
+`[1:], caPath, host, host)
 }
 
 func runDockerPush(args *docopt.Args, client controller.Client) error {


### PR DESCRIPTION
Example output:

```
$ flynn docker login
WARN: docker configuration failed with a TLS error.
WARN:
WARN: Copy the TLS CA certificate /Users/lewis/.flynn/ca-certs/default.pem
WARN: to /etc/docker/certs.d/docker.54.154.214.235.xip.io/ca.crt
WARN: on the docker daemon's host and restart docker.
WARN:
WARN: If using Docker for Mac, go to Docker -> Preferences
WARN: -> Advanced, add "docker.54.154.214.235.xip.io" as an
WARN: Insecure Registry and hit "Apply & Restart"
WARN: (although it is labelled as "insecure", connections
WARN: will continue to use TLS)

Error configuring docker, follow the above instructions and try again.
```