### PR TITLE
host/containerinit: Wait 2 seconds before forwarding SIGTERM/INT

### DIFF
--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -513,7 +513,8 @@ func babySit(process *os.Process, hbs []discoverd.Heartbeater) int {
 				continue
 			}
 			if sig == syscall.SIGTERM || sig == syscall.SIGINT {
-				go shutdownOnce.Do(closeHBs)
+				shutdownOnce.Do(closeHBs)
+				time.Sleep(2 * time.Second)
 			}
 			log.Info("forwarding signal to command", "type", sig)
 			process.Signal(sig)


### PR DESCRIPTION
We also now close the heartbeaters synchronously.

The purpose of this change is to give the router additional grace period to remove backends that will be shutting down shortly from it's routing table.

This ensures that new client requests won't be sent on dead or soon to be dead connections during scale down events, like during a deploy for instance.