### PR TITLE
pkg/backup: Use --flush-privileges when backing up MariaDB

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -45,7 +45,7 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 			Args: []string{
 				"bash",
 				"-c",
-				fmt.Sprintf("set -o pipefail; /usr/bin/mysqldump -h %s -u %s --all-databases | gzip -9", mysqlRelease.Env["MYSQL_HOST"], mysqlRelease.Env["MYSQL_USER"]),
+				fmt.Sprintf("set -o pipefail; /usr/bin/mysqldump -h %s -u %s --all-databases --flush-privileges | gzip -9", mysqlRelease.Env["MYSQL_HOST"], mysqlRelease.Env["MYSQL_USER"]),
 			},
 			Env: map[string]string{
 				"MYSQL_PWD": mysqlRelease.Env["MYSQL_PWD"],


### PR DESCRIPTION
This emits a `FLUSH PRIVILEGES` command at the end of the dump to ensure
information restored from the `mysql` database is made active.

Closes #3394