### PR TITLE
scheduler: Fix host IDs in TestFailingAddJob

### DIFF
--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1092,7 +1092,7 @@ outer:
 		if err == nil {
 			return
 		}
-		log.Error("error adding job to the cluster", "err", err)
+		log.Error("error adding job to the cluster", "attempts", attempt+1, "err", err)
 
 		if attempt > 0 {
 			// when making multiple attempts, backoff in increments
@@ -1101,7 +1101,7 @@ outer:
 			if delay > 30*time.Second {
 				delay = 30 * time.Second
 			}
-			log.Warn(fmt.Sprintf("failed to start job after %d attempts, waiting %s before trying again", attempt, delay))
+			log.Warn(fmt.Sprintf("waiting %s before re-attempting job placement", delay))
 			time.Sleep(delay)
 		}
 	}

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -867,7 +867,7 @@ type failingHostClient struct {
 
 func newFailingHostClient() *failingHostClient {
 	return &failingHostClient{
-		FakeHostClient: NewFakeHostClient("failing-host", false),
+		FakeHostClient: NewFakeHostClient("failing_host", false),
 		addJob:         make(chan struct{}),
 	}
 }
@@ -898,7 +898,7 @@ func (TestSuite) TestFailingAddJob(c *C) {
 	s.waitForError(addJobErr)
 
 	// add an ok host, wait for the job to be scheduled on it
-	okHost := NewFakeHostClient("ok-host", false)
+	okHost := NewFakeHostClient("ok_host", false)
 	events := make(chan *host.Event)
 	stream, err := okHost.StreamEvents("", events)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Host IDs should not contain dashes because that is the separator used to extract the host ID part of a job ID (see [`cluster.ExtractHostID`](https://github.com/flynn/flynn/blob/master/pkg/cluster/utils.go#L12-L18)).

I've also fixed the logging of attempts in `StartJob` (it was previously always one behind, and not logged after the first attempt failure).