### PR TITLE
controller: Delete data volumes when one-off jobs stop 

### DIFF
--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -111,7 +111,7 @@ func (a *RunAppAction) Run(s *State) error {
 			config := utils.JobConfig(a.ExpandedFormation, typ, host.ID(), "")
 			hostresource.SetDefaults(&config.Resources)
 			for _, vol := range a.ExpandedFormation.Release.Processes[typ].Volumes {
-				if err := utils.ProvisionVolume(&vol, host, config); err != nil {
+				if _, err := utils.ProvisionVolume(&vol, host, config); err != nil {
 					return err
 				}
 			}

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -312,7 +312,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 
 	// provision data volume if required
 	if newJob.Data {
-		vol := &ct.VolumeReq{Path: "/data"}
+		vol := &ct.VolumeReq{Path: "/data", DeleteOnStop: true}
 		if err := utils.ProvisionVolume(vol, client, job); err != nil {
 			respondWithError(w, err)
 			return

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -313,7 +313,7 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 	// provision data volume if required
 	if newJob.Data {
 		vol := &ct.VolumeReq{Path: "/data", DeleteOnStop: true}
-		if err := utils.ProvisionVolume(vol, client, job); err != nil {
+		if _, err := utils.ProvisionVolume(vol, client, job); err != nil {
 			respondWithError(w, err)
 			return
 		}

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1092,7 +1092,7 @@ outer:
 
 		for _, vol := range job.Volumes() {
 			log.Info("provisioning volume", "host.id", host.ID, "vol.path", vol.Path)
-			if err := utils.ProvisionVolume(&vol, host.client, config); err != nil {
+			if _, err := utils.ProvisionVolume(&vol, host.client, config); err != nil {
 				log.Error("error provisioning volume", "err", err)
 				continue outer
 			}

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -120,7 +120,8 @@ type Port struct {
 }
 
 type VolumeReq struct {
-	Path string `json:"path"`
+	Path         string `json:"path"`
+	DeleteOnStop bool   `json:"delete_on_stop"`
 }
 
 type Artifact struct {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -83,9 +83,10 @@ func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) error {
 		return err
 	}
 	job.Config.Volumes = []host.VolumeBinding{{
-		Target:    req.Path,
-		VolumeID:  vol.ID,
-		Writeable: true,
+		Target:       req.Path,
+		VolumeID:     vol.ID,
+		Writeable:    true,
+		DeleteOnStop: req.DeleteOnStop,
 	}}
 	return nil
 }

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -77,10 +77,10 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 	return job
 }
 
-func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) error {
+func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) (*volume.Info, error) {
 	vol, err := h.CreateVolume("default")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	job.Config.Volumes = []host.VolumeBinding{{
 		Target:       req.Path,
@@ -88,7 +88,7 @@ func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) error {
 		Writeable:    true,
 		DeleteOnStop: req.DeleteOnStop,
 	}}
-	return nil
+	return vol, nil
 }
 
 func JobMetaFromMetadata(metadata map[string]string) map[string]string {

--- a/host/fixer/sirenia.go
+++ b/host/fixer/sirenia.go
@@ -199,7 +199,7 @@ outer:
 		if syncJob == nil {
 			syncJob = primaryJob
 			vol := &ct.VolumeReq{Path: "/data"}
-			if err := utils.ProvisionVolume(vol, syncHost, syncJob); err != nil {
+			if _, err := utils.ProvisionVolume(vol, syncHost, syncJob); err != nil {
 				return fmt.Errorf("error creating volume on %s: %s", syncHost.ID(), err)
 			}
 		}

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -917,6 +917,7 @@ func (c *Container) cleanup() error {
 		}
 	}
 	log.Info("finished cleanup")
+	c.l.State.SendCleanupEvent(c.job.ID)
 	return nil
 }
 

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -908,6 +908,14 @@ func (c *Container) cleanup() error {
 	if !c.job.Config.HostNetwork && c.l.bridgeNet != nil {
 		c.l.ipalloc.ReleaseIP(c.l.bridgeNet, c.IP)
 	}
+	for _, v := range c.job.Config.Volumes {
+		if !v.DeleteOnStop {
+			continue
+		}
+		if err := c.l.VolManager.DestroyVolume(v.VolumeID); err != nil {
+			log.Error("error destroying volume", "vol.id", v.VolumeID, "err", err)
+		}
+	}
 	log.Info("finished cleanup")
 	return nil
 }

--- a/host/state.go
+++ b/host/state.go
@@ -491,7 +491,7 @@ func (s *State) RemoveListener(jobID string, ch chan host.Event) {
 	close(ch)
 }
 
-func (s *State) sendEvent(job *host.ActiveJob, event string) {
+func (s *State) sendEvent(job *host.ActiveJob, event host.JobEventType) {
 	j := job.Dup()
 	go func() {
 		s.listenMtx.RLock()

--- a/host/state.go
+++ b/host/state.go
@@ -491,6 +491,14 @@ func (s *State) RemoveListener(jobID string, ch chan host.Event) {
 	close(ch)
 }
 
+func (s *State) SendCleanupEvent(jobID string) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if job, ok := s.jobs[jobID]; ok {
+		s.sendEvent(job, host.JobEventCleanup)
+	}
+}
+
 func (s *State) sendEvent(job *host.ActiveJob, event host.JobEventType) {
 	j := job.Dup()
 	go func() {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -171,8 +171,9 @@ type VolumeBinding struct {
 	// Target defines the filesystem path inside the container where the volume will be mounted.
 	Target string `json:"target"`
 	// VolumeID can be thought of as the source path if this were a simple bind-mount.  It is resolved by a VolumeManager.
-	VolumeID  string `json:"volume"`
-	Writeable bool   `json:"writeable"`
+	VolumeID     string `json:"volume"`
+	Writeable    bool   `json:"writeable"`
+	DeleteOnStop bool   `json:"delete_on_stop"`
 }
 
 type Artifact struct {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -196,9 +196,9 @@ type Host struct {
 }
 
 type Event struct {
-	Event string     `json:"event,omitempty"`
-	JobID string     `json:"job_id,omitempty"`
-	Job   *ActiveJob `json:"job,omitempty"`
+	Event JobEventType `json:"event,omitempty"`
+	JobID string       `json:"job_id,omitempty"`
+	Job   *ActiveJob   `json:"job,omitempty"`
 }
 
 type ActiveJob struct {
@@ -302,11 +302,13 @@ type HostStatus struct {
 	Version   string            `json:"version"`
 }
 
+type JobEventType string
+
 const (
-	JobEventCreate string = "create"
-	JobEventStart  string = "start"
-	JobEventStop   string = "stop"
-	JobEventError  string = "error"
+	JobEventCreate JobEventType = "create"
+	JobEventStart  JobEventType = "start"
+	JobEventStop   JobEventType = "stop"
+	JobEventError  JobEventType = "error"
 )
 
 type ResourceCheck struct {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -305,10 +305,11 @@ type HostStatus struct {
 type JobEventType string
 
 const (
-	JobEventCreate JobEventType = "create"
-	JobEventStart  JobEventType = "start"
-	JobEventStop   JobEventType = "stop"
-	JobEventError  JobEventType = "error"
+	JobEventCreate  JobEventType = "create"
+	JobEventStart   JobEventType = "start"
+	JobEventStop    JobEventType = "stop"
+	JobEventError   JobEventType = "error"
+	JobEventCleanup JobEventType = "cleanup"
 )
 
 type ResourceCheck struct {

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -140,6 +140,12 @@ func (c *Host) CreateVolume(providerId string) (*volume.Info, error) {
 	return &res, err
 }
 
+// GetVolume gets a volume by ID
+func (c *Host) GetVolume(volumeID string) (*volume.Info, error) {
+	var volume volume.Info
+	return &volume, c.c.Get(fmt.Sprintf("/storage/volumes/%s", volumeID), &volume)
+}
+
 // ListVolume returns a list of volume IDs
 func (c *Host) ListVolumes() ([]*volume.Info, error) {
 	var volumes []*volume.Info

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -67,7 +67,7 @@ func (s *HostSuite) TestAddFailingJob(t *c.C) {
 	t.Assert(h.AddJob(job), c.IsNil)
 
 	// check we get a create then error event
-	actual := make(map[string]*host.Event, 2)
+	actual := make(map[host.JobEventType]*host.Event, 2)
 loop:
 	for {
 		select {


### PR DESCRIPTION
I think eventually we want volume GC at a higher level than flynn-host, but for now this prevents leaking data volumes which we know are ephemeral.