### PR TITLE
router: Fix incorrect cancellation of pipelined requests

### DIFF
--- a/router/http_test.go
+++ b/router/http_test.go
@@ -1677,6 +1677,7 @@ func (s *S) TestHTTPCloseNotify(c *C) {
 	discoverdRegisterHTTP(c, l, srv.Listener.Addr().String())
 
 	req := newReq("http://"+l.Addr, "example.com")
+	req.Method = "POST"
 	req.Cancel = cancel
 	res, err := httpClient.Do(req)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
CloseNotify can trigger early with HTTP/1.1 pipelined requests. Since there is no way to detect if a request is pipelined, we instead check if the request was made over HTTP/2 or if the method
is defined as idempotent. Pipelining is relatively rare in the wild, the most common client that uses pipelining is Safari on iOS, which also supports HTTP/2 so this is only relevant when no TLS certificate is configured for the route. There may be obscure non-browser API clients that use POST/PUT/DELETE with pipelining. If this issue comes up again, we can add a route tunable to disable CloseNotify or suggest that the client stop using pipelining or switch to HTTP/2. The issue presents itself as request cancellations that result in 503s in response to random pipelined requests.

https://golang.org/issue/13165
https://golang.org/pkg/net/http/#CloseNotifier

Thanks to @rikur for reporting this.