### PR TITLE
pkg/backup: Run database dumps in background partition

### DIFF
--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -284,6 +284,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 			DisableLog: newJob.DisableLog,
 		},
 		Resources: newJob.Resources,
+		Partition: string(newJob.Partition),
 	}
 	resource.SetDefaults(&job.Resources)
 	if len(newJob.Args) > 0 {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -250,6 +250,14 @@ func JobDownEvents(count int) map[JobState]int {
 	return map[JobState]int{JobStateDown: count}
 }
 
+type PartitionType string
+
+const (
+	PartitionTypeBackground PartitionType = "background"
+	PartitionTypeSystem     PartitionType = "system"
+	PartitionTypeUser       PartitionType = "user"
+)
+
 type NewJob struct {
 	ReleaseID  string             `json:"release,omitempty"`
 	ArtifactID string             `json:"artifact,omitempty"`
@@ -263,6 +271,7 @@ type NewJob struct {
 	DisableLog bool               `json:"disable_log,omitempty"`
 	Resources  resource.Resources `json:"resources,omitempty"`
 	Data       bool               `json:"data,omitempty"`
+	Partition  PartitionType      `json:"partition,omitempty"`
 
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -32,6 +32,7 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 			"PGPASSWORD": pgRelease.Env["PGPASSWORD"],
 		},
 		DisableLog: true,
+		Partition:  ct.PartitionTypeBackground,
 	}
 	if err := tw.WriteCommandOutput(client, "postgres.sql.gz", "postgres", pgJob); err != nil {
 		return fmt.Errorf("error dumping postgres database: %s", err)
@@ -51,6 +52,7 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 				"MYSQL_PWD": mysqlRelease.Env["MYSQL_PWD"],
 			},
 			DisableLog: true,
+			Partition:  ct.PartitionTypeBackground,
 		}
 		if err := tw.WriteCommandOutput(client, "mysql.sql.gz", "mariadb", mysqlJob); err != nil {
 			return fmt.Errorf("error dumping mariadb database: %s", err)
@@ -71,6 +73,7 @@ func Run(client controller.Client, out io.Writer, progress ProgressBar) error {
 				"MONGO_PWD": mongodbRelease.Env["MONGO_PWD"],
 			},
 			DisableLog: true,
+			Partition:  ct.PartitionTypeBackground,
 		}
 		if err := tw.WriteCommandOutput(client, "mongodb.archive.gz", "mongodb", mongodbJob); err != nil {
 			return fmt.Errorf("error dumping mongodb database: %s", err)

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -66,6 +66,11 @@
     "deploy_timeout": {
       "description": "deployment timeout (default 120s)",
       "type": "integer"
+    },
+    "partition": {
+      "description": "job partition",
+      "type": "string",
+      "enum": ["background", "user", "system"]
     }
   }
 }

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -57,6 +57,9 @@
     },
     "data": {
       "type": "boolean"
+    },
+    "partition": {
+      "$ref": "/schema/controller/common#/definitions/partition"
     }
   }
 }


### PR DESCRIPTION
This runs the database dumps on the cluster in the `background` partition so they run at reduced priority to user jobs.

Also adds capability to scheduler jobs with custom partition via the controller.
