### PR TITLE
appliance/postgres: Grant user privileges instead of owner

### DIFF
--- a/appliance/postgresql/cmd/flynn-postgres-api/main.go
+++ b/appliance/postgresql/cmd/flynn-postgres-api/main.go
@@ -78,7 +78,13 @@ func (p *pgAPI) createDatabase(ctx context.Context, w http.ResponseWriter, req *
 		httphelper.Error(w, err)
 		return
 	}
-	if err := p.db.Exec(fmt.Sprintf(`CREATE DATABASE "%s" WITH OWNER = "%s"`, database, username)); err != nil {
+	if err := p.db.Exec(fmt.Sprintf(`CREATE DATABASE "%s"`, database)); err != nil {
+		p.db.Exec(fmt.Sprintf(`DROP USER "%s"`, username))
+		httphelper.Error(w, err)
+		return
+	}
+	if err := p.db.Exec(fmt.Sprintf(`GRANT ALL ON DATABASE "%s" TO "%s"`, database, username)); err != nil {
+		p.db.Exec(fmt.Sprintf(`DROP DATABASE "%s"`, database))
 		p.db.Exec(fmt.Sprintf(`DROP USER "%s"`, username))
 		httphelper.Error(w, err)
 		return


### PR DESCRIPTION
This mirrors what is done for MariaDB and avoids issues caused by the
user being able to run DROP, but not CREATE DATABASE.

Fixes #3537