### PR TITLE
test: Test restoring historic cluster backups

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -58,7 +58,8 @@
     "release": {
       "env": {
         "DISCOVERD": "none",
-        "BACKEND": "{{ getenv \"FLANNEL_BACKEND\" }}"
+        "BACKEND": "{{ getenv \"FLANNEL_BACKEND\" }}",
+        "NETWORK": "{{ getenv \"FLANNEL_NETWORK\" }}"
       },
       "processes": {
         "app": {

--- a/flannel/wrapper/runner.go
+++ b/flannel/wrapper/runner.go
@@ -35,7 +35,10 @@ func main() {
 	if backend := os.Getenv("BACKEND"); backend != "" {
 		config.Backend.Type = backend
 	}
-	flag.StringVar(&config.Network, "network", "100.100.0.0/16", "container network")
+	config.Network = os.Getenv("NETWORK")
+	if config.Network == "" {
+		config.Network = "100.100.0.0/16"
+	}
 	flag.StringVar(&config.SubnetMin, "subnet-min", "", "container network min subnet")
 	flag.StringVar(&config.SubnetMax, "subnet-max", "", "container network max subnet")
 	flag.UintVar(&config.SubnetLen, "subnet-len", 0, "container network subnet length")

--- a/host/host.go
+++ b/host/host.go
@@ -190,6 +190,10 @@ func runDaemon(args *docopt.Args) {
 		maxJobConcurrency = m
 	}
 
+	if path, err := filepath.Abs(flynnInit); err == nil {
+		flynnInit = path
+	}
+
 	var partitionCGroups = make(map[string]int64) // name -> cpu shares
 	for _, p := range strings.Split(args.String["--partitions"], " ") {
 		nameShares := strings.Split(p, "=cpu_shares:")

--- a/pkg/httphelper/httphelper.go
+++ b/pkg/httphelper/httphelper.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/flynn/flynn/pkg/cors"
 	"github.com/flynn/flynn/pkg/ctxhelper"
+	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/jackc/pgx"
 	"github.com/julienschmidt/httprouter"
@@ -19,6 +20,8 @@ import (
 )
 
 type ErrorCode string
+
+var RetryClient = &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
 
 const (
 	NotFoundErrorCode           ErrorCode = "not_found"

--- a/script/generate-backups
+++ b/script/generate-backups
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/ui.sh"
+
+usage() {
+  cat <<USAGE >&2
+usage: $0 [options] DIR
+
+Generate backups from historically versioned clusters into DIR.
+
+OPTIONS:
+  -h, --help    Show this message
+  -f, --force   Create the backups even if they exist
+USAGE
+}
+
+main() {
+  local force=false
+
+  while true; do
+    case "$1" in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -f | --force)
+        force=true
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  local dir=$1
+
+  local tmp="$(mktemp --directory)"
+  trap "rm -rf ${tmp}" EXIT
+
+  local src="${tmp}/src"
+  clone_app "${src}"
+
+  export FLYNNRC="${tmp}/flynnrc"
+  local app="nodejs"
+
+  for version in "v20160309.0" "v20160423.0" "v20160624.1" "v20160721.2" "v20160814.0"; do
+    local out="${dir}/${version}-nodejs-redis.tar"
+
+    if [[ -e "${out}" ]] && ! $force; then
+      info "backup of ${version} already exists"
+      continue
+    fi
+
+    bootstrap_cluster "${version}"
+    git_deploy_app
+    add_redis_resource
+    backup_cluster "${out}"
+  done
+}
+
+clone_app() {
+  local path=$1
+
+  info "cloning Node.js example app"
+  git clone "https://github.com/flynn-examples/nodejs-flynn-example.git" "${path}"
+}
+
+bootstrap_cluster() {
+  local version=$1
+
+  local out="${tmp}/bootstrap-${version}.txt"
+
+  info "bootstrapping ${version} cluster"
+  local cluster_add=$("${ROOT}/script/bootstrap-flynn" --version "${version}" &> >(tee "${out}") | tail -3 | head -1)
+
+  if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then
+    warn "bootstrap failed:"
+    cat "${out}"
+    fail "bootstrap failed"
+  fi
+
+  flynn cluster remove default
+
+  if [[ "${version:1:8}" -ge "20160609" ]]; then
+    flynn cluster add --docker ${cluster_add:18}
+  else
+    flynn cluster add ${cluster_add:18}
+  fi
+}
+
+git_deploy_app() {
+  info "deploying app using 'git push'"
+
+  pushd "${src}" >/dev/null
+
+  flynn create --yes "${app}"
+
+  local out="${tmp}/git-push-${version}.txt"
+  if ! git push flynn master &> "${out}"; then
+    warn "git push failed:"
+    cat "${out}"
+    fail "git push failed"
+  fi
+
+  popd >/dev/null
+}
+
+add_redis_resource() {
+  info "adding Redis resource"
+  flynn -a "${app}" resource add redis
+}
+
+backup_cluster() {
+  local file=$1
+
+  info "backing up cluster to ${file}"
+  flynn cluster backup --file "${file}"
+}
+
+flynn() {
+  "${ROOT}/cli/bin/flynn" $@
+}
+
+main $@

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -106,6 +106,7 @@ main() {
     "--flynnrc ${FLYNNRC}"
     "--cli ${flynn}"
     "--flynn-host ${flynn_host}"
+    "--backups-dir" "${ROOT}/backups"
     "--debug"
   )
 

--- a/test/arg/arg.go
+++ b/test/arg/arg.go
@@ -37,6 +37,7 @@ func Parse() *Args {
 	flag.StringVar(&args.BootConfig.Kernel, "kernel", "rootfs/vmlinuz", "path to the Linux binary")
 	flag.StringVar(&args.BootConfig.Network, "network", "10.52.0.1/24", "the network to use for vms")
 	flag.StringVar(&args.BootConfig.NatIface, "nat", "eth0", "the interface to provide NAT to vms")
+	flag.StringVar(&args.BootConfig.BackupsDir, "backups-dir", "", "directory containing historic cluster backups")
 	flag.StringVar(&args.RootFS, "rootfs", "rootfs/rootfs.img", "filesystem image to use with QEMU")
 	flag.StringVar(&args.CLI, "cli", "flynn", "path to flynn-cli binary")
 	flag.StringVar(&args.FlynnHost, "flynn-host", "../host/bin/flynn-host", "path to flynn-host binary")

--- a/test/cluster/instance.go
+++ b/test/cluster/instance.go
@@ -28,14 +28,15 @@ type VMManager struct {
 }
 
 type VMConfig struct {
-	Kernel string
-	User   int
-	Group  int
-	Memory string
-	Cores  int
-	Drives map[string]*VMDrive
-	Args   []string
-	Out    io.Writer `json:"-"`
+	Kernel     string
+	User       int
+	Group      int
+	Memory     string
+	Cores      int
+	Drives     map[string]*VMDrive
+	Args       []string
+	Out        io.Writer `json:"-"`
+	BackupsDir string
 
 	netFS string
 }
@@ -138,6 +139,7 @@ func (i *Instance) Start() error {
 		"-netdev", "tap,id=vmnic,ifname="+i.tap.Name+",script=no,downscript=no",
 		"-device", "virtio-net,netdev=vmnic,mac="+macaddr,
 		"-virtfs", "fsdriver=local,path="+i.netFS+",security_model=passthrough,readonly,mount_tag=netfs",
+		"-virtfs", "fsdriver=local,path="+i.BackupsDir+",security_model=passthrough,readonly,mount_tag=backupsfs",
 		"-nographic",
 	)
 	if i.Memory != "" {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -346,12 +346,17 @@ git config --global user.name "CI"
 
 cd test
 
+# mount the backups dir
+sudo mkdir -p /mnt/backups
+sudo mount -t 9p -o trans=virtio backupsfs /mnt/backups
+
 cmd="bin/flynn-test \
   --flynnrc $HOME/.flynnrc \
   --cluster-api https://{{ .Cluster.BridgeIP }}:{{ .ListenPort }}/cluster/{{ .Cluster.ID }} \
   --cli $(pwd)/../cli/bin/flynn \
   --flynn-host $(pwd)/../host/bin/flynn-host \
   --router-ip {{ .Cluster.RouterIP }} \
+  --backups-dir "/mnt/backups" \
   --debug"
 
 timeout --signal=QUIT --kill-after=10 35m $cmd

--- a/test/scripts/upstart.conf
+++ b/test/scripts/upstart.conf
@@ -45,5 +45,6 @@ script
     --db       "${dir}/flynn-test.db" \
     --tls-cert "${dir}/ci_flynn_io.crt" \
     --tls-key  "${dir}/ci_flynn_io.key" \
+    --backups-dir "${dir}/backups" \
     --gist
 end script

--- a/test/test_backup.go
+++ b/test/test_backup.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/flynn/flynn/cli/config"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/attempt"
+	c "github.com/flynn/go-check"
+)
+
+type BackupSuite struct {
+	Helper
+}
+
+var _ = c.ConcurrentSuite(&BackupSuite{})
+
+func (s *BackupSuite) TestClusterBackups(t *c.C) {
+	if args.BootConfig.BackupsDir == "" {
+		t.Skip("--backups-dir not set")
+	}
+
+	backups, err := ioutil.ReadDir(args.BootConfig.BackupsDir)
+	t.Assert(err, c.IsNil)
+	if len(backups) == 0 {
+		t.Fatal("backups dir is empty")
+	}
+
+	for i, backup := range backups {
+		s.testClusterBackup(t, i, filepath.Join(args.BootConfig.BackupsDir, backup.Name()))
+	}
+}
+
+func (s *BackupSuite) testClusterBackup(t *c.C, index int, path string) {
+	debugf(t, "restoring cluster backup %s", filepath.Base(path))
+
+	// boot the cluster using an RFC 5737 TEST-NET IP, avoiding conflicts
+	// with those used by script/bootstrap-flynn so the test can be run in
+	// development
+	ip := fmt.Sprintf("192.0.2.%d", index+100)
+	device := fmt.Sprintf("eth0:%d", index+10)
+	t.Assert(run(t, exec.Command("sudo", "ifconfig", device, ip)), Succeeds)
+
+	dir := t.MkDir()
+	debugf(t, "using tempdir %s", dir)
+
+	debug(t, "starting flynn-host")
+	cmd := exec.Command(
+		"sudo",
+		"../host/bin/flynn-host",
+		"daemon",
+		"--id", fmt.Sprintf("backup%d", index),
+		"--external-ip", ip,
+		"--listen-ip", ip,
+		"--bridge-name", fmt.Sprintf("backupbr%d", index),
+		"--state", filepath.Join(dir, "host-state.bolt"),
+		"--volpath", filepath.Join(dir, "volumes"),
+		"--log-dir", filepath.Join(dir, "logs"),
+		"--flynn-init", "../host/bin/flynn-init",
+	)
+	out, err := os.Create(filepath.Join(dir, "flynn-host.log"))
+	t.Assert(err, c.IsNil)
+	defer out.Close()
+	cmd.Stdout = out
+	cmd.Stderr = out
+	t.Assert(cmd.Start(), c.IsNil)
+	go cmd.Process.Wait()
+	defer exec.Command("sudo", "kill", strconv.Itoa(cmd.Process.Pid)).Run()
+
+	debugf(t, "bootstrapping flynn from backup")
+	cmd = exec.Command(
+		"../host/bin/flynn-host",
+		"bootstrap",
+		"--peer-ips", ip,
+		"--from-backup", path,
+		"../bootstrap/bin/manifest.json",
+	)
+	cmd.Env = []string{
+		"CLUSTER_DOMAIN=1.localflynn.com",
+		fmt.Sprintf("DISCOVERD=%s:1111", ip),
+		fmt.Sprintf("FLANNEL_NETWORK=100.%d.0.0/16", index+101),
+	}
+	logR, logW := io.Pipe()
+	defer logW.Close()
+	go func() {
+		buf := bufio.NewReader(logR)
+		for {
+			line, err := buf.ReadString('\n')
+			if err != nil {
+				return
+			}
+			debug(t, line[0:len(line)-1])
+		}
+	}()
+	cmd.Stdout = logW
+	cmd.Stderr = logW
+	t.Assert(cmd.Run(), c.IsNil)
+
+	debug(t, "waiting for nodejs-web service")
+	disc := discoverd.NewClientWithURL(fmt.Sprintf("http://%s:1111", ip))
+	_, err = disc.Instances("nodejs-web", 30*time.Second)
+	t.Assert(err, c.IsNil)
+
+	debug(t, "checking HTTP requests")
+	req, err := http.NewRequest("GET", "http://"+ip, nil)
+	t.Assert(err, c.IsNil)
+	req.Host = "nodejs.1.localflynn.com"
+	var res *http.Response
+	// try multiple times in case we get a 503 from the router as it has
+	// not seen the service yet
+	err = attempt.Strategy{Total: 10 * time.Second, Delay: 100 * time.Millisecond}.Run(func() (err error) {
+		res, err = http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		} else if res.StatusCode == http.StatusServiceUnavailable {
+			return errors.New("router returned 503")
+		}
+		return nil
+	})
+	t.Assert(err, c.IsNil)
+	t.Assert(res.StatusCode, c.Equals, http.StatusOK)
+
+	debug(t, "configuring flynn CLI")
+	controllerInstances, err := disc.Instances("controller", 30*time.Second)
+	t.Assert(err, c.IsNil)
+	flynnrc := filepath.Join(dir, ".flynnrc")
+	conf := &config.Config{}
+	t.Assert(conf.Add(&config.Cluster{
+		Name:          "default",
+		ControllerURL: "http://" + controllerInstances[0].Addr,
+		Key:           controllerInstances[0].Meta["AUTH_KEY"],
+	}, true), c.IsNil)
+	t.Assert(conf.SaveTo(flynnrc), c.IsNil)
+	flynn := func(cmdArgs ...string) *CmdResult {
+		cmd := exec.Command(args.CLI, cmdArgs...)
+		cmd.Env = flynnEnv(flynnrc)
+		cmd.Env = append(cmd.Env, "FLYNN_APP=nodejs")
+		return run(t, cmd)
+	}
+
+	debug(t, "checking redis resource")
+	// try multiple times as the Redis resource is not guaranteed to be up yet
+	var redisResult *CmdResult
+	err = attempt.Strategy{Total: 10 * time.Second, Delay: 100 * time.Millisecond}.Run(func() error {
+		redisResult = flynn("redis", "redis-cli", "--", "PING")
+		return redisResult.Err
+	})
+	t.Assert(err, c.IsNil)
+	t.Assert(redisResult, SuccessfulOutputContains, "PONG")
+}


### PR DESCRIPTION
This adds `script/generate-backups` which bootstraps a Flynn cluster at various versions, deploys the Node.js example app, adds a Redis resource and backs up the cluster to a file.

There is also a test which iterates through those backups, bootstraps a cluster then checks the app came up with Redis correctly.

We probably want to expand this a little going further (e.g. use docker push, provision different resources etc.) but this at least gives us a good starting point to start avoiding cluster restore regressions.