### PR TITLE
demo: fix 'make dashboard'

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -74,7 +74,7 @@ token:
 
 # Open dashboard in browser
 dashboard:
-	@open http://dashboard.${CLUSTER_DOMAIN}?token=${$(MAKE) token}
+	@URL=http://dashboard.${CLUSTER_DOMAIN}?token=${$(MAKE) token} && xdg-open $$URL || open $$URL
 
 # Run a command in the VM via SSH
 ssh-cmd:

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -74,7 +74,8 @@ token:
 
 # Open dashboard in browser
 dashboard:
-	@URL=http://dashboard.${CLUSTER_DOMAIN}?token=${$(MAKE) token} && xdg-open $$URL || open $$URL
+	@CMD=open && which xdg-open > /dev/null && CMD=xdg-open; \
+	$$CMD http://dashboard.${CLUSTER_DOMAIN}?token=${$(MAKE) token}
 
 # Run a command in the VM via SSH
 ssh-cmd:


### PR DESCRIPTION
This PR fixes #3450 by trying `xdg-open` first, which is the Linux equivalent of OS X `open`
Then, if that fails, use `open`... I don't know if there's a better way to do this, but this works for me! :)

Signed-off-by: Joe Marty <jmarty@iexposure.com>