### PR TITLE
discoverd: Allow setting service leader during SetServiceMeta

### DIFF
--- a/discoverd/client/service.go
+++ b/discoverd/client/service.go
@@ -175,6 +175,11 @@ func (s *service) Leaders(leaders chan *Instance) (stream.Stream, error) {
 type ServiceMeta struct {
 	Data json.RawMessage `json:"data"`
 
+	// LeaderID is the optional ID of an instance to set as a leader when
+	// applying the new service metadata. It is only used for writes and is not
+	// returned during reads.
+	LeaderID string `json:"leader_id,omitempty"`
+
 	// When calling SetMeta, Index is checked against the current index and the
 	// set only succeeds if the index is the same. A zero index means the meta
 	// does not currently exist.

--- a/pkg/sirenia/discoverd/discoverd.go
+++ b/pkg/sirenia/discoverd/discoverd.go
@@ -32,16 +32,13 @@ func (d *Discoverd) SetState(state *state.DiscoverdState) error {
 		return err
 	}
 	meta := &discoverd.ServiceMeta{Index: state.Index, Data: data}
+	if state.State.Primary != nil {
+		meta.LeaderID = state.State.Primary.ID
+	}
 	if err := d.service.SetMeta(meta); err != nil {
 		return err
 	}
 	state.Index = meta.Index
-	if state.State.Primary != nil {
-		if err := d.service.SetLeader(state.State.Primary.ID); err != nil {
-			d.log.Error("error setting discoverd leader", "id", state.State.Primary.ID, "err", err)
-			// TODO(titanous): can we do anything about this?
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
This allows us to transactionally set the leader and the service meta at the same time, which is in turn used by Sirenia to prevent the metadata from getting out of sync with the leader entry.

Closes #3219