### PR TITLE
discoverd: Fix closing the heartbeater on shutdown

### DIFF
--- a/discoverd/main.go
+++ b/discoverd/main.go
@@ -393,14 +393,21 @@ func (m *Main) Demote() error {
 	return nil
 }
 
+func (m *Main) Deregister() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hb != nil {
+		m.logger.Println("deregistering service")
+		return m.hb.Close()
+	}
+	return nil
+}
+
 // Close shuts down all open servers.
 func (m *Main) Close() (info dt.TargetLogIndex, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.logger.Println("discoverd shutting down")
-	if m.hb != nil {
-		m.hb.Close()
-	}
 	if m.httpServer != nil {
 		// Disable keep alives so that persistent connections will close
 		m.httpServer.SetKeepAlivesEnabled(false)


### PR DESCRIPTION
The heartbeater uses the HTTP API, so shutting down the API before closing the heartbeater leads to a "discoverd: shutting down" error, and since the error is a retriable one, the heartbeat close blocks for 10s.

When this happens on the leader during a deployment, it causes all service heartbeats to expire, wreaking havoc on the cluster.