### PR TITLE
blobstore: Delete replaced files from external backend

### DIFF
--- a/blobstore/Dockerfile
+++ b/blobstore/Dockerfile
@@ -3,5 +3,6 @@ FROM ubuntu:trusty-20160217
 RUN apt-get update && apt-get -qy install ca-certificates && apt-get clean
 ADD ./bin/flynn-blobstore /bin/flynn-blobstore
 ADD ./bin/flynn-blobstore-migrate /bin/flynn-blobstore-migrate
+ADD ./bin/flynn-blobstore-cleanup /bin/flynn-blobstore-cleanup
 
 ENTRYPOINT ["/bin/flynn-blobstore"]

--- a/blobstore/Tupfile
+++ b/blobstore/Tupfile
@@ -1,4 +1,5 @@
 include_rules
 : |> !go |> bin/flynn-blobstore
 : |> !go ./cmd/flynn-blobstore-migrate |> bin/flynn-blobstore-migrate
+: |> !go ./cmd/flynn-blobstore-cleanup |> bin/flynn-blobstore-cleanup
 : bin/* |> !docker-bootstrapped |>

--- a/blobstore/cmd/flynn-blobstore-cleanup/cleanup.go
+++ b/blobstore/cmd/flynn-blobstore-cleanup/cleanup.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"sync"
+
+	"github.com/flynn/flynn/blobstore/data"
+	"github.com/flynn/flynn/pkg/postgres"
+)
+
+func main() {
+	concurrency := flag.Int("concurrency", 4, "number of parallel file deletions to run at a time")
+	flag.Parse()
+
+	db := postgres.Wait(nil, nil)
+	repo, err := data.NewFileRepoFromEnv(db)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	files, err := repo.ListDeletedFilesForCleanup()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	tokens := make(chan struct{}, *concurrency)
+	for i, f := range files {
+		if f.Backend == nil {
+			log.Printf("[%d/%d] Skipping %s (%s) because backend is not configured", i+1, len(files), f.FileInfo.Name, f.ID)
+			continue
+		}
+		tokens <- struct{}{}
+		wg.Add(1)
+		go func(f data.BackendFile) {
+			if err := f.Backend.Delete(nil, f.FileInfo); err == nil {
+				log.Printf("[%d/%d] Successfully deleted %s (%s) from backend %s", i+1, len(files), f.FileInfo.Name, f.ID, f.Backend.Name())
+			}
+			<-tokens
+			wg.Done()
+		}(f)
+	}
+
+	wg.Wait()
+	db.Close()
+
+	log.Printf("Done.")
+}


### PR DESCRIPTION
Also, add a command that can cleanup files in external backends that have been marked as deleted:

    flynn -a blobstore run /bin/flynn-blobstore-cleanup

Closes #3344