### PR TITLE
cli: Add mongodb to help message.

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -57,6 +57,7 @@ Commands:
 	route       manage routes
 	pg          manage postgres database
 	mysql       manage mysql database
+	mongodb     manage mongodb database
 	redis       manage redis database
 	provider    manage resource providers
 	docker      deploy Docker images to a Flynn cluster


### PR DESCRIPTION
While installing a test cluster tonight to try out the mongodb component, I noticed that the mongodb module is not mentioned by `flynn --help`.  This tiny PR adds that.  I looked through the CLI tests and didn't see anything explicitly testing the output of `--help`, but if I missed that, I'd be happy to update it.

```
vagrant@flynn:~/go/src/github.com/flynn/flynn$ flynn --help
usage: flynn [-a <app>] [-c <cluster>] <command> [<args>...]

Options:
	-a <app>
	-c <cluster>
	-h, --help

Commands:
	help        show usage for a specific command
	install     install flynn
	cluster     manage clusters
	create      create an app
	delete      delete an app
	apps        list apps
	info        show app information
	ps          list jobs
	kill        kill jobs
	log         get app log
	scale       change formation
	run         run a job
	env         manage env variables
	limit       manage resource limits
	meta        manage app metadata
	route       manage routes
	pg          manage postgres database
	mysql       manage mysql database
	mongodb     manage mongodb database
	redis       manage redis database
	provider    manage resource providers
	docker      deploy Docker images to a Flynn cluster
	remote      manage git remotes
	resource    provision a new resource
	release     manage app releases
	deployment  list deployments
	export      export app data
	import      create app from exported data
	version     show flynn version
```