### PR TITLE
host/cli: Fix volume garbage collection

### DIFF
--- a/host/cli/volume.go
+++ b/host/cli/volume.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/go-docopt"
@@ -69,7 +70,9 @@ func runVolumeGarbageCollection(args *docopt.Args, client *cluster.Client) error
 		}
 		for _, j := range jobs {
 			for _, vb := range j.Job.Config.Volumes {
-				attached[vb.VolumeID] = struct{}{}
+				if j.Status == host.StatusRunning || j.Status == host.StatusStarting {
+					attached[vb.VolumeID] = struct{}{}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Volumes from stopped jobs are still considered attached.
This fixes volume gc so that unless the volume is attached to a running
or starting job it will be collected.