### PR TITLE
cli: Add --jobs to commands that invoke pg_restore

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -56,6 +56,7 @@ Options:
 	-n, --name=<name>  name of app to create (defaults to exported app name)
 	-q, --quiet        don't print progress
 	-r, --routes       import routes
+	-j, --jobs=<jobs>  number of pg_restore jobs to use [default: 4]
 `)
 }
 
@@ -284,6 +285,10 @@ func runExport(args *docopt.Args, client controller.Client) error {
 }
 
 func runImport(args *docopt.Args, client controller.Client) error {
+	jobs, err := strconv.Atoi(args.String["--jobs"])
+	if err != nil {
+		return err
+	}
 	var src io.Reader = os.Stdin
 	if filename := args.String["--file"]; filename != "" {
 		f, err := os.Open(filename)
@@ -473,7 +478,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			config.Stdin = bar.NewProxyReader(config.Stdin)
 		}
 		config.Exit = false
-		if err := pgRestore(client, config); err != nil {
+		if err := pgRestore(client, config, jobs); err != nil {
 			return fmt.Errorf("error restoring postgres database: %s", err)
 		}
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -302,3 +302,15 @@ func listRec(w io.Writer, a ...interface{}) {
 		}
 	}
 }
+
+func compatCheck(client controller.Client, minVersion string, message string) error {
+	status, err := client.Status()
+	if err != nil {
+		return err
+	}
+	v := version.Parse(status.Version)
+	if v.Before(version.Parse(minVersion)) && !v.Dev {
+		return fmt.Errorf(message, minVersion)
+	}
+	return nil
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -80,6 +80,7 @@ type runConfig struct {
 	Stderr     io.Writer
 	DisableLog bool
 	Exit       bool
+	Data       bool
 }
 
 func runJob(client controller.Client, config runConfig) error {
@@ -91,6 +92,7 @@ func runJob(client controller.Client, config runConfig) error {
 		Env:        config.Env,
 		ReleaseEnv: config.ReleaseEnv,
 		DisableLog: config.DisableLog,
+		Data:       config.Data,
 	}
 
 	// ensure slug apps from old clusters use /runner/init

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
 	"github.com/flynn/flynn/pkg/pinned"
+	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/stream"
 	"github.com/flynn/flynn/router/types"
 )
@@ -89,6 +90,7 @@ type Client interface {
 	GetBackupMeta() (*ct.ClusterBackup, error)
 	DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error)
 	ScheduleAppGarbageCollection(appID string) error
+	Status() (*status.Status, error)
 }
 
 type Config struct {

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -18,6 +18,7 @@ import (
 	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/httpclient"
 	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/stream"
 	"github.com/flynn/flynn/router/types"
 )
@@ -745,6 +746,18 @@ func (c *Client) DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, er
 // ScheduleAppGarbageCollection schedules a garbage collection cycle for the app
 func (c *Client) ScheduleAppGarbageCollection(appID string) error {
 	return c.Post(fmt.Sprintf("/apps/%s/gc", appID), nil, nil)
+}
+
+// Status gets the controller status
+func (c *Client) Status() (*status.Status, error) {
+	type statusResponse struct {
+		Data status.Status `json:"data"`
+	}
+	s := &statusResponse{}
+	if err := c.Get(status.Path, s); err != nil {
+		return nil, err
+	}
+	return &s.Data, nil
 }
 
 func (c *Client) Put(path string, in, out interface{}) error {

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flynn/flynn/controller/schema"
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
@@ -305,6 +306,14 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 		job.FileArtifacts = make([]*host.Artifact, len(release.FileArtifactIDs()))
 		for i, id := range release.FileArtifactIDs() {
 			job.FileArtifacts[i] = artifacts[id].HostArtifact()
+		}
+	}
+
+	// provision data volume if required
+	if newJob.Data {
+		if err := utils.ProvisionVolume(client, job); err != nil {
+			respondWithError(w, err)
+			return
 		}
 	}
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -255,6 +255,7 @@ type NewJob struct {
 	Lines      int                `json:"tty_lines,omitempty"`
 	DisableLog bool               `json:"disable_log,omitempty"`
 	Resources  resource.Resources `json:"resources,omitempty"`
+	Data       bool               `json:"data,omitempty"`
 
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -54,6 +54,9 @@
     },
     "resources": {
       "$ref": "/schema/controller/common#/definitions/resources"
+    },
+    "data": {
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
Allows altering the concurrency of the restore process.
This change also changes the default behaviour to use 4 jobs.