### PR TITLE
host,updater: Update Redis app and resources

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -197,7 +197,7 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 				},
 				Data:    true,
 				Args:    []string{"/bin/start-flynn-redis", "redis"},
-				Service: "redis",
+				Service: serviceName,
 			},
 		},
 		Env: map[string]string{

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/flynn/flynn/host/resource"
@@ -38,6 +39,10 @@ type App struct {
 func (a *App) System() bool {
 	v, ok := a.Meta["flynn-system-app"]
 	return ok && v == "true"
+}
+
+func (a *App) RedisAppliance() bool {
+	return a.System() && strings.HasPrefix(a.Name, "redis-")
 }
 
 // Critical apps cannot be completely scaled down by the scheduler

--- a/updater/types/types.go
+++ b/updater/types/types.go
@@ -42,4 +42,5 @@ var SystemApps = []SystemApp{
 	{Name: "slugrunner", ImageOnly: true},
 	{Name: "mariadb", Optional: true},
 	{Name: "mongodb", Optional: true},
+	{Name: "redis"},
 }


### PR DESCRIPTION
This also fixes updating slug images during restore.

I have manually tested by rebuilding the Redis / slugbuilder / slugrunner images with a trivial change then restoring two backups, one still referencing `IMAGE_URI` variables and another using the more recent `IMAGE_ID` variables, and verifying the relevant changes happened:

list the new image IDs:

```
$ for name in redis slugbuilder slugrunner; do echo "$(printf '%12s' $name): $(docker images --no-trunc --quiet flynn/$name)"; done
       redis: 0f452870faaa232cc3e5cf3b768dcf753dc1c16920a7a6cb063e1c74a848834f
 slugbuilder: edc297bea0c70a3fad77ee6baefd3f86c466cb19ff5be3f255503ef1e1217837
  slugrunner: c8c728a73ab01a66a6bde7d717e1393e04ccf6655e10d58439ff8da85663a04d
```


check the `IMAGE_ID` var for `gitreceive` / `taffy` / `redis`;

```
$ flynn -a controller pg psql -- -c "SELECT uri FROM artifacts WHERE artifact_id IN ('$(flynn -a gitreceive env get SLUGBUILDER_IMAGE_ID)', '$(flynn -a gitreceive env get SLUGRUNNER_IMAGE_ID)')"                                                                                                                                   
                                                        uri                                                         
--------------------------------------------------------------------------------------------------------------------
 https://dl.flynn.io/tuf?name=flynn/slugbuilder&id=edc297bea0c70a3fad77ee6baefd3f86c466cb19ff5be3f255503ef1e1217837
 https://dl.flynn.io/tuf?name=flynn/slugrunner&id=c8c728a73ab01a66a6bde7d717e1393e04ccf6655e10d58439ff8da85663a04d

$ flynn -a controller pg psql -- -c "SELECT uri FROM artifacts WHERE artifact_id IN ('$(flynn -a taffy env get SLUGBUILDER_IMAGE_ID)', '$(flynn -a taffy env get SLUGRUNNER_IMAGE_ID)')"
                                                        uri                                                         
--------------------------------------------------------------------------------------------------------------------
 https://dl.flynn.io/tuf?name=flynn/slugbuilder&id=edc297bea0c70a3fad77ee6baefd3f86c466cb19ff5be3f255503ef1e1217837
 https://dl.flynn.io/tuf?name=flynn/slugrunner&id=c8c728a73ab01a66a6bde7d717e1393e04ccf6655e10d58439ff8da85663a04d

$ flynn -a controller pg psql -- -c "SELECT uri FROM artifacts WHERE artifact_id IN ('$(flynn -a redis env get REDIS_IMAGE_ID)')"
                                                     uri                                                      
--------------------------------------------------------------------------------------------------------------
 https://dl.flynn.io/tuf?name=flynn/redis&id=0f452870faaa232cc3e5cf3b768dcf753dc1c16920a7a6cb063e1c74a848834f
```

check the artifact URI for Redis resource apps:

```
$ flynn -a controller pg psql -- -c "SELECT uri FROM artifacts WHERE artifact_id IN (SELECT artifact_id FROM release_artifacts WHERE release_id IN (SELECT release_id FROM apps WHERE name LIKE 'redis-%'))"
                                                     uri                                                      
--------------------------------------------------------------------------------------------------------------
 https://dl.flynn.io/tuf?name=flynn/redis&id=0f452870faaa232cc3e5cf3b768dcf753dc1c16920a7a6cb063e1c74a848834f
```

check the artifact URI for slug apps:

```
$ flynn -a controller pg psql -- -c "SELECT uri FROM artifacts WHERE artifact_id IN (SELECT artifact_id FROM release_artifacts WHERE release_id IN (SELECT release_id FROM apps WHERE name = 'nodejs')) AND type = 'docker'"
                                                        uri                                                        
-------------------------------------------------------------------------------------------------------------------
 https://dl.flynn.io/tuf?name=flynn/slugrunner&id=c8c728a73ab01a66a6bde7d717e1393e04ccf6655e10d58439ff8da85663a04d
```

Fixes #3180 #3253.