### PR TITLE
vendor: Fix serialization bug in old EC2 client

### DIFF
--- a/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go
+++ b/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go
@@ -161,6 +161,10 @@ func (c *EC2Client) loadStruct(v url.Values, value reflect.Value, prefix string)
 					v.Set(fmt.Sprintf("%s.%d", name, i+1), val)
 				}
 			}
+		case []byte:
+			if len(casted) != 0 {
+				v.Set(name, string(casted))
+			}
 		case time.Time:
 			if !casted.IsZero() {
 				const ISO8601UTC = "2006-01-02T15:04:05Z"


### PR DESCRIPTION
I'm hot patching this because the client is so old that the repo is gone. I'm not sure how this code ever worked. Fixes a panic while serializing the key import request to EC2.

    INFO[07-22|03:24:31] Event: log: Creating key pair
    panic: reflect: call of reflect.Value.NumField on uint8 Value

    goroutine 173 [running]:
    panic(0x8f5980, 0xc82040eb80)
            /usr/local/go/src/runtime/panic.go:481 +0x3e6
    reflect.flag.mustBe(0x88, 0x19)
            /usr/local/go/src/reflect/value.go:202 +0xa6
    reflect.Value.NumField(0x7d1440, 0xc8205203e1, 0x88, 0x18d90a8)
            /usr/local/go/src/reflect/value.go:1153 +0x2a
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).loadStruct(0xc82018d1a0, 0xc8203e2e10, 0x7d1440, 0xc8205203e1, 0x88, 0xc82040eb40, 0x13, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:123 +0x118
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).loadValues(0xc82018d1a0, 0xc8203e2e10, 0x7d1440, 0xc8205203e1, 0xc82040eb40, 0x13, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:114 +0x38c
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).loadValues(0xc82018d1a0, 0xc8203e2e10, 0x7b7da0, 0xc82040eb20, 0xb65f05, 0x11, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:107 +0x235
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).loadStruct(0xc82018d1a0, 0xc8203e2e10, 0x968fc0, 0xc8203e2db0, 0x199, 0x0, 0x0, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:170 +0x97f
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).loadValues(0xc82018d1a0, 0xc8203e2e10, 0x790bc0, 0xc8203e2db0, 0x0, 0x0, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:114 +0x38c
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws.(*EC2Client).Do(0xc82018d1a0, 0xa665e0, 0xd, 0xa57c40, 0x4, 0xa55cc8, 0x1, 0x790bc0, 0xc8203e2db0, 0x790c20, ...)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/aws/ec2.go:27 +0x236
    github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/gen/ec2.(*EC2).ImportKeyPair(0xc820188328, 0xc8203e2db0, 0xc820520390, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/vendor/github.com/awslabs/aws-sdk-go/gen/ec2/ec2.go:1700 +0xd8
    github.com/flynn/flynn/installer.(*AWSCluster).createKeyPair.func1(0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:291 +0x12a
    github.com/flynn/flynn/installer.(*AWSCluster).wrapRequest(0xc820255ee0, 0xc82072bc90, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:76 +0x70
    github.com/flynn/flynn/installer.(*AWSCluster).createKeyPair(0xc820255ee0, 0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:293 +0x6a4
    github.com/flynn/flynn/installer.(*AWSCluster).(github.com/flynn/flynn/installer.createKeyPair)-fm(0x0, 0x0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:155 +0x2e
    github.com/flynn/flynn/installer.(*AWSCluster).Run.func1(0xc820255ee0)
            /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:167 +0x38d
    created by github.com/flynn/flynn/installer.(*AWSCluster).Run
    /tmp/tmp.hz2AJHZNg0/src/github.com/flynn/flynn/installer/aws_cluster.go:181 +0x35