### PR TITLE
router: Bump response header timeout to ten minutes

### DIFF
--- a/router/proxy/transport.go
+++ b/router/proxy/transport.go
@@ -26,7 +26,10 @@ var (
 
 	httpTransport = &http.Transport{
 		Dial: customDial,
-		ResponseHeaderTimeout: 120 * time.Second,
+		// The response header timeout is currently set pretty high because
+		// gitreceive doesn't send headers until it is done unpacking the repo,
+		// it should be lowered after this is fixed.
+		ResponseHeaderTimeout: 10 * time.Minute,
 		TLSHandshakeTimeout:   10 * time.Second, // unused, but safer to leave default in place
 	}
 


### PR DESCRIPTION
This gives gitreceive enough time to download/unpack large repos.

Refs #2848
Closes #2788
Closes #2787