### PR TITLE
controller: Use event listener for formation streams

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -453,8 +453,6 @@ func (c *controllerAPI) GetCACert(_ context.Context, w http.ResponseWriter, _ *h
 }
 
 func (c *controllerAPI) Shutdown() {
-	c.formationRepo.stopListener <- struct{}{}
-
 	if c.eventListener != nil {
 		c.eventListener.CloseWithError(ErrShutdown)
 	}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1423,6 +1423,13 @@ func (s *Scheduler) handleFormation(ef *ct.ExpandedFormation) (formation *Format
 		log.Info("adding new formation", "processes", ef.Processes)
 		formation = s.formations.Add(NewFormation(ef))
 	} else {
+		// ignore stale formation changes
+		if formation.UpdatedAt.After(ef.UpdatedAt) {
+			log.Warn("ignoring stale formation change", "diff", formation.UpdatedAt.Sub(ef.UpdatedAt))
+			return
+		}
+		formation.UpdatedAt = ef.UpdatedAt
+
 		diff := Processes(ef.Processes).Diff(formation.OriginalProcesses)
 		if diff.IsEmpty() && utils.FormationTagsEqual(formation.Tags, ef.Tags) {
 			return

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -405,6 +405,10 @@ $$ LANGUAGE plpgsql`,
 	migrations.Add(21,
 		`INSERT INTO job_states (name) VALUES ('stopping')`,
 	)
+	migrations.Add(22,
+		`DROP TRIGGER notify_formation ON formations`,
+		`DROP FUNCTION notify_formation()`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -23,6 +23,7 @@ type ExpandedFormation struct {
 	Processes     map[string]int               `json:"processes,omitempty"`
 	Tags          map[string]map[string]string `json:"tags,omitempty"`
 	UpdatedAt     time.Time                    `json:"updated_at,omitempty"`
+	Deleted       bool                         `json:"deleted,omitempty"`
 }
 
 type App struct {


### PR DESCRIPTION
This simplifies formation streaming by subscribing to scale events, getting formations since the given time, and then streaming the events to the client, all in the HTTP handler rather than spread across multiple goroutines.

I've also updated the scheduler to ignore stale formation updates.

Fixes #3449.