### PR TITLE
bootstrap: Convert slugs and Docker images on cluster restore 

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -499,6 +499,7 @@
               }
             }
           ],
+          "service": "gitreceive",
           "volumes": [{"path": "/tmp", "delete_on_stop": true}]
         }
       }

--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -184,7 +184,8 @@
         "web": {
           "ports": [{"port": 80, "proto": "tcp"}],
           "args": ["/bin/start-flynn-controller", "controller"],
-          "service": "controller"
+          "service": "controller",
+          "volumes": [{"path": "/tmp", "delete_on_stop": true}]
         },
         "scheduler": {
           "args": ["/bin/start-flynn-controller", "scheduler"],
@@ -497,7 +498,8 @@
                 "create": true
               }
             }
-          ]
+          ],
+          "volumes": [{"path": "/tmp", "delete_on_stop": true}]
         }
       }
     },

--- a/docker-receive/Dockerfile
+++ b/docker-receive/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get install --yes squashfs-tools
 
 ADD bin/docker-receive /bin/docker-receive
 ADD bin/docker-artifact /bin/docker-artifact
+ADD bin/docker-migrator /bin/docker-migrator
 ADD bin/ca-certs.pem /etc/ssl/certs/ca-certs.pem
 
 CMD ["/bin/docker-receive"]

--- a/docker-receive/Tupfile
+++ b/docker-receive/Tupfile
@@ -1,5 +1,6 @@
 include_rules
 : |> !go |> bin/docker-receive
 : |> !go ./artifact |> bin/docker-artifact
+: |> !go ./migrator |> bin/docker-migrator
 : $(ROOT)/util/ca-certs/ca-certs.pem |> !cp |> bin/ca-certs.pem
-: bin/docker-receive bin/docker-artifact bin/ca-certs.pem |> !image-bootstrapped |>
+: bin/docker-receive bin/docker-artifact bin/docker-migrator bin/ca-certs.pem |> !image-bootstrapped |>

