### PR TITLE
controller: Fix formation streaming test

### DIFF
--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -122,7 +122,7 @@ func (c *Client) StreamFormations(since *time.Time, output chan<- *ct.ExpandedFo
 		s := time.Unix(0, 0)
 		since = &s
 	}
-	t := since.UTC().Format(time.RFC3339)
+	t := since.UTC().Format(time.RFC3339Nano)
 	return c.Stream("GET", "/formations?since="+t, nil, output)
 }
 

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -395,7 +395,7 @@ func (c *controllerAPI) streamFormations(ctx context.Context, w http.ResponseWri
 		}
 	}()
 
-	since, err := time.Parse(time.RFC3339, req.FormValue("since"))
+	since, err := time.Parse(time.RFC3339Nano, req.FormValue("since"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The test has been failing intermittently since merging #3456, this change makes it slightly more robust.