### PR TITLE
appliance/postgresql: Install explicit version of postgis

### DIFF
--- a/appliance/postgresql/Dockerfile
+++ b/appliance/postgresql/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update &&\
       postgresql-contrib-9.5 \
       postgresql-9.5-pgextwlist \
       postgresql-9.5-plv8 \
-      postgresql-9.5-postgis \
+      postgresql-9.5-postgis-2.3 \
       postgresql-9.5-pgrouting &&\
     apt-get clean &&\
     apt-get autoremove -y &&\


### PR DESCRIPTION
Without the explicit 2.3 version, the package fails to install with:

```
The following packages have unmet dependencies:
 postgresql-9.5-postgis-2.3-scripts : Conflicts: postgresql-9.5-postgis-2.2-scripts but 2.2.2+dfsg-7~137.gite11228b.pgdg14.04+1 is to be installed
```

This bug report seems related:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839182

@josephglanville @titanous I don't know if this is a change we actually want, but we can't currently build the pg appliance without it (so CI isn't coming back).