### PR TITLE
worker: Don't wait for old jobs to actually stop

### DIFF
--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -122,14 +122,11 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 		log.Error("error scaling old formation down to zero", "err", err)
 		return ErrSkipRollback{err.Error()}
 	}
-	if diff.Count() > 0 {
-		log.Info(fmt.Sprintf("waiting for %d job down event(s)", diff.Count()), "diff", diff)
-		if err := d.waitForJobEvents(d.OldReleaseID, diff, log); err != nil {
-			log.Error("error waiting for job down events", "diff", diff, "err", err)
-			return ErrSkipRollback{err.Error()}
-		}
-	}
 
+	// treat the deployment as finished now (rather than potentially
+	// waiting for the jobs to actually stop) as we can trust that the
+	// scheduler will actually kill the jobs, so no need to delay the
+	// deployment.
 	log.Info("finished one-by-one deployment")
 	return nil
 }


### PR DESCRIPTION
If a formation change is accepted by the controller, we can then leave it up to the scheduler to actually stop the jobs. Failing the deployment if the events aren't received (e.g. because they are already down we just didn't know it yet) won't make any difference.

Fixes #3285.