### PR TITLE
bootstrap: Wait for Sirenia databases to become read/write

### DIFF
--- a/bootstrap/sirenia_wait_action.go
+++ b/bootstrap/sirenia_wait_action.go
@@ -1,0 +1,41 @@
+package bootstrap
+
+import (
+	"time"
+
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/attempt"
+	"github.com/flynn/flynn/pkg/sirenia/client"
+)
+
+type SireniaWaitAction struct {
+	Service string `json:"service"`
+}
+
+func init() {
+	Register("sirenia-wait", &SireniaWaitAction{})
+}
+
+func (a *SireniaWaitAction) Run(s *State) error {
+	// use discoverd client to lookup leader
+	d, err := s.DiscoverdClient()
+	if err != nil {
+		return err
+	}
+
+	var leader *discoverd.Instance
+	err = attempt.Strategy{
+		Min:   5,
+		Total: 5 * time.Minute,
+		Delay: 500 * time.Millisecond,
+	}.Run(func() error {
+		leader, err = d.Service(a.Service).Leader()
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// connect using sirenia client and wait until database reports read/write
+	return client.NewClient(leader.Addr).WaitForReadWrite(5 * time.Minute)
+}

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -373,7 +373,7 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'flannel');
 		`, network))
 	}
 
-	// start discoverd/flannel/postgres/mariadb
+	// start discoverd/flannel/postgres
 	cfg.Singleton = data.Postgres.Release.Env["SINGLETON"] == "true"
 	systemSteps := bootstrap.Manifest{
 		step("discoverd", "run-app", &bootstrap.RunAppAction{
@@ -386,8 +386,8 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'flannel');
 		step("postgres", "run-app", &bootstrap.RunAppAction{
 			ExpandedFormation: data.Postgres,
 		}),
-		step("postgres-wait", "wait", &bootstrap.WaitAction{
-			URL: "http://postgres-api.discoverd/ping",
+		step("postgres-wait", "sirenia-wait", &bootstrap.SireniaWaitAction{
+			Service: "postgres",
 		}),
 	}
 
@@ -462,8 +462,8 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 			step("mariadb", "run-app", &bootstrap.RunAppAction{
 				ExpandedFormation: data.MariaDB,
 			}),
-			step("mariadb-wait", "wait", &bootstrap.WaitAction{
-				URL: "http://mariadb-api.discoverd/ping",
+			step("mariadb-wait", "sirenia-wait", &bootstrap.SireniaWaitAction{
+				Service: "mariadb",
 			}),
 		}.RunWithState(ch, state)
 		if err != nil {
@@ -502,8 +502,8 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 			step("mongodb", "run-app", &bootstrap.RunAppAction{
 				ExpandedFormation: data.MongoDB,
 			}),
-			step("mongodb-wait", "wait", &bootstrap.WaitAction{
-				URL: "http://mongodb-api.discoverd/ping",
+			step("mongodb-wait", "sirenia-wait", &bootstrap.SireniaWaitAction{
+				Service: "mongodb",
 			}),
 		}.RunWithState(ch, state)
 		if err != nil {


### PR DESCRIPTION
This fixes a race condition where attempting to restore the MariaDB database would deadlock with the initial replication backup transfer. However it's also correct to use this for Postgres and MongoDB so updated both of those to use this new wait step too.

Fixes #3527