### PR TITLE
Fix bootstrapping from older backups

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/views/provider-route-create.js.jsx
+++ b/dashboard/app/lib/javascripts/dashboard/views/provider-route-create.js.jsx
@@ -76,10 +76,8 @@ var CreateProviderRoute = React.createClass({
 				name: 'PROVISION_RESOURCE',
 				providerID: this.props.providerID
 			});
-		} else {
-			// go back to where we came from
-			this.props.onHide();
 		}
+		this.props.onHide();
 	},
 
 	__handleCreateBtnClick: function (e) {

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -22,6 +23,7 @@ import (
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/exec"
 	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/tlscert"
 	"github.com/flynn/go-docopt"
 )
 
@@ -256,6 +258,14 @@ $function$;
 			}
 		}
 	}
+	manifestStepMap := make(map[string]bootstrap.Step, len(manifestSteps))
+	steps, err := bootstrap.UnmarshalManifest(manifest, nil)
+	if err != nil {
+		return fmt.Errorf("error decoding manifest json: %s", err)
+	}
+	for _, step := range steps {
+		manifestStepMap[step.StepMeta.ID] = step
+	}
 
 	artifactURIs := make(map[string]string)
 	updateProcArgs := func(f *ct.ExpandedFormation, step *manifestStep) {
@@ -314,17 +324,9 @@ $$;`, step.Artifact.URI, step.ID))
 	data.Controller.ImageArtifact.URI = artifactURIs["controller"]
 	if data.MariaDB != nil {
 		data.MariaDB.ImageArtifact.URI = artifactURIs["mariadb"]
-		if data.MariaDB.Processes["mariadb"] == 0 {
-			// skip mariadb if it wasn't scaled up in the backup
-			data.MariaDB = nil
-		}
 	}
 	if data.MongoDB != nil {
 		data.MongoDB.ImageArtifact.URI = artifactURIs["mongodb"]
-		if data.MongoDB.Processes["mongodb"] == 0 {
-			// skip mongodb if it wasn't scaled up in the backup
-			data.MongoDB = nil
-		}
 	}
 
 	// create the slugbuilder artifact if gitreceive still references
@@ -396,26 +398,6 @@ WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
 		}),
 	}
 
-	// Only run up MariaDB if it's in the backup
-	if data.MariaDB != nil {
-		systemSteps = append(systemSteps, step("mariadb", "run-app", &bootstrap.RunAppAction{
-			ExpandedFormation: data.MariaDB,
-		}))
-		systemSteps = append(systemSteps, step("mariadb-wait", "wait", &bootstrap.WaitAction{
-			URL: "http://mariadb-api.discoverd/ping",
-		}))
-	}
-
-	// Only run up MongoDB if it's in the backup
-	if data.MongoDB != nil {
-		systemSteps = append(systemSteps, step("mongodb", "run-app", &bootstrap.RunAppAction{
-			ExpandedFormation: data.MongoDB,
-		}))
-		systemSteps = append(systemSteps, step("mongodb-wait", "wait", &bootstrap.WaitAction{
-			URL: "http://mongodb-api.discoverd/ping",
-		}))
-	}
-
 	state, err := systemSteps.Run(ch, cfg)
 	if err != nil {
 		return err
@@ -424,8 +406,17 @@ WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
 	// set DISCOVERD_PEERS in release
 	sqlBuf.WriteString(fmt.Sprintf(`
 UPDATE releases SET env = pg_temp.json_object_update_key(env, 'DISCOVERD_PEERS', '%s')
-WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
+WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd');
 `, state.StepData["discoverd"].(*bootstrap.RunAppState).Release.Env["DISCOVERD_PEERS"]))
+
+	// make sure STATUS_KEY has the correct value in the dashboard release
+	sqlBuf.WriteString(`
+UPDATE releases SET env = jsonb_set(env, '{STATUS_KEY}', (
+	SELECT env->'AUTH_KEY' FROM releases
+	WHERE release_id = (SELECT release_id FROM apps WHERE name = 'status')
+))
+WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
+`)
 
 	// load data into postgres
 	cmd := exec.JobUsingHost(state.Hosts[0], host.Artifact{Type: data.Postgres.ImageArtifact.Type, URI: data.Postgres.ImageArtifact.URI}, nil)
@@ -455,16 +446,37 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 	}
 	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
 
-	var mysqldb io.Reader
-	if data.MariaDB != nil {
-		mysqldb, err = getFile("mysql.sql.gz")
+	// start controller API
+	data.Controller.Processes = map[string]int{"web": 1}
+	_, err = bootstrap.Manifest{
+		step("controller", "run-app", &bootstrap.RunAppAction{
+			ExpandedFormation: data.Controller,
+		}),
+	}.RunWithState(ch, state)
+
+	// wait for controller to come up
+	meta = bootstrap.StepMeta{ID: "wait-controller", Action: "wait-controller"}
+	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "start", Timestamp: time.Now().UTC()}
+	controllerInstances, err := discoverd.GetInstances("controller", 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("error getting controller instance: %s", err)
+	}
+
+	// start mariadb and load data if it was present in the backup.
+	mysqldb, err := getFile("mysql.sql.gz")
+	if err == nil && data.MariaDB != nil {
+		_, err = bootstrap.Manifest{
+			step("mariadb", "run-app", &bootstrap.RunAppAction{
+				ExpandedFormation: data.MariaDB,
+			}),
+			step("mariadb-wait", "wait", &bootstrap.WaitAction{
+				URL: "http://mariadb-api.discoverd/ping",
+			}),
+		}.RunWithState(ch, state)
 		if err != nil {
 			return err
 		}
-	}
 
-	// load data into mariadb if it was present in the backup.
-	if mysqldb != nil && data.MariaDB != nil {
 		cmd = exec.JobUsingHost(state.Hosts[0], host.Artifact{Type: data.MariaDB.ImageArtifact.Type, URI: data.MariaDB.ImageArtifact.URI}, nil)
 		cmd.Args = []string{"mysql", "-u", "flynn", "-h", "leader.mariadb.discoverd"}
 		cmd.Env = map[string]string{
@@ -490,16 +502,21 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 		ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
 	}
 
-	var mongodb io.Reader
-	if data.MongoDB != nil {
-		mongodb, err = getFile("mongodb.archive.gz")
+	// start mongodb and load data if it was present in the backup.
+	mongodb, err := getFile("mongodb.archive.gz")
+	if err == nil && data.MongoDB != nil {
+		_, err = bootstrap.Manifest{
+			step("mongodb", "run-app", &bootstrap.RunAppAction{
+				ExpandedFormation: data.MongoDB,
+			}),
+			step("mongodb-wait", "wait", &bootstrap.WaitAction{
+				URL: "http://mongodb-api.discoverd/ping",
+			}),
+		}.RunWithState(ch, state)
 		if err != nil {
 			return err
 		}
-	}
 
-	// load data into mongodb if it was present in the backup.
-	if mongodb != nil && data.MongoDB != nil {
 		cmd = exec.JobUsingHost(state.Hosts[0], host.Artifact{Type: data.MongoDB.ImageArtifact.Type, URI: data.MongoDB.ImageArtifact.URI}, nil)
 		cmd.Args = []string{"mongorestore", "-h", "leader.mongodb.discoverd", "-u", "flynn", "-p", data.MongoDB.Release.Env["MONGO_PWD"], "--archive"}
 		cmd.Stdin = mongodb
@@ -522,27 +539,13 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 		ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
 	}
 
-	// start controller API
-	data.Controller.Processes = map[string]int{"web": 1}
-	_, err = bootstrap.Manifest{
-		step("controller", "run-app", &bootstrap.RunAppAction{
-			ExpandedFormation: data.Controller,
-		}),
-	}.RunWithState(ch, state)
-
-	// wait for controller to come up
-	meta = bootstrap.StepMeta{ID: "wait-controller", Action: "wait-controller"}
-	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "start", Timestamp: time.Now().UTC()}
-	controllerInstances, err := discoverd.GetInstances("controller", 30*time.Second)
-	if err != nil {
-		return fmt.Errorf("error getting controller instance: %s", err)
-	}
-
-	// get blobstore config
-	client, err := controller.NewClient("http://"+controllerInstances[0].Addr, data.Controller.Release.Env["AUTH_KEY"])
+	controllerKey := data.Controller.Release.Env["AUTH_KEY"]
+	client, err := controller.NewClient("http://"+controllerInstances[0].Addr, controllerKey)
 	if err != nil {
 		return err
 	}
+
+	// get blobstore config
 	blobstoreRelease, err := client.GetAppRelease("blobstore")
 	if err != nil {
 		return fmt.Errorf("error getting blobstore release: %s", err)
@@ -551,7 +554,7 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 	if err != nil {
 		return fmt.Errorf("error getting blobstore expanded formation: %s", err)
 	}
-	state.SetControllerKey(data.Controller.Release.Env["AUTH_KEY"])
+	state.SetControllerKey(controllerKey)
 	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
 
 	// start blobstore, scheduler, and enable cluster monitor
@@ -581,6 +584,64 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'discoverd')
 	}.RunWithState(ch, state)
 	if err != nil {
 		return err
+	}
+
+	// mariadb and mongodb steps require the controller key
+	state.StepData["controller-key"] = &bootstrap.RandomData{controllerKey}
+
+	// deploy mariadb if it wasn't restored from the backup
+	if data.MariaDB == nil {
+		steps := bootstrap.Manifest{
+			manifestStepMap["mariadb-password"],
+			manifestStepMap["mariadb"],
+			manifestStepMap["add-mysql-provider"],
+			manifestStepMap["mariadb-wait"],
+		}
+		if _, err := steps.RunWithState(ch, state); err != nil {
+			return fmt.Errorf("error deploying mariadb: %s", err)
+		}
+	}
+
+	// deploy mongodb if it wasn't restored from the backup
+	if data.MongoDB == nil {
+		steps := bootstrap.Manifest{
+			manifestStepMap["mongodb-password"],
+			manifestStepMap["mongodb"],
+			manifestStepMap["add-mongodb-provider"],
+			manifestStepMap["mongodb-wait"],
+		}
+		if _, err := steps.RunWithState(ch, state); err != nil {
+			return fmt.Errorf("error deploying mongodb: %s", err)
+		}
+	}
+
+	// deploy docker-receive if it wasn't in the backup
+	if _, err := client.GetApp("docker-receive"); err == controller.ErrNotFound {
+		routes, err := client.RouteList("controller")
+		if len(routes) == 0 {
+			err = errors.New("no routes found")
+		}
+		if err != nil {
+			return fmt.Errorf("error listing controller routes: %s", err)
+		}
+		for _, r := range routes {
+			if r.Domain == fmt.Sprintf("controller.%s", data.Controller.Release.Env["DEFAULT_ROUTE_DOMAIN"]) {
+				state.StepData["controller-cert"] = &tlscert.Cert{
+					Cert:       r.Certificate.Cert,
+					PrivateKey: r.Certificate.Key,
+				}
+				break
+			}
+		}
+		steps := bootstrap.Manifest{
+			manifestStepMap["docker-receive-secret"],
+			manifestStepMap["docker-receive"],
+			manifestStepMap["docker-receive-route"],
+			manifestStepMap["docker-receive-wait"],
+		}
+		if _, err := steps.RunWithState(ch, state); err != nil {
+			return fmt.Errorf("error deploying docker-receive: %s", err)
+		}
 	}
 
 	return nil

--- a/script/generate-backups
+++ b/script/generate-backups
@@ -53,10 +53,12 @@ main() {
   local app="nodejs"
 
   for version in "v20160309.0" "v20160423.0" "v20160624.1" "v20160721.2" "v20160814.0"; do
-    local out="${dir}/${version}-nodejs-redis.tar"
+    local name="${version}-nodejs-redis.tar"
+    local out="${dir}/${name}"
 
+    info "generating ${name}"
     if [[ -e "${out}" ]] && ! $force; then
-      info "backup of ${version} already exists"
+      info "backup ${name} already exists"
       continue
     fi
 
@@ -65,6 +67,10 @@ main() {
     add_redis_resource
     backup_cluster "${out}"
   done
+
+  backup_mysql_cluster
+
+  backup_mongodb_cluster
 }
 
 clone_app() {
@@ -72,6 +78,40 @@ clone_app() {
 
   info "cloning Node.js example app"
   git clone "https://github.com/flynn-examples/nodejs-flynn-example.git" "${path}"
+}
+
+backup_mysql_cluster() {
+  local version="v20160814.0"
+  local name="${version}-nodejs-mysql.tar"
+  local out="${dir}/${name}"
+
+  info "generating ${name}"
+  if [[ -e "${out}" ]] && ! $force; then
+    info "backup ${name} already exists"
+    continue
+  fi
+
+  bootstrap_cluster "${version}"
+  git_deploy_app
+  add_mysql_resource
+  backup_cluster "${out}"
+}
+
+backup_mongodb_cluster() {
+  local version="v20160814.0"
+  local name="${version}-nodejs-mongodb.tar"
+  local out="${dir}/${name}"
+
+  info "generating ${name}"
+  if [[ -e "${out}" ]] && ! $force; then
+    info "backup ${name} already exists"
+    continue
+  fi
+
+  bootstrap_cluster "${version}"
+  git_deploy_app
+  add_mongodb_resource
+  backup_cluster "${out}"
 }
 
 bootstrap_cluster() {
@@ -119,6 +159,18 @@ add_redis_resource() {
   flynn -a "${app}" resource add redis
 }
 
+add_mysql_resource() {
+  info "adding MySQL resource"
+  flynn -a "${app}" resource add mysql
+  flynn -a "${app}" mysql console -- -e "CREATE TABLE foos (data TEXT); INSERT INTO foos (data) VALUES ('foobar')"
+}
+
+add_mongodb_resource() {
+  info "adding MongoDB resource"
+  flynn -a "${app}" resource add mongodb
+  flynn -a "${app}" mongodb mongo -- --eval 'db.foos.insert({data: "foobar"})'
+}
+
 backup_cluster() {
   local file=$1
 
@@ -127,7 +179,7 @@ backup_cluster() {
 }
 
 flynn() {
-  "${ROOT}/cli/bin/flynn" $@
+  "${ROOT}/cli/bin/flynn" "$@"
 }
 
 main $@

--- a/status/status.go
+++ b/status/status.go
@@ -157,6 +157,7 @@ var services = []Service{
 	{Name: "logaggregator", ReqFn: LeaderReqFn("logaggregator", "80")},
 	{Name: "postgres", ReqFn: LeaderReqFn("postgres", "5433")},
 	{Name: "mariadb", ReqFn: LeaderReqFn("mariadb", "3307"), Optional: true},
+	{Name: "mongodb", ReqFn: LeaderReqFn("mongodb", "27018"), Optional: true},
 	{Name: "router", ReqFn: RandomReqFn("router-api")},
 }
 

--- a/test/test_healthcheck.go
+++ b/test/test_healthcheck.go
@@ -130,8 +130,8 @@ func (s *HealthcheckSuite) TestStatus(t *c.C) {
 	t.Assert(err, c.IsNil)
 
 	t.Assert(data.Data.Status, c.Equals, status.CodeHealthy)
-	t.Assert(data.Data.Detail, c.HasLen, 13)
-	optional := map[string]bool{"mariadb": true}
+	t.Assert(data.Data.Detail, c.HasLen, 14)
+	optional := map[string]bool{"mariadb": true, "mongodb": true}
 	for name, s := range data.Data.Detail {
 		if !optional[name] {
 			t.Assert(s.Status, c.Equals, status.CodeHealthy, c.Commentf("name = %s", name))

--- a/test/test_zz_backup.go
+++ b/test/test_zz_backup.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/cli/config"
+	"github.com/flynn/flynn/controller/client"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/attempt"
 	c "github.com/flynn/go-check"
@@ -132,15 +133,23 @@ func (s *ZZBackupSuite) testClusterBackup(t *c.C, index int, path string) {
 	t.Assert(err, c.IsNil)
 	t.Assert(res.StatusCode, c.Equals, http.StatusOK)
 
-	debug(t, "configuring flynn CLI")
+	debug(t, "getting app release")
 	controllerInstances, err := disc.Instances("controller", 30*time.Second)
 	t.Assert(err, c.IsNil)
+	controllerURL := "http://" + controllerInstances[0].Addr
+	controllerKey := controllerInstances[0].Meta["AUTH_KEY"]
+	client, err := controller.NewClient(controllerURL, controllerKey)
+	t.Assert(err, c.IsNil)
+	release, err := client.GetAppRelease("nodejs")
+	t.Assert(err, c.IsNil)
+
+	debug(t, "configuring flynn CLI")
 	flynnrc := filepath.Join(dir, ".flynnrc")
 	conf := &config.Config{}
 	t.Assert(conf.Add(&config.Cluster{
 		Name:          "default",
-		ControllerURL: "http://" + controllerInstances[0].Addr,
-		Key:           controllerInstances[0].Meta["AUTH_KEY"],
+		ControllerURL: controllerURL,
+		Key:           controllerKey,
 	}, true), c.IsNil)
 	t.Assert(conf.SaveTo(flynnrc), c.IsNil)
 	flynn := func(cmdArgs ...string) *CmdResult {
@@ -150,13 +159,36 @@ func (s *ZZBackupSuite) testClusterBackup(t *c.C, index int, path string) {
 		return run(t, cmd)
 	}
 
-	debug(t, "checking redis resource")
-	// try multiple times as the Redis resource is not guaranteed to be up yet
-	var redisResult *CmdResult
-	err = attempt.Strategy{Total: 10 * time.Second, Delay: 100 * time.Millisecond}.Run(func() error {
-		redisResult = flynn("redis", "redis-cli", "--", "PING")
-		return redisResult.Err
-	})
-	t.Assert(err, c.IsNil)
-	t.Assert(redisResult, SuccessfulOutputContains, "PONG")
+	if _, ok := release.Env["FLYNN_REDIS"]; ok {
+		debug(t, "checking redis resource")
+		// try multiple times as the Redis resource is not guaranteed to be up yet
+		var redisResult *CmdResult
+		err = attempt.Strategy{Total: 10 * time.Second, Delay: 100 * time.Millisecond}.Run(func() error {
+			redisResult = flynn("redis", "redis-cli", "--", "PING")
+			return redisResult.Err
+		})
+		t.Assert(err, c.IsNil)
+		t.Assert(redisResult, SuccessfulOutputContains, "PONG")
+	}
+
+	debug(t, "checking mysql resource")
+	if _, ok := release.Env["FLYNN_MYSQL"]; ok {
+		t.Assert(flynn("mysql", "console", "--", "-e", "SELECT * FROM foos"), SuccessfulOutputContains, "foobar")
+	} else {
+		t.Assert(flynn("resource", "add", "mysql"), Succeeds)
+	}
+
+	debug(t, "checking mongodb resource")
+	if _, ok := release.Env["FLYNN_MONGO"]; ok {
+		t.Assert(flynn("mongodb", "mongo", "--", "--eval", "db.foos.find()"), SuccessfulOutputContains, "foobar")
+	} else {
+		t.Assert(flynn("resource", "add", "mongodb"), Succeeds)
+	}
+
+	debug(t, "checking dashboard STATUS_KEY matches status AUTH_KEY")
+	dashboardStatusKeyResult := flynn("-a", "dashboard", "env", "get", "STATUS_KEY")
+	t.Assert(dashboardStatusKeyResult, Succeeds)
+	statusAuthKeyResult := flynn("-a", "status", "env", "get", "AUTH_KEY")
+	t.Assert(statusAuthKeyResult, Succeeds)
+	t.Assert(dashboardStatusKeyResult.Output, c.Equals, statusAuthKeyResult.Output)
 }


### PR DESCRIPTION
- Ensures that MariaDB, MongoDB, and docker-receive are deployed,
and that STATUS_KEY is set in the dashboard
- Add mongodb to status app

<del>This isn't ready to merge just yet as MariaDB isn't healthy when it scales up. @josephglanville any input you can provide here would be appreciated.</del>
<br/>

Closes #3198
Closes #2988