--- a/docker-receive/migrator/main.go
+++ b/docker-receive/migrator/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/random"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+func main() {
+	log15.Info("running image migrator")
+	if err := migrate(); err != nil {
+		log15.Error("error running image migrator", "err", err)
+		os.Exit(1)
+	}
+}
+
+func migrate() error {
+	db := postgres.Wait(nil, nil)
+
+	artifacts, err := getImageArtifacts(db)
+	if err != nil {
+		return err
+	}
+
+	for _, artifact := range artifacts {
+		newID, err := convert(artifact.URI)
+		if err != nil {
+			return err
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE release_artifacts SET artifact_id = $1 WHERE artifact_id = $2`, newID, artifact.ID); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Exec(`UPDATE artifacts SET deleted_at = now() WHERE artifact_id = $1`, artifact.ID); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getImageArtifacts(db *postgres.DB) ([]*ct.Artifact, error) {
+	sql := `
+SELECT artifact_id, uri FROM artifacts
+WHERE type = 'docker' AND meta->>'docker-receive.repository' IS NOT NULL
+AND artifact_id IN (
+  SELECT artifact_id FROM release_artifacts
+  WHERE release_id IN (
+    SELECT release_id FROM releases
+    WHERE meta->>'docker-receive' = 'true'
+  )
+)
+`
+	rows, err := db.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var artifacts []*ct.Artifact
+	for rows.Next() {
+		var artifact ct.Artifact
+		if err := rows.Scan(&artifact.ID, &artifact.URI); err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, &artifact)
+	}
+	return artifacts, rows.Err()
+}
+
+func convert(imageURL string) (string, error) {
+	id := random.UUID()
+	cmd := exec.Command("/bin/docker-artifact", imageURL)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("ARTIFACT_ID=%s", id))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return id, cmd.Run()
+}

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -314,6 +314,7 @@ func appendEnvDir(stdin io.Reader, pipe io.WriteCloser, env map[string]string) e
 	defer pipe.Close()
 	tr := tar.NewReader(stdin)
 	tw := tar.NewWriter(pipe)
+	defer tw.Close()
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -323,7 +324,6 @@ func appendEnvDir(stdin io.Reader, pipe io.WriteCloser, env map[string]string) e
 		if err != nil {
 			return err
 		}
-		hdr.Name = path.Join("app", hdr.Name)
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
 		}
@@ -334,7 +334,7 @@ func appendEnvDir(stdin io.Reader, pipe io.WriteCloser, env map[string]string) e
 	// append env dir
 	for key, value := range env {
 		hdr := &tar.Header{
-			Name:    path.Join("env", key),
+			Name:    path.Join(".ENV_DIR_bdca46b87df0537eaefe79bb632d37709ff1df18", key),
 			Mode:    0644,
 			ModTime: time.Now(),
 			Size:    int64(len(value)),
@@ -347,11 +347,5 @@ func appendEnvDir(stdin io.Reader, pipe io.WriteCloser, env map[string]string) e
 			return err
 		}
 	}
-	hdr := &tar.Header{
-		Name:    ".ENV_DIR_bdca46b87df0537eaefe79bb632d37709ff1df18",
-		Mode:    0400,
-		ModTime: time.Now(),
-		Size:    0,
-	}
-	return tw.WriteHeader(hdr)
+	return nil
 }

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -210,11 +210,10 @@ $function$;
 `)
 
 	type manifestStep struct {
-		ID       string
-		Artifact struct {
-			URI string
-		}
-		Release struct {
+		ID        string
+		Artifacts []*ct.Artifact
+		Artifact  *ct.Artifact
+		Release   struct {
 			Env       map[string]string
 			Processes map[string]ct.ProcessType
 		}
@@ -233,7 +232,7 @@ $function$;
 		manifestStepMap[step.StepMeta.ID] = step
 	}
 
-	artifactURIs := make(map[string]string)
+	artifacts := make(map[string]*ct.Artifact)
 	updateProcArgs := func(f *ct.ExpandedFormation, step *manifestStep) {
 		for typ, proc := range step.Release.Processes {
 			p := f.Release.Processes[typ]
@@ -268,43 +267,23 @@ $function$;
 				updateVolumes(data.MongoDB, step)
 			}
 		}
-		if step.Artifact.URI != "" {
-			artifactURIs[step.ID] = step.Artifact.URI
-
-			// update current artifact in database for service, taking care to
-			// check the database version as migration 15 changed the way
-			// artifacts are related to releases in the database
-			sqlBuf.WriteString(fmt.Sprintf(`
-DO $$
-  BEGIN
-    IF (SELECT MAX(id) FROM schema_migrations) < 15 THEN
-      UPDATE artifacts SET uri = '%[1]s' WHERE artifact_id = (
-	SELECT artifact_id FROM releases WHERE release_id = (
-	  SELECT release_id FROM apps WHERE name = '%[2]s'
-	)
-      );
-    ELSE
-      UPDATE artifacts SET uri = '%[1]s' WHERE type = 'docker' AND artifact_id = (
-	SELECT artifact_id FROM release_artifacts WHERE release_id = (
-	  SELECT release_id FROM apps WHERE name = '%[2]s'
-	)
-      );
-    END IF;
-  END;
-$$;`, step.Artifact.URI, step.ID))
+		if step.Artifact != nil {
+			artifacts[step.ID] = step.Artifact
+		} else if len(step.Artifacts) > 0 {
+			artifacts[step.ID] = step.Artifacts[0]
 		}
 	}
 
-	data.Discoverd.ImageArtifact.URI = artifactURIs["discoverd"]
+	data.Discoverd.Artifacts = []*ct.Artifact{artifacts["discoverd"]}
 	data.Discoverd.Release.Env["DISCOVERD_PEERS"] = "{{ range $ip := .SortedHostIPs }}{{ $ip }}:1111,{{ end }}"
-	data.Postgres.ImageArtifact.URI = artifactURIs["postgres"]
-	data.Flannel.ImageArtifact.URI = artifactURIs["flannel"]
-	data.Controller.ImageArtifact.URI = artifactURIs["controller"]
+	data.Postgres.Artifacts = []*ct.Artifact{artifacts["postgres"]}
+	data.Flannel.Artifacts = []*ct.Artifact{artifacts["flannel"]}
+	data.Controller.Artifacts = []*ct.Artifact{artifacts["controller"]}
 	if data.MariaDB != nil {
-		data.MariaDB.ImageArtifact.URI = artifactURIs["mariadb"]
+		data.MariaDB.Artifacts = []*ct.Artifact{artifacts["mariadb"]}
 	}
 	if data.MongoDB != nil {
-		data.MongoDB.ImageArtifact.URI = artifactURIs["mongodb"]
+		data.MongoDB.Artifacts = []*ct.Artifact{artifacts["mongodb"]}
 	}
 
 	// set TELEMETRY_CLUSTER_ID
@@ -322,47 +301,6 @@ UPDATE releases SET env = jsonb_set(env, '{TELEMETRY_BOOTSTRAP_ID}', '%q')
 WHERE release_id = (SELECT release_id FROM apps WHERE name = 'controller');
 `, telemetryClusterID))
 		data.Controller.Release.Env["TELEMETRY_BOOTSTRAP_ID"] = telemetryClusterID
-	}
-
-	// create the slugbuilder artifact if gitreceive still references
-	// SLUGBUILDER_IMAGE_URI (in which case there is no slugbuilder
-	// artifact in the database)
-	sqlBuf.WriteString(fmt.Sprintf(`
-DO $$
-  BEGIN
-    IF (SELECT env->>'SLUGBUILDER_IMAGE_ID' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive')) IS NULL THEN
-      INSERT INTO artifacts (artifact_id, type, uri) VALUES ('%s', 'docker', '%s');
-    END IF;
-  END;
-$$;`, random.UUID(), artifactURIs["slugbuilder-image"]))
-
-	// update the URI of slug artifacts currently being referenced by
-	// gitreceive (which will also update all current user releases
-	// to use the latest slugrunner)
-	for _, name := range []string{"slugbuilder", "slugrunner"} {
-		sqlBuf.WriteString(fmt.Sprintf(`
-UPDATE artifacts SET uri = '%[1]s'
-WHERE artifact_id = (SELECT (env->>'%[2]s_IMAGE_ID')::uuid FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive'))
-OR uri = (SELECT env->>'%[2]s_IMAGE_URI' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive'));`,
-			artifactURIs[name+"-image"], strings.ToUpper(name)))
-	}
-
-	// update the URI of redis artifacts currently being referenced by
-	// the redis app (which will also update all current redis
-	// resources to use the latest redis image)
-	sqlBuf.WriteString(fmt.Sprintf(`
-UPDATE artifacts SET uri = '%s'
-WHERE artifact_id = (SELECT (env->>'REDIS_IMAGE_ID')::uuid FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'redis'))
-OR uri = (SELECT env->>'REDIS_IMAGE_URI' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'redis'));`,
-		artifactURIs["redis-image"]))
-
-	// ensure the image ID environment variables are set for legacy apps
-	// which use image URI variables
-	for _, name := range []string{"redis", "slugbuilder", "slugrunner"} {
-		sqlBuf.WriteString(fmt.Sprintf(`
-UPDATE releases SET env = pg_temp.json_object_update_key(env, '%[1]s_IMAGE_ID', (SELECT artifact_id::text FROM artifacts WHERE uri = '%[2]s'))
-WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
-			strings.ToUpper(name), artifactURIs[name+"-image"]))
 	}
 
 	step := func(id, name string, action bootstrap.Action) bootstrap.Step {
@@ -423,7 +361,7 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 `)
 
 	// load data into postgres
-	cmd := exec.JobUsingHost(state.Hosts[0], data.Postgres.ImageArtifact, nil)
+	cmd := exec.JobUsingHost(state.Hosts[0], artifacts["postgres"], nil)
 	cmd.Args = []string{"psql"}
 	cmd.Env = map[string]string{
 		"PGHOST":     "leader.postgres.discoverd",
@@ -481,7 +419,7 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 			return err
 		}
 
-		cmd = exec.JobUsingHost(state.Hosts[0], data.MariaDB.ImageArtifact, nil)
+		cmd = exec.JobUsingHost(state.Hosts[0], artifacts["mariadb"], nil)
 		cmd.Args = []string{"mysql", "-u", "flynn", "-h", "leader.mariadb.discoverd"}
 		cmd.Env = map[string]string{
 			"MYSQL_PWD": data.MariaDB.Release.Env["MYSQL_PWD"],
@@ -521,7 +459,7 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 			return err
 		}
 
-		cmd = exec.JobUsingHost(state.Hosts[0], data.MongoDB.ImageArtifact, nil)
+		cmd = exec.JobUsingHost(state.Hosts[0], artifacts["mongodb"], nil)
 		cmd.Args = []string{"mongorestore", "-h", "leader.mongodb.discoverd", "-u", "flynn", "-p", data.MongoDB.Release.Env["MONGO_PWD"], "--archive"}
 		cmd.Stdin = mongodb
 		meta = bootstrap.StepMeta{ID: "restore", Action: "restore-mongodb"}
@@ -561,12 +499,8 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 	state.SetControllerKey(controllerKey)
 	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
 
-	// start blobstore, scheduler, and enable cluster monitor
-	data.Controller.Processes = map[string]int{"scheduler": 1}
-	// only start one scheduler instance
-	schedulerProcess := data.Controller.Release.Processes["scheduler"]
-	schedulerProcess.Omni = false
-	data.Controller.Release.Processes["scheduler"] = schedulerProcess
+	// start the blobstore
+	blobstoreFormation.Artifacts = []*ct.Artifact{artifacts["blobstore"]}
 	_, err = bootstrap.Manifest{
 		step("blobstore", "run-app", &bootstrap.RunAppAction{
 			ExpandedFormation: blobstoreFormation,
@@ -575,6 +509,234 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'dashboard');
 			URL:    "http://blobstore.discoverd",
 			Status: 200,
 		}),
+	}.RunWithState(ch, state)
+	if err != nil {
+		return err
+	}
+
+	// now that the controller and blobstore are up and controller
+	// migrations have run (so we know artifacts have a manifest column),
+	// migrate all artifacts to Flynn images
+	jsonb := func(v interface{}) []byte {
+		data, _ := json.Marshal(v)
+		return data
+	}
+	sqlBuf.Reset()
+	for _, step := range manifestSteps {
+		artifact, ok := artifacts[step.ID]
+		if !ok {
+			continue
+		}
+
+		// update current artifact in database for service
+		sqlBuf.WriteString(fmt.Sprintf(`
+UPDATE artifacts SET uri = '%s', type = 'flynn', manifest = '%s', hashes = '%s', size = %d, layer_url_template = '%s' WHERE artifact_id = (
+  SELECT artifact_id FROM release_artifacts WHERE release_id = (
+    SELECT release_id FROM apps WHERE name = '%s'
+  )
+);`, artifact.URI, jsonb(&artifact.RawManifest), jsonb(artifact.Hashes), artifact.Size, artifact.LayerURLTemplate, step.ID))
+	}
+
+	// create the slugbuilder artifact if gitreceive still references it by
+	// URI (in which case there is no slugbuilder artifact in the database)
+	slugBuilder := artifacts["slugbuilder-image"]
+	sqlBuf.WriteString(fmt.Sprintf(`
+DO $$
+  BEGIN
+    IF (SELECT env->>'SLUGBUILDER_IMAGE_ID' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive')) IS NULL THEN
+      INSERT INTO artifacts (artifact_id, type, uri, manifest, hashes, size, layer_url_template) VALUES ('%s', 'flynn', '%s', '%s', '%s', %d, '%s');
+    END IF;
+  END;
+$$;`, random.UUID(), slugBuilder.URI, jsonb(&slugBuilder.RawManifest), jsonb(slugBuilder.Hashes), slugBuilder.Size, slugBuilder.LayerURLTemplate))
+
+	// create the slugrunner artifact if it doesn't exist (which can be the
+	// case if no apps were deployed with git push in older clusters where
+	// it was created lazily)
+	slugRunner := artifacts["slugrunner-image"]
+	sqlBuf.WriteString(fmt.Sprintf(`
+DO $$
+  BEGIN
+    IF (SELECT env->>'SLUGRUNNER_IMAGE_ID' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive')) IS NULL THEN
+      IF NOT EXISTS (SELECT 1 FROM artifacts WHERE uri = (SELECT env->>'SLUGRUNNER_IMAGE_URI' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive'))) THEN
+        INSERT INTO artifacts (artifact_id, type, uri, manifest, hashes, size, layer_url_template) VALUES ('%s', 'flynn', '%s', '%s', '%s', %d, '%s');
+      END IF;
+    END IF;
+  END;
+$$;`, random.UUID(), slugRunner.URI, jsonb(&slugRunner.RawManifest), jsonb(slugRunner.Hashes), slugRunner.Size, slugRunner.LayerURLTemplate))
+
+	// update slug artifacts currently being referenced by gitreceive
+	// (which will also update all current user releases to use the
+	// latest slugrunner)
+	for _, name := range []string{"slugbuilder", "slugrunner"} {
+		artifact := artifacts[name+"-image"]
+		sqlBuf.WriteString(fmt.Sprintf(`
+UPDATE artifacts SET uri = '%[1]s', type = 'flynn', manifest = '%[2]s', hashes = '%[3]s', size = %[4]d, layer_url_template = '%[5]s'
+WHERE artifact_id = (SELECT (env->>'%[6]s_IMAGE_ID')::uuid FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive'))
+OR uri = (SELECT env->>'%[6]s_IMAGE_URI' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'gitreceive'));`,
+			artifact.URI, jsonb(&artifact.RawManifest), jsonb(artifact.Hashes), artifact.Size, artifact.LayerURLTemplate, strings.ToUpper(name)))
+	}
+
+	// update the URI of redis artifacts currently being referenced by
+	// the redis app (which will also update all current redis resources
+	// to use the latest redis image)
+	redisImage := artifacts["redis-image"]
+	sqlBuf.WriteString(fmt.Sprintf(`
+UPDATE artifacts SET uri = '%s', type = 'flynn', manifest = '%s', hashes = '%s', size = %d, layer_url_template = '%s'
+WHERE artifact_id = (SELECT (env->>'REDIS_IMAGE_ID')::uuid FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'redis'))
+OR uri = (SELECT env->>'REDIS_IMAGE_URI' FROM releases WHERE release_id = (SELECT release_id FROM apps WHERE name = 'redis'));`,
+		redisImage.URI, jsonb(&redisImage.RawManifest), jsonb(redisImage.Hashes), redisImage.Size, redisImage.LayerURLTemplate))
+
+	// ensure the image ID environment variables are set for legacy apps
+	// which use image URI variables
+	for _, name := range []string{"redis", "slugbuilder", "slugrunner"} {
+		sqlBuf.WriteString(fmt.Sprintf(`
+UPDATE releases SET env = jsonb_set(env, '{%[1]s_IMAGE_ID}', ('"' || (SELECT artifact_id::text FROM artifacts WHERE uri = '%[2]s') || '"')::jsonb, true)
+WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
+			strings.ToUpper(name), artifacts[name+"-image"].URI))
+	}
+
+	// run the above artifact migration SQL against the controller database
+	cmd = exec.JobUsingHost(state.Hosts[0], artifacts["postgres"], nil)
+	cmd.Args = []string{"psql", "--echo-queries"}
+	cmd.Env = map[string]string{
+		"PGHOST":     "leader.postgres.discoverd",
+		"PGUSER":     data.Controller.Release.Env["PGUSER"],
+		"PGDATABASE": data.Controller.Release.Env["PGDATABASE"],
+		"PGPASSWORD": data.Controller.Release.Env["PGPASSWORD"],
+	}
+	cmd.Stdin = sqlBuf
+	meta = bootstrap.StepMeta{ID: "migrate-artifacts", Action: "migrate-artifacts"}
+	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "start", Timestamp: time.Now().UTC()}
+	out, err = cmd.CombinedOutput()
+	if os.Getenv("DEBUG") != "" {
+		fmt.Println(string(out))
+	}
+	if err != nil {
+		ch <- &bootstrap.StepInfo{
+			StepMeta:  meta,
+			State:     "error",
+			Error:     fmt.Sprintf("error migrating artifacts: %s - %q", err, string(out)),
+			Err:       err,
+			Timestamp: time.Now().UTC(),
+		}
+		return err
+	}
+
+	// determine whether any releases have slugs or docker images which
+	// need to be converted to Flynn images
+	releases, err := client.ReleaseList()
+	if err != nil {
+		return fmt.Errorf("error listing releases: %s", err)
+	}
+	migrateSlugs := false
+	migrateDocker := false
+	for _, release := range releases {
+		if migrateSlugs && migrateDocker {
+			break
+		}
+		if !migrateSlugs && release.IsGitDeploy() && len(release.ArtifactIDs) == 2 {
+			artifact, err := client.GetArtifact(release.ArtifactIDs[1])
+			if err == nil && artifact.Type == ct.DeprecatedArtifactTypeFile {
+				migrateSlugs = true
+			}
+		}
+		if !migrateDocker && release.IsDockerReceiveDeploy() && len(release.ArtifactIDs) == 1 {
+			artifact, err := client.GetArtifact(release.ArtifactIDs[0])
+			if err == nil && artifact.Type == ct.DeprecatedArtifactTypeDocker {
+				migrateDocker = true
+			}
+		}
+	}
+
+	if migrateSlugs {
+		cmd = exec.JobUsingHost(state.Hosts[0], artifacts["slugbuilder-image"], nil)
+		cmd.Args = []string{"/bin/slug-migrator"}
+		cmd.Env = map[string]string{
+			"CONTROLLER_KEY": data.Controller.Release.Env["AUTH_KEY"],
+			"FLYNN_POSTGRES": data.Controller.Release.Env["FLYNN_POSTGRES"],
+			"PGHOST":         "leader.postgres.discoverd",
+			"PGUSER":         data.Controller.Release.Env["PGUSER"],
+			"PGDATABASE":     data.Controller.Release.Env["PGDATABASE"],
+			"PGPASSWORD":     data.Controller.Release.Env["PGPASSWORD"],
+		}
+		cmd.Volumes = []*ct.VolumeReq{{Path: "/tmp", DeleteOnStop: true}}
+		out, err = cmd.CombinedOutput()
+		if os.Getenv("DEBUG") != "" {
+			fmt.Println(string(out))
+		}
+		if err != nil {
+			ch <- &bootstrap.StepInfo{
+				StepMeta:  meta,
+				State:     "error",
+				Error:     fmt.Sprintf("error migrating slug artifacts: %s - %q", err, string(out)),
+				Err:       err,
+				Timestamp: time.Now().UTC(),
+			}
+			return err
+		}
+	}
+
+	if migrateDocker {
+		// start docker-receive
+		dockerRelease, err := client.GetAppRelease("docker-receive")
+		if err != nil {
+			return fmt.Errorf("error getting docker-receive release: %s", err)
+		}
+		dockerFormation, err := client.GetExpandedFormation("docker-receive", dockerRelease.ID)
+		if err != nil {
+			return fmt.Errorf("error getting docker-receive expanded formation: %s", err)
+		}
+		dockerFormation.Artifacts = []*ct.Artifact{artifacts["docker-receive"]}
+		_, err = bootstrap.Manifest{
+			step("docker-receive", "run-app", &bootstrap.RunAppAction{
+				ExpandedFormation: dockerFormation,
+			}),
+			step("docker-receive-wait", "wait", &bootstrap.WaitAction{
+				URL:    "http://docker-receive.discoverd/v2/",
+				Status: 401,
+			}),
+		}.RunWithState(ch, state)
+		if err != nil {
+			return err
+		}
+
+		// run the docker image migrator
+		cmd = exec.JobUsingHost(state.Hosts[0], artifacts["docker-receive"], nil)
+		cmd.Args = []string{"/bin/docker-migrator"}
+		cmd.Env = map[string]string{
+			"CONTROLLER_KEY": data.Controller.Release.Env["AUTH_KEY"],
+			"FLYNN_POSTGRES": data.Controller.Release.Env["FLYNN_POSTGRES"],
+			"PGHOST":         "leader.postgres.discoverd",
+			"PGUSER":         data.Controller.Release.Env["PGUSER"],
+			"PGDATABASE":     data.Controller.Release.Env["PGDATABASE"],
+			"PGPASSWORD":     data.Controller.Release.Env["PGPASSWORD"],
+		}
+		cmd.Volumes = []*ct.VolumeReq{{Path: "/data", DeleteOnStop: true}}
+
+		out, err = cmd.CombinedOutput()
+		if os.Getenv("DEBUG") != "" {
+			fmt.Println(string(out))
+		}
+		if err != nil {
+			ch <- &bootstrap.StepInfo{
+				StepMeta:  meta,
+				State:     "error",
+				Error:     fmt.Sprintf("error migrating docker artifacts: %s - %q", err, string(out)),
+				Err:       err,
+				Timestamp: time.Now().UTC(),
+			}
+			return err
+		}
+	}
+	ch <- &bootstrap.StepInfo{StepMeta: meta, State: "done", Timestamp: time.Now().UTC()}
+
+	// start scheduler and enable cluster monitor
+	data.Controller.Processes = map[string]int{"scheduler": 1}
+	// only start one scheduler instance
+	schedulerProcess := data.Controller.Release.Processes["scheduler"]
+	schedulerProcess.Omni = false
+	data.Controller.Release.Processes["scheduler"] = schedulerProcess
+	_, err = bootstrap.Manifest{
 		step("controller-scheduler", "run-app", &bootstrap.RunAppAction{
 			ExpandedFormation: data.Controller,
 		}),

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -111,24 +111,10 @@ func getApps(client controller.Client) (map[string]*ct.ExpandedFormation, error)
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s app formation: %s", name, err)
 		}
-		imageArtifact, err := client.GetArtifact(release.ImageArtifactID())
-		if err != nil {
-			return nil, fmt.Errorf("error getting %s app artifact: %s", name, err)
-		}
-		fileArtifacts := make([]*ct.Artifact, len(release.FileArtifactIDs()))
-		for i, artifactID := range release.FileArtifactIDs() {
-			fileArtifact, err := client.GetArtifact(artifactID)
-			if err != nil {
-				return nil, fmt.Errorf("error getting %s app file artifact: %s", name, err)
-			}
-			fileArtifacts[i] = fileArtifact
-		}
 		data[name] = &ct.ExpandedFormation{
-			App:           app,
-			Release:       release,
-			ImageArtifact: imageArtifact,
-			FileArtifacts: fileArtifacts,
-			Processes:     formation.Processes,
+			App:       app,
+			Release:   release,
+			Processes: formation.Processes,
 		}
 	}
 	return data, nil

--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get install --yes squashfs-tools
 
 ADD convert-legacy-slug.sh /bin/convert-legacy-slug.sh
 ADD bin/create-artifact /bin/create-artifact
+ADD bin/migrator /bin/slug-migrator
 ADD builder/build.sh /builder/
 ADD builder/create-user.sh /builder/
 

--- a/slugbuilder/Dockerfile
+++ b/slugbuilder/Dockerfile
@@ -12,5 +12,8 @@ ADD bin/create-artifact /bin/create-artifact
 ADD builder/build.sh /builder/
 ADD builder/create-user.sh /builder/
 
+# allow custom buildpack install by unprivileged user
+RUN chmod ugo+w /builder/buildpacks
+
 ENTRYPOINT ["/builder/build.sh"]
 CMD []

--- a/slugbuilder/Tupfile
+++ b/slugbuilder/Tupfile
@@ -1,3 +1,4 @@
 include_rules
 : |> !go ./artifact |> bin/create-artifact
-: bin/create-artifact $(ROOT)/util/cedarish/<image> |> !image-cedarish |>
+: |> !go ./migrator |> bin/migrator
+: bin/create-artifact bin/migrator $(ROOT)/util/cedarish/<image> |> !image-cedarish |>

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -83,13 +83,8 @@ cd ${app_dir}
 ## Load source from STDIN
 cat | tar -xm
 
-
-if [[ -f "${env_cookie}" ]]; then
-  rm "${env_cookie}"
-  tmpdir="$(mktemp --directory)"
-  mv app env "${tmpdir}"
-  rsync -aq "${tmpdir}/app/" .
-  rm -rf "${tmpdir}/app"
+if [[ -d "${env_cookie}" ]]; then
+  mv "${env_cookie}" "${env_dir}"
   envdir="true"
 fi
 

--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 export TMPDIR="${TMPDIR:-"/tmp"}"
 
-app_dir=/app
+app_dir="${TMPDIR}/app"
 env_dir="${TMPDIR}/env"
 build_root="${TMPDIR}/build"
 build_dir="${build_root}/app"
@@ -86,9 +86,10 @@ cat | tar -xm
 
 if [[ -f "${env_cookie}" ]]; then
   rm "${env_cookie}"
-  mv app env "${TMPDIR}"
-  rsync -aq "${TMPDIR}/app/" .
-  rm -rf "${TMPDIR}/app"
+  tmpdir="$(mktemp --directory)"
+  mv app env "${tmpdir}"
+  rsync -aq "${tmpdir}/app/" .
+  rm -rf "${tmpdir}/app"
   envdir="true"
 fi
 
@@ -99,6 +100,7 @@ fi
 # In heroku, there are two separate directories, and some
 # buildpacks expect that.
 cp -r . ${build_dir}
+ln -s "${app_dir}" "/app"
 chown -R "${USER}:${USER}" \
   "${TMPDIR}" \
   "${app_dir}" \

--- a/slugbuilder/builder/install-buildpack
+++ b/slugbuilder/builder/install-buildpack
@@ -41,7 +41,7 @@ else
   popd > /dev/null
 fi
 
-popd > /dev/null
-
 # Ensure buildpack directories are writeable (see https://github.com/heroku/heroku-buildpack-nodejs/issues/152)
-chmod -R ugo+w "${buildpacks_dir}"
+chmod -R ugo+w "${buildpack_name}"
+
+popd > /dev/null

--- a/slugbuilder/migrator/main.go
+++ b/slugbuilder/migrator/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/random"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+func main() {
+	log15.Info("running slug migrator")
+	if err := migrate(); err != nil {
+		log15.Error("error running slug migrator", "err", err)
+		os.Exit(1)
+	}
+}
+
+func migrate() error {
+	db := postgres.Wait(nil, nil)
+
+	artifacts, err := getSlugArtifacts(db)
+	if err != nil {
+		return err
+	}
+
+	for _, artifact := range artifacts {
+		newID, err := convert(artifact.URI)
+		if err != nil {
+			return err
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE release_artifacts SET artifact_id = $1 WHERE artifact_id = $2`, newID, artifact.ID); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Exec(`UPDATE artifacts SET deleted_at = now() WHERE artifact_id = $1`, artifact.ID); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getSlugArtifacts(db *postgres.DB) ([]*ct.Artifact, error) {
+	sql := `
+SELECT artifact_id, uri FROM artifacts
+WHERE type = 'file' AND meta->>'blobstore' = 'true'
+AND artifact_id IN (
+  SELECT artifact_id FROM release_artifacts
+  WHERE release_id IN (
+    SELECT release_id FROM releases
+    WHERE meta->>'git' = 'true'
+  )
+)
+`
+	rows, err := db.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var artifacts []*ct.Artifact
+	for rows.Next() {
+		var artifact ct.Artifact
+		if err := rows.Scan(&artifact.ID, &artifact.URI); err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, &artifact)
+	}
+	return artifacts, rows.Err()
+}
+
+func convert(slugURL string) (string, error) {
+	res, err := http.Get(slugURL)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	id := random.UUID()
+	cmd := exec.Command("/bin/convert-legacy-slug.sh")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("SLUG_IMAGE_ID=%s", id))
+	cmd.Stdin = res.Body
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return id, cmd.Run()
+}

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -577,7 +577,6 @@ func (s *ControllerSuite) TestBackup(t *c.C) {
 		t.Assert(ok, c.Equals, true)
 		t.Assert(ef.App, c.Not(c.IsNil))
 		t.Assert(ef.Release, c.Not(c.IsNil))
-		t.Assert(ef.Artifacts, c.HasLen, 1)
 		t.Assert(ef.Processes, c.Not(c.IsNil))
 		t.Assert(ef.App.Name, c.Equals, name)
 	}


### PR DESCRIPTION
Some small updates plus the addition of slug and docker-receive migrators which convert to Flynn images on cluster restore.

The migrators connect directly to the controller database so that it can update the release artifacts in place and in a transaction, rather than creating new releases via the controller API.

I've also moved the various artifact update SQL to run after the controller has started so that we know the artifacts have the new manifest columns.