### PR TITLE
cli: Don’t round-trip MySQL dumps through log tier

### DIFF
--- a/cli/mysql.go
+++ b/cli/mysql.go
@@ -83,7 +83,7 @@ func getMysqlRunConfig(client controller.Client, appName string, appRelease *ct.
 		App:        appName,
 		Release:    release.ID,
 		Env:        make(map[string]string),
-		DisableLog: false, // true,
+		DisableLog: true,
 		Exit:       true,
 	}
 


### PR DESCRIPTION
This ensures that dumps are not mangled by line splitting, and do not get stored in log files and buffers.

Closes #3573