### PR TITLE
worker: Fix deployment timeout

### DIFF
--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -303,6 +303,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 	}
 
 	jobEvents := d.ReleaseJobEvents(releaseID)
+	timeout := time.After(time.Duration(d.DeployTimeout) * time.Second)
 	for {
 		select {
 		case <-d.stop:
@@ -361,7 +362,7 @@ func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, lo
 			case JobEventTypeError:
 				return e.Error
 			}
-		case <-time.After(time.Duration(d.DeployTimeout) * time.Second):
+		case <-timeout:
 			return fmt.Errorf("timed out waiting for job events: %v", expected)
 		}
 	}


### PR DESCRIPTION
Previously we were using a timeout for each individual job event, which means it was reset every time the scheduler tries to restart a failing job.