### PR TITLE
gitreceive: Persist slugbuilder limit across deploys

### DIFF
--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -221,6 +221,9 @@ Options:
 		}
 		procs[t] = proc
 	}
+	if sb, ok := prevRelease.Processes["slugbuilder"]; ok {
+		procs["slugbuilder"] = sb
+	}
 	release.Processes = procs
 
 	if err := client.CreateRelease(release); err != nil {

--- a/test/test_gitreceive.go
+++ b/test/test_gitreceive.go
@@ -55,6 +55,10 @@ func (s *GitreceiveSuite) TestSlugbuilderLimit(t *c.C) {
 	t.Assert(push, Succeeds)
 	t.Assert(push, OutputContains, "524288000")
 
+	limit := r.flynn("limit")
+	t.Assert(limit, Succeeds)
+	t.Assert(limit.Output, Matches, "slugbuilder:.+memory=500MB")
+
 	t.Assert(r.flynn("-a", "gitreceive", "env", "unset", "SLUGBUILDER_DEFAULT_MEMORY_LIMIT"), Succeeds)
 }
 


### PR DESCRIPTION
Before this patch, doing a `git push` deploy would remove the slugbuilder process type from the release, removing any custom per-app limits.