### PR TITLE
controller: Add "stopping" job state 

### DIFF
--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -55,6 +55,7 @@ func (s *S) TestJobListActive(c *C) {
 		createJob(ct.JobStatePending),
 		createJob(ct.JobStateStarting),
 		createJob(ct.JobStateUp),
+		createJob(ct.JobStateStopping),
 		createJob(ct.JobStateDown),
 		createJob(ct.JobStatePending),
 		createJob(ct.JobStateStarting),
@@ -63,11 +64,11 @@ func (s *S) TestJobListActive(c *C) {
 
 	list, err := s.c.JobListActive()
 	c.Assert(err, IsNil)
-	c.Assert(list, HasLen, 6)
+	c.Assert(list, HasLen, 7)
 
-	// check that we only get jobs with a pending, starting or up state,
-	// most recently updated first
-	expected := []*ct.Job{jobs[6], jobs[5], jobs[4], jobs[2], jobs[1], jobs[0]}
+	// check that we only get jobs with a pending, starting, up or stopping
+	// state, most recently updated first
+	expected := []*ct.Job{jobs[7], jobs[6], jobs[5], jobs[3], jobs[2], jobs[1], jobs[0]}
 	for i, job := range expected {
 		actual := list[i]
 		c.Assert(actual.UUID, Equals, job.UUID)

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -153,6 +153,8 @@ func (j *Job) ControllerJob() *ct.Job {
 		job.State = ct.JobStateStarting
 	case JobStateRunning:
 		job.State = ct.JobStateUp
+	case JobStateStopping:
+		job.State = ct.JobStateStopping
 	case JobStateStopped:
 		job.State = ct.JobStateDown
 	}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -458,7 +458,8 @@ func (s *Scheduler) SyncJobs() (err error) {
 		// persist the job if it has a different in-memory state
 		if job.State == ct.JobStatePending && j.State != JobStatePending ||
 			job.State == ct.JobStateStarting && j.State != JobStateStarting ||
-			job.State == ct.JobStateUp && j.State != JobStateRunning {
+			job.State == ct.JobStateUp && j.State != JobStateRunning ||
+			job.State == ct.JobStateStopping {
 			s.persistJob(j)
 		}
 	}
@@ -1512,6 +1513,7 @@ func (s *Scheduler) stopJob(job *Job) error {
 	// still trying to start the job, in which case it will get an
 	// ErrJobNotPending error on the next call to PlaceJob
 	job.State = JobStateStopping
+	s.persistJob(job)
 
 	log.Info("requesting host to stop job", "host.id", job.HostID)
 	// call host.StopJob in a goroutine so it doesn't block the main

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -402,6 +402,9 @@ $$ LANGUAGE plpgsql`,
 		) r
 		WHERE release_id = r.id`,
 	)
+	migrations.Add(21,
+		`INSERT INTO job_states (name) VALUES ('stopping')`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -294,7 +294,7 @@ SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, met
 FROM job_cache WHERE app_id = $1 ORDER BY created_at DESC`
 	jobListActiveQuery = `
 SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
-FROM job_cache WHERE state = 'pending' OR state = 'starting' OR state = 'up' ORDER BY updated_at DESC`
+FROM job_cache WHERE state = 'pending' OR state = 'starting' OR state = 'up' OR state = 'stopping' ORDER BY updated_at DESC`
 	jobSelectQuery = `
 SELECT cluster_id, job_id, host_id, app_id, release_id, process_type, state, meta, exit_status, host_error, run_at, restarts, created_at, updated_at
 FROM job_cache WHERE job_id = $1`

--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -20,13 +20,6 @@ func (d *DeployJob) deployAllAtOnce() error {
 			total *= d.hostCount
 		}
 		existing := d.newReleaseState[typ]
-		for i := existing; i < total; i++ {
-			d.deployEvents <- ct.DeploymentEvent{
-				ReleaseID: d.NewReleaseID,
-				JobState:  ct.JobStateStarting,
-				JobType:   typ,
-			}
-		}
 		if total > existing {
 			expected[typ] = ct.JobUpEvents(total - existing)
 		}
@@ -52,15 +45,7 @@ func (d *DeployJob) deployAllAtOnce() error {
 
 	expected = make(ct.JobEvents)
 	for typ := range d.Processes {
-		existing := d.oldReleaseState[typ]
-		for i := 0; i < existing; i++ {
-			d.deployEvents <- ct.DeploymentEvent{
-				ReleaseID: d.OldReleaseID,
-				JobState:  ct.JobStateStopping,
-				JobType:   typ,
-			}
-		}
-		if existing > 0 {
+		if existing := d.oldReleaseState[typ]; existing > 0 {
 			expected[typ] = ct.JobDownEvents(existing)
 		}
 	}

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -290,7 +290,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 			return
 		}
 
-		// don't send duplicate events
+		// ignore duplicate events
 		if _, ok := d.knownJobStates[jobIDState{jobID, state}]; ok {
 			return
 		}
@@ -300,11 +300,6 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 			actual[typ] = make(map[ct.JobState]int)
 		}
 		actual[typ][state] += 1
-		d.deployEvents <- ct.DeploymentEvent{
-			ReleaseID: releaseID,
-			JobState:  state,
-			JobType:   typ,
-		}
 	}
 
 	jobEvents := d.ReleaseJobEvents(releaseID)

--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -64,13 +64,6 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 				nlog.Error("error scaling new formation up by one", "type", typ, "err", err)
 				return err
 			}
-			for i := 0; i < diff; i++ {
-				d.deployEvents <- ct.DeploymentEvent{
-					ReleaseID: d.NewReleaseID,
-					JobState:  ct.JobStateStarting,
-					JobType:   typ,
-				}
-			}
 			nlog.Info(fmt.Sprintf("waiting for %d job up event(s)", diff), "type", typ)
 			if err := waitJobs(d.NewReleaseID, ct.JobEvents{typ: ct.JobUpEvents(diff)}, nlog); err != nil {
 				nlog.Error("error waiting for job up events", "err", err)
@@ -86,13 +79,6 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 			}); err != nil {
 				olog.Error("error scaling old formation down by one", "type", typ, "err", err)
 				return err
-			}
-			for i := 0; i < diff; i++ {
-				d.deployEvents <- ct.DeploymentEvent{
-					ReleaseID: d.OldReleaseID,
-					JobState:  ct.JobStateStopping,
-					JobType:   typ,
-				}
 			}
 
 			olog.Info(fmt.Sprintf("waiting for %d job down event(s)", diff), "type", typ)

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -36,7 +36,7 @@
     },
     "state": {
       "type": "string",
-      "enum": ["pending", "starting", "up", "down", "crashed", "failed"]
+      "enum": ["pending", "starting", "up", "stopping", "down", "crashed", "failed"]
     },
     "cmd": {
       "$ref": "/schema/controller/common#/definitions/cmd"


### PR DESCRIPTION
Change extracted from #3421.

I have also updated deployments so they don't send job events as deployment events (given clients can subscribe to both deployment and job events at the same time,  there isn't really a need for the duplication).