### PR TITLE
discoverd/client: Ensure that AddService is always retried

### DIFF
--- a/discoverd/client/heartbeat.go
+++ b/discoverd/client/heartbeat.go
@@ -36,15 +36,11 @@ var runAttempts = attempt.Strategy{
 }
 
 func (c *Client) maybeAddService(service string) error {
-	return runAttempts.Run(func() error {
-		if err := c.AddService(service, nil); err != nil {
-			if !hh.IsObjectExistsError(err) {
-				return err
-			}
-			return nil
-		}
+	err := c.AddService(service, nil)
+	if hh.IsObjectExistsError(err) {
 		return nil
-	})
+	}
+	return err
 }
 
 func (c *Client) AddServiceAndRegister(service, addr string) (Heartbeater, error) {

--- a/discoverd/client/service.go
+++ b/discoverd/client/service.go
@@ -38,7 +38,12 @@ func (c *Client) AddService(name string, conf *ServiceConfig) error {
 	if conf.LeaderType == "" {
 		conf.LeaderType = LeaderTypeOldest
 	}
-	return c.Put("/services/"+name, conf, nil)
+	return runAttempts.RunWithValidator(func() error {
+		return c.Put("/services/"+name, conf, nil)
+	}, func(err error) bool {
+		// TODO(titanous): fix Retry error field to be correct for discoverd
+		return !hh.IsObjectExistsError(err)
+	})
 }
 
 func (c *Client) RemoveService(name string) error {


### PR DESCRIPTION
Move the logic from `maybeAddService` to `AddService` so that direct callers of `AddService` get retries as well. Fixes a intermittent failure while bootstrapping where the flannel wrapper errors out while discoverd is starting.

Thanks to @tianx2 for reporting this.