### PR TITLE
gitreceive/receiver: Allow changing default build memory limit

### DIFF
--- a/docs/content/apps.md
+++ b/docs/content/apps.md
@@ -190,3 +190,13 @@ the `slugbuilder` process:
 ```text
 flynn limit set slugbuilder memory=4GB
 ```
+
+You can also specify a default `slugbuilder` memory limit globally, set the
+`SLUGBUILDER_DEFAULT_MEMORY_LIMIT` environment variable for the apps that handle
+`git push` and Dashboard deploys:
+
+```text
+limit=SLUGBUILDER_DEFAULT_MEMORY_LIMIT=2GB
+flynn -a gitreceive env set $limit
+flynn -a taffy env set $limit
+```

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/exec"
@@ -135,6 +136,13 @@ Options:
 	}
 	if sb, ok := prevRelease.Processes["slugbuilder"]; ok {
 		job.Resources = sb.Resources
+	} else if rawLimit := os.Getenv("SLUGBUILDER_DEFAULT_MEMORY_LIMIT"); rawLimit != "" {
+		if limit, err := resource.ParseLimit(resource.TypeMemory, rawLimit); err == nil {
+			r := make(resource.Resources)
+			resource.SetDefaults(&r)
+			r[resource.TypeMemory] = resource.Spec{Limit: &limit, Request: &limit}
+			job.Resources = r
+		}
 	}
 
 	cmd := exec.Job(*slugBuilder.HostArtifact(), job)

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -261,17 +261,6 @@ func (s *GitDeploySuite) TestGitSubmodules(t *c.C) {
 	t.Assert(r.flynn("run", "ls", "go-flynn-example"), SuccessfulOutputContains, "main.go")
 }
 
-func (s *GitDeploySuite) TestSlugbuilderLimit(t *c.C) {
-	r := s.newGitRepo(t, "slugbuilder-limit")
-	t.Assert(r.flynn("create"), Succeeds)
-	t.Assert(r.flynn("env", "set", "BUILDPACK_URL=git@github.com:kr/heroku-buildpack-inline.git"), Succeeds)
-	t.Assert(r.flynn("limit", "set", "slugbuilder", "memory=500MB"), Succeeds)
-
-	push := r.git("push", "flynn", "master")
-	t.Assert(push, Succeeds)
-	t.Assert(push, OutputContains, "524288000")
-}
-
 func (s *GitDeploySuite) TestCancel(t *c.C) {
 	r := s.newGitRepo(t, "cancel-hang")
 	t.Assert(r.flynn("create", "cancel-hang"), Succeeds)

--- a/test/test_gitreceive.go
+++ b/test/test_gitreceive.go
@@ -33,3 +33,23 @@ func (s *GitreceiveSuite) TestRepoCaching(t *c.C) {
 	// should only contain one object
 	t.Assert(push, SuccessfulOutputContains, "Counting objects: 1, done.")
 }
+
+func (s *GitreceiveSuite) TestSlugbuilderLimit(t *c.C) {
+	r := s.newGitRepo(t, "slugbuilder-limit")
+	t.Assert(r.flynn("create"), Succeeds)
+	t.Assert(r.flynn("env", "set", "BUILDPACK_URL=git@github.com:kr/heroku-buildpack-inline.git"), Succeeds)
+	t.Assert(r.flynn("-a", "gitreceive", "env", "set", "SLUGBUILDER_DEFAULT_MEMORY_LIMIT=2GB"), Succeeds)
+
+	push := r.git("push", "flynn", "master")
+	t.Assert(push, Succeeds)
+	t.Assert(push, OutputContains, "2147483648")
+
+	t.Assert(r.flynn("limit", "set", "slugbuilder", "memory=500MB"), Succeeds)
+
+	t.Assert(r.git("commit", "-m", "bump", "--allow-empty"), Succeeds)
+	push = r.git("push", "flynn", "master")
+	t.Assert(push, Succeeds)
+	t.Assert(push, OutputContains, "524288000")
+
+	t.Assert(r.flynn("-a", "gitreceive", "env", "unset", "SLUGBUILDER_DEFAULT_MEMORY_LIMIT"), Succeeds)
+}


### PR DESCRIPTION
`SLUGBUILDER_DEFAULT_MEMORY_LIMIT` will be used if a slugbuilder process type limit is not specified for the app's previous release.

Refs #3108