### PR TITLE
Migrate slugs and docker-receive releases to Flynn images

### DIFF
--- a/blobstore/Dockerfile
+++ b/blobstore/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty-20160217
 
-RUN apt-get update && apt-get -qy install ca-certificates && apt-get clean
+RUN apt-get update && apt-get -qy install ca-certificates curl && apt-get clean
 ADD ./bin/flynn-blobstore /bin/flynn-blobstore
 
 ENTRYPOINT ["/bin/flynn-blobstore", "server"]

--- a/cli/export.go
+++ b/cli/export.go
@@ -117,14 +117,88 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	var artifact *ct.Artifact
-	if artifactID := release.ImageArtifactID(); artifactID != "" {
-		artifact, err = client.GetArtifact(artifactID)
+	blobstoreRelease, err := client.GetAppRelease("blobstore")
+	if err != nil {
+		return fmt.Errorf("error getting blobstore release: %s", err)
+	}
+	download := func(name, url string, release *ct.Release) error {
+		reqR, reqW := io.Pipe()
+		config := runConfig{
+			App:        mustApp(),
+			Release:    release.ID,
+			Artifacts:  release.ArtifactIDs[:1],
+			DisableLog: true,
+			Args:       []string{"curl", "--include", "--location", "--raw", url},
+			Stdout:     reqW,
+			Stderr:     ioutil.Discard,
+		}
+		if bar != nil {
+			config.Stdout = io.MultiWriter(config.Stdout, bar)
+		}
+		go func() {
+			if err := runJob(client, config); err != nil {
+				shutdown.Fatalf("error downloading %s: %s", name, err)
+			}
+		}()
+		req := bufio.NewReader(reqR)
+		var res *http.Response
+		maxRedirects := 5
+		for i := 0; i < maxRedirects; i++ {
+			res, err = http.ReadResponse(req, nil)
+			if err != nil {
+				return fmt.Errorf("error reading HTTP response: %s", err)
+			}
+			if res.StatusCode != http.StatusFound {
+				break
+			}
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status downloading %s: %d", name, res.StatusCode)
+		}
+		length, err := strconv.Atoi(res.Header.Get("Content-Length"))
+		if err != nil {
+			return fmt.Errorf("download of %s has missing or malformed Content-Length", name)
+		}
+
+		if err := tw.WriteHeader(name, length); err != nil {
+			return fmt.Errorf("error writing header for %s: %s", name, err)
+		}
+		if _, err := io.Copy(tw, res.Body); err != nil {
+			return fmt.Errorf("error writing %s: %s", name, err)
+		}
+		return nil
+	}
+
+	artifacts := make([]*ct.Artifact, 0, len(release.ArtifactIDs))
+	for _, id := range release.ArtifactIDs {
+		artifact, err := client.GetArtifact(id)
 		if err != nil && err != controller.ErrNotFound {
-			return fmt.Errorf("error retrieving artifact: %s", err)
+			return fmt.Errorf("error retrieving artifact %s: %s", id, err)
 		} else if err == nil {
-			if err := tw.WriteJSON("artifact.json", artifact); err != nil {
-				return fmt.Errorf("error exporting artifact: %s", err)
+			artifacts = append(artifacts, artifact)
+		}
+	}
+	if len(artifacts) > 0 {
+		if err := tw.WriteJSON("artifacts.json", artifacts); err != nil {
+			return fmt.Errorf("error exporting artifacts: %s", err)
+		}
+	}
+	// save layers of any Flynn artifacts stored in the blobstore
+	for _, artifact := range artifacts {
+		if artifact.Type != ct.ArtifactTypeFlynn {
+			continue
+		}
+		if !artifact.Blobstore() {
+			continue
+		}
+		for _, rootfs := range artifact.Manifest().Rootfs {
+			for _, layer := range rootfs.Layers {
+				name := layer.ID + ".layer"
+				url := artifact.LayerURL(layer)
+				if err := download(name, url, blobstoreRelease); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -138,9 +212,10 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	// if the release was deployed via docker-receive, pull the docker
-	// image and add it to the export using "docker save"
-	if release.IsDockerReceiveDeploy() && artifact != nil {
+	// if the release was deployed via docker-receive and has a deprecated
+	// "docker" artifact, pull the docker image and add it to the export
+	// using "docker save"
+	if release.IsDockerReceiveDeploy() && len(artifacts) > 0 && artifacts[0].Type == ct.DeprecatedArtifactTypeDocker {
 		cluster, err := getCluster()
 		if err != nil {
 			return err
@@ -153,8 +228,8 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		// the artifact will have an internal discoverd URL which will
 		// not work if the Docker daemon is outside the cluster, so
 		// generate a reference using the configured DockerPushURL
-		repo := artifact.Meta["docker-receive.repository"]
-		digest := artifact.Meta["docker-receive.digest"]
+		repo := artifacts[0].Meta["docker-receive.repository"]
+		digest := artifacts[0].Meta["docker-receive.digest"]
 		ref := fmt.Sprintf("%s/%s@%s", host, repo, digest)
 
 		// pull the Docker image
@@ -190,70 +265,18 @@ func runExport(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	// expect releases deployed via git to have a slug as their first file
-	// artifact, and legacy releases to have SLUG_URL set
+	// explicitly export slugs from old clusters which either have them as
+	// file artifacts or in SLUG_URL
 	var slugURL string
-	if release.IsGitDeploy() && len(release.FileArtifactIDs()) > 0 {
-		slugArtifact, err := client.GetArtifact(release.FileArtifactIDs()[0])
-		if err != nil && err != controller.ErrNotFound {
-			return fmt.Errorf("error retrieving slug artifact: %s", err)
-		} else if err == nil {
-			slugURL = slugArtifact.URI
-		}
+	if release.IsGitDeploy() && len(artifacts) > 1 && artifacts[1].Type == ct.DeprecatedArtifactTypeFile {
+		slugURL = artifacts[1].URI
 	} else if u, ok := release.Env["SLUG_URL"]; ok {
 		slugURL = u
 	}
 	if slugURL != "" {
-		reqR, reqW := io.Pipe()
-		config := runConfig{
-			App:        mustApp(),
-			Release:    release.ID,
-			DisableLog: true,
-			Args:       []string{"curl", "--include", "--location", "--raw", slugURL},
-			Stdout:     reqW,
-			Stderr:     ioutil.Discard,
+		if err := download("slug.tar.gz", slugURL, release); err != nil {
+			return err
 		}
-
-		// use just the slugrunner image as we don't need the
-		// extracted slug to run curl, and this also prevents
-		// the slug from interfering (e.g. logging output)
-		config.Artifacts = release.ArtifactIDs[:1]
-
-		if bar != nil {
-			config.Stdout = io.MultiWriter(config.Stdout, bar)
-		}
-		go func() {
-			if err := runJob(client, config); err != nil {
-				shutdown.Fatalf("error retrieving slug: %s", err)
-			}
-		}()
-		req := bufio.NewReader(reqR)
-		var res *http.Response
-		maxRedirects := 5
-		for i := 0; i < maxRedirects; i++ {
-			res, err = http.ReadResponse(req, nil)
-			if err != nil {
-				return fmt.Errorf("error reading slug response: %s", err)
-			}
-			if res.StatusCode != http.StatusFound {
-				break
-			}
-		}
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status getting slug: %d", res.StatusCode)
-		}
-		length, err := strconv.Atoi(res.Header.Get("Content-Length"))
-		if err != nil {
-			return fmt.Errorf("slug has missing or malformed Content-Length")
-		}
-
-		if err := tw.WriteHeader("slug.tar.gz", length); err != nil {
-			return fmt.Errorf("error writing slug header: %s", err)
-		}
-		if _, err := io.Copy(tw, res.Body); err != nil {
-			return fmt.Errorf("error writing slug: %s", err)
-		}
-		res.Body.Close()
 	}
 
 	if pgConfig, err := getAppPgRunConfig(client); err == nil {
@@ -300,13 +323,13 @@ func runImport(args *docopt.Args, client controller.Client) error {
 	tr := tar.NewReader(src)
 
 	var (
-		app           *ct.App
-		release       *ct.Release
-		imageArtifact *ct.Artifact
-		formation     *ct.Formation
-		routes        []router.Route
-		slug          io.Reader
-		dockerImage   struct {
+		app         *ct.App
+		release     *ct.Release
+		artifacts   []*ct.Artifact
+		formation   *ct.Formation
+		routes      []router.Route
+		legacySlug  io.Reader
+		dockerImage struct {
 			config struct {
 				Tag string `json:"tag"`
 			}
@@ -318,6 +341,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 	)
 	numResources := 0
 	numRoutes := 1
+	layers := make(map[string]io.Reader)
 
 	for {
 		header, err := tr.Next()
@@ -327,7 +351,26 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			return fmt.Errorf("error reading export tar: %s", err)
 		}
 
-		switch path.Base(header.Name) {
+		filename := path.Base(header.Name)
+		if strings.HasSuffix(filename, ".layer") {
+			f, err := ioutil.TempFile("", "flynn-layer-")
+			if err != nil {
+				return fmt.Errorf("error creating layer tempfile: %s", err)
+			}
+			defer f.Close()
+			defer os.Remove(f.Name())
+			if _, err := io.Copy(f, tr); err != nil {
+				return fmt.Errorf("error reading %s: %s", header.Name, err)
+			}
+			if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+				return fmt.Errorf("error seeking layer tempfile: %s", err)
+			}
+			layers[strings.TrimSuffix(filename, ".layer")] = f
+			uploadSize += header.Size
+			continue
+		}
+
+		switch filename {
 		case "app.json":
 			app = &ct.App{}
 			if err := json.NewDecoder(tr).Decode(app); err != nil {
@@ -341,12 +384,10 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			}
 			release.ID = ""
 			release.ArtifactIDs = nil
-		case "artifact.json":
-			imageArtifact = &ct.Artifact{}
-			if err := json.NewDecoder(tr).Decode(imageArtifact); err != nil {
-				return fmt.Errorf("error decoding image artifact: %s", err)
+		case "artifacts.json":
+			if err := json.NewDecoder(tr).Decode(&artifacts); err != nil {
+				return fmt.Errorf("error decoding artifacts: %s", err)
 			}
-			imageArtifact.ID = ""
 		case "formation.json":
 			formation = &ct.Formation{}
 			if err := json.NewDecoder(tr).Decode(formation); err != nil {
@@ -375,7 +416,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			if _, err := f.Seek(0, os.SEEK_SET); err != nil {
 				return fmt.Errorf("error seeking slug tempfile: %s", err)
 			}
-			slug = f
+			legacySlug = f
 			uploadSize += header.Size
 		case "docker-image.json":
 			if err := json.NewDecoder(tr).Decode(&dockerImage.config); err != nil {
@@ -531,30 +572,81 @@ func runImport(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	uploadSlug := release != nil && imageArtifact != nil && slug != nil
+	var uploadLegacySlug bool
 
-	if uploadSlug {
-		// Use current slugrunner as the artifact
-		gitreceiveRelease, err := client.GetAppRelease("gitreceive")
-		if err != nil {
-			return fmt.Errorf("unable to retrieve gitreceive release: %s", err)
-		}
-		if id, ok := gitreceiveRelease.Env["SLUGRUNNER_IMAGE_ID"]; ok {
-			imageArtifact, err = client.GetArtifact(id)
+	if legacySlug != nil {
+		if err := func() error {
+			gitreceiveRelease, err := client.GetAppRelease("gitreceive")
 			if err != nil {
-				return fmt.Errorf("unable to get slugrunner image artifact: %s", err)
+				return fmt.Errorf("unable to retrieve gitreceive release: %s", err)
 			}
-		} else if uri, ok := gitreceiveRelease.Env["SLUGRUNNER_IMAGE_URI"]; ok {
-			imageArtifact = &ct.Artifact{
-				Type: ct.DeprecatedArtifactTypeDocker,
-				URI:  uri,
-			}
-		} else {
-			return fmt.Errorf("gitreceive env missing slug runner image")
-		}
-	}
 
-	if dockerImage.config.Tag != "" && dockerImage.archive != nil {
+			// handle legacy clusters which reference Docker image URIs
+			if uri, ok := gitreceiveRelease.Env["SLUGRUNNER_IMAGE_URI"]; ok {
+				artifact := &ct.Artifact{
+					Type: ct.DeprecatedArtifactTypeDocker,
+					URI:  uri,
+				}
+				if err := client.CreateArtifact(artifact); err != nil {
+					return fmt.Errorf("error creating image artifact: %s", err)
+				}
+				uploadLegacySlug = true
+				release.ArtifactIDs = []string{artifact.ID}
+				return nil
+			}
+
+			slugBuilderID, ok := gitreceiveRelease.Env["SLUGBUILDER_IMAGE_ID"]
+			if !ok {
+				return fmt.Errorf("gitreceive env missing slugbuilder image")
+			}
+			slugRunnerID, ok := gitreceiveRelease.Env["SLUGRUNNER_IMAGE_ID"]
+			if !ok {
+				return fmt.Errorf("gitreceive env missing slugrunner image")
+			}
+
+			// handle legacy tarball based slugbuilders (which are Docker based)
+			slugBuilderImage, err := client.GetArtifact(slugBuilderID)
+			if err != nil {
+				return fmt.Errorf("unable to get slugbuilder image artifact: %s", err)
+			}
+			if slugBuilderImage.Type == ct.DeprecatedArtifactTypeDocker {
+				uploadLegacySlug = true
+				release.ArtifactIDs = []string{slugRunnerID}
+				return nil
+			}
+
+			// Use slugbuilder to convert the legacy slug to a
+			// Flynn squashfs image
+			slugImageID := random.UUID()
+			config := runConfig{
+				App:        app.ID,
+				Release:    gitreceiveRelease.ID,
+				ReleaseEnv: true,
+				Artifacts:  []string{slugBuilderID},
+				DisableLog: true,
+				Args:       []string{"/bin/convert-legacy-slug.sh"},
+				Stdin:      legacySlug,
+				Stdout:     ioutil.Discard,
+				Stderr:     ioutil.Discard,
+				Env:        map[string]string{"SLUG_IMAGE_ID": slugImageID},
+			}
+			if bar != nil {
+				config.Stdin = bar.NewProxyReader(config.Stdin)
+			}
+			if err := runJob(client, config); err != nil {
+				return fmt.Errorf("error uploading slug: %s", err)
+			}
+			release.ID = ""
+			release.ArtifactIDs = []string{slugRunnerID, slugImageID}
+			if release.Meta == nil {
+				release.Meta = make(map[string]string, 1)
+			}
+			release.Meta["git"] = "true"
+			return nil
+		}(); err != nil {
+			return err
+		}
+	} else if dockerImage.config.Tag != "" && dockerImage.archive != nil {
 		// load the docker image into the Docker daemon
 		cmd := exec.Command("docker", "load")
 		cmd.Stdin = dockerImage.archive
@@ -583,17 +675,79 @@ func runImport(args *docopt.Args, client controller.Client) error {
 		}
 
 		release.ArtifactIDs = []string{artifact.ID}
-	} else if imageArtifact != nil {
-		if imageArtifact.ID == "" {
-			if err := client.CreateArtifact(imageArtifact); err != nil {
-				return fmt.Errorf("error creating image artifact: %s", err)
-			}
+	} else if len(artifacts) > 0 {
+		// import blobstore Flynn artifacts
+		blobstoreRelease, err := client.GetAppRelease("blobstore")
+		if err != nil {
+			return fmt.Errorf("unable to retrieve blobstore release: %s", err)
 		}
-		release.ArtifactIDs = []string{imageArtifact.ID}
+		upload := func(id, url string) error {
+			layer, ok := layers[id]
+			if !ok {
+				return fmt.Errorf("missing layer in export: %s", id)
+			}
+			config := runConfig{
+				App:        app.ID,
+				Release:    blobstoreRelease.ID,
+				DisableLog: true,
+				Args:       []string{"curl", "--request", "PUT", "--upload-file", "-", url},
+				Stdin:      layer,
+				Stdout:     ioutil.Discard,
+				Stderr:     ioutil.Discard,
+			}
+			if bar != nil {
+				config.Stdin = bar.NewProxyReader(config.Stdin)
+			}
+			if err := runJob(client, config); err != nil {
+				return fmt.Errorf("error uploading layer: %s", err)
+			}
+			return nil
+		}
+
+		release.ArtifactIDs = make([]string, len(artifacts))
+		for i, artifact := range artifacts {
+			if artifact.Type != ct.ArtifactTypeFlynn {
+				continue
+			}
+			if !artifact.Blobstore() {
+				continue
+			}
+			for _, rootfs := range artifact.Manifest().Rootfs {
+				for _, layer := range rootfs.Layers {
+					if err := upload(layer.ID, artifact.LayerURL(layer)); err != nil {
+						return err
+					}
+				}
+			}
+			artifact.ID = ""
+			if err := client.CreateArtifact(artifact); err != nil {
+				return fmt.Errorf("error creating artifact: %s", err)
+			}
+			release.ArtifactIDs[i] = artifact.ID
+		}
+
+		// use the current slugrunner image for slug releases
+		if release.IsGitDeploy() {
+			gitreceiveRelease, err := client.GetAppRelease("gitreceive")
+			if err != nil {
+				return fmt.Errorf("unable to retrieve gitreceive release: %s", err)
+			}
+			slugRunnerID, ok := gitreceiveRelease.Env["SLUGRUNNER_IMAGE_ID"]
+			if !ok {
+				return fmt.Errorf("gitreceive env missing slugrunner image")
+			}
+			release.ArtifactIDs[0] = slugRunnerID
+		}
 	}
 
 	if release != nil {
 		for t, proc := range release.Processes {
+			// update legacy slug releases to use Args rather than the
+			// deprecated Entrypoint and Cmd fields
+			if release.IsGitDeploy() && len(proc.Args) == 0 {
+				proc.Args = append([]string{"/runner/init"}, proc.DeprecatedCmd...)
+				proc.DeprecatedCmd = nil
+			}
 			for i, port := range proc.Ports {
 				if port.Service != nil && strings.HasPrefix(port.Service.Name, oldName) {
 					proc.Ports[i].Service.Name = strings.Replace(port.Service.Name, oldName, app.Name, 1)
@@ -609,14 +763,14 @@ func runImport(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	if uploadSlug {
+	if uploadLegacySlug {
 		slugURI := fmt.Sprintf("http://blobstore.discoverd/%s/slug.tgz", random.UUID())
 		config := runConfig{
 			App:        app.ID,
 			Release:    release.ID,
 			DisableLog: true,
 			Args:       []string{"curl", "--request", "PUT", "--upload-file", "-", slugURI},
-			Stdin:      slug,
+			Stdin:      legacySlug,
 			Stdout:     ioutil.Discard,
 			Stderr:     ioutil.Discard,
 		}

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flynn/flynn/pkg/httprecorder"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/resource"
+	"github.com/flynn/flynn/pkg/typeconv"
 	"github.com/flynn/flynn/router/types"
 )
 
@@ -293,6 +294,8 @@ func (e *generator) createArtifact() {
 				Env:        map[string]string{"key": "other-val"},
 				WorkingDir: "/app",
 				Args:       []string{"/bin/web-server"},
+				Uid:        typeconv.Uint32Ptr(1000),
+				Gid:        typeconv.Uint32Ptr(1000),
 			},
 		},
 		Rootfs: []*ct.ImageRootfs{

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -326,6 +326,7 @@ func (e *generator) createArtifact() {
 		URI:              e.resourceIds["SLUGRUNNER_IMAGE_URI"],
 		RawManifest:      manifest.RawManifest(),
 		Hashes:           manifest.Hashes(),
+		Size:             int64(len(manifest.RawManifest())),
 		LayerURLTemplate: "https://dl.flynn.io/tuf?target=/layers/{id}.squashfs",
 	}
 	err := e.client.CreateArtifact(artifact)

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -554,6 +554,8 @@ type ImageEntrypoint struct {
 	WorkingDir        string            `json:"cwd,omitempty"`
 	Args              []string          `json:"args,omitempty"`
 	LinuxCapabilities []string          `json:"linux_capabilities,omitempty"`
+	Uid               *uint32           `json:"uid,omitempty"`
+	Gid               *uint32           `json:"gid,omitempty"`
 }
 
 type ImageRootfs struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -54,6 +54,8 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 			Args:        entrypoint.Args,
 			Env:         env,
 			WorkingDir:  entrypoint.WorkingDir,
+			Uid:         entrypoint.Uid,
+			Gid:         entrypoint.Gid,
 			HostNetwork: t.HostNetwork,
 		},
 		Resurrect: t.Resurrect,

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -18,7 +18,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 	t := f.Release.Processes[name]
 
 	var entrypoint ct.ImageEntrypoint
-	if e := getEntrypoint(f.Artifacts, name); e != nil {
+	if e := GetEntrypoint(f.Artifacts, name); e != nil {
 		entrypoint = *e
 	}
 
@@ -84,14 +84,14 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 	return job
 }
 
-// getEntrypoint returns an image entrypoint for a process type from a list of
+// GetEntrypoint returns an image entrypoint for a process type from a list of
 // artifacts, first iterating through them and returning any entrypoint having
 // the exact type, then iterating through them and returning the artifact's
 // default entrypoint if it has one.
 //
 // The artifacts are traversed in reverse order so that entrypoints in the
 // image being overlayed at the top are considered first.
-func getEntrypoint(artifacts []*ct.Artifact, typ string) *ct.ImageEntrypoint {
+func GetEntrypoint(artifacts []*ct.Artifact, typ string) *ct.ImageEntrypoint {
 	for i := len(artifacts) - 1; i >= 0; i-- {
 		artifact := artifacts[i]
 		if artifact.Type != ct.ArtifactTypeFlynn {

--- a/docker-receive/Dockerfile
+++ b/docker-receive/Dockerfile
@@ -1,6 +1,9 @@
-FROM flynn/busybox:trusty-20160217
+FROM ubuntu:trusty-20160217
+
+RUN apt-get install --yes squashfs-tools
 
 ADD bin/docker-receive /bin/docker-receive
+ADD bin/docker-artifact /bin/docker-artifact
 ADD bin/ca-certs.pem /etc/ssl/certs/ca-certs.pem
 
 CMD ["/bin/docker-receive"]

--- a/docker-receive/Tupfile
+++ b/docker-receive/Tupfile
@@ -1,4 +1,5 @@
 include_rules
 : |> !go |> bin/docker-receive
+: |> !go ./artifact |> bin/docker-artifact
 : $(ROOT)/util/ca-certs/ca-certs.pem |> !cp |> bin/ca-certs.pem
-: bin/docker-receive bin/ca-certs.pem |> !image-bootstrapped |>
+: bin/docker-receive bin/docker-artifact bin/ca-certs.pem |> !image-bootstrapped |>

--- a/docker-receive/artifact/graphdriver.go
+++ b/docker-receive/artifact/graphdriver.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
+)
+
+func init() {
+	graphdriver.Register("flynn", newGraphDriver)
+}
+
+func newGraphDriver(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return nil, err
+	}
+	return &GraphDriver{root}, nil
+}
+
+// GraphDriver implements the graphdriver.Driver interface by storing diffs as
+// single files on the filesystem, and is used when converting Docker images to
+// Flynn squashfs images to avoid extra libraries or privileges required by
+// standard Docker drivers (e.g. AUFS)
+type GraphDriver struct {
+	root string
+}
+
+func (d *GraphDriver) String() string {
+	return "flynn"
+}
+
+func (d *GraphDriver) Status() [][2]string {
+	return nil
+}
+
+func (d *GraphDriver) GetMetadata(id string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (d *GraphDriver) Cleanup() error {
+	return nil
+}
+
+func (d *GraphDriver) Create(id, parent string) error {
+	return os.MkdirAll(d.dir(id), 0755)
+}
+
+func (d *GraphDriver) Remove(id string) error {
+	return os.RemoveAll(d.dir(id))
+}
+
+func (d *GraphDriver) Get(id, mountLabel string) (string, error) {
+	return d.dir(id), nil
+}
+
+func (d *GraphDriver) Put(id string) error {
+	return nil
+}
+
+func (d *GraphDriver) Exists(id string) bool {
+	_, err := os.Stat(d.dir(id))
+	return err == nil
+}
+
+func (d *GraphDriver) Diff(id, parent string) (archive.Archive, error) {
+	return os.Open(d.path(id))
+}
+
+func (d *GraphDriver) Changes(id, parent string) ([]archive.Change, error) {
+	return nil, nil
+}
+
+func (d *GraphDriver) ApplyDiff(id, parent string, diff archive.Reader) (int64, error) {
+	f, err := os.Create(d.path(id))
+	if err != nil {
+		return 0, err
+	}
+	return io.Copy(f, diff)
+}
+
+func (d *GraphDriver) DiffSize(id, parent string) (int64, error) {
+	stat, err := os.Stat(d.path(id))
+	if err != nil {
+		return 0, err
+	}
+	return stat.Size(), nil
+}
+
+func (d *GraphDriver) dir(id string) string {
+	return filepath.Join(d.root, filepath.Base(id))
+}
+
+func (d *GraphDriver) path(id string) string {
+	return filepath.Join(d.dir(id), "diff.tar")
+}

--- a/docker-receive/artifact/main.go
+++ b/docker-receive/artifact/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pinkerton"
+	"github.com/flynn/flynn/pkg/dialer"
+	"github.com/flynn/flynn/pkg/imagebuilder"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	if len(os.Args) != 2 {
+		log.Fatalf("usage: %s URL", os.Args[0])
+	}
+	if err := run(os.Args[1]); err != nil {
+		log.Fatalln("ERROR:", err)
+	}
+}
+
+func run(url string) error {
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
+	if err != nil {
+		return err
+	}
+
+	context, err := pinkerton.BuildContext("flynn", "/data")
+	if err != nil {
+		return err
+	}
+
+	builder := &imagebuilder.Builder{
+		Store:   &layerStore{},
+		Context: context,
+	}
+
+	// pull the docker image
+	ref, err := pinkerton.NewRef(url)
+	if err != nil {
+		return err
+	}
+	if _, err := context.PullDocker(url, pinkerton.DockerPullPrinter(os.Stdout)); err != nil {
+		return err
+	}
+
+	// create squashfs for each layer
+	image, err := builder.Build(ref.DockerRef(), false)
+	if err != nil {
+		return err
+	}
+
+	// add the app name to the manifest to change its resulting ID so
+	// pushing the same image to multiple apps leads to different artifacts
+	// in the controller (and hence distinct artifact events)
+	if image.Meta == nil {
+		image.Meta = make(map[string]string, 1)
+	}
+	image.Meta["docker-receive.repository"] = ref.Name()
+
+	// upload manifest to blobstore
+	rawManifest := image.RawManifest()
+	imageURL := fmt.Sprintf("http://blobstore.discoverd/docker-receive/images/%s.json", image.ID())
+	if err := upload(bytes.NewReader(rawManifest), imageURL); err != nil {
+		return err
+	}
+
+	// create the artifact
+	artifact := &ct.Artifact{
+		ID:   os.Getenv("ARTIFACT_ID"),
+		Type: ct.ArtifactTypeFlynn,
+		URI:  imageURL,
+		Meta: map[string]string{
+			"blobstore":                 "true",
+			"docker-receive.uri":        url,
+			"docker-receive.repository": ref.Name(),
+			"docker-receive.digest":     ref.ID(),
+		},
+		RawManifest:      rawManifest,
+		Hashes:           image.Hashes(),
+		LayerURLTemplate: layerURLTemplate,
+	}
+	return client.CreateArtifact(artifact)
+}
+
+func upload(data io.Reader, url string) error {
+	req, err := http.NewRequest("PUT", url, data)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status: %s", res.Status)
+	}
+	return nil
+}
+
+type layerStore struct{}
+
+func (l *layerStore) Load(id string) (*ct.ImageLayer, error) {
+	res, err := http.Get(jsonURL(id))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		// the layer doesn't exist, just return nil
+		// so that the imagebuilder builds it
+		return nil, nil
+	} else if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status: %s", res.Status)
+	}
+	var layer ct.ImageLayer
+	return &layer, json.NewDecoder(res.Body).Decode(&layer)
+}
+
+func (l *layerStore) Save(id, path string, layer *ct.ImageLayer) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := upload(f, layerURL(layer)); err != nil {
+		return err
+	}
+	data, err := json.Marshal(layer)
+	if err != nil {
+		return err
+	}
+	return upload(bytes.NewReader(data), jsonURL(id))
+}
+
+func jsonURL(id string) string {
+	return fmt.Sprintf("http://blobstore.discoverd/docker-receive/layers/%s.json", id)
+}
+
+const layerURLTemplate = "http://blobstore.discoverd/docker-receive/layers/{id}.squashfs"
+
+func layerURL(layer *ct.ImageLayer) string {
+	return fmt.Sprintf("http://blobstore.discoverd/docker-receive/layers/%s.squashfs", layer.ID)
+}

--- a/docker-receive/artifact/main.go
+++ b/docker-receive/artifact/main.go
@@ -86,6 +86,7 @@ func run(url string) error {
 		},
 		RawManifest:      rawManifest,
 		Hashes:           image.Hashes(),
+		Size:             int64(len(rawManifest)),
 		LayerURLTemplate: layerURLTemplate,
 	}
 	return client.CreateArtifact(artifact)

--- a/docker-receive/main.go
+++ b/docker-receive/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/docker-receive/blobstore"
+	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/version"
 )
@@ -119,18 +121,31 @@ func (m *manifestService) Put(manifest *manifest.SignedManifest) error {
 		return err
 	}
 
-	return m.createArtifact(dgst)
+	return m.runArtifactJob(dgst)
 }
 
-func (m *manifestService) createArtifact(dgst digest.Digest) error {
-	return m.client.CreateArtifact(&ct.Artifact{
-		Type: ct.DeprecatedArtifactTypeDocker,
-		URI:  fmt.Sprintf("http://flynn:%s@docker-receive.discoverd?name=%s&id=%s", m.authKey, m.repository.Name(), dgst),
-		Meta: map[string]string{
-			"docker-receive.repository": m.repository.Name(),
-			"docker-receive.digest":     string(dgst),
-		},
-	})
+func (m *manifestService) runArtifactJob(dgst digest.Digest) error {
+	url := fmt.Sprintf("http://flynn:%s@docker-receive.discoverd?name=%s&id=%s", m.authKey, m.repository.Name(), dgst)
+	job := &ct.NewJob{
+		Args:       []string{"/bin/docker-artifact", url},
+		ReleaseID:  os.Getenv("FLYNN_RELEASE_ID"),
+		ReleaseEnv: true,
+		Data:       true,
+	}
+	rwc, err := m.client.RunJobAttached(os.Getenv("FLYNN_APP_ID"), job)
+	if err != nil {
+		return err
+	}
+	defer rwc.Close()
+	attachClient := cluster.NewAttachClient(rwc)
+	var out bytes.Buffer
+	exitStatus, err := attachClient.Receive(&out, &out)
+	if err != nil {
+		return err
+	} else if exitStatus != 0 {
+		return fmt.Errorf("artifact job exited with non-zero exit status %d: output: %s", exitStatus, out.String())
+	}
+	return nil
 }
 
 // digestManifest is a modified version of:

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -593,15 +593,14 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		TTY:       job.Config.TTY,
 		OpenStdin: job.Config.Stdin,
 		WorkDir:   job.Config.WorkingDir,
+		Uid:       job.Config.Uid,
+		Gid:       job.Config.Gid,
 		Resources: job.Resources,
 		LogLevel:  l.InitLogLevel,
 	}
 	if !job.Config.HostNetwork {
 		initConfig.IP = container.IP.String() + "/24"
 		initConfig.Gateway = l.bridgeAddr.String()
-	}
-	if job.Config.Uid > 0 {
-		initConfig.User = strconv.Itoa(job.Config.Uid)
 	}
 	for _, port := range job.Config.Ports {
 		initConfig.Ports = append(initConfig.Ports, port)

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -93,7 +93,8 @@ type ContainerConfig struct {
 	Volumes     []VolumeBinding   `json:"volumes,omitempty"`
 	Ports       []Port            `json:"ports,omitempty"`
 	WorkingDir  string            `json:"working_dir,omitempty"`
-	Uid         int               `json:"uid,omitempty"`
+	Uid         *uint32           `json:"uid,omitempty"`
+	Gid         *uint32           `json:"gid,omitempty"`
 	HostNetwork bool              `json:"host_network,omitempty"`
 	DisableLog  bool              `json:"disable_log,omitempty"`
 }
@@ -129,8 +130,11 @@ func (x ContainerConfig) Merge(y ContainerConfig) ContainerConfig {
 	if y.WorkingDir != "" {
 		x.WorkingDir = y.WorkingDir
 	}
-	if y.Uid != 0 {
+	if y.Uid != nil {
 		x.Uid = y.Uid
+	}
+	if y.Gid != nil {
+		x.Gid = y.Gid
 	}
 	x.HostNetwork = x.HostNetwork || y.HostNetwork
 	return x

--- a/pinkerton/ref.go
+++ b/pinkerton/ref.go
@@ -55,6 +55,10 @@ func (r *Ref) ID() string {
 	return r.imageID
 }
 
+func (r *Ref) Name() string {
+	return r.repo
+}
+
 func (r *Ref) DockerRepo() string {
 	return r.host + "/" + r.repo
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -28,6 +28,8 @@ type Cmd struct {
 
 	Env map[string]string
 
+	Data bool
+
 	Stdin io.Reader
 
 	Stdout io.Writer
@@ -204,7 +206,6 @@ func (c *Cmd) Start() error {
 	if c.Job.ID == "" {
 		c.Job.ID = cluster.GenerateJobID(c.HostID, "")
 	}
-	utils.SetupMountspecs(c.Job, []*ct.Artifact{c.ImageArtifact})
 
 	if c.host == nil {
 		var err error
@@ -213,6 +214,14 @@ func (c *Cmd) Start() error {
 			return err
 		}
 	}
+
+	if c.Data {
+		if err := utils.ProvisionVolume(c.host, c.Job); err != nil {
+			return err
+		}
+	}
+
+	utils.SetupMountspecs(c.Job, []*ct.Artifact{c.ImageArtifact})
 
 	if c.Stdout != nil || c.Stderr != nil || c.Stdin != nil || c.stdinPipe != nil {
 		req := &host.AttachReq{

--- a/pkg/typeconv/typeconv.go
+++ b/pkg/typeconv/typeconv.go
@@ -4,6 +4,7 @@ import "time"
 
 func IntPtr(i int) *int              { return &i }
 func Int32Ptr(i int32) *int32        { return &i }
+func Uint32Ptr(i uint32) *uint32     { return &i }
 func Int64Ptr(i int64) *int64        { return &i }
 func StringPtr(s string) *string     { return &s }
 func TimePtr(t time.Time) *time.Time { return &t }

--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -7,6 +7,7 @@ RUN nl -nrz /builder/buildpacks.txt | awk '{print $2 "\t" $1}' | xargs -L 1 /bui
 
 RUN apt-get install --yes squashfs-tools
 
+ADD convert-legacy-slug.sh /bin/convert-legacy-slug.sh
 ADD bin/create-artifact /bin/create-artifact
 ADD builder/build.sh /builder/
 ADD builder/create-user.sh /builder/

--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -1,12 +1,15 @@
 FROM flynn/cedarish
 
-ADD builder/buildpacks.txt /tmp/builder/
-ADD builder/install-buildpack /tmp/builder/
+ADD builder/buildpacks.txt /builder/
+ADD builder/install-buildpack /builder/
 # Explicitly number the buildpacks directory based on the order of buildpacks.txt
-RUN nl -nrz /tmp/builder/buildpacks.txt | awk '{print $2 "\t" $1}' | xargs -L 1 /tmp/builder/install-buildpack /tmp/buildpacks && \
-    chown -R nobody:nogroup /tmp/buildpacks
+RUN nl -nrz /builder/buildpacks.txt | awk '{print $2 "\t" $1}' | xargs -L 1 /builder/install-buildpack /builder/buildpacks
 
-ADD builder/build.sh /tmp/builder/
+RUN apt-get install --yes squashfs-tools
 
-ENTRYPOINT ["/tmp/builder/build.sh"]
+ADD bin/create-artifact /bin/create-artifact
+ADD builder/build.sh /builder/
+ADD builder/create-user.sh /builder/
+
+ENTRYPOINT ["/builder/build.sh"]
 CMD []

--- a/slugbuilder/Tupfile
+++ b/slugbuilder/Tupfile
@@ -1,2 +1,3 @@
 include_rules
-: $(ROOT)/util/cedarish/<image> |> !image-cedarish |>
+: |> !go ./artifact |> bin/create-artifact
+: bin/create-artifact $(ROOT)/util/cedarish/<image> |> !image-cedarish |>

--- a/slugbuilder/artifact/main.go
+++ b/slugbuilder/artifact/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/docker/go-units"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	hh "github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/typeconv"
+)
+
+func main() {
+	dir := flag.String("dir", "", "slug parent directory")
+	uid := flag.Int("uid", -1, "UID")
+	gid := flag.Int("gid", -1, "GID")
+	flag.Parse()
+
+	if *dir == "" {
+		fmt.Fprintf(os.Stderr, "missing --dir")
+		os.Exit(1)
+	}
+	if *uid < 0 {
+		fmt.Fprintf(os.Stderr, "missing --uid")
+		os.Exit(1)
+	}
+	if *gid < 0 {
+		fmt.Fprintf(os.Stderr, "missing --gid")
+		os.Exit(1)
+	}
+
+	if err := run(*dir, *uid, *gid); err != nil {
+		log.Fatalln("ERROR:", "could not create slug image:", err)
+	}
+}
+
+func run(dir string, uid, gid int) error {
+	client, err := controller.NewClient("", os.Getenv("CONTROLLER_KEY"))
+	if err != nil {
+		return err
+	}
+
+	// create a squashfs layer
+	layer, err := ioutil.TempFile("", "squashfs-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(layer.Name())
+	defer layer.Close()
+
+	if out, err := exec.Command("mksquashfs", dir, layer.Name(), "-noappend").CombinedOutput(); err != nil {
+		return fmt.Errorf("mksquashfs error: %s: %s", err, out)
+	}
+
+	h := sha512.New512_256()
+	length, err := io.Copy(h, layer)
+	if err != nil {
+		return err
+	}
+	layerSHA := hex.EncodeToString(h.Sum(nil))
+
+	// upload the layer to the blobstore
+	if _, err := layer.Seek(0, os.SEEK_SET); err != nil {
+		return err
+	}
+	layerURL := fmt.Sprintf("http://blobstore.discoverd/slugs/layers/%s.squashfs", layerSHA)
+	if err := upload(layer, layerURL); err != nil {
+		return err
+	}
+
+	manifest := &ct.ImageManifest{
+		Type: ct.ImageManifestTypeV1,
+
+		// TODO: parse Procfile / .release and add to manifest.Entrypoints
+		Entrypoints: map[string]*ct.ImageEntrypoint{
+			"_default": {
+				Env: map[string]string{
+					"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+					"TERM": "xterm",
+					"HOME": "/app",
+				},
+				WorkingDir: "/app",
+				Args:       []string{"/runner/init", "bash"},
+				Uid:        typeconv.Uint32Ptr(uint32(uid)),
+				Gid:        typeconv.Uint32Ptr(uint32(gid)),
+			},
+		},
+
+		Rootfs: []*ct.ImageRootfs{{
+			Platform: ct.DefaultImagePlatform,
+			Layers: []*ct.ImageLayer{{
+				ID:     layerSHA,
+				Type:   ct.ImageLayerTypeSquashfs,
+				Length: length,
+				Hashes: map[string]string{"sha512_256": layerSHA},
+			}},
+		}},
+	}
+
+	rawManifest := manifest.RawManifest()
+	manifestURL := fmt.Sprintf("http://blobstore.discoverd/slugs/images/%s.json", manifest.ID())
+	if err := upload(bytes.NewReader(rawManifest), manifestURL); err != nil {
+		return err
+	}
+
+	artifact := &ct.Artifact{
+		ID:   os.Getenv("SLUG_IMAGE_ID"),
+		Type: ct.ArtifactTypeFlynn,
+		URI:  manifestURL,
+		Meta: map[string]string{
+			"blobstore": "true",
+		},
+		RawManifest:      rawManifest,
+		Hashes:           manifest.Hashes(),
+		LayerURLTemplate: "http://blobstore.discoverd/slugs/layers/{id}.squashfs",
+	}
+
+	// create artifact
+	if err := client.CreateArtifact(artifact); err != nil {
+		return err
+	}
+
+	fmt.Printf("-----> Compiled slug size is %s\n", units.BytesSize(float64(length)))
+	return nil
+}
+
+func upload(data io.Reader, url string) error {
+	req, err := http.NewRequest("PUT", url, data)
+	if err != nil {
+		return err
+	}
+	res, err := hh.RetryClient.Do(req)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status: %s", res.Status)
+	}
+	return nil
+}

--- a/slugbuilder/artifact/main.go
+++ b/slugbuilder/artifact/main.go
@@ -122,6 +122,7 @@ func run(dir string, uid, gid int) error {
 		},
 		RawManifest:      rawManifest,
 		Hashes:           manifest.Hashes(),
+		Size:             int64(len(rawManifest)),
 		LayerURLTemplate: "http://blobstore.discoverd/slugs/layers/{id}.squashfs",
 	}
 

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -1,55 +1,44 @@
 #!/bin/bash
 set -eo pipefail
 
-if [[ "$1" == "-" ]]; then
-  slug_file="$1"
-else
-  slug_file=/tmp/slug.tgz
-  if [[ "$1" ]]; then
-    put_url="$1"
-  fi
-fi
+export TMPDIR="${TMPDIR:-"/tmp"}"
 
 app_dir=/app
-env_dir=/tmp/env
-build_root=/tmp/build
-cache_root=/tmp/cache
-buildpack_root=/tmp/buildpacks
+env_dir="${TMPDIR}/env"
+build_root="${TMPDIR}/build"
+build_dir="${build_root}/app"
+cache_root="${TMPDIR}/cache"
+buildpack_root="/builder/buildpacks"
 env_cookie=.ENV_DIR_bdca46b87df0537eaefe79bb632d37709ff1df18
 
 mkdir -p ${app_dir}
 mkdir -p ${cache_root}
 mkdir -p ${buildpack_root}
-mkdir -p ${build_root}/.profile.d
+mkdir -p ${build_dir}/.profile.d
 
-output_redirect() {
-  if [[ "${slug_file}" == "-" ]]; then
-    cat - 1>&2
-  else
-    cat -
-  fi
-}
+# create the "flynn" user
+source "/builder/create-user.sh"
 
 echo_title() {
-  echo $'\e[1G----->' $* | output_redirect
+  echo $'\e[1G----->' $*
 }
 
 echo_normal() {
-  echo $'\e[1G      ' $* | output_redirect
+  echo $'\e[1G      ' $*
 }
 
 ensure_indent() {
   while read line; do
     if [[ "${line}" == --* ]]; then
-      echo $'\e[1G'${line} | output_redirect
+      echo $'\e[1G'${line}
     else
-      echo $'\e[1G      ' "${line}" | output_redirect
+      echo $'\e[1G      ' "${line}"
     fi
   done
 }
 
 run_unprivileged() {
-  setuidgid nobody $@
+  setuidgid "${USER}" $@
 }
 
 # run curl silently and retry upto 3 times
@@ -70,7 +59,7 @@ prune_slugignore() {
   # read slugignore into array
   local globs=()
   local paths=()
-  readarray -t globs < "${build_root}/.slugignore"
+  readarray -t globs < "${build_dir}/.slugignore"
   # for line in slugignore
   for glob in ${globs[@]}; do
     # strip whitespace
@@ -82,7 +71,7 @@ prune_slugignore() {
     # remove leading slash(es)
     glob="${glob#"${glob%%[!"/"]*}"}"
     # append to build root and add to array of paths to remove
-    paths=("${paths[@]}" ${build_root}/${glob})
+    paths=("${paths[@]}" ${build_dir}/${glob})
   done
   echo_title "Deleting ${#paths[@]} files matching .slugignore patterns."
   rm -rf ${paths[@]}
@@ -97,9 +86,9 @@ cat | tar -xm
 
 if [[ -f "${env_cookie}" ]]; then
   rm "${env_cookie}"
-  mv app env /tmp
-  rsync -aq /tmp/app/ .
-  rm -rf /tmp/app
+  mv app env "${TMPDIR}"
+  rsync -aq "${TMPDIR}/app/" .
+  rm -rf "${TMPDIR}/app"
   envdir="true"
 fi
 
@@ -109,14 +98,17 @@ fi
 
 # In heroku, there are two separate directories, and some
 # buildpacks expect that.
-cp -r . ${build_root}
-chown -R nobody:nogroup ${app_dir} ${build_root} ${cache_root}
+cp -r . ${build_dir}
+chown -R "${USER}:${USER}" \
+  "${TMPDIR}" \
+  "${app_dir}" \
+  "${build_dir}" \
+  "${cache_root}"
 
 ## Buildpack fixes
 
 export APP_DIR="${app_dir}"
 export HOME="${app_dir}"
-usermod --home $HOME nobody
 export REQUEST_ID="flynn-build"
 export STACK=cedar-14
 export CF_STACK=cflinuxfs2
@@ -126,7 +118,7 @@ if [[ -n "${SSH_CLIENT_KEY}" ]]; then
   mkdir -p ${HOME}/.ssh
   file="${HOME}/.ssh/id_rsa"
   echo "${SSH_CLIENT_KEY}" > ${file}
-  chown -R nobody:nogroup ${HOME}/.ssh
+  chown -R "${USER}:${USER}" ${HOME}/.ssh
   chmod 600 ${file}
   unset SSH_CLIENT_KEY
 fi
@@ -136,7 +128,7 @@ if [[ -n "${SSH_CLIENT_HOSTS}" ]]; then
   mkdir -p ${HOME}/.ssh
   file="${HOME}/.ssh/known_hosts"
   echo "${SSH_CLIENT_HOSTS}" > ${file}
-  chown -R nobody:nogroup ${HOME}/.ssh
+  chown -R "${USER}:${USER}" ${HOME}/.ssh
   chmod 600 ${file}
   unset SSH_CLIENT_HOSTS
 fi
@@ -149,7 +141,7 @@ export CURL_CONNECT_TIMEOUT=30
 export CURL_TIMEOUT=600
 
 # Remove files matched by .slugignore
-if [[ -f "${build_root}/.slugignore" ]]; then
+if [[ -f "${build_dir}/.slugignore" ]]; then
   prune_slugignore
 fi
 
@@ -164,7 +156,7 @@ if [[ -n "${BUILDPACK_URL}" ]]; then
 
   buildpack="${buildpack_root}/custom*"
   rm -rf "${buildpack}"
-  run_unprivileged /tmp/builder/install-buildpack \
+  run_unprivileged "/builder/install-buildpack" \
     "${buildpack_root}" \
     "${BUILDPACK_URL}" \
     custom \
@@ -172,10 +164,10 @@ if [[ -n "${BUILDPACK_URL}" ]]; then
     &> /dev/null
   buildpacks=($buildpack)
   selected_buildpack=${buildpack[0]}
-  buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_root}")
+  buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_dir}")
 else
   for buildpack in "${buildpacks[@]}"; do
-    buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_root}") \
+    buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_dir}") \
       && selected_buildpack="${buildpack}" \
       && break
   done
@@ -191,55 +183,50 @@ fi
 ## Buildpack compile
 if [[ -n "${envdir}" ]]; then
   run_unprivileged ${selected_buildpack}/bin/compile \
-    "${build_root}" \
+    "${build_dir}" \
     "${cache_root}" \
     "${env_dir}" \
     | ensure_indent
 else
   run_unprivileged ${selected_buildpack}/bin/compile \
-    "${build_root}" \
+    "${build_dir}" \
     "${cache_root}" \
     | ensure_indent
 fi
 
 run_unprivileged ${selected_buildpack}/bin/release \
-  "${build_root}" \
+  "${build_dir}" \
   "${cache_root}" \
-  > ${build_root}/.release
+  > ${build_dir}/.release
 
 ## Display process types
 
 echo_title "Discovering process types"
-if [[ -f "${build_root}/Procfile" ]]; then
-  types=$(ruby -r yaml -e "puts YAML.load_file('${build_root}/Procfile').keys.join(', ')")
+if [[ -f "${build_dir}/Procfile" ]]; then
+  types=$(ruby -r yaml -e "puts YAML.load_file('${build_dir}/Procfile').keys.join(', ')")
   echo_normal "Procfile declares types -> ${types}"
 fi
 default_types=""
-if [[ -s "${build_root}/.release" ]]; then
-  default_types=$(ruby -r yaml -e "puts (YAML.load_file('${build_root}/.release') || {}).fetch('default_process_types', {}).keys.join(', ')")
+if [[ -s "${build_dir}/.release" ]]; then
+  default_types=$(ruby -r yaml -e "puts (YAML.load_file('${build_dir}/.release') || {}).fetch('default_process_types', {}).keys.join(', ')")
   if [[ -n "${default_types}" ]]; then
     echo_normal "Default process types for ${buildpack_name} -> ${default_types}"
   fi
 fi
 
+# ensure all app files are owned by USER
+chown -R "${USER}:${USER}" "${build_dir}"
+
+# import user information
+mkdir -p "${build_root}/etc"
+cp "/etc/passwd" "${build_root}/etc/passwd"
+cp "/etc/group" "${build_root}/etc/group"
 
 ## Produce slug
-tar \
-  --exclude='./.git' \
-  --use-compress-program=pigz \
-  -C ${build_root} \
-  -cf ${slug_file} \
-  . \
-  | cat
-
-if [[ "${slug_file}" != "-" ]]; then
-  slug_size=$(du -Sh "${slug_file}" | cut -f1)
-  echo_title "Compiled slug size is ${slug_size}"
-
-  if [[ ${put_url} ]]; then
-    curl -0 -o "$(mktemp)" -X PUT -T ${slug_file} "${put_url}"
-  fi
-fi
+/bin/create-artifact \
+  --dir "${build_root}" \
+  --uid "${USER_UID}" \
+  --gid "${USER_GID}"
 
 if [[ -n "${BUILD_CACHE_URL}" ]]; then
   tar \

--- a/slugbuilder/builder/create-user.sh
+++ b/slugbuilder/builder/create-user.sh
@@ -1,0 +1,15 @@
+# create a user with a well known name / uid / gid
+export USER="flynn"
+export USER_UID="5000"
+export USER_GID="5000"
+
+groupadd \
+  --gid "${USER_GID}" \
+  "${USER}"
+
+useradd \
+  --uid     "${USER_UID}" \
+  --gid     "${USER_GID}" \
+  --comment "Flynn slug user" \
+  --home    "/app" \
+  "${USER}"

--- a/slugbuilder/convert-legacy-slug.sh
+++ b/slugbuilder/convert-legacy-slug.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# A script to convert a legacy slug tarball to a Flynn squashfs image
+
+# exit on failure
+set -eo pipefail
+
+# create a tmp dir
+tmp="$(mktemp --directory)"
+trap "rm -rf ${tmp}" EXIT
+
+# extract the slug tarball from stdin into an "app" directory
+mkdir "${tmp}/app"
+cat | tar xz -C "${tmp}/app"
+
+# create the "flynn" user
+source "/builder/create-user.sh"
+
+# update file ownership
+chown -R "${USER_UID}:${USER_GID}" "${tmp}/app"
+
+# import user information
+mkdir -p "${tmp}/etc"
+cp "/etc/passwd" "${tmp}/etc/passwd"
+cp "/etc/group" "${tmp}/etc/group"
+
+# ensure the root dir can be searched
+chmod 755 "${tmp}"
+
+# create the artifact
+/bin/create-artifact \
+  --dir "${tmp}" \
+  --uid "${USER_UID}" \
+  --gid "${USER_GID}"

--- a/slugrunner/runner/init
+++ b/slugrunner/runner/init
@@ -3,23 +3,6 @@
 
 set -eo pipefail
 
-export HOME=/app
-mkdir -p "${HOME}"
-
-if [[ -n $(ls -A "${HOME}") ]]; then
-  true
-elif [[ -s "/artifacts/slug.tgz" ]]; then
-  tar xzf "/artifacts/slug.tgz" -C "${HOME}"
-elif ! [[ -z "${SLUG_URL}" ]]; then
-  curl --silent --location --noproxy "discoverd" --retry 5 --fail "${SLUG_URL}" | tar -xzC "${HOME}"
-  unset SLUG_URL
-fi
-cd "${HOME}"
-
-## Set home to $HOME
-
-usermod --home $HOME nobody
-
 ## Load profile.d, profile and release config
 
 shopt -s nullglob
@@ -56,10 +39,6 @@ case "$1" in
     ;;
 esac
 
-# allow the user to access /dev/std{out,err}
-chown nobody:nogroup /dev/std{out,err}
-
 ## Run!
 
-chown -R nobody:nogroup .
-exec setuidgid nobody bash -c "${command}"
+exec bash -c "${command}"

--- a/test/test_blobstore.go
+++ b/test/test_blobstore.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
+	ct "github.com/flynn/flynn/controller/types"
 	c "github.com/flynn/go-check"
 )
 
@@ -74,11 +75,13 @@ func (s *BlobstoreSuite) testBlobstoreBackend(t *c.C, name, redirectPattern stri
 	// get slug artifact details
 	release, err := s.controllerClient(t).GetAppRelease("blobstore-backend-test-" + name)
 	t.Assert(err, c.IsNil)
-	artifact, err := s.controllerClient(t).GetArtifact(release.FileArtifactIDs()[0])
+	artifact, err := s.controllerClient(t).GetArtifact(release.ArtifactIDs[1])
 	t.Assert(err, c.IsNil)
+	t.Assert(artifact.Type, c.Equals, ct.ArtifactTypeFlynn)
 
 	// migrate slug to external backend
-	u, err := url.Parse(artifact.URI)
+	layer := artifact.Manifest().Rootfs[0].Layers[0]
+	u, err := url.Parse(artifact.LayerURL(layer))
 	t.Assert(err, c.IsNil)
 	migration := flynn(t, "/", "-a", "blobstore", "run", "-e", "/bin/flynn-blobstore", "migrate", "--delete", "--prefix", u.Path)
 	t.Assert(migration, Succeeds)
@@ -89,7 +92,7 @@ func (s *BlobstoreSuite) testBlobstoreBackend(t *c.C, name, redirectPattern stri
 	noRedirectsClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error { return errors.New("no redirects") },
 	}
-	res, err := noRedirectsClient.Get(artifact.URI)
+	res, err := noRedirectsClient.Get(u.String())
 	if res == nil {
 		t.Fatal(err)
 	}

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -1214,6 +1214,7 @@ func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
 			Meta:             map[string]string{"blobstore": "true"},
 			RawManifest:      data,
 			Hashes:           manifest.Hashes(),
+			Size:             int64(len(data)),
 			LayerURLTemplate: "http://blobstore.discoverd/layer/{id}.squashfs",
 		}
 		t.Assert(client.CreateArtifact(artifact), c.IsNil)

--- a/util/release/manifest.go
+++ b/util/release/manifest.go
@@ -63,6 +63,7 @@ func interpolateManifest(imageDir, imageRepository string, src io.Reader, dest i
 			artifact := &ct.Artifact{
 				Type:        ct.ArtifactTypeFlynn,
 				RawManifest: manifest,
+				Size:        int64(len(manifest)),
 				Meta:        map[string]string{"flynn.component": name},
 			}
 			artifact.URI = fmt.Sprintf("%s?target=/images/%s.json", imageRepository, artifact.Manifest().ID())


### PR DESCRIPTION
This includes the following changes:

* Add `Uid` / `Gid` to `ImageEntrypoint` which controls the User / Group used for the job process
* Build slugs as Flynn images containing `/app` and `/etc/{passwd,group}` with a `flynn` user
* Convert Docker images to Flynn images when pushed to `docker-receive`
* Update app import / export to support Flynn images
* Delete images from `docker-receive` based apps when deleting releases