### PR TITLE
host: Fix resurrection deadlock

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -768,8 +768,8 @@ func (c *Container) watch(ready chan<- error, buffer host.LogBuffer) error {
 	}
 	if err != nil {
 		log.Error("error connecting to container", "err", err)
-		c.l.state.SetStatusFailed(c.job.ID, errors.New("failed to connect to container"))
 		readyErr(err)
+		c.l.state.SetStatusFailed(c.job.ID, errors.New("failed to connect to container"))
 		return err
 	}
 	defer c.Client.Close()


### PR DESCRIPTION
During resurrection, the state database is open for reading, so `SetStatusFailed` (which tries to update the state database) will block until the resurrection has completed, but then that causes a deadlock with `UnmarshalState` which is waiting to receive the error on the ready channel, so this change sends the error before making the blocking `SetStatusFailed` call.

Fixes #3232.