### PR TITLE
host,logaggregator: Include init logs in app log

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/flynn/flynn/controller/client/v1"
 	ct "github.com/flynn/flynn/controller/types"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
 	"github.com/flynn/flynn/pkg/pinned"
@@ -57,8 +58,8 @@ type Client interface {
 	GetRelease(releaseID string) (*ct.Release, error)
 	GetArtifact(artifactID string) (*ct.Artifact, error)
 	GetApp(appID string) (*ct.App, error)
-	GetAppLog(appID string, options *ct.LogOpts) (io.ReadCloser, error)
-	StreamAppLog(appID string, options *ct.LogOpts, output chan<- *ct.SSELogChunk) (stream.Stream, error)
+	GetAppLog(appID string, options *logagg.LogOpts) (io.ReadCloser, error)
+	StreamAppLog(appID string, options *logagg.LogOpts, output chan<- *ct.SSELogChunk) (stream.Stream, error)
 	GetDeployment(deploymentID string) (*ct.Deployment, error)
 	CreateDeployment(appID, releaseID string) (*ct.Deployment, error)
 	DeploymentList(appID string) ([]*ct.Deployment, error)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/client"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
@@ -170,7 +171,7 @@ func streamRouterEvents(rc routerc.Client, db *postgres.DB, doneCh chan struct{}
 }
 
 type logClient interface {
-	GetLog(channelID string, options *logaggc.LogOpts) (io.ReadCloser, error)
+	GetLog(channelID string, options *logagg.LogOpts) (io.ReadCloser, error)
 }
 
 type handlerConfig struct {

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -17,6 +17,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	g "github.com/flynn/flynn/pkg/examplegenerator"
 	"github.com/flynn/flynn/pkg/httprecorder"
 	"github.com/flynn/flynn/pkg/random"
@@ -209,7 +210,7 @@ func (e *generator) getAppLog() {
 	e.resourceIds["controller"] = app.ID // save ID for streamAppLog
 	e.recorder.GetRequests()             // discard above request
 	lines := 10
-	res, err := e.client.GetAppLog(app.ID, &ct.LogOpts{
+	res, err := e.client.GetAppLog(app.ID, &logagg.LogOpts{
 		Lines: &lines,
 	})
 	if err == nil {
@@ -221,7 +222,7 @@ func (e *generator) getAppLog() {
 func (e *generator) streamAppLog() {
 	output := make(chan *ct.SSELogChunk)
 	lines := 10
-	e.client.StreamAppLog(e.resourceIds["controller"], &ct.LogOpts{
+	e.client.StreamAppLog(e.resourceIds["controller"], &logagg.LogOpts{
 		Lines: &lines,
 	}, output)
 	timeout := time.After(10 * time.Second)

--- a/controller/log_test.go
+++ b/controller/log_test.go
@@ -14,6 +14,7 @@ import (
 
 	ct "github.com/flynn/flynn/controller/types"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/typeconv"
 
 	. "github.com/flynn/go-check"
@@ -61,7 +62,7 @@ type fakeLogAggregatorClient struct {
 	subs map[string]<-chan *logaggc.Message
 }
 
-func (f *fakeLogAggregatorClient) GetLog(channelID string, options *logaggc.LogOpts) (io.ReadCloser, error) {
+func (f *fakeLogAggregatorClient) GetLog(channelID string, options *logagg.LogOpts) (io.ReadCloser, error) {
 	buf, ok := f.logs[channelID]
 	if !ok {
 		buf = sampleMessages
@@ -121,26 +122,26 @@ func (s *S) TestGetAppLog(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "get-app-log-test"})
 
 	tests := []struct {
-		opts     *ct.LogOpts
+		opts     *logagg.LogOpts
 		expected []logaggc.Message
 	}{
 		{
 			expected: sampleMessages,
 		},
 		{
-			opts:     &ct.LogOpts{Lines: typeconv.IntPtr(1)},
+			opts:     &logagg.LogOpts{Lines: typeconv.IntPtr(1)},
 			expected: sampleMessages[2:],
 		},
 		{
-			opts:     &ct.LogOpts{ProcessType: typeconv.StringPtr("web")},
+			opts:     &logagg.LogOpts{ProcessType: typeconv.StringPtr("web")},
 			expected: sampleMessages[1:2],
 		},
 		{
-			opts:     &ct.LogOpts{ProcessType: typeconv.StringPtr("")},
+			opts:     &logagg.LogOpts{ProcessType: typeconv.StringPtr("")},
 			expected: sampleMessages[:1],
 		},
 		{
-			opts:     &ct.LogOpts{JobID: "11111111111111111111111111111111"},
+			opts:     &logagg.LogOpts{JobID: "11111111111111111111111111111111"},
 			expected: sampleMessages[1:2],
 		},
 	}
@@ -186,7 +187,7 @@ func (s *S) TestGetAppLogFollow(c *C) {
 	s.flac.subs[app.ID] = subc
 	defer func() { delete(s.flac.subs, app.ID) }()
 
-	rc, err := s.c.GetAppLog(app.Name, &ct.LogOpts{
+	rc, err := s.c.GetAppLog(app.Name, &logagg.LogOpts{
 		Lines:  nil,
 		Follow: true,
 	})

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -343,13 +343,6 @@ type SSELogChunk struct {
 	Data  json.RawMessage `json:"data,omitempty"`
 }
 
-type LogOpts struct {
-	Follow      bool
-	JobID       string
-	Lines       *int
-	ProcessType *string
-}
-
 type EventType string
 
 const (

--- a/host/host.go
+++ b/host/host.go
@@ -301,16 +301,16 @@ func runDaemon(args *docopt.Args) {
 	var backend Backend
 	switch backendName {
 	case "libcontainer":
-		backend, err = NewLibcontainerBackend(
-			state,
-			vman,
-			bridgeName,
-			flynnInit,
-			initLogLevel,
-			mux,
-			partitionCGroups,
-			logger.New("host.id", hostID, "component", "backend", "backend", "libcontainer"),
-		)
+		backend, err = NewLibcontainerBackend(&LibcontainerConfig{
+			State:            state,
+			VolManager:       vman,
+			BridgeName:       bridgeName,
+			InitPath:         flynnInit,
+			InitLogLevel:     initLogLevel,
+			LogMux:           mux,
+			PartitionCGroups: partitionCGroups,
+			Logger:           logger.New("host.id", hostID, "component", "backend", "backend", "libcontainer"),
+		})
 	case "mock":
 		backend = MockBackend{}
 	default:

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -69,7 +69,7 @@ var defaultCapabilities = []string{
 	"CAP_SYS_CHROOT",
 }
 
-func NewLibcontainerBackend(state *State, vman *volumemanager.Manager, bridgeName, initPath string, mux *logmux.Mux, partitionCGroups map[string]int64, logger log15.Logger) (Backend, error) {
+func NewLibcontainerBackend(state *State, vman *volumemanager.Manager, bridgeName, initPath string, initLogLevel log15.Lvl, mux *logmux.Mux, partitionCGroups map[string]int64, logger log15.Logger) (Backend, error) {
 	factory, err := libcontainer.New(
 		containerRoot,
 		libcontainer.Cgroupfs,
@@ -103,6 +103,7 @@ func NewLibcontainerBackend(state *State, vman *volumemanager.Manager, bridgeNam
 		partitionCGroups:    partitionCGroups,
 		logger:              logger,
 		globalState:         &libcontainerGlobalState{},
+		initLogLevel:        initLogLevel,
 	}, nil
 }
 
@@ -139,6 +140,8 @@ type LibcontainerBackend struct {
 
 	globalStateMtx sync.Mutex
 	globalState    *libcontainerGlobalState
+
+	initLogLevel log15.Lvl
 }
 
 type Container struct {
@@ -586,6 +589,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		WorkDir:       job.Config.WorkingDir,
 		Resources:     job.Resources,
 		FileArtifacts: job.FileArtifacts,
+		LogLevel:      l.initLogLevel,
 	}
 	if !job.Config.HostNetwork {
 		initConfig.IP = container.IP.String() + "/24"

--- a/host/logmux/logmux.go
+++ b/host/logmux/logmux.go
@@ -204,9 +204,6 @@ func (m *Mux) addAggregator(addr string) {
 					}
 				}
 			}
-			if string(m.MsgID) == "ID3" {
-				continue
-			}
 			if _, err := conn.Write(rfc6587.Bytes(m.Message)); err != nil {
 				l.Error("failed to write message", "error", err)
 				return

--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -162,6 +162,8 @@ func streamName(msgID []byte) string {
 		return "stdout"
 	case "ID2":
 		return "stderr"
+	case "ID3":
+		return "init"
 	default:
 		return "unknown"
 	}

--- a/logaggregator/api_test.go
+++ b/logaggregator/api_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 	"github.com/flynn/flynn/pkg/typeconv"
 	. "github.com/flynn/go-check"
@@ -37,7 +38,7 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
 	s.agg.feed(msg4)
 	s.agg.feed(msg5)
 
-	runtest := func(opts client.LogOpts, expected string) {
+	runtest := func(opts logagg.LogOpts, expected string) {
 		numLines := -1
 		if opts.Lines != nil {
 			numLines = *opts.Lines
@@ -90,7 +91,7 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogBuffer(c *C) {
 		},
 	}
 	for _, test := range tests {
-		opts := client.LogOpts{
+		opts := logagg.LogOpts{
 			Follow: false,
 			JobID:  test.jobID,
 		}
@@ -144,7 +145,7 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogFollow(c *C) {
 		s.agg.feed(msg1)
 		s.agg.feed(msg2)
 
-		logrc, err := s.client.GetLog(appID, &client.LogOpts{
+		logrc, err := s.client.GetLog(appID, &logagg.LogOpts{
 			Follow: true,
 			Lines:  &test.nLines,
 		})
@@ -202,7 +203,7 @@ func (s *LogAggregatorTestSuite) TestNewMessageFromSyslog(c *C) {
 	c.Assert(m.JobID, Equals, "flynn-abcd1234")
 	c.Assert(m.ProcessType, Equals, "web")
 	c.Assert(m.Source, Equals, "app")
-	c.Assert(m.Stream, Equals, "stdout")
+	c.Assert(m.Stream, Equals, logagg.StreamTypeStdout)
 	c.Assert(m.Timestamp, Equals, timestamp)
 }
 
@@ -249,6 +250,7 @@ func newMessageForApp(appname, procID, msg string) *rfc5424.Message {
 		&rfc5424.Header{
 			AppName: []byte(appname),
 			ProcID:  []byte(procID),
+			MsgID:   []byte("ID1"),
 		},
 		[]byte(msg),
 	)

--- a/logaggregator/filter.go
+++ b/logaggregator/filter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 )
 
@@ -40,6 +41,17 @@ func filterProcessType(processType string) filterFunc {
 	return func(m *rfc5424.Message) bool {
 		b, _ := splitProcID(m.ProcID)
 		return bytes.Equal(a, b)
+	}
+}
+
+func filterStreamType(streams ...logagg.StreamType) filterFunc {
+	lookup := make(map[logagg.StreamType]struct{}, len(streams))
+	for _, stream := range streams {
+		lookup[stream] = struct{}{}
+	}
+	return func(m *rfc5424.Message) bool {
+		_, ok := lookup[streamType(m.MsgID)]
+		return ok
 	}
 }
 

--- a/logaggregator/iterator_test.go
+++ b/logaggregator/iterator_test.go
@@ -12,26 +12,31 @@ import (
 var (
 	appAMessages = buildTestData(200, &rfc5424.Header{
 		AppName: []byte("app-A"),
+		MsgID:   []byte("ID1"),
 	})
 
 	appBJob1Messages = buildTestData(100, &rfc5424.Header{
 		AppName: []byte("app-B"),
 		ProcID:  []byte("web.job1"),
+		MsgID:   []byte("ID1"),
 	})
 
 	appBJob2Messages = buildTestData(100, &rfc5424.Header{
 		AppName: []byte("app-B"),
 		ProcID:  []byte("web.job2"),
+		MsgID:   []byte("ID1"),
 	})
 
 	appCWebMessages = buildTestData(100, &rfc5424.Header{
 		AppName: []byte("app-C"),
 		ProcID:  []byte("web.job1"),
+		MsgID:   []byte("ID1"),
 	})
 
 	appCRunMessages = buildTestData(100, &rfc5424.Header{
 		AppName: []byte("app-C"),
 		ProcID:  []byte("run.job2"),
+		MsgID:   []byte("ID1"),
 	})
 
 	nopFilter = Filter(make(filterSlice, 0))

--- a/logaggregator/server_test.go
+++ b/logaggregator/server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/logaggregator/utils"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 	"github.com/flynn/flynn/pkg/syslog/rfc6587"
@@ -29,7 +30,7 @@ func (s *ServerTestSuite) TestServerDurability(c *C) {
 	defer conn.Close()
 
 	zero := 0
-	rc, err := cl.GetLog("app-A", &client.LogOpts{Follow: true, Lines: &zero})
+	rc, err := cl.GetLog("app-A", &logagg.LogOpts{Follow: true, Lines: &zero})
 	c.Assert(err, IsNil)
 
 	for _, msg := range appAMessages {
@@ -41,7 +42,7 @@ func (s *ServerTestSuite) TestServerDurability(c *C) {
 	for _, want := range appAMessages {
 		c.Assert(dec.Decode(&got), IsNil)
 		c.Assert(got.HostID, Equals, string(want.Hostname))
-		c.Assert(got.Stream, Equals, streamName(want.MsgID))
+		c.Assert(got.Stream, Equals, streamType(want.MsgID))
 		c.Assert(got.Timestamp.Equal(want.Timestamp), Equals, true)
 
 		procType, jobID := splitProcID(want.ProcID)

--- a/logaggregator/types/types.go
+++ b/logaggregator/types/types.go
@@ -1,0 +1,52 @@
+package logaggregator
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type LogOpts struct {
+	Follow      bool
+	JobID       string
+	Lines       *int
+	ProcessType *string
+	StreamTypes []StreamType
+}
+
+func (o *LogOpts) EncodedQuery() string {
+	query := url.Values{}
+	if o.Follow {
+		query.Set("follow", "true")
+	}
+	if o.JobID != "" {
+		query.Set("job_id", o.JobID)
+	}
+	if o.Lines != nil && *o.Lines >= 0 {
+		query.Set("lines", strconv.Itoa(*o.Lines))
+	}
+	if o.ProcessType != nil {
+		query.Set("process_type", *o.ProcessType)
+	}
+	if len(o.StreamTypes) > 0 {
+		streamTypes := make([]string, len(o.StreamTypes))
+		for i, typ := range o.StreamTypes {
+			streamTypes[i] = string(typ)
+		}
+		query.Set("stream_types", strings.Join(streamTypes, ","))
+	} else {
+		// default to just stdout / stderr
+		query.Set("stream_types", fmt.Sprintf("%s,%s", StreamTypeStdout, StreamTypeStderr))
+	}
+	return query.Encode()
+}
+
+type StreamType string
+
+const (
+	StreamTypeStdout  StreamType = "stdout"
+	StreamTypeStderr  StreamType = "stderr"
+	StreamTypeInit    StreamType = "init"
+	StreamTypeUnknown StreamType = "unknown"
+)

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -134,6 +134,7 @@ main() {
     --volpath "${vol_path}" \
     --log-dir "${log_dir}" \
     --flynn-init "${bin_dir}/flynn-init" \
+    --init-log-level "debug" \
     ${peer_ips} \
     &>"${log}"
 

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -471,6 +471,7 @@ sudo start-stop-daemon \
   --force \
   --peer-ips {{ .Peers }} \
   --max-job-concurrency 8 \
+  --init-log-level debug \
   &>/tmp/flynn-host.log
 `[1:]))
 

--- a/test/test_host_update.go
+++ b/test/test_host_update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flynn/flynn/host/types"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/exec"
@@ -58,7 +59,7 @@ func (s *HostUpdateSuite) TestUpdateLogs(t *c.C) {
 	// stream the log from the logaggregator
 	logc, err := logaggc.New("")
 	t.Assert(err, c.IsNil)
-	log, err := logc.GetLog("partial-logger", &logaggc.LogOpts{Follow: true})
+	log, err := logc.GetLog("partial-logger", &logagg.LogOpts{Follow: true})
 	t.Assert(err, c.IsNil)
 	defer log.Close()
 	msgs := make(chan *logaggc.Message)

--- a/test/test_logaggregator.go
+++ b/test/test_logaggregator.go
@@ -10,6 +10,7 @@ import (
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	c "github.com/flynn/go-check"
 )
 
@@ -81,7 +82,7 @@ func (s *LogAggregatorSuite) TestReplication(t *c.C) {
 	readLines := func(expectedLines ...string) {
 		lineCount := 10
 		lc, _ := client.New("http://" + aggHost)
-		out, err := lc.GetLog(app.id, &client.LogOpts{Follow: true, Lines: &lineCount})
+		out, err := lc.GetLog(app.id, &logagg.LogOpts{Follow: true, Lines: &lineCount})
 		t.Assert(err, c.IsNil)
 
 		done := make(chan struct{})

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/typeconv"
@@ -81,7 +82,7 @@ func (s *SchedulerSuite) TestScaleTags(t *c.C) {
 	leader, err := s.discoverdClient(t).Service("controller-scheduler").Leader()
 	t.Assert(err, c.IsNil)
 	client := s.controllerClient(t)
-	res, err := client.GetAppLog("controller", &ct.LogOpts{
+	res, err := client.GetAppLog("controller", &logagg.LogOpts{
 		Follow:      true,
 		JobID:       leader.Meta["FLYNN_JOB_ID"],
 		ProcessType: typeconv.StringPtr("scheduler"),


### PR DESCRIPTION
Example:

```
$ flynn -a nodejs-flynn-example log --init --raw
t=2016-10-12T12:26:05+0000 lvl=info msg="starting the job" component=containerinit args="[/runner/init start web]"
t=2016-10-12T12:26:05+0000 lvl=info msg="monitoring service" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp
t=2016-10-12T12:26:05+0000 lvl=info msg="adding healthcheck" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp type=tcp interval=0s threshold=0
t=2016-10-12T12:26:05+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
t=2016-10-12T12:26:06+0000 lvl=warn msg="healthcheck error" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor check=tcp://100.100.23.18:8080 err="dial tcp 100.100.23.18:8080: getsockopt: connection refused"
Listening on 8080
t=2016-10-12T12:26:06+0000 lvl=info msg="new monitor status" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=monitor status=up check=tcp://100.100.23.18:8080
t=2016-10-12T12:26:06+0000 lvl=info msg="created heartbeater" component=containerinit name=nodejs-flynn-example-web port=8080 proto=tcp component=registrar addr=100.100.23.18:8080
t=2016-10-12T12:26:07+0000 lvl=info msg="received deregister request" component=containerinit
t=2016-10-12T12:26:07+0000 lvl=info msg="service deregistered" component=containerinit addr=
t=2016-10-12T12:26:07+0000 lvl=info msg="forwarding signal to job" component=containerinit type=terminated
t=2016-10-12T12:26:07+0000 lvl=info msg="job exited" component=containerinit status=0
t=2016-10-12T12:26:07+0000 lvl=info msg="received signal" component=containerinit type="child exited"
t=2016-10-12T12:26:07+0000 lvl=info msg=exiting component=containerinit
```

Closes #2669.