### PR TITLE
host: Use SquashFS + OverlayFS via Mountspecs 

### DIFF
--- a/host/cli/inspect.go
+++ b/host/cli/inspect.go
@@ -74,9 +74,8 @@ func printJobDesc(job *host.ActiveJob, out io.Writer, env bool, redactEnv []stri
 	listRec(w, "ExitStatus", exitStatus)
 	listRec(w, "Error", jobError)
 	listRec(w, "IP Address", job.InternalIP)
-	listRec(w, "ImageArtifact", job.Job.ImageArtifact.URI)
-	for i, artifact := range job.Job.FileArtifacts {
-		listRec(w, fmt.Sprintf("FileArtifact[%d]", i), artifact.URI)
+	for i, m := range job.Job.Mountspecs {
+		listRec(w, fmt.Sprintf("Mountspec[%d]", i), m)
 	}
 	for _, vb := range job.Job.Config.Volumes {
 		listRec(w, fmt.Sprintf("Volume[%s]", vb.Target), vb.VolumeID)

--- a/host/http.go
+++ b/host/http.go
@@ -355,9 +355,9 @@ func (h *jobAPI) AddJob(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		h.addJobRateLimitBucket.Put()
 		return
 	}
-	if job.ImageArtifact == nil {
-		log.Warn("rejecting job as no ImageArtifact set")
-		httphelper.ValidationError(w, "ImageArtifact", "must be set")
+	if len(job.Mountspecs) == 0 {
+		log.Warn("rejecting job as no mountspecs set")
+		httphelper.ValidationError(w, "mountspecs", "must be set")
 		h.addJobRateLimitBucket.Put()
 		return
 	}

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -2,14 +2,20 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -28,16 +34,19 @@ import (
 	"github.com/flynn/flynn/host/logmux"
 	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/host/volume/manager"
-	"github.com/flynn/flynn/pinkerton"
 	"github.com/flynn/flynn/pkg/iptables"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/rpcplus"
+	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
+	"github.com/golang/groupcache/singleflight"
 	"github.com/miekg/dns"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/rancher/sparse-tools/sparse"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -76,21 +85,21 @@ func NewLibcontainerBackend(state *State, vman *volumemanager.Manager, bridgeNam
 		libcontainer.InitArgs(os.Args[0], "libcontainer-init"),
 	)
 
-	pinkertonCtx, err := pinkerton.BuildContext("aufs", imageRoot)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := setupCGroups(partitionCGroups); err != nil {
 		return nil, err
 	}
+
+	defaultTmpfs, err := createTmpfs(resource.DefaultTempDiskSize)
+	if err != nil {
+		return nil, err
+	}
+	shutdown.BeforeExit(func() { defaultTmpfs.Delete() })
 
 	return &LibcontainerBackend{
 		InitPath:            initPath,
 		factory:             factory,
 		state:               state,
 		vman:                vman,
-		pinkerton:           pinkertonCtx,
 		logStreams:          make(map[string]map[string]*logmux.LogStream),
 		containers:          make(map[string]*Container),
 		defaultEnv:          make(map[string]string),
@@ -103,17 +112,17 @@ func NewLibcontainerBackend(state *State, vman *volumemanager.Manager, bridgeNam
 		partitionCGroups:    partitionCGroups,
 		logger:              logger,
 		globalState:         &libcontainerGlobalState{},
+		defaultTmpfs:        defaultTmpfs,
 	}, nil
 }
 
 type LibcontainerBackend struct {
-	InitPath  string
-	factory   libcontainer.Factory
-	state     *State
-	vman      *volumemanager.Manager
-	host      *Host
-	pinkerton *pinkerton.Context
-	ipalloc   *ipallocator.IPAllocator
+	InitPath string
+	factory  libcontainer.Factory
+	state    *State
+	vman     *volumemanager.Manager
+	host     *Host
+	ipalloc  *ipallocator.IPAllocator
 
 	bridgeName string
 	bridgeAddr net.IP
@@ -139,11 +148,15 @@ type LibcontainerBackend struct {
 
 	globalStateMtx sync.Mutex
 	globalState    *libcontainerGlobalState
+
+	defaultTmpfs *Tmpfs
+	layerLoader  singleflight.Group
 }
 
 type Container struct {
 	ID       string `json:"id"`
 	RootPath string `json:"root_path"`
+	TmpPath  string `json:"tmp_path"`
 	IP       net.IP `json:"ip"`
 
 	container libcontainer.Container
@@ -335,7 +348,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		return nil
 	}
 
-	log.Info("starting job", "job.artifact.uri", job.ImageArtifact.URI, "job.args", job.Config.Args)
+	log.Info("starting job", "job.args", job.Config.Args)
 
 	defer func() {
 		if err != nil {
@@ -389,41 +402,23 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		}
 	}()
 
-	log.Info("pulling image")
-	artifactURI, err := l.resolveDiscoverdURI(job.ImageArtifact.URI)
-	if err != nil {
-		log.Error("error resolving artifact URI", "err", err)
-		return err
-	}
-	// TODO(lmars): stream pull progress (maybe to the app log?)
-	imageID, err := l.pinkerton.PullDocker(artifactURI, ioutil.Discard)
-	if err != nil {
-		log.Error("error pulling image", "err", err)
-		return err
-	}
-
-	log.Info("reading image config")
-	imageConfig, err := readDockerImageConfig(imageID)
-	if err != nil {
-		log.Error("error reading image config", "err", err)
-		return err
-	}
-
-	log.Info("checking out image")
-	var rootPath string
-	// creating an AUFS mount can fail intermittently with EINVAL, so try a
-	// few times (see https://github.com/flynn/flynn/issues/2044)
-	for start := time.Now(); time.Since(start) < time.Second; time.Sleep(50 * time.Millisecond) {
-		rootPath, err = l.pinkerton.Checkout(job.ID, imageID)
-		if err == nil || !strings.HasSuffix(err.Error(), "invalid argument") {
-			break
+	log.Info("setting up rootfs")
+	rootPath := filepath.Join("/var/lib/flynn/image/mnt", job.ID)
+	tmpPath := filepath.Join("/var/lib/flynn/image/tmp", job.ID)
+	for _, path := range []string{rootPath, tmpPath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			log.Error("error setting up rootfs", "err", err)
+			return err
 		}
 	}
+	rootMount, err := l.rootOverlayMount(job)
 	if err != nil {
-		log.Error("error checking out image", "err", err)
+		log.Error("error setting up rootfs", "err", err)
 		return err
 	}
+
 	container.RootPath = rootPath
+	container.TmpPath = tmpPath
 
 	config := &configs.Config{
 		Rootfs:       rootPath,
@@ -448,7 +443,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 			"/proc/sys", "/proc/sysrq-trigger", "/proc/irq", "/proc/bus",
 		},
 		Devices: configs.DefaultAutoCreatedDevices,
-		Mounts: []*configs.Mount{
+		Mounts: append([]*configs.Mount{rootMount}, []*configs.Mount{
 			{
 				Source:      "proc",
 				Destination: "/proc",
@@ -487,7 +482,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 				Device:      "cgroup",
 				Flags:       defaultMountFlags | syscall.MS_RDONLY,
 			},
-		},
+		}...),
 	}
 
 	if spec, ok := job.Resources[resource.TypeMaxFD]; ok && spec.Limit != nil && spec.Request != nil {
@@ -519,26 +514,32 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	if len(hostname) > 64 {
 		hostname = hostname[:64]
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "etc"), 0755); err != nil {
-		log.Error("error creating /etc in container root", "err", err)
+	if err := os.MkdirAll(filepath.Join(tmpPath, "etc"), 0755); err != nil {
+		log.Error("error creating container /etc", "err", err)
 		return err
 	}
-	if err := writeHostname(filepath.Join(rootPath, "etc/hosts"), hostname); err != nil {
+	etcHosts := filepath.Join(tmpPath, "etc/hosts")
+	if err := writeHostname(etcHosts, hostname); err != nil {
 		log.Error("error writing hosts file", "err", err)
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".container-shared"), 0700); err != nil {
-		log.Error("error createing .container-shared", "err", err)
+	sharedDir := filepath.Join(tmpPath, ".container-shared")
+	if err := os.MkdirAll(sharedDir, 0700); err != nil {
+		log.Error("error creating .container-shared", "err", err)
 		return err
 	}
 
-	addBindMount(config, l.InitPath, "/.containerinit", false)
-	addBindMount(config, l.resolvConf, "/etc/resolv.conf", false)
+	config.Mounts = append(config.Mounts,
+		bindMount(l.InitPath, "/.containerinit", false),
+		bindMount(l.resolvConf, "/etc/resolv.conf", false),
+		bindMount(etcHosts, "/etc/hosts", true),
+		bindMount(sharedDir, "/.container-shared", true),
+	)
 	for _, m := range job.Config.Mounts {
 		if m.Target == "" {
 			return errors.New("host: invalid empty mount target")
 		}
-		addBindMount(config, m.Target, m.Location, m.Writeable)
+		config.Mounts = append(config.Mounts, bindMount(m.Target, m.Location, m.Writeable))
 	}
 
 	// apply volumes
@@ -549,7 +550,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 			log.Error("missing required volume", "volumeID", v.VolumeID, "err", err)
 			return err
 		}
-		addBindMount(config, vol.Location(), v.Target, v.Writeable)
+		config.Mounts = append(config.Mounts, bindMount(vol.Location(), v.Target, v.Writeable))
 	}
 
 	// mutating job state, take state write lock
@@ -580,35 +581,27 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	l.state.mtx.Unlock()
 
 	initConfig := &containerinit.Config{
-		Args:          job.Config.Args,
-		TTY:           job.Config.TTY,
-		OpenStdin:     job.Config.Stdin,
-		WorkDir:       job.Config.WorkingDir,
-		Resources:     job.Resources,
-		FileArtifacts: job.FileArtifacts,
+		Args:      job.Config.Args,
+		TTY:       job.Config.TTY,
+		OpenStdin: job.Config.Stdin,
+		WorkDir:   job.Config.WorkingDir,
+		Resources: job.Resources,
 	}
 	if !job.Config.HostNetwork {
 		initConfig.IP = container.IP.String() + "/24"
 		initConfig.Gateway = l.bridgeAddr.String()
 	}
-	if initConfig.WorkDir == "" {
-		initConfig.WorkDir = imageConfig.WorkingDir
-	}
 	if job.Config.Uid > 0 {
 		initConfig.User = strconv.Itoa(job.Config.Uid)
-	} else if imageConfig.User != "" {
-		// TODO: check and lookup user from image config
-	}
-	if len(job.Config.Args) == 0 {
-		initConfig.Args = append(imageConfig.Entrypoint, imageConfig.Cmd...)
 	}
 	for _, port := range job.Config.Ports {
 		initConfig.Ports = append(initConfig.Ports, port)
 	}
 
 	log.Info("writing config")
+	configPath := filepath.Join(tmpPath, ".containerconfig")
 	l.envMtx.RLock()
-	err = writeContainerConfig(filepath.Join(rootPath, ".containerconfig"), initConfig,
+	err = writeContainerConfig(configPath, initConfig,
 		map[string]string{
 			"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"TERM": "xterm",
@@ -625,6 +618,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		log.Error("error writing config", "err", err)
 		return err
 	}
+	config.Mounts = append(config.Mounts, bindMount(configPath, "/.containerconfig", false))
 
 	if job.Config.HostNetwork {
 		// allow host network jobs to configure the network
@@ -687,16 +681,188 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	return nil
 }
 
-// resolveDiscoverdURI resolves a discoverd host in the given URI to an address
-// using the configured discoverd URL as the host is likely not using discoverd
-// to resolve DNS queries
-func (l *LibcontainerBackend) resolveDiscoverdURI(uri string) (string, error) {
-	u, err := url.Parse(uri)
+func (l *LibcontainerBackend) rootOverlayMount(job *host.Job) (*configs.Mount, error) {
+	layers := make([]string, 0, len(job.Mountspecs)+1)
+	for _, spec := range job.Mountspecs {
+		if spec.Type != host.MountspecTypeSquashfs {
+			return nil, fmt.Errorf("unknown mountspec type: %q", spec.Type)
+		}
+		path, err := l.mountSquashfs(spec)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, path)
+	}
+	tmpfs, err := l.mountTmpfs(job)
+	if err != nil {
+		return nil, err
+	}
+	layers = append(layers, tmpfs)
+	dirs := make([]string, len(layers))
+	for i, layer := range layers {
+		// append mount paths in reverse order as overlay
+		// lower dirs are stacked from right to left
+		dirs[len(layers)-i-1] = layer
+	}
+	upperDir := filepath.Join(tmpfs, "overlay-upperdir")
+	workDir := filepath.Join(tmpfs, "overlay-workdir")
+	for _, dir := range []string{upperDir, workDir} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return nil, err
+		}
+	}
+	return &configs.Mount{
+		Source:      "overlay",
+		Destination: "/",
+		Device:      "overlay",
+		Data:        fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(dirs[1:], ":"), upperDir, workDir),
+	}, nil
+}
+
+func (l *LibcontainerBackend) mountSquashfs(m *host.Mountspec) (string, error) {
+	// use the layerLoader to ensure only one caller downloads any
+	// given layer ID
+	path, err := l.layerLoader.Do(m.ID, func() (interface{}, error) {
+		if vol := l.vman.GetVolume(m.ID); vol != nil {
+			return vol.Location(), nil
+		}
+
+		if m.URL == "" {
+			return "", fmt.Errorf("error getting squashfs layer %s: missing URL", m.ID)
+		}
+
+		if len(m.Hashes) == 0 {
+			return "", fmt.Errorf("error getting squashfs layer %s: missing Hashes", m.ID)
+		}
+		hashes := make(map[string]hash.Hash, len(m.Hashes))
+		for algorithm := range m.Hashes {
+			var h hash.Hash
+			switch algorithm {
+			case "sha256":
+				h = sha256.New()
+			case "sha512":
+				h = sha512.New()
+			case "sha512_256":
+				h = sha512.New512_256()
+			default:
+				return "", fmt.Errorf("error getting squashfs layer %s: unknown hash algorithm %q", m.ID, algorithm)
+			}
+			hashes[algorithm] = h
+		}
+
+		u, err := url.Parse(m.URL)
+		if err != nil {
+			return "", err
+		}
+
+		var layer io.ReadCloser
+		switch u.Scheme {
+		case "file":
+			f, err := os.Open(u.Path)
+			if err != nil {
+				return "", fmt.Errorf("error getting squashfs layer %s: %s", m.URL, err)
+			}
+			layer = f
+		case "http", "https":
+			url, err := l.resolveDiscoverdURL(u)
+			if err != nil {
+				return "", err
+			}
+			res, err := http.Get(url)
+			if err != nil {
+				return "", fmt.Errorf("error getting squashfs layer from %s: %s", m.URL, err)
+			}
+			if res.StatusCode != http.StatusOK {
+				return "", fmt.Errorf("error getting squashfs layer from %s: unexpected HTTP status %s", m.URL, res.Status)
+			}
+			layer = res.Body
+		default:
+			return "", fmt.Errorf("unknown layer URI scheme: %s", u.Scheme)
+		}
+		defer layer.Close()
+
+		// write the layer to a temp file and verify it has the
+		// expected hashes
+		tmp, err := ioutil.TempFile("", "flynn-layer-")
+		if err != nil {
+			return "", err
+		}
+		defer os.Remove(tmp.Name())
+		defer tmp.Close()
+		r := io.LimitReader(layer, m.Size)
+		for _, hash := range hashes {
+			r = io.TeeReader(r, hash)
+		}
+		if _, err := io.Copy(tmp, r); err != nil {
+			return "", fmt.Errorf("error getting squashfs layer from %s: %s", m.URL, err)
+		}
+		for algorithm, hash := range hashes {
+			actual := hex.EncodeToString(hash.Sum(nil))
+			expected := m.Hashes[algorithm]
+			if actual != expected {
+				return "", fmt.Errorf("error getting squashfs layer from %s: expected %s hash %q but got %q", m.URL, algorithm, expected, actual)
+			}
+		}
+
+		if _, err := tmp.Seek(0, os.SEEK_SET); err != nil {
+			return "", fmt.Errorf("error seeking squashfs layer temp file: %s", err)
+		}
+		vol, err := l.vman.ImportFilesystem("default", &volume.Filesystem{
+			ID:         m.ID,
+			Data:       tmp,
+			Size:       m.Size,
+			Type:       "squashfs",
+			MountFlags: syscall.MS_RDONLY,
+		})
+		if err != nil {
+			return "", fmt.Errorf("error importing squashfs layer: %s", err)
+		}
+
+		return vol.Location(), nil
+	})
 	if err != nil {
 		return "", err
 	}
+	return path.(string), nil
+}
+
+func (l *LibcontainerBackend) mountTmpfs(job *host.Job) (string, error) {
+	tmpfs := l.defaultTmpfs
+	if spec, ok := job.Resources[resource.TypeTempDisk]; ok && spec.Limit != nil && *spec.Limit != tmpfs.Size {
+		var err error
+		tmpfs, err = createTmpfs(*spec.Limit)
+		if err != nil {
+			return "", err
+		}
+		defer tmpfs.Delete()
+	}
+
+	f, err := os.Open(tmpfs.Path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	vol, err := l.vman.ImportFilesystem("default", &volume.Filesystem{
+		ID:         job.ID,
+		Data:       sparse.NewBufferedFileIoProcessorByFP(f),
+		Size:       tmpfs.Size,
+		Type:       "ext2",
+		MountFlags: syscall.MS_NOATIME,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error importing tmpfs: %s", err)
+	}
+
+	return vol.Location(), nil
+}
+
+// resolveDiscoverdURL resolves a discoverd host in the given URL to an address
+// using the configured discoverd URL as the host is likely not using discoverd
+// to resolve DNS queries
+func (l *LibcontainerBackend) resolveDiscoverdURL(u *url.URL) (string, error) {
 	if !strings.HasSuffix(u.Host, ".discoverd") {
-		return uri, nil
+		return u.String(), nil
 	}
 
 	// ensure discoverd is configured
@@ -739,7 +905,7 @@ func (c *Container) watch(ready chan<- error, buffer host.LogBuffer) error {
 	var symlinked bool
 	var err error
 	symlink := "/tmp/containerinit-rpc." + c.job.ID
-	socketPath := path.Join(c.RootPath, containerinit.SocketPath)
+	socketPath := path.Join(c.TmpPath, containerinit.SocketPath)
 	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; time.Sleep(time.Millisecond) {
 		if !symlinked {
 			// We can't connect to the socket file directly because
@@ -888,12 +1054,16 @@ func (c *Container) cleanup() error {
 	delete(c.l.logStreams, c.job.ID)
 	c.l.logStreamMtx.Unlock()
 
-	if err := c.l.pinkerton.Cleanup(c.job.ID); err != nil {
-		log.Error("error running pinkerton cleanup", "err", err)
-	}
 	if !c.job.Config.HostNetwork && c.l.bridgeNet != nil {
 		c.l.ipalloc.ReleaseIP(c.l.bridgeNet, c.IP)
 	}
+
+	// remove the tmpfs volume (which has the same ID as the job)
+	if err := c.l.vman.DestroyVolume(c.job.ID); err != nil {
+		log.Error("error removing tmpfs volume", "err", err)
+	}
+
+	os.RemoveAll(c.TmpPath)
 	log.Info("finished cleanup")
 	return nil
 }
@@ -1289,17 +1459,17 @@ func (l *LibcontainerBackend) CloseLogs() (host.LogBuffers, error) {
 	return buffers, nil
 }
 
-func addBindMount(config *configs.Config, src, dest string, writeable bool) {
+func bindMount(src, dest string, writeable bool) *configs.Mount {
 	flags := syscall.MS_BIND | syscall.MS_REC
 	if !writeable {
 		flags |= syscall.MS_RDONLY
 	}
-	config.Mounts = append(config.Mounts, &configs.Mount{
+	return &configs.Mount{
 		Source:      src,
 		Destination: dest,
 		Device:      "bind",
 		Flags:       flags,
-	})
+	}
 }
 
 // Taken from Kubernetes:
@@ -1385,4 +1555,32 @@ func createCGroupPartition(name string, cpuShares int64) error {
 		return fmt.Errorf("error writing cgroup param: %s", err)
 	}
 	return nil
+}
+
+type Tmpfs struct {
+	Path string
+	Size int64
+}
+
+func (t *Tmpfs) Delete() error {
+	return os.Remove(t.Path)
+}
+
+func createTmpfs(size int64) (*Tmpfs, error) {
+	f, err := ioutil.TempFile("", "flynn-ext2-")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if err := f.Truncate(size); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("mkfs.ext2", "-F", "-L", "rootfs", "-m", "0", f.Name())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("error creating ext2 filesystem: %s: %s", err, out)
+	}
+
+	return &Tmpfs{Path: f.Name(), Size: size}, nil
 }

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -13,12 +13,12 @@ const TagPrefix = "tag:"
 type Job struct {
 	ID string `json:"id,omitempty"`
 
+	Mountspecs []*Mountspec `json:"mountspecs,omitempty"`
+
 	Metadata map[string]string `json:"metadata,omitempty"`
 
-	ImageArtifact *Artifact          `json:"artifact,omitempty"`
-	FileArtifacts []*Artifact        `json:"file_artifacts,omitempty"`
-	Resources     resource.Resources `json:"resources,omitempty"`
-	Partition     string             `json:"partition,omitempty"`
+	Resources resource.Resources `json:"resources,omitempty"`
+	Partition string             `json:"partition,omitempty"`
 
 	Config ContainerConfig `json:"config,omitempty"`
 
@@ -65,6 +65,18 @@ func (j *Job) Dup() *Job {
 	}
 
 	return &job
+}
+
+type MountspecType string
+
+const MountspecTypeSquashfs MountspecType = "squashfs"
+
+type Mountspec struct {
+	Type   MountspecType     `json:"type,omitempty"`
+	ID     string            `json:"id,omitempty"`
+	URL    string            `json:"url,omitempty"`
+	Size   int64             `json:"size,omitempty"`
+	Hashes map[string]string `json:"hashes,omitempty"`
 }
 
 type JobResources struct {
@@ -174,18 +186,6 @@ type VolumeBinding struct {
 	VolumeID  string `json:"volume"`
 	Writeable bool   `json:"writeable"`
 }
-
-type Artifact struct {
-	URI  string       `json:"url,omitempty"`
-	Type ArtifactType `json:"type,omitempty"`
-}
-
-type ArtifactType string
-
-const (
-	ArtifactTypeDocker ArtifactType = "docker"
-	ArtifactTypeFile   ArtifactType = "file"
-)
 
 type Host struct {
 	ID string `json:"id,omitempty"`

--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -17,6 +17,7 @@ type Provider interface {
 	Kind() string
 
 	NewVolume() (Volume, error)
+	ImportFilesystem(*Filesystem) (Volume, error)
 	DestroyVolume(Volume) error
 	CreateSnapshot(Volume) (Volume, error)
 	ForkVolume(Volume) (Volume, error)

--- a/host/volume/manager/manager.go
+++ b/host/volume/manager/manager.go
@@ -44,6 +44,7 @@ var (
 	ErrNoSuchProvider = errors.New("no such provider")
 	ErrProviderExists = errors.New("provider exists")
 	ErrNoSuchVolume   = errors.New("no such volume")
+	ErrVolumeExists   = errors.New("volume exists")
 )
 
 func New(dbPath string, defaultProvider func() (volume.Provider, error)) *Manager {
@@ -195,6 +196,40 @@ func (m *Manager) GetVolume(id string) volume.Volume {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	return m.volumes[id]
+}
+
+func (m *Manager) ImportFilesystem(providerID string, fs *volume.Filesystem) (volume.Volume, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if _, ok := m.volumes[fs.ID]; ok {
+		return nil, ErrVolumeExists
+	}
+
+	if providerID == "" {
+		providerID = "default"
+	}
+	provider, ok := m.providers[providerID]
+	if !ok {
+		return nil, ErrNoSuchProvider
+	}
+
+	if err := m.LockDB(); err != nil {
+		return nil, err
+	}
+	defer m.UnlockDB()
+
+	vol, err := provider.ImportFilesystem(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	m.volumes[fs.ID] = vol
+	m.persist(func(tx *bolt.Tx) error {
+		return m.persistVolume(tx, vol)
+	})
+
+	return vol, nil
 }
 
 func (m *Manager) DestroyVolume(id string) error {

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -1,5 +1,7 @@
 package volume
 
+import "io"
+
 /*
 	A Volume is a persistent and sharable filesystem.  Unlike most of the filesystem in a job's
 	container, which is ephemeral and is discarded after job termination, Volumes can be used to
@@ -31,8 +33,13 @@ type Volume interface {
 	It is a serializable structure intended for API use.
 */
 type Info struct {
-	// Volumes have a unique identifier.
-	// These are guid formatted (v4, random); selected by the server;
-	// and though not globally sync'd, entropy should be high enough to be unique.
 	ID string `json:"id"`
+}
+
+type Filesystem struct {
+	ID         string    `json:"id"`
+	Data       io.Reader `json:"-"`
+	Size       int64     `json:"size"`
+	Type       string    `json:"type"`
+	MountFlags uintptr   `json:"flags"`
 }


### PR DESCRIPTION
Summary of changes:

* Support importing raw (possibly sparse) filesystem images into zvols and then mounting them
* Add `host.Mountspec` having `URL` and `Hashes` which reference a SquashFS filesystem, allowing the host to download, verify and import it into a volume
* Add `job.Mountspecs` which is a list of SquashFS mountspecs which are layered at the root directory of the container using OverlayFS, with a read-write Ext2 volume on top
* Add `resource.TypeDisk` which controls how big the read-write Ext2 volume is for each job

Things to note:

* I have made the default disk limit 100MB because most jobs should not need to write to the filesystem, and if they do they should provision a data volume and use that, but in case this is problematic I've added support to make it configurable in a future PR (i.e. via `flynn limit set disk=1G`)
* I don't expect this to pass CI (or to even build) but this should give a good idea of the changes needed in other components (i.e. providing `job.Mountspecs` instead of `job.ImageArtifact` / `job.FileArtifacts`)