### PR TITLE
appliance/mariadb: Update the Percona APT signing key

### DIFF
--- a/appliance/mariadb/Dockerfile
+++ b/appliance/mariadb/Dockerfile
@@ -4,9 +4,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update &&\
     apt-get install -y software-properties-common apt-transport-https &&\
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db &&\
+    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1BB943DB 8507EFA5 &&\
     add-apt-repository 'deb http://mirrors.syringanetworks.net/mariadb/repo/10.1/ubuntu trusty main' &&\
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1C4CBDCDCD2EFD2A &&\
     add-apt-repository 'deb http://repo.percona.com/apt trusty main' &&\
     apt-get update &&\
     apt-get install -y sudo &&\


### PR DESCRIPTION
See this article for details on the key rotation.
https://www.percona.com/blog/2016/10/13/new-signing-key-for-percona-debian-and-ubuntu-packages/