### PR TITLE
Fix syntax for blobstore migrate command in production docs

### DIFF
--- a/docs/content/production.html.md
+++ b/docs/content/production.html.md
@@ -139,7 +139,7 @@ Finally, migrate the existing blobs from Postgres to S3 and remove them from
 Postgres:
 
 ```text
-flynn -a blobstore run /bin/flynn-blobstore migrate --delete
+flynn -a blobstore run /bin/flynn-blobstore-migrate --delete
 ```
 
 ### Google Cloud Storage

--- a/docs/content/production.html.md
+++ b/docs/content/production.html.md
@@ -139,6 +139,12 @@ Finally, migrate the existing blobs from Postgres to S3 and remove them from
 Postgres:
 
 ```text
+flynn -a blobstore run /bin/flynn-blobstore migrate --delete
+```
+
+Or if you're on a version of Flynn older than v20160924.0:
+
+```text
 flynn -a blobstore run /bin/flynn-blobstore-migrate --delete
 ```
 


### PR DESCRIPTION
Ran into this while migrating my blobs to s3. Was just missing the ```-```.