### PR TITLE
controller: Add root CA certificates

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -3,6 +3,7 @@ FROM flynn/busybox:trusty-20160217
 ADD bin/flynn-controller /bin/flynn-controller
 ADD bin/flynn-scheduler /bin/flynn-scheduler
 ADD bin/flynn-worker /bin/flynn-worker
+ADD bin/ca-certs.pem /etc/ssl/certs/ca-certs.pem
 ADD start.sh /bin/start-flynn-controller
 ADD bin/jsonschema /etc/flynn-controller/jsonschema
 

--- a/controller/Tupfile
+++ b/controller/Tupfile
@@ -2,6 +2,7 @@ include_rules
 : |> !go |> bin/flynn-controller
 : |> !go ./scheduler |> bin/flynn-scheduler
 : |> !go ./worker |> bin/flynn-worker
+: $(ROOT)/util/ca-certs/ca-certs.pem |> !cp |> bin/ca-certs.pem
 : foreach $(ROOT)/schema/*.json |> !cp |> bin/jsonschema/%g.json
 : foreach $(ROOT)/schema/controller/*.json |> !cp |> bin/jsonschema/controller/%g.json
 : foreach $(ROOT)/schema/router/*.json |> !cp |> bin/jsonschema/router/%g.json


### PR DESCRIPTION
This ensures that the controller can make outbound HTTPS requests, for example to the telemetry endpoint.