### PR TITLE
pkg/sirenia: Adjust Sirenia client timeout

### DIFF
--- a/pkg/sirenia/client/client.go
+++ b/pkg/sirenia/client/client.go
@@ -43,8 +43,8 @@ func NewClient(addr string) *Client {
 		c: &httpclient.Client{
 			URL: fmt.Sprintf("http://%s:%d", host, port+1),
 			HTTP: &http.Client{
-				Timeout:   60 * time.Second,
-				Transport: &http.Transport{Dial: dialer.Retry.Dial},
+				Timeout:   3 * time.Minute, // client operation timeout
+				Transport: &http.Transport{Dial: dialer.Default.Dial},
 			},
 		},
 	}


### PR DESCRIPTION
* Increase the client timeout to 3 minutes, shutdown operations can occasionally take quite some time to complete.
* Drop the Retry dialer in favor of the Default dialer.

Closes #3218