### PR TITLE
controller: Replace ProcessType.Data with ProcessType.Volumes

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -196,7 +196,7 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 					{Port: 6379, Proto: "tcp"},
 					{Port: 6380, Proto: "tcp"},
 				},
-				Data:    true,
+				Volumes: []ct.VolumeReq{{Path: "/data"}},
 				Args:    []string{"/bin/start-flynn-redis", "redis"},
 				Service: serviceName,
 			},

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -33,7 +33,7 @@
       "processes": {
         "app": {
           "ports": [{"port": 1111, "proto": "tcp"}, {"port": 53, "proto": "tcp"}],
-          "data": true,
+          "volumes": [{"path": "/data"}],
           "host_network": true,
           "omni": true,
           "service": "discoverd"
@@ -108,7 +108,7 @@
       "processes": {
         "postgres": {
           "ports": [{"port": 5432, "proto": "tcp"}],
-          "data": true,
+          "volumes": [{"path": "/data"}],
           "args": ["/bin/start-flynn-postgres", "postgres"],
           "service": "postgres"
         },
@@ -374,7 +374,7 @@
           "ports": [{"port": 3306, "proto": "tcp"}],
           "args": ["/bin/start-flynn-mariadb", "mariadb"],
           "service": "mariadb",
-          "data": true
+          "volumes": [{"path": "/data"}]
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
@@ -428,7 +428,7 @@
           "ports": [{"port": 27017, "proto": "tcp"}],
           "args": ["/bin/start-flynn-mongodb", "mongodb"],
           "service": "mongodb",
-          "data": true
+          "volumes": [{"path": "/data"}]
         },
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],

--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -110,8 +110,8 @@ func (a *RunAppAction) Run(s *State) error {
 			host := hosts[i%len(hosts)]
 			config := utils.JobConfig(a.ExpandedFormation, typ, host.ID(), "")
 			hostresource.SetDefaults(&config.Resources)
-			if a.ExpandedFormation.Release.Processes[typ].Data {
-				if err := utils.ProvisionVolume(host, config); err != nil {
+			for _, vol := range a.ExpandedFormation.Release.Processes[typ].Volumes {
+				if err := utils.ProvisionVolume(&vol, host, config); err != nil {
 					return err
 				}
 			}

--- a/cli/release.go
+++ b/cli/release.go
@@ -280,8 +280,12 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 			if len(procUpdate.Ports) > 0 {
 				procRelease.Ports = procUpdate.Ports
 			}
-			if procUpdate.Data {
-				procRelease.Data = true
+			if len(procUpdate.Volumes) > 0 {
+				procRelease.Volumes = procUpdate.Volumes
+			}
+			if procUpdate.DeprecatedData {
+				fmt.Fprintln(os.Stderr, `WARN: ProcessType.Data is deprecated and will be removed in future versions, populate ProcessType.Volumes instead e.g. "volumes": [{"path": "/data"}]`)
+				procRelease.DeprecatedData = true
 			}
 			if procUpdate.Omni {
 				procRelease.Omni = true

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -311,7 +311,8 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 
 	// provision data volume if required
 	if newJob.Data {
-		if err := utils.ProvisionVolume(client, job); err != nil {
+		vol := &ct.VolumeReq{Path: "/data"}
+		if err := utils.ProvisionVolume(vol, client, job); err != nil {
 			respondWithError(w, err)
 			return
 		}

--- a/controller/release.go
+++ b/controller/release.go
@@ -59,6 +59,11 @@ func (r *ReleaseRepo) Add(data interface{}) error {
 		if len(proc.DeprecatedCmd) > 0 {
 			proc.Args = append(proc.Args, proc.DeprecatedCmd...)
 		}
+		// handle deprecated Data
+		if proc.DeprecatedData && len(proc.Volumes) == 0 {
+			proc.Volumes = []ct.VolumeReq{{Path: "/data"}}
+			proc.DeprecatedData = false
+		}
 		resource.SetDefaults(&proc.Resources)
 		release.Processes[typ] = proc
 	}

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -117,10 +117,14 @@ func (j *Job) TagsMatchHost(host *Host) bool {
 	return true
 }
 
-// needsVolume indicates whether a volume should be provisioned in the cluster
-// for the job, determined from the corresponding process type in the release
-func (j *Job) needsVolume() bool {
-	return j.Formation.Release.Processes[j.Type].Data
+func (j *Job) Volumes() []ct.VolumeReq {
+	proc := j.Formation.Release.Processes[j.Type]
+	if len(proc.Volumes) > 0 {
+		return proc.Volumes
+	} else if proc.DeprecatedData {
+		return []ct.VolumeReq{{Path: "/data"}}
+	}
+	return nil
 }
 
 func (j *Job) IsRunning() bool {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -415,6 +415,9 @@ $$ LANGUAGE plpgsql`,
 	migrations.Add(24,
 		`UPDATE apps SET meta = jsonb_merge(CASE WHEN meta = 'null' THEN '{}' ELSE meta END, '{"gc.max_inactive_slug_releases":"10"}') WHERE meta->>'gc.max_inactive_slug_releases' IS NULL`,
 	)
+	migrations.AddSteps(25,
+		migrateProcessData,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {
@@ -499,6 +502,60 @@ func migrateProcessArgs(tx *postgres.DBTx) error {
 				args = v.([]interface{})
 			}
 			proc["args"] = append(args, cmd...)
+			release.Processes[typ] = proc
+		}
+
+		// save the processes back to the db
+		if err := tx.Exec("UPDATE releases SET processes = $1 WHERE release_id = $2", release.Processes, release.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// migrateProcessData populates ProcessType.Volumes if ProcessType.Data is set
+func migrateProcessData(tx *postgres.DBTx) error {
+	type Release struct {
+		ID string
+
+		// use map[string]interface{} for process types so we can just
+		// update Volumes and Data and leave other fields untouched
+		Processes map[string]map[string]interface{}
+	}
+
+	var releases []Release
+	rows, err := tx.Query("SELECT release_id, processes FROM releases")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var release Release
+		if err := rows.Scan(&release.ID, &release.Processes); err != nil {
+			return err
+		}
+		releases = append(releases, release)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, release := range releases {
+		for typ, proc := range release.Processes {
+			v, ok := proc["data"]
+			if !ok {
+				continue
+			}
+			data, ok := v.(bool)
+			if !ok || !data {
+				continue
+			}
+			proc["volumes"] = []struct {
+				Path string `json:"path"`
+			}{
+				{Path: "/data"},
+			}
+			delete(proc, "data")
 			release.Processes[typ] = proc
 		}
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -98,7 +98,7 @@ type ProcessType struct {
 	Args        []string           `json:"args,omitempty"`
 	Env         map[string]string  `json:"env,omitempty"`
 	Ports       []Port             `json:"ports,omitempty"`
-	Data        bool               `json:"data,omitempty"`
+	Volumes     []VolumeReq        `json:"volumes,omitempty"`
 	Omni        bool               `json:"omni,omitempty"` // omnipresent - present on all hosts
 	HostNetwork bool               `json:"host_network,omitempty"`
 	Service     string             `json:"service,omitempty"`
@@ -108,12 +108,19 @@ type ProcessType struct {
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`
 	DeprecatedEntrypoint []string `json:"entrypoint,omitempty"`
+
+	// Data is DEPRECATED: populate Volumes instead
+	DeprecatedData bool `json:"data,omitempty"`
 }
 
 type Port struct {
 	Port    int           `json:"port"`
 	Proto   string        `json:"proto"`
 	Service *host.Service `json:"service,omitempty"`
+}
+
+type VolumeReq struct {
+	Path string `json:"path"`
 }
 
 type Artifact struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -77,13 +77,13 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 	return job
 }
 
-func ProvisionVolume(h VolumeCreator, job *host.Job) error {
+func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) error {
 	vol, err := h.CreateVolume("default")
 	if err != nil {
 		return err
 	}
 	job.Config.Volumes = []host.VolumeBinding{{
-		Target:    "/data",
+		Target:    req.Path,
 		VolumeID:  vol.ID,
 		Writeable: true,
 	}}

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -242,19 +242,31 @@ $function$;
 			f.Release.Processes[typ] = p
 		}
 	}
+	updateVolumes := func(f *ct.ExpandedFormation, step *manifestStep) {
+		for typ, proc := range step.Release.Processes {
+			p := f.Release.Processes[typ]
+			p.Volumes = proc.Volumes
+			f.Release.Processes[typ] = p
+		}
+	}
 	for _, step := range manifestSteps {
 		switch step.ID {
+		case "discoverd":
+			updateVolumes(data.Discoverd, step)
 		case "postgres":
 			updateProcArgs(data.Postgres, step)
+			updateVolumes(data.Postgres, step)
 		case "controller":
 			updateProcArgs(data.Controller, step)
 		case "mariadb":
 			if data.MariaDB != nil {
 				updateProcArgs(data.MariaDB, step)
+				updateVolumes(data.MariaDB, step)
 			}
 		case "mongodb":
 			if data.MongoDB != nil {
 				updateProcArgs(data.MongoDB, step)
+				updateVolumes(data.MongoDB, step)
 			}
 		}
 		if step.Artifact.URI != "" {

--- a/host/fixer/sirenia.go
+++ b/host/fixer/sirenia.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
@@ -197,7 +198,8 @@ outer:
 		// and provision a new volume
 		if syncJob == nil {
 			syncJob = primaryJob
-			if err := utils.ProvisionVolume(syncHost, syncJob); err != nil {
+			vol := &ct.VolumeReq{Path: "/data"}
+			if err := utils.ProvisionVolume(vol, syncHost, syncJob); err != nil {
 				return fmt.Errorf("error creating volume on %s: %s", syncHost.ID(), err)
 			}
 		}

--- a/schema/controller/process_type.json
+++ b/schema/controller/process_type.json
@@ -25,7 +25,14 @@
         "$ref": "/schema/controller/port"
       }
     },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "$ref": "/schema/controller/volume_req"
+      }
+    },
     "data": {
+      "description": "DEPRECATED (use volumes instead)",
       "type": "boolean"
     },
     "omni": {

--- a/schema/controller/volume_req.json
+++ b/schema/controller/volume_req.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://flynn.io/schema/controller/volume_req#",
+  "title": "Volume Request",
+  "description": "",
+  "sortIndex": 20,
+  "type": "object",
+  "require": ["path"],
+  "additionalProperties": false,
+  "properties": {
+    "path": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This gives us more flexibility for specifying extra configuration for volume provisioning (e.g. indicating that the volume should be deleted when the job stops).

I have introduced a `VolumeReq` type (rather than just `Volume`) because in the future we want to model actual volumes in the controller, whereas `ProcessType.Volumes` are just requests for volumes to be provisioned.