### PR TITLE
util/packer: Delete ephemeral Packer SSH public key

### DIFF
--- a/util/packer/ubuntu-14.04/scripts/install.sh
+++ b/util/packer/ubuntu-14.04/scripts/install.sh
@@ -36,6 +36,7 @@ main() {
   install_flynn
   disable_docker_start
   apt_cleanup
+  packer_cleanup
 
   if vagrant_build; then
     net_cleanup
@@ -221,6 +222,10 @@ apt_cleanup() {
     | egrep ${kernel_pkg} \
     | egrep -v "${cur_kernel}|${meta_pkg}" \
     | awk '{print $2}')
+}
+
+packer_cleanup() {
+  rm -f /home/ubuntu/.ssh/authorized_keys
 }
 
 net_cleanup() {


### PR DESCRIPTION
This key is generated by EC2 during the build process, and only lives in memory during the Packer build process. It never touches the disk and is not saved anywhere.

https://github.com/mitchellh/packer/blob/ae2b31c4ec2e677dce833371b02cdbf48adcf1cd/builder/amazon/common/step_key_pair.go