### PR TITLE
pkg/postgres: Switch to using EXCLUSIVE locking on schema_migrations

### DIFF
--- a/pkg/postgres/migrate.go
+++ b/pkg/postgres/migrate.go
@@ -48,7 +48,7 @@ func (m Migrations) Migrate(db *DB) error {
 			return err
 		}
 
-		if err := tx.Exec("LOCK TABLE schema_migrations IN ACCESS EXCLUSIVE MODE"); err != nil {
+		if err := tx.Exec("LOCK TABLE schema_migrations IN EXCLUSIVE MODE"); err != nil {
 			tx.Rollback()
 			return err
 		}


### PR DESCRIPTION
Previously an ACCESS EXCLUSIVE lock was held while performing database
migrations. This lock however cannot be attained while an ACCESS SHARE
lock is being held on the table, which is the case when `pg_dump` is
currently in the progress of dumping the database.

Advisory locks were also considered as they would be faster but they
are somewhat more complex and not the best fit as they don't honor
transaction semantics.