### PR TITLE
scheduler: Treat "stopping" jobs as stopped

### DIFF
--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -128,7 +128,7 @@ func (j *Job) IsRunning() bool {
 }
 
 func (j *Job) IsInFormation(key utils.FormationKey) bool {
-	return j.State != JobStateStopped && j.Formation != nil && j.Formation.key() == key
+	return j.State != JobStateStopped && j.State != JobStateStopping && j.Formation != nil && j.Formation.key() == key
 }
 
 func (j *Job) IsInApp(appID string) bool {


### PR DESCRIPTION
Before this change, `findJobToStop` would continually choose the same `stopping` job when scaling down multiple jobs, causing the scheduler to thrash, trying to stop that job multiple times before then choosing another job to stop once that one has actually stopped.

`stopping` jobs are now considered as stopped, and `SyncJobs` has been updated to make sure that any jobs in the `stopping` state get stopped.

This also fixes #2774.