### PR TITLE
pkg/stream: Use pointer receiver for Basic struct

### DIFF
--- a/pkg/stream/basic_stream.go
+++ b/pkg/stream/basic_stream.go
@@ -31,11 +31,11 @@ type Basic struct {
 	Error  error
 }
 
-func (s Basic) Close() error {
+func (s *Basic) Close() error {
 	close(s.StopCh)
 	return nil
 }
 
-func (s Basic) Err() error {
+func (s *Basic) Err() error {
 	return s.Error
 }


### PR DESCRIPTION
This avoids copying the struct contents for every method call, which can cause data races.

Closes #3157