### PR TITLE
Log Sink support.

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -601,7 +601,7 @@
     "release": {
       "processes": {
         "app": {
-          "args": ["/bin/logaggregator", "-logaddr", ":514", "-apiaddr", ":80"],
+          "args": ["/bin/logaggregator"],
           "ports": [
             {"port": 80, "proto": "tcp"},
             {"port": 514, "proto": "tcp"}

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -88,6 +88,11 @@ type Client interface {
 	DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error)
 	ScheduleAppGarbageCollection(appID string) error
 	Status() (*status.Status, error)
+	CreateSink(sink *ct.Sink) error
+	GetSink(sinkID string) (*ct.Sink, error)
+	DeleteSink(sinkID string) (*ct.Sink, error)
+	ListSinks() ([]*ct.Sink, error)
+	StreamSinks(since *time.Time, output chan *ct.Sink) (stream.Stream, error)
 }
 
 type Config struct {

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -746,6 +746,40 @@ func (c *Client) Status() (*status.Status, error) {
 	return &s.Data, nil
 }
 
+// CreateSink creates a new log sink
+func (c *Client) CreateSink(sink *ct.Sink) error {
+	return c.Post("/sinks", sink, sink)
+}
+
+// GetSink gets a log sink
+func (c *Client) GetSink(sinkID string) (*ct.Sink, error) {
+	sink := &ct.Sink{}
+	return sink, c.Get(fmt.Sprintf("/sinks/%s", sinkID), sink)
+}
+
+// DeleteSink removes a log sink
+func (c *Client) DeleteSink(sinkID string) (*ct.Sink, error) {
+	sink := &ct.Sink{}
+	return sink, c.Delete(fmt.Sprintf("/sinks/%s", sinkID), sink)
+}
+
+// ListSink returns all log sinks
+func (c *Client) ListSinks() ([]*ct.Sink, error) {
+	var sinks []*ct.Sink
+	return sinks, c.Get("/sinks", &sinks)
+}
+
+// StreamSinks yields a series of Sink into the provided channel.
+// If since is not nil, only retrieves sink updates since the specified time.
+func (c *Client) StreamSinks(since *time.Time, output chan *ct.Sink) (stream.Stream, error) {
+	if since == nil {
+		s := time.Unix(0, 0)
+		since = &s
+	}
+	t := since.UTC().Format(time.RFC3339Nano)
+	return c.Stream("GET", "/sinks?since="+t, nil, output)
+}
+
 func (c *Client) Put(path string, in, out interface{}) error {
 	return c.send("PUT", path, in, out)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -216,6 +216,7 @@ func appHandler(c handlerConfig) http.Handler {
 	deploymentRepo := NewDeploymentRepo(c.db)
 	eventRepo := NewEventRepo(c.db)
 	backupRepo := NewBackupRepo(c.db)
+	sinkRepo := NewSinkRepo(c.db)
 
 	api := controllerAPI{
 		domainMigrationRepo: domainMigrationRepo,
@@ -229,6 +230,7 @@ func appHandler(c handlerConfig) http.Handler {
 		deploymentRepo:      deploymentRepo,
 		eventRepo:           eventRepo,
 		backupRepo:          backupRepo,
+		sinkRepo:            sinkRepo,
 		clusterClient:       c.cc,
 		logaggc:             c.lc,
 		routerc:             c.rc,
@@ -307,6 +309,11 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.GET("/events", httphelper.WrapHandler(api.Events))
 	httpRouter.GET("/events/:id", httphelper.WrapHandler(api.GetEvent))
 
+	httpRouter.POST("/sinks", httphelper.WrapHandler(api.CreateSink))
+	httpRouter.GET("/sinks", httphelper.WrapHandler(api.GetSinks))
+	httpRouter.GET("/sinks/:sink_id", httphelper.WrapHandler(api.GetSink))
+	httpRouter.DELETE("/sinks/:sink_id", httphelper.WrapHandler(api.DeleteSink))
+
 	return httphelper.ContextInjector("controller",
 		httphelper.NewRequestLogger(muxHandler(httpRouter, c.keys)))
 }
@@ -357,6 +364,7 @@ type controllerAPI struct {
 	deploymentRepo      *DeploymentRepo
 	eventRepo           *EventRepo
 	backupRepo          *BackupRepo
+	sinkRepo            *SinkRepo
 	clusterClient       utils.ClusterClient
 	logaggc             logClient
 	routerc             routerc.Client

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -669,6 +670,28 @@ func (s *S) TestProviderList(c *C) {
 
 	c.Assert(len(list) > 0, Equals, true)
 	c.Assert(list[0].ID, Not(Equals), "")
+}
+
+func (s *S) TestCreateSink(c *C) {
+	config := &ct.SyslogSinkConfig{
+		URL:    "syslog://example.com:514",
+		Prefix: "test",
+		UseIDs: true,
+	}
+	cfg, _ := json.Marshal(config)
+	in := &ct.Sink{
+		Kind:   ct.SinkKindSyslog,
+		Config: cfg,
+	}
+	c.Assert(s.c.CreateSink(in), IsNil)
+	c.Assert(in.ID, Not(Equals), "")
+	out, err := s.c.GetSink(in.ID)
+	c.Assert(err, IsNil)
+	c.Assert(out.ID, Equals, in.ID)
+	outConfig := &ct.SyslogSinkConfig{}
+	err = json.Unmarshal(out.Config, outConfig)
+	c.Assert(err, IsNil)
+	c.Assert(outConfig, DeepEquals, config)
 }
 
 func (s *S) TestGetCACertWithAuth(c *C) {

--- a/controller/scheduler/host.go
+++ b/controller/scheduler/host.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/controller/testutils"
+	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/stream"
@@ -118,6 +119,18 @@ func (h *Host) StreamEventsTo(ch chan *host.Event) (map[string]host.ActiveJob, e
 		}
 	}()
 	return jobs, nil
+}
+
+func (h *Host) GetSinks() ([]*ct.Sink, error) {
+	return h.client.GetSinks()
+}
+
+func (h *Host) AddSink(sink *ct.Sink) error {
+	return h.client.AddSink(sink)
+}
+
+func (h *Host) RemoveSink(id string) error {
+	return h.client.RemoveSink(id)
 }
 
 func (h *Host) Close() {

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -462,6 +462,19 @@ $$ LANGUAGE plpgsql`,
 		`CREATE INDEX ON releases (app_id) WHERE deleted_at IS NULL`,
 		`ALTER TABLE releases ADD CHECK (app_id IS NOT NULL OR deleted_at IS NOT NULL)`,
 	)
+	migrations.Add(28,
+		`CREATE TABLE sink_kinds (name text PRIMARY KEY)`,
+		`INSERT INTO sink_kinds (name) VALUES ('syslog')`,
+		`INSERT INTO event_types (name) VALUES ('sink'), ('sink_deletion')`,
+		`CREATE TABLE sinks (
+			sink_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+			kind text NOT NULL REFERENCES sink_kinds,
+			config jsonb NOT NULL,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			deleted_at timestamptz
+		)`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -74,6 +74,11 @@ var preparedStatements = map[string]string{
 	"backup_insert":                         backupInsert,
 	"backup_update":                         backupUpdate,
 	"backup_select_latest":                  backupSelectLatest,
+	"sink_list":                             sinkListQuery,
+	"sink_list_since":                       sinkListSinceQuery,
+	"sink_select":                           sinkSelectQuery,
+	"sink_insert":                           sinkInsertQuery,
+	"sink_delete":                           sinkDeleteQuery,
 }
 
 func PrepareStatements(conn *pgx.Conn) error {
@@ -400,4 +405,14 @@ INSERT INTO backups (status, sha512, size, error, completed_at) VALUES ($1, $2, 
 UPDATE backups SET status = $2, sha512 = $3, size = $4, error = $5, completed_at = $6, updated_at = now() WHERE backup_id = $1 RETURNING updated_at`
 	backupSelectLatest = `
 SELECT backup_id, status, sha512, size, error, created_at, updated_at, completed_at FROM backups WHERE deleted_at IS NULL ORDER BY updated_at DESC LIMIT 1`
+	sinkListQuery = `
+SELECT sink_id, kind, config, created_at, updated_at FROM sinks WHERE deleted_at IS NULL ORDER BY updated_at DESC`
+	sinkListSinceQuery = `
+SELECT sink_id, kind, config, created_at, updated_at FROM sinks WHERE updated_at >= $1 AND deleted_at IS NULL ORDER BY updated_at DESC`
+	sinkSelectQuery = `
+SELECT sink_id, kind, config, created_at, updated_at FROM sinks WHERE sink_id = $1`
+	sinkInsertQuery = `
+INSERT INTO sinks (sink_id, kind, config) VALUES ($1, $2, $3) RETURNING created_at, updated_at`
+	sinkDeleteQuery = `
+UPDATE sinks SET deleted_at = now() WHERE sink_id = $1 AND deleted_at IS NULL`
 )

--- a/controller/sink.go
+++ b/controller/sink.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/flynn/flynn/controller/schema"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/ctxhelper"
+	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/sse"
+	"github.com/jackc/pgx"
+	"golang.org/x/net/context"
+)
+
+type SinkRepo struct {
+	db *postgres.DB
+}
+
+func NewSinkRepo(db *postgres.DB) *SinkRepo {
+	return &SinkRepo{
+		db: db,
+	}
+}
+
+func (r *SinkRepo) Add(s *ct.Sink) error {
+	if s.ID == "" {
+		s.ID = random.UUID()
+	}
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	err = tx.QueryRow("sink_insert", s.ID, s.Kind, []byte(s.Config)).Scan(&s.CreatedAt, &s.UpdatedAt)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	// create sink event
+	if err := createEvent(tx.Exec, &ct.Event{
+		AppID:      "",
+		ObjectID:   s.ID,
+		ObjectType: ct.EventTypeSink,
+	}, s); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func scanSinks(rows *pgx.Rows) ([]*ct.Sink, error) {
+	var sinks []*ct.Sink
+	for rows.Next() {
+		sink, err := scanSink(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		sinks = append(sinks, sink)
+	}
+	return sinks, rows.Err()
+}
+
+func scanSink(s postgres.Scanner) (*ct.Sink, error) {
+	sink := &ct.Sink{}
+	err := s.Scan(&sink.ID, &sink.Kind, &sink.Config, &sink.CreatedAt, &sink.UpdatedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			err = ErrNotFound
+		}
+		return nil, err
+	}
+	return sink, err
+}
+
+func (r *SinkRepo) Get(id string) (*ct.Sink, error) {
+	row := r.db.QueryRow("sink_select", id)
+	return scanSink(row)
+}
+
+func (r *SinkRepo) List() ([]*ct.Sink, error) {
+	rows, err := r.db.Query("sink_list")
+	if err != nil {
+		return nil, err
+	}
+	return scanSinks(rows)
+}
+
+func (r *SinkRepo) ListSince(since time.Time) ([]*ct.Sink, error) {
+	rows, err := r.db.Query("sink_list_since", since)
+	if err != nil {
+		return nil, err
+	}
+	return scanSinks(rows)
+}
+
+func (r *SinkRepo) Remove(id string) error {
+	sink, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	err = tx.Exec("sink_delete", sink.ID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	// create sink remove event
+	if err := createEvent(tx.Exec, &ct.Event{
+		AppID:      "",
+		ObjectID:   sink.ID,
+		ObjectType: ct.EventTypeSinkDeletion,
+	}, sink); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+// Create a new sink
+func (c *controllerAPI) CreateSink(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	var sink ct.Sink
+	if err := httphelper.DecodeJSON(req, &sink); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if err := schema.Validate(&sink); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if err := c.sinkRepo.Add(&sink); err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, &sink)
+}
+
+// Get a sink
+func (c *controllerAPI) GetSink(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+
+	sink, err := c.sinkRepo.Get(params.ByName("sink_id"))
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	httphelper.JSON(w, 200, sink)
+}
+
+// List sinks
+func (c *controllerAPI) GetSinks(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		c.streamSinks(ctx, w, req)
+		return
+	}
+
+	list, err := c.sinkRepo.List()
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	httphelper.JSON(w, 200, list)
+}
+
+func (c *controllerAPI) streamSinks(ctx context.Context, w http.ResponseWriter, req *http.Request) (err error) {
+	l, _ := ctxhelper.LoggerFromContext(ctx)
+	ch := make(chan *ct.Sink)
+	stream := sse.NewStream(w, ch, l)
+	stream.Serve()
+	defer func() {
+		if err == nil {
+			stream.Close()
+		} else {
+			stream.CloseWithError(err)
+		}
+	}()
+
+	since, err := time.Parse(time.RFC3339Nano, req.FormValue("since"))
+	if err != nil {
+		return err
+	}
+
+	eventListener, err := c.maybeStartEventListener()
+	if err != nil {
+		l.Error("error starting event listener")
+		return err
+	}
+
+	sub, err := eventListener.Subscribe("", []string{string(ct.EventTypeSink), string(ct.EventTypeSinkDeletion)}, "")
+	if err != nil {
+		return err
+	}
+	defer sub.Close()
+
+	sinks, err := c.sinkRepo.ListSince(since)
+	if err != nil {
+		return err
+	}
+	currentUpdatedAt := since
+	for _, sink := range sinks {
+		select {
+		case <-stream.Done:
+			return nil
+		case ch <- sink:
+			if sink.UpdatedAt.After(currentUpdatedAt) {
+				currentUpdatedAt = *sink.UpdatedAt
+			}
+		}
+	}
+
+	select {
+	case <-stream.Done:
+		return nil
+	case ch <- &ct.Sink{}:
+	}
+
+	for {
+		select {
+		case <-stream.Done:
+			return
+		case event, ok := <-sub.Events:
+			if !ok {
+				return sub.Err
+			}
+			var sink ct.Sink
+			if err := json.Unmarshal(event.Data, &sink); err != nil {
+				l.Error("error deserializing sink event", "event.id", event.ID, "err", err)
+				continue
+			}
+			if sink.UpdatedAt.Before(currentUpdatedAt) {
+				continue
+			}
+			if event.ObjectType == ct.EventTypeSinkDeletion {
+				sink.Config = nil
+			}
+			select {
+			case <-stream.Done:
+				return nil
+			case ch <- &sink:
+			}
+		}
+	}
+}
+
+// Delete a sink
+func (c *controllerAPI) DeleteSink(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	sinkID := params.ByName("sink_id")
+
+	sink, err := c.sinkRepo.Get(sinkID)
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if err = c.sinkRepo.Remove(sinkID); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	httphelper.JSON(w, 200, sink)
+}

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -259,6 +259,14 @@ func (c *FakeControllerClient) JobListActive() ([]*ct.Job, error) {
 	return list, nil
 }
 
+func (c *FakeControllerClient) ListSinks() ([]*ct.Sink, error) {
+	return nil, nil
+}
+
+func (c *FakeControllerClient) StreamSinks(*time.Time, chan *ct.Sink) (stream.Stream, error) {
+	return nil, nil
+}
+
 func NewRelease(id string, artifact *ct.Artifact, processes map[string]int) *ct.Release {
 	return NewReleaseOmni(id, artifact, processes, false)
 }

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -212,6 +212,18 @@ func (c *FakeHostClient) GetStatus() (*host.HostStatus, error) {
 	return &host.HostStatus{ID: c.ID()}, nil
 }
 
+func (c *FakeHostClient) GetSinks() ([]*ct.Sink, error) {
+	return nil, nil
+}
+
+func (c *FakeHostClient) AddSink(*ct.Sink) error {
+	return nil
+}
+
+func (c *FakeHostClient) RemoveSink(string) error {
+	return nil
+}
+
 type attachFunc func(req *host.AttachReq, wait bool) (cluster.AttachClient, error)
 
 type HostStream struct {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -422,6 +422,8 @@ const (
 	EventTypeDomainMigration      EventType = "domain_migration"
 	EventTypeClusterBackup        EventType = "cluster_backup"
 	EventTypeAppGarbageCollection EventType = "app_garbage_collection"
+	EventTypeSink                 EventType = "sink"
+	EventTypeSinkDeletion         EventType = "sink_deletion"
 )
 
 type Event struct {
@@ -606,3 +608,29 @@ const (
 	ImagePullTypeImage ImagePullType = "image"
 	ImagePullTypeLayer ImagePullType = "layer"
 )
+
+type SinkKind string
+
+const (
+	SinkKindSyslog        SinkKind = "syslog"
+	SinkKindLogaggregator SinkKind = "logaggregator"
+)
+
+type Sink struct {
+	ID          string          `json:"id"`
+	Kind        SinkKind        `json:"kind"`
+	HostManaged bool            `json:"host_managed,omitempty"`
+	Config      json.RawMessage `json:"config,omitempty"`
+	CreatedAt   *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time      `json:"updated_at,omitempty"`
+}
+
+type SyslogSinkConfig struct {
+	URL    string `json:"url"`
+	Prefix string `json:"template"`
+	UseIDs bool   `json:"use_ids"`
+}
+
+type LogAggregatorSinkConfig struct {
+	Addr string `json:"addr"`
+}

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -257,6 +257,9 @@ type HostClient interface {
 	ListJobs() (map[string]host.ActiveJob, error)
 	StreamEvents(id string, ch chan *host.Event) (stream.Stream, error)
 	GetStatus() (*host.HostStatus, error)
+	GetSinks() ([]*ct.Sink, error)
+	AddSink(*ct.Sink) error
+	RemoveSink(string) error
 }
 
 type ClusterClient interface {
@@ -279,6 +282,8 @@ type ControllerClient interface {
 	FormationListActive() ([]*ct.ExpandedFormation, error)
 	PutJob(*ct.Job) error
 	JobListActive() ([]*ct.Job, error)
+	StreamSinks(since *time.Time, ch chan *ct.Sink) (stream.Stream, error)
+	ListSinks() ([]*ct.Sink, error)
 }
 
 func ClusterClientWrapper(c *cluster.Client) clusterClientWrapper {

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -310,6 +310,12 @@ WHERE release_id = (SELECT release_id FROM apps WHERE name = 'controller');
 		data.Controller.Release.Env["TELEMETRY_BOOTSTRAP_ID"] = telemetryClusterID
 	}
 
+	// update logaggregator args
+	sqlBuf.WriteString(`
+UPDATE releases SET processes = jsonb_set(processes, '{app,args}', '["/bin/logaggregator"]')
+WHERE release_id IN (SELECT release_id FROM apps WHERE name = 'logaggregator');
+`)
+
 	step := func(id, name string, action bootstrap.Action) bootstrap.Step {
 		if ra, ok := action.(*bootstrap.RunAppAction); ok {
 			ra.ID = id

--- a/host/cli/log_sink.go
+++ b/host/cli/log_sink.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/go-docopt"
+)
+
+func init() {
+	Register("log-sink", runLogSink, `
+usage: flynn-host log-sink list <host>
+
+Commands:
+    list    Display a list of sinks configured for a host
+
+Examples:
+
+    $ flynn-host log-sink list host1
+`)
+}
+
+func runLogSink(args *docopt.Args, client *cluster.Client) error {
+	switch {
+	case args.Bool["list"]:
+		return runLogSinkList(args, client)
+	}
+	return nil
+}
+
+func runLogSinkList(args *docopt.Args, client *cluster.Client) error {
+	hostClient, err := client.Host(args.String["<host>"])
+	if err != nil {
+		return fmt.Errorf("could not connect to host: %s", err)
+	}
+	sinks, err := hostClient.GetSinks()
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	listRec(w,
+		"ID",
+		"KIND",
+		"CONFIG",
+		"HOST MANAGED",
+	)
+
+	for _, sink := range sinks {
+		listRec(w,
+			sink.ID,
+			sink.Kind,
+			string(sink.Config),
+			sink.HostManaged,
+		)
+	}
+	return nil
+}

--- a/host/host.go
+++ b/host/host.go
@@ -44,6 +44,7 @@ options:
   --external-ip=IP           external IP of host
   --listen-ip=IP             bind host network services to this IP
   --state=PATH               path to state file [default: /var/lib/flynn/host-state.bolt]
+  --sink-state=PATH          path to the sink state file [default: /var/lib/flynn/sink-state.bolt]
   --id=ID                    host id
   --tags=TAGS                host tags (comma separated list of KEY=VAL pairs, used for job constraints in the scheduler)
   --force                    kill all containers booted by flynn-host before starting
@@ -107,6 +108,7 @@ Commands:
   discover                   Return low-level information about a service
   promote                    Promotes a Flynn node to a member of the consensus cluster
   demote                     Demotes a Flynn node, removing it from the consensus cluster
+  log-sink                   Manage host log sinks
 
 See 'flynn-host help <command>' for more information on a specific command.
 `
@@ -168,6 +170,7 @@ func runDaemon(args *docopt.Args) {
 	externalIP := args.String["--external-ip"]
 	listenIP := args.String["--listen-ip"]
 	stateFile := args.String["--state"]
+	sinkFile := args.String["--sink-state"]
 	hostID := args.String["--id"]
 	tags := parseTagArgs(args.String["--tags"])
 	force := args.Bool["--force"]
@@ -292,6 +295,8 @@ func runDaemon(args *docopt.Args) {
 	shutdown.BeforeExit(func() { vman.CloseDB() })
 
 	mux := logmux.New(hostID, logDir, logger.New("host.id", hostID, "component", "logmux"))
+	sman := logmux.NewSinkManager(sinkFile, mux, state, logger.New("host.id", hostID, "component", "sinkManager"))
+	shutdown.BeforeExit(func() { sman.CloseDB() })
 
 	log.Info("initializing job backend", "type", backendName)
 	var backend Backend
@@ -319,7 +324,7 @@ func runDaemon(args *docopt.Args) {
 	backend.SetDefaultEnv("LISTEN_IP", listenIP)
 
 	var buffers host.LogBuffers
-	discoverdManager := NewDiscoverdManager(backend, mux, hostID, publishAddr, tags)
+	discoverdManager := NewDiscoverdManager(backend, sman, hostID, publishAddr, tags)
 	publishURL := "http://" + publishAddr
 	host := &Host{
 		id:  hostID,
@@ -332,6 +337,7 @@ func runDaemon(args *docopt.Args) {
 		state:   state,
 		backend: backend,
 		vman:    vman,
+		sman:    sman,
 		volAPI:  volumeapi.NewHTTPAPI(vman),
 		discMan: discoverdManager,
 		log:     logger.New("host.id", hostID),

--- a/host/logmux/sink.go
+++ b/host/logmux/sink.go
@@ -1,0 +1,628 @@
+package logmux
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/boltdb/bolt"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/logaggregator/client"
+	"github.com/flynn/flynn/logaggregator/utils"
+	"github.com/flynn/flynn/pkg/dialer"
+	hh "github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/lru"
+	"github.com/flynn/flynn/pkg/syslog/rfc6587"
+	"github.com/flynn/flynn/pkg/tlsconfig"
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+var SinkExistsError = errors.New("sink with that id already exists")
+var SinkNotFoundError = errors.New("sink with that id couldn't be found")
+
+type SinkManager struct {
+	mtx    sync.RWMutex
+	mux    *Mux
+	logger log15.Logger
+	sinks  map[string]Sink
+	state  JobStateGetter
+
+	dbPath string
+	db     *bolt.DB
+
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+type JobStateGetter interface {
+	GetJob(id string) *host.ActiveJob
+}
+
+func NewSinkManager(dbPath string, mux *Mux, state JobStateGetter, logger log15.Logger) *SinkManager {
+	return &SinkManager{
+		dbPath:     dbPath,
+		mux:        mux,
+		logger:     logger,
+		sinks:      make(map[string]Sink),
+		state:      state,
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+type SinkHTTPAPI struct {
+	sm *SinkManager
+}
+
+func (s *SinkHTTPAPI) GetSinks(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	s.sm.mtx.RLock()
+	sinks := make([]*ct.Sink, 0, len(s.sm.sinks))
+	for _, s := range s.sm.sinks {
+		info := s.Info()
+		sinks = append(sinks, &ct.Sink{
+			ID:          info.ID,
+			Kind:        info.Kind,
+			Config:      info.Config,
+			HostManaged: info.HostManaged,
+		})
+	}
+	s.sm.mtx.RUnlock()
+	hh.JSON(w, 200, sinks)
+}
+
+func (s *SinkHTTPAPI) AddSink(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	var info SinkInfo
+	if err := hh.DecodeJSON(req, &info); err != nil {
+		hh.Error(w, err)
+		return
+	}
+	err := s.sm.AddSink(ps.ByName("id"), &info)
+	if err != nil && err != SinkExistsError {
+		hh.Error(w, err)
+		return
+	}
+	hh.JSON(w, 200, info)
+}
+
+func (s *SinkHTTPAPI) RemoveSink(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	err := s.sm.RemoveSink(ps.ByName("id"))
+	if err == SinkNotFoundError {
+		hh.ObjectNotFoundError(w, err.Error())
+		return
+	} else if err != nil {
+		hh.Error(w, err)
+		return
+	}
+	hh.JSON(w, 200, struct{}{})
+}
+
+func (sm *SinkManager) RegisterRoutes(r *httprouter.Router) {
+	api := &SinkHTTPAPI{sm}
+	r.GET("/sinks", api.GetSinks)
+	r.PUT("/sinks/:id", api.AddSink)
+	r.DELETE("/sinks/:id", api.RemoveSink)
+}
+
+func (sm *SinkManager) OpenDB() error {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+	if sm.dbPath == "" {
+		return nil
+	}
+
+	// open database file
+	if err := os.MkdirAll(filepath.Dir(sm.dbPath), 0755); err != nil {
+		return fmt.Errorf("could not mkdir for sink persistence db: %s", err)
+	}
+	db, err := bolt.Open(sm.dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		return fmt.Errorf("could not open sink persistence db: %s", err)
+	}
+
+	// create buckets if they don't already exist
+	if err := db.Update(func(tx *bolt.Tx) error {
+		tx.CreateBucketIfNotExists([]byte("sinks"))
+		return nil
+	}); err != nil {
+		return fmt.Errorf("could not initialise sink persistence db: %s", err)
+	}
+	sm.db = db
+
+	// restore previous state if any
+	if err := sm.restore(); err != nil {
+		return err
+	}
+
+	// start persistence routine
+	go sm.persistSinks()
+	return nil
+}
+
+func (sm *SinkManager) CloseDB() error {
+	// Shutdown persistence routine
+	sm.shutdownOnce.Do(func() {
+		close(sm.shutdownCh)
+	})
+
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+
+	for id, s := range sm.sinks {
+		s.Shutdown()
+		sm.persistSink(id)
+	}
+
+	if sm.db == nil {
+		return nil
+	}
+	if err := sm.db.Close(); err != nil {
+		return err
+	}
+	sm.db = nil
+	return nil
+}
+
+type SinkInfo struct {
+	ID          string            `json:"id"`
+	Kind        ct.SinkKind       `json:"kind"`
+	Cursor      *utils.HostCursor `json:"cursor,omitempty"`
+	Config      []byte            `json:"config"`
+	HostManaged bool              `json:"host_managed"`
+}
+
+func (sm *SinkManager) restore() error {
+	// read back from buckets into in-memory structure
+	return sm.db.View(func(tx *bolt.Tx) error {
+		sinkBucket := tx.Bucket([]byte("sinks"))
+		return sinkBucket.ForEach(func(k, v []byte) error {
+			sinkInfo := &SinkInfo{}
+			if err := json.Unmarshal(v, sinkInfo); err != nil {
+				return fmt.Errorf("failed to deserialize sink info: %s", err)
+			}
+			return sm.addSink(string(k), sinkInfo, false)
+		})
+	})
+}
+
+func (sm *SinkManager) newSink(s *SinkInfo) (Sink, error) {
+	switch s.Kind {
+	case ct.SinkKindLogaggregator:
+		return NewLogAggregatorSink(sm, s)
+	case ct.SinkKindSyslog:
+		return NewSyslogSink(sm, s)
+	default:
+		return nil, fmt.Errorf("unknown sink kind: %q", s.Kind)
+	}
+}
+
+func (sm *SinkManager) persistSink(id string) error {
+	if err := sm.db.Update(func(tx *bolt.Tx) error {
+		sinkBucket := tx.Bucket([]byte("sinks"))
+		k := []byte(id)
+
+		// remove sink from database if not found in current sinks
+		sink, sinkExists := sm.sinks[id]
+		if !sinkExists {
+			sinkBucket.Delete(k)
+			return nil
+		}
+
+		// serialize sink info and persist to disk
+		b, err := json.Marshal(sink.Info())
+		if err != nil {
+			return fmt.Errorf("failed to serialize sink info: %s", err)
+		}
+		err = sinkBucket.Put(k, b)
+		if err != nil {
+			return fmt.Errorf("failed to persist sink info to boltdb: %s", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sm *SinkManager) persistSinks() {
+	log := sm.logger.New("fn", "persistSinks")
+	log.Info("starting sink persistence routine")
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sm.shutdownCh:
+			return
+		case <-ticker.C:
+			sm.mtx.Lock()
+			for id := range sm.sinks {
+				if err := sm.persistSink(id); err != nil {
+					log.Warn("error persisting sink", "sink.id", id, "err", err)
+				}
+			}
+			sm.mtx.Unlock()
+		}
+	}
+}
+
+func (sm *SinkManager) AddSink(id string, s *SinkInfo) error {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+
+	return sm.addSink(id, s, true)
+}
+
+func (sm *SinkManager) addSink(id string, s *SinkInfo, persist bool) error {
+	if _, ok := sm.sinks[id]; ok {
+		// TODO: handle sink config change
+		return SinkExistsError
+	}
+	sink, err := sm.newSink(s)
+	if err != nil {
+		return err
+	}
+	sm.sinks[id] = sink
+	if persist {
+		if err := sm.persistSink(id); err != nil {
+			return err
+		}
+	}
+	go sm.mux.addSink(sink)
+	return nil
+}
+
+func (sm *SinkManager) RemoveSink(id string) error {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+
+	return sm.removeSink(id)
+}
+
+func (sm *SinkManager) removeSink(id string) error {
+	if s, ok := sm.sinks[id]; !ok {
+		return SinkNotFoundError
+	} else {
+		s.Shutdown()
+	}
+	delete(sm.sinks, id)
+	return sm.persistSink(id)
+}
+
+func (sm *SinkManager) StreamToAggregators(s discoverd.Service) error {
+	log := sm.logger.New("fn", "StreamToAggregators")
+	ch := make(chan *discoverd.Event)
+	_, err := s.Watch(ch)
+	if err != nil {
+		log.Error("failed to connect to discoverd watch", "error", err)
+		return err
+	}
+	log.Info("connected to discoverd watch")
+	sm.mtx.RLock()
+	initial := make(map[string]struct{})
+	for id, sink := range sm.sinks {
+		if sink.Info().Kind == ct.SinkKindLogaggregator && sink.Info().HostManaged == true {
+			initial[id] = struct{}{}
+		}
+	}
+	sm.mtx.RUnlock()
+
+	go func() {
+		for e := range ch {
+			switch e.Kind {
+			case discoverd.EventKindUp:
+				if _, ok := initial[e.Instance.Addr]; ok {
+					delete(initial, e.Instance.Addr)
+					continue // skip adding as we already have this sink.
+				}
+				log.Info("connecting to new aggregator", "addr", e.Instance.Addr)
+				cfg, _ := json.Marshal(ct.LogAggregatorSinkConfig{Addr: e.Instance.Addr})
+				info := &SinkInfo{ID: e.Instance.Addr, Kind: ct.SinkKindLogaggregator, Config: cfg, HostManaged: true}
+				sm.AddSink(e.Instance.Addr, info)
+			case discoverd.EventKindDown:
+				log.Info("disconnecting from aggregator", "addr", e.Instance.Addr)
+				sm.RemoveSink(e.Instance.Addr)
+			case discoverd.EventKindCurrent:
+				for id := range initial {
+					log.Info("removing stale aggregator", "addr", id)
+					delete(initial, id)
+					sm.RemoveSink(id)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+type Sink interface {
+	Info() *SinkInfo
+	Connect() error
+	Close()
+	GetCursor(hostID string) (*utils.HostCursor, error)
+	Write(m message) error
+	Shutdown()
+	ShutdownCh() chan struct{}
+}
+
+type LogAggregatorSink struct {
+	sm *SinkManager
+
+	id          string
+	logger      log15.Logger
+	addr        string
+	hostManaged bool
+
+	conn             net.Conn
+	aggregatorClient *client.Client
+
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+func NewLogAggregatorSink(sm *SinkManager, info *SinkInfo) (*LogAggregatorSink, error) {
+	cfg := &ct.LogAggregatorSinkConfig{}
+	if err := json.Unmarshal(info.Config, cfg); err != nil {
+		return nil, err
+	}
+	return &LogAggregatorSink{
+		sm:          sm,
+		id:          info.ID,
+		addr:        cfg.Addr,
+		hostManaged: info.HostManaged,
+		shutdownCh:  make(chan struct{}),
+	}, nil
+}
+
+func (s *LogAggregatorSink) Info() *SinkInfo {
+	config, _ := json.Marshal(ct.LogAggregatorSinkConfig{Addr: s.addr})
+	return &SinkInfo{
+		ID:          s.id,
+		Kind:        ct.SinkKindLogaggregator,
+		Config:      config,
+		HostManaged: s.hostManaged,
+	}
+}
+
+func (s *LogAggregatorSink) Connect() error {
+	// Connect TCP connection to aggregator
+	conn, err := dialer.Retry.Dial("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	// Connect to logaggregator HTTP endpoint
+	host, _, _ := net.SplitHostPort(s.addr)
+	c, err := client.New("http://" + host)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	s.conn = conn
+	s.aggregatorClient = c
+	return nil
+}
+
+func (s *LogAggregatorSink) Close() {
+	s.conn.Close()
+}
+
+func (s *LogAggregatorSink) GetCursor(hostID string) (*utils.HostCursor, error) {
+	cursors, err := s.aggregatorClient.GetCursors()
+	if err != nil {
+		return nil, err
+	}
+	var aggCursor *utils.HostCursor
+	if c, ok := cursors[hostID]; ok {
+		aggCursor = &c
+	}
+	return aggCursor, nil
+}
+
+func (s *LogAggregatorSink) Write(m message) error {
+	_, err := s.conn.Write(rfc6587.Bytes(m.Message))
+	return err
+}
+
+func (s *LogAggregatorSink) Shutdown() {
+	s.shutdownOnce.Do(func() { close(s.shutdownCh) })
+}
+
+func (s *LogAggregatorSink) ShutdownCh() chan struct{} {
+	return s.shutdownCh
+}
+
+// SyslogSink is a flexible sink that can connect to TCP/TLS endpoints that use syslog framing.
+// The prefix of the message can be customised using a template.
+type SyslogSink struct {
+	sm *SinkManager
+
+	id     string
+	url    string
+	prefix string
+	useIDs bool
+
+	mtx          sync.RWMutex
+	cache        *lru.Cache
+	cursor       *utils.HostCursor
+	template     *template.Template
+	conn         net.Conn
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+func NewSyslogSink(sm *SinkManager, info *SinkInfo) (sink *SyslogSink, err error) {
+	cfg := &ct.SyslogSinkConfig{}
+	if err := json.Unmarshal(info.Config, cfg); err != nil {
+		return nil, err
+	}
+	var t *template.Template
+	if cfg.Prefix != "" {
+		t, err = template.New("").Parse(cfg.Prefix)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &SyslogSink{
+		sm:         sm,
+		id:         info.ID,
+		url:        cfg.URL,
+		prefix:     cfg.Prefix,
+		useIDs:     cfg.UseIDs,
+		cache:      lru.New(1000),
+		template:   t,
+		cursor:     info.Cursor,
+		shutdownCh: make(chan struct{}),
+	}, nil
+}
+
+func (s *SyslogSink) Info() *SinkInfo {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	config, _ := json.Marshal(ct.SyslogSinkConfig{URL: s.url, Prefix: s.prefix})
+	return &SinkInfo{
+		ID:     s.id,
+		Kind:   ct.SinkKindSyslog,
+		Config: config,
+		Cursor: s.cursor,
+	}
+}
+
+func (s *SyslogSink) Connect() error {
+	u, err := url.Parse(s.url)
+	if err != nil {
+		return err
+	}
+	host, port, _ := net.SplitHostPort(u.Host)
+	if port == "" {
+		port = "514"
+	}
+	addr := net.JoinHostPort(host, port)
+	var conn net.Conn
+	switch u.Scheme {
+	case "syslog":
+		conn, err = net.Dial("tcp", addr)
+	case "syslog+tls":
+		tlsConfig := tlsconfig.SecureCiphers(&tls.Config{})
+		conn, err = tls.Dial("tcp", addr, tlsConfig)
+	default:
+		return fmt.Errorf("unknown protocol %s", u.Scheme)
+	}
+	if err != nil {
+		return err
+	}
+	s.conn = conn
+	return nil
+}
+
+func (s *SyslogSink) GetCursor(_ string) (*utils.HostCursor, error) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.cursor, nil
+}
+
+// Parses JobID and ProcType from header ProcID field
+// Always returns JobID, returns ProcType if available
+func parseProcID(procID []byte) (string, string) {
+	procTypeID := strings.SplitN(string(procID), ".", 2)
+	if len(procTypeID) == 2 {
+		return procTypeID[1], procTypeID[0]
+	}
+	return procTypeID[0], ""
+}
+
+var msgSep = []byte{' '}
+
+type cachedJob struct {
+	AppName string
+	Prefix  []byte
+}
+
+func (s *SyslogSink) Write(m message) error {
+	// Lookup job in cache
+	var appName string
+	var prefix []byte
+	if cached, ok := s.cache.Get(string(m.Message.ProcID)); ok {
+		if c, ok := cached.(cachedJob); ok {
+			appName = c.AppName
+			prefix = c.Prefix
+		}
+	}
+
+	var updateCache bool
+	// Get the job name if the cache hasn't been populated yet
+	var job *host.ActiveJob
+	if appName == "" {
+		jobID, _ := parseProcID(m.Message.ProcID)
+		job = s.sm.state.GetJob(jobID)
+		if job != nil && job.Job != nil {
+			appName = job.Job.Metadata["flynn-controller.app_name"]
+			updateCache = true
+		}
+	}
+
+	// If not in the cache execute the template
+	if s.template != nil && prefix == nil {
+		if job != nil && job.Job != nil {
+			var buf bytes.Buffer
+			if err := s.template.Execute(&buf, job.Job); err != nil {
+				return err
+			}
+			prefix = buf.Bytes()
+			updateCache = true
+		}
+	}
+
+	// Update the cache with app name and prefix
+	if updateCache {
+		s.cache.Add(string(m.Message.ProcID), cachedJob{
+			AppName: appName,
+			Prefix:  prefix,
+		})
+	}
+
+	// If the generated/cached prefix isn't 0 length then modify the message body
+	if len(prefix) != 0 {
+		m.Message.Msg = bytes.Join([][]byte{prefix, m.Message.Msg}, msgSep)
+	}
+
+	// Overwrite syslog APP_NAME with controller app name unless IDs are to be used
+	if !s.useIDs {
+		m.Message.AppName = []byte(appName)
+	}
+
+	// Write to the remote syslog
+	_, err := s.conn.Write(rfc6587.Bytes(m.Message))
+	if err != nil {
+		return err
+	}
+
+	// Cursor needs to be mutex protected to prevent race when persisting to disk
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.cursor = m.HostCursor
+	return nil
+}
+
+func (s *SyslogSink) Close() {
+	if s.conn != nil {
+		s.conn.Close()
+	}
+}
+
+func (s *SyslogSink) Shutdown() {
+	s.shutdownOnce.Do(func() { close(s.shutdownCh) })
+}
+
+func (s *SyslogSink) ShutdownCh() chan struct{} {
+	return s.shutdownCh
+}

--- a/host/start.sh
+++ b/host/start.sh
@@ -30,6 +30,7 @@ ZPOOL="flynn-${FLYNN_JOB_ID}"
 
 ARGS=(
   --state      "${DIR}/host-state.bolt"
+  --sink-state "${DIR}/sink-state.bolt"
   --volpath    "${DIR}/volumes"
   --log-dir    "${DIR}/logs"
   --zpool-name "${ZPOOL}"

--- a/logaggregator/main.go
+++ b/logaggregator/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"net"
 	"os"
 
@@ -15,20 +14,26 @@ import (
 func main() {
 	defer shutdown.Exit()
 
-	apiPort := os.Getenv("PORT")
+	apiPort := os.Getenv("PORT_0")
 	if apiPort == "" {
 		apiPort = "5000"
 	}
 
-	logAddr := flag.String("logaddr", ":3000", "syslog input listen address")
-	apiAddr := flag.String("apiaddr", ":"+apiPort, "api listen address")
-	flag.Parse()
+	logPort := os.Getenv("PORT_1")
+	if logPort == "" {
+		logPort = "3000"
+	}
+
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "logaggregator"
+	}
 
 	conf := ServerConfig{
-		SyslogAddr:  *logAddr,
-		ApiAddr:     *apiAddr,
+		SyslogAddr:  ":" + logPort,
+		ApiAddr:     ":" + apiPort,
 		Discoverd:   discoverd.DefaultClient,
-		ServiceName: "logaggregator",
+		ServiceName: serviceName,
 	}
 
 	srv := NewServer(conf)

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -223,4 +224,23 @@ func (c *Host) Update(name string, args ...string) (pid int, err error) {
 
 func (c *Host) UpdateTags(tags map[string]string) error {
 	return c.c.Post("/host/tags", tags, nil)
+}
+
+func (c *Host) GetSinks() ([]*ct.Sink, error) {
+	var sinks []*ct.Sink
+	return sinks, c.c.Get("/sinks", &sinks)
+}
+
+func (c *Host) AddSink(info *ct.Sink) error {
+	if info.ID == "" {
+		return errors.New("missing ID")
+	}
+	return c.c.Put("/sinks/"+info.ID, info, nil)
+}
+
+func (c *Host) RemoveSink(id string) error {
+	if id == "" {
+		return errors.New("missing ID")
+	}
+	return c.c.Delete("/sinks/" + id)
 }

--- a/pkg/lru/LICENSE
+++ b/pkg/lru/LICENSE
@@ -1,0 +1,193 @@
+Derived from https://github.com/golang/groupcache
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/lru/lru.go
+++ b/pkg/lru/lru.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specificies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}

--- a/pkg/lru/lru_test.go
+++ b/pkg/lru/lru_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+import (
+	"testing"
+)
+
+type simpleStruct struct {
+	int
+	string
+}
+
+type complexStruct struct {
+	int
+	simpleStruct
+}
+
+var getTests = []struct {
+	name       string
+	keyToAdd   interface{}
+	keyToGet   interface{}
+	expectedOk bool
+}{
+	{"string_hit", "myKey", "myKey", true},
+	{"string_miss", "myKey", "nonsense", false},
+	{"simple_struct_hit", simpleStruct{1, "two"}, simpleStruct{1, "two"}, true},
+	{"simeple_struct_miss", simpleStruct{1, "two"}, simpleStruct{0, "noway"}, false},
+	{"complex_struct_hit", complexStruct{1, simpleStruct{2, "three"}},
+		complexStruct{1, simpleStruct{2, "three"}}, true},
+}
+
+func TestGet(t *testing.T) {
+	for _, tt := range getTests {
+		lru := New(0)
+		lru.Add(tt.keyToAdd, 1234)
+		val, ok := lru.Get(tt.keyToGet)
+		if ok != tt.expectedOk {
+			t.Fatalf("%s: cache hit = %v; want %v", tt.name, ok, !ok)
+		} else if ok && val != 1234 {
+			t.Fatalf("%s expected get to return 1234 but got %v", tt.name, val)
+		}
+	}
+}
+
+func TestRemove(t *testing.T) {
+	lru := New(0)
+	lru.Add("myKey", 1234)
+	if val, ok := lru.Get("myKey"); !ok {
+		t.Fatal("TestRemove returned no match")
+	} else if val != 1234 {
+		t.Fatalf("TestRemove failed.  Expected %d, got %v", 1234, val)
+	}
+
+	lru.Remove("myKey")
+	if _, ok := lru.Get("myKey"); ok {
+		t.Fatal("TestRemove returned a removed entry")
+	}
+}

--- a/schema/controller/event.json
+++ b/schema/controller/event.json
@@ -33,6 +33,8 @@
         "resource_deletion",
         "route",
         "route_deletion",
+        "sink",
+        "sink_deletion",
         "scale"
       ]
     }

--- a/schema/controller/sink.json
+++ b/schema/controller/sink.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://flynn.io/schema/controller/sink#",
+  "title": "Sink",
+  "description": "",
+  "sortIndex": 20,
+  "type": "object",
+  "examples": [
+    "schema/examples/controller/sink_create#",
+    "schema/examples/controller/sink_list#"
+  ],
+  "definitions": {
+    "sink_kind": {
+      "type": "string",
+      "enum": ["syslog"]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "kind": {
+      "$ref": "#/definitions/sink_kind"
+    },
+    "config": {
+      "type": "object"
+    },
+    "host_managed": {
+      "type": "boolean"
+    },
+    "created_at": {
+      "$ref": "/schema/controller/common#/definitions/created_at"
+    },
+    "updated_at": {
+      "$ref": "/schema/controller/common#/definitions/updated_at"
+    }
+  }
+}

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -83,6 +83,7 @@ main() {
 
   local id="host${index}"
   local state="/tmp/flynn-host-state-${index}.bolt"
+  local sinkstate="/tmp/flynn-host-sink-state-${index}.bolt"
   local pidfile="/tmp/flynn-host-${index}.pid"
   local bridge_name="flynnbr${index}"
   local vol_path="/var/lib/flynn/volumes-${index}"
@@ -94,6 +95,7 @@ main() {
   # delete the old state
   if $destroy_state; then
     sudo rm -f "${state}"
+    sudo rm -f "${sinkstate}"
   fi
 
   if $destroy_vols; then
@@ -141,6 +143,7 @@ main() {
     --bridge-name "${bridge_name}" \
     --force \
     --state "${state}" \
+    --sink-state "${sinkstate}" \
     --volpath "${vol_path}" \
     --log-dir "${log_dir}" \
     --flynn-init "${bin_dir}/flynn-init" \


### PR DESCRIPTION
Adds support for connecting Flynn to external logging services.

This first pass adds support for a flexible SyslogSink backend that can connect to services that support RFC 6587 framing. Additionally users can specify a prefix that can be templated with variables on a per job basis. This can be used to provide token authentication or make use of metadata in the job for tagging etc.
It also supports rudimentary TLS using system trusted roots, custom roots and insecure modes to follow.

Closes #1422 
Closes #3335