### PR TITLE
gitreceive: Add support for customizing port config

### DIFF
--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -203,7 +203,7 @@ Options:
 	for _, t := range types {
 		proc := prevRelease.Processes[t]
 		proc.Args = []string{"/runner/init", "start", t}
-		if t == "web" || strings.HasSuffix(t, "-web") {
+		if (t == "web" || strings.HasSuffix(t, "-web")) && proc.Service == "" {
 			proc.Service = app.Name + "-" + t
 			proc.Ports = []ct.Port{{
 				Port:  8080,


### PR DESCRIPTION
This ensures that custom port, service, and health check configurations are not replaced by subsequent deploys.

Closes #3387