### PR TITLE
host: Log OOM kills to the job's init log

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -675,7 +675,6 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		c.Destroy()
 		return err
 	}
-	// TODO: detach? an update will detach all container anyway
 	go process.Wait()
 
 	container.container = c

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -679,9 +679,6 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 
 	container.container = c
 
-	// TODO: still necessary?
-	l.State.SetContainerID(job.ID, job.ID)
-
 	go container.watch(nil, nil)
 
 	log.Info("job started")

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -201,17 +201,16 @@ type Event struct {
 }
 
 type ActiveJob struct {
-	Job         *Job      `json:"job,omitempty"`
-	HostID      string    `json:"host_id,omitempty"`
-	ContainerID string    `json:"container_id,omitempty"`
-	InternalIP  string    `json:"internal_ip,omitempty"`
-	ForceStop   bool      `json:"force_stop,omitempty"`
-	Status      JobStatus `json:"status,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	StartedAt   time.Time `json:"started_at,omitempty"`
-	EndedAt     time.Time `json:"ended_at,omitempty"`
-	ExitStatus  *int      `json:"exit_status,omitempty"`
-	Error       *string   `json:"error,omitempty"`
+	Job        *Job      `json:"job,omitempty"`
+	HostID     string    `json:"host_id,omitempty"`
+	InternalIP string    `json:"internal_ip,omitempty"`
+	ForceStop  bool      `json:"force_stop,omitempty"`
+	Status     JobStatus `json:"status,omitempty"`
+	CreatedAt  time.Time `json:"created_at,omitempty"`
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	EndedAt    time.Time `json:"ended_at,omitempty"`
+	ExitStatus *int      `json:"exit_status,omitempty"`
+	Error      *string   `json:"error,omitempty"`
 }
 
 func (j *ActiveJob) Dup() *ActiveJob {

--- a/logaggregator/api.go
+++ b/logaggregator/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flynn/flynn/logaggregator/client"
 	"github.com/flynn/flynn/logaggregator/snapshot"
 	logagg "github.com/flynn/flynn/logaggregator/types"
+	"github.com/flynn/flynn/logaggregator/utils"
 	"github.com/flynn/flynn/pkg/ctxhelper"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/status"
@@ -148,7 +149,7 @@ func NewMessageFromSyslog(m *rfc5424.Message) client.Message {
 		ProcessType: string(processType),
 		// TODO(bgentry): source is always "app" for now, could be router in future
 		Source:    "app",
-		Stream:    streamType(m.MsgID),
+		Stream:    utils.StreamType(m),
 		Timestamp: m.Timestamp,
 	}
 }
@@ -164,17 +165,4 @@ func splitProcID(procID []byte) (processType, jobID []byte) {
 		jobID = split[1]
 	}
 	return
-}
-
-func streamType(msgID []byte) logagg.StreamType {
-	switch string(msgID) {
-	case "ID1":
-		return logagg.StreamTypeStdout
-	case "ID2":
-		return logagg.StreamTypeStderr
-	case "ID3":
-		return logagg.StreamTypeInit
-	default:
-		return logagg.StreamTypeUnknown
-	}
 }

--- a/logaggregator/filter.go
+++ b/logaggregator/filter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	logagg "github.com/flynn/flynn/logaggregator/types"
+	"github.com/flynn/flynn/logaggregator/utils"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 )
 
@@ -50,7 +51,7 @@ func filterStreamType(streams ...logagg.StreamType) filterFunc {
 		lookup[stream] = struct{}{}
 	}
 	return func(m *rfc5424.Message) bool {
-		_, ok := lookup[streamType(m.MsgID)]
+		_, ok := lookup[utils.StreamType(m)]
 		return ok
 	}
 }

--- a/logaggregator/server_test.go
+++ b/logaggregator/server_test.go
@@ -42,7 +42,7 @@ func (s *ServerTestSuite) TestServerDurability(c *C) {
 	for _, want := range appAMessages {
 		c.Assert(dec.Decode(&got), IsNil)
 		c.Assert(got.HostID, Equals, string(want.Hostname))
-		c.Assert(got.Stream, Equals, streamType(want.MsgID))
+		c.Assert(got.Stream, Equals, utils.StreamType(want))
 		c.Assert(got.Timestamp.Equal(want.Timestamp), Equals, true)
 
 		procType, jobID := splitProcID(want.ProcID)

--- a/logaggregator/types/types.go
+++ b/logaggregator/types/types.go
@@ -50,3 +50,11 @@ const (
 	StreamTypeInit    StreamType = "init"
 	StreamTypeUnknown StreamType = "unknown"
 )
+
+type MsgID string
+
+const (
+	MsgIDStdout MsgID = "ID1"
+	MsgIDStderr MsgID = "ID2"
+	MsgIDInit   MsgID = "ID3"
+)

--- a/logaggregator/utils/utils.go
+++ b/logaggregator/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/syslog/rfc5424"
 )
 
@@ -52,4 +53,17 @@ type HostCursor struct {
 
 func (c HostCursor) After(other HostCursor) bool {
 	return c.Time.After(other.Time) || (c.Time.Equal(other.Time) && c.Seq > other.Seq)
+}
+
+func StreamType(msg *rfc5424.Message) logagg.StreamType {
+	switch logagg.MsgID(msg.MsgID) {
+	case logagg.MsgIDStdout:
+		return logagg.StreamTypeStdout
+	case logagg.MsgIDStderr:
+		return logagg.StreamTypeStderr
+	case logagg.MsgIDInit:
+		return logagg.StreamTypeInit
+	default:
+		return logagg.StreamTypeUnknown
+	}
 }

--- a/test/apps/Dockerfile
+++ b/test/apps/Dockerfile
@@ -6,3 +6,4 @@ ADD bin/signal /bin/signal
 ADD bin/ish /bin/ish
 ADD bin/partial-logger /bin/partial-logger
 ADD bin/http-blocker /bin/http-blocker
+ADD bin/oom /bin/oom

--- a/test/apps/Tupfile
+++ b/test/apps/Tupfile
@@ -5,4 +5,5 @@ include_rules
 : |> !go ./ish |> bin/ish
 : |> !go ./partial-logger |> bin/partial-logger
 : |> !go ./http-blocker |> bin/http-blocker
+: |> !go ./oom |> bin/oom
 : bin/* |> docker build -t flynn/test-apps . |>

--- a/test/apps/oom/main.go
+++ b/test/apps/oom/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "bytes"
+
+func main() {
+	var buf bytes.Buffer
+	for {
+		buf.Write(make([]byte, 1024*1024))
+	}
+}


### PR DESCRIPTION
As well as logging the OOM notifications to the init log, I have introduced a `MsgID` type which encapsulates the "IDx" message IDs used in raw syslog messages, plus a cleanup of the unused `ActiveJob.ContainerID`.

Closes #3375.