### PR TITLE
host/cli: Fix volume garbage collection

### DIFF
--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -135,6 +135,7 @@ func SetupMountspecs(job *host.Job, artifacts []*ct.Artifact) {
 				URL:    artifact.LayerURL(layer),
 				Size:   layer.Length,
 				Hashes: layer.Hashes,
+				Meta:   artifact.Meta,
 			})
 		}
 	}

--- a/host/cli/volume.go
+++ b/host/cli/volume.go
@@ -92,10 +92,10 @@ outer:
 		}
 		if err := v.Host.DestroyVolume(v.Volume.ID); err != nil {
 			success = false
-			fmt.Printf("could not delete volume %s: %s\n", v.Volume.ID, err)
+			fmt.Printf("could not delete %s volume %s: %s\n", v.Volume.Type, v.Volume.ID, err)
 			continue outer
 		}
-		fmt.Println(v.Volume.ID, "deleted")
+		fmt.Println("Deleted", v.Volume.Type, "volume", v.Volume.ID)
 	}
 	if !success {
 		return errors.New("could not garbage collect all volumes")
@@ -199,12 +199,14 @@ func runVolumeList(args *docopt.Args, client *cluster.Client) error {
 	defer w.Flush()
 	listRec(w,
 		"ID",
+		"TYPE",
 		"HOST",
 	)
 
 	for _, volume := range volumes {
 		listRec(w,
 			volume.Volume.ID,
+			volume.Volume.Type,
 			volume.Host.ID(),
 		)
 	}

--- a/host/cli/volume.go
+++ b/host/cli/volume.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/flynn/flynn/host/types"
@@ -201,13 +202,19 @@ func runVolumeList(args *docopt.Args, client *cluster.Client) error {
 		"ID",
 		"TYPE",
 		"HOST",
+		"META",
 	)
 
 	for _, volume := range volumes {
+		meta := make([]string, 0, len(volume.Volume.Meta))
+		for k, v := range volume.Volume.Meta {
+			meta = append(meta, fmt.Sprintf("%s=%s", k, v))
+		}
 		listRec(w,
 			volume.Volume.ID,
 			volume.Volume.Type,
 			volume.Host.ID(),
+			strings.Join(meta, " "),
 		)
 	}
 	return nil

--- a/host/downloader/downloader.go
+++ b/host/downloader/downloader.go
@@ -171,7 +171,7 @@ func (d *Downloader) downloadSquashfsLayer(layer *ct.ImageLayer, layerURL string
 		ID:         layer.ID,
 		Data:       tmp,
 		Size:       layer.Length,
-		Type:       "squashfs",
+		Type:       volume.VolumeTypeSquashfs,
 		MountFlags: syscall.MS_RDONLY,
 	})
 	return err

--- a/host/downloader/downloader.go
+++ b/host/downloader/downloader.go
@@ -137,7 +137,7 @@ func (d *Downloader) downloadImage(artifact *ct.Artifact, info chan *ct.ImagePul
 				Layer: layer,
 			}
 
-			if err := d.downloadSquashfsLayer(layer, artifact.LayerURL(layer)); err != nil {
+			if err := d.downloadSquashfsLayer(layer, artifact.LayerURL(layer), artifact.Meta); err != nil {
 				return fmt.Errorf("error downloading layer: %s", err)
 			}
 		}
@@ -146,7 +146,7 @@ func (d *Downloader) downloadImage(artifact *ct.Artifact, info chan *ct.ImagePul
 	return nil
 }
 
-func (d *Downloader) downloadSquashfsLayer(layer *ct.ImageLayer, layerURL string) error {
+func (d *Downloader) downloadSquashfsLayer(layer *ct.ImageLayer, layerURL string, meta map[string]string) error {
 	if vol := d.vman.GetVolume(layer.ID); vol != nil {
 		return nil
 	}
@@ -173,6 +173,7 @@ func (d *Downloader) downloadSquashfsLayer(layer *ct.ImageLayer, layerURL string
 		Size:       layer.Length,
 		Type:       volume.VolumeTypeSquashfs,
 		MountFlags: syscall.MS_RDONLY,
+		Meta:       meta,
 	})
 	return err
 }

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -796,6 +796,7 @@ func (l *LibcontainerBackend) mountSquashfs(m *host.Mountspec) (string, error) {
 			Size:       m.Size,
 			Type:       volume.VolumeTypeSquashfs,
 			MountFlags: syscall.MS_RDONLY,
+			Meta:       m.Meta,
 		})
 		if err != nil {
 			return "", fmt.Errorf("error importing squashfs layer: %s", err)

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -794,7 +794,7 @@ func (l *LibcontainerBackend) mountSquashfs(m *host.Mountspec) (string, error) {
 			ID:         m.ID,
 			Data:       tmp,
 			Size:       m.Size,
-			Type:       "squashfs",
+			Type:       volume.VolumeTypeSquashfs,
 			MountFlags: syscall.MS_RDONLY,
 		})
 		if err != nil {
@@ -830,7 +830,7 @@ func (l *LibcontainerBackend) mountTmpfs(job *host.Job) (string, error) {
 		ID:         job.ID,
 		Data:       sparse.NewBufferedFileIoProcessorByFP(f),
 		Size:       tmpfs.Size,
-		Type:       "ext2",
+		Type:       volume.VolumeTypeExt2,
 		MountFlags: syscall.MS_NOATIME,
 	})
 	if err != nil {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -77,6 +77,7 @@ type Mountspec struct {
 	URL    string            `json:"url,omitempty"`
 	Size   int64             `json:"size,omitempty"`
 	Hashes map[string]string `json:"hashes,omitempty"`
+	Meta   map[string]string `json:"meta,omitempty"`
 }
 
 type JobResources struct {

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -33,13 +33,28 @@ type Volume interface {
 	It is a serializable structure intended for API use.
 */
 type Info struct {
-	ID string `json:"id"`
+	ID   string     `json:"id"`
+	Type VolumeType `json:"type"`
+}
+
+type VolumeType string
+
+const (
+	VolumeTypeData     VolumeType = "data"
+	VolumeTypeSquashfs VolumeType = "squashfs"
+	VolumeTypeExt2     VolumeType = "ext2"
+)
+
+var VolumeTypes = []VolumeType{
+	VolumeTypeData,
+	VolumeTypeSquashfs,
+	VolumeTypeExt2,
 }
 
 type Filesystem struct {
-	ID         string    `json:"id"`
-	Data       io.Reader `json:"-"`
-	Size       int64     `json:"size"`
-	Type       string    `json:"type"`
-	MountFlags uintptr   `json:"flags"`
+	ID         string     `json:"id"`
+	Data       io.Reader  `json:"-"`
+	Size       int64      `json:"size"`
+	Type       VolumeType `json:"type"`
+	MountFlags uintptr    `json:"flags"`
 }

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -1,6 +1,9 @@
 package volume
 
-import "io"
+import (
+	"io"
+	"time"
+)
 
 /*
 	A Volume is a persistent and sharable filesystem.  Unlike most of the filesystem in a job's
@@ -33,9 +36,10 @@ type Volume interface {
 	It is a serializable structure intended for API use.
 */
 type Info struct {
-	ID   string            `json:"id"`
-	Type VolumeType        `json:"type"`
-	Meta map[string]string `json:"meta,omitempty"`
+	ID        string            `json:"id"`
+	Type      VolumeType        `json:"type"`
+	Meta      map[string]string `json:"meta,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
 }
 
 type VolumeType string

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -33,8 +33,9 @@ type Volume interface {
 	It is a serializable structure intended for API use.
 */
 type Info struct {
-	ID   string     `json:"id"`
-	Type VolumeType `json:"type"`
+	ID   string            `json:"id"`
+	Type VolumeType        `json:"type"`
+	Meta map[string]string `json:"meta,omitempty"`
 }
 
 type VolumeType string
@@ -52,9 +53,18 @@ var VolumeTypes = []VolumeType{
 }
 
 type Filesystem struct {
-	ID         string     `json:"id"`
-	Data       io.Reader  `json:"-"`
-	Size       int64      `json:"size"`
-	Type       VolumeType `json:"type"`
-	MountFlags uintptr    `json:"flags"`
+	ID         string            `json:"id"`
+	Data       io.Reader         `json:"-"`
+	Size       int64             `json:"size"`
+	Type       VolumeType        `json:"type"`
+	MountFlags uintptr           `json:"flags"`
+	Meta       map[string]string `json:"meta,omitempty"`
+}
+
+func (f *Filesystem) Info() *Info {
+	return &Info{
+		ID:   f.ID,
+		Type: f.Type,
+		Meta: f.Meta,
+	}
 }

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -173,7 +173,11 @@ func (p *Provider) Kind() string {
 
 func (p *Provider) NewVolume() (volume.Volume, error) {
 	id := random.UUID()
-	info := &volume.Info{ID: id, Type: volume.VolumeTypeData}
+	info := &volume.Info{
+		ID:        id,
+		Type:      volume.VolumeTypeData,
+		CreatedAt: time.Now(),
+	}
 	v := &zfsVolume{
 		info:      info,
 		provider:  p,
@@ -200,6 +204,7 @@ func (p *Provider) ImportFilesystem(fs *volume.Filesystem) (volume.Volume, error
 		fs.ID = random.UUID()
 	}
 	info := fs.Info()
+	info.CreatedAt = time.Now()
 	v := &zfsVolume{
 		info:       info,
 		provider:   p,

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -199,7 +199,7 @@ func (p *Provider) ImportFilesystem(fs *volume.Filesystem) (volume.Volume, error
 	if fs.ID == "" {
 		fs.ID = random.UUID()
 	}
-	info := &volume.Info{ID: fs.ID, Type: fs.Type}
+	info := fs.Info()
 	v := &zfsVolume{
 		info:       info,
 		provider:   p,

--- a/util/release/manifest.go
+++ b/util/release/manifest.go
@@ -64,7 +64,10 @@ func interpolateManifest(imageDir, imageRepository string, src io.Reader, dest i
 				Type:        ct.ArtifactTypeFlynn,
 				RawManifest: manifest,
 				Size:        int64(len(manifest)),
-				Meta:        map[string]string{"flynn.component": name},
+				Meta: map[string]string{
+					"flynn.component":    name,
+					"flynn.system-image": "true",
+				},
 			}
 			artifact.URI = fmt.Sprintf("%s?target=/%s/images/%s.json", imageRepository, version.String(), artifact.Manifest().ID())
 			artifact.Hashes = artifact.Manifest().Hashes()


### PR DESCRIPTION
I've added some new fields to `volume.Info`, and updated `flynn-host volume gc` so that it doesn't delete in-use SquashFS / Ext2 image layers or any system images.

`flynn-host volume list` now looks like this:

```
$ flynn-host volume list
ID                                                                TYPE      HOST   CREATED        META
0a56e34d-233a-4c15-b98e-2eb48e090479                              data      host0  8 minutes ago  
2072951ba2a2ea37ce85743b76040d86e3cb6c03c3ccba4285c3db6cedb2de44  squashfs  host0  8 minutes ago  flynn.system-image=true flynn.component=discoverd
444345d958273e600f89a7e020532fa827555e6a447e0a46adf4fd1cef333952  squashfs  host0  8 minutes ago  flynn.component=discoverd flynn.system-image=true
host0-4afb8e79-b3db-4e3b-b288-031dbaaaceb9                        ext2      host0  8 minutes ago  
178a270fca427cdc09a3549d690a35804cdb892447b56041fb8fa5df6a1a6fe5  squashfs  host0  8 minutes ago  flynn.component=flannel flynn.system-image=true
host0-fcca7237-aed9-4508-9f22-36e757467646                        ext2      host0  8 minutes ago  
11af63dc-1a00-4f46-99f7-8cd228638091                              data      host0  8 minutes ago  
29449538baa54f7a92a0da303322657f820262dcbaade4f20564a1a296fc811f  squashfs  host0  8 minutes ago  flynn.component=postgres flynn.system-image=true
7888305f34c64cf4a0aab3718976ef2c15b462c6f5e8b132ad0f874e2f1386a9  squashfs  host0  8 minutes ago  flynn.component=postgres flynn.system-image=true
```

I've also namespaced the ZFS volumes:

```
$ sudo zfs list
NAME                                                                                      USED  AVAIL  REFER  MOUNTPOINT
flynn-default                                                                             743M   199G    19K  none
flynn-default/data                                                                       62.7M   199G    19K  none
flynn-default/data/0a56e34d-233a-4c15-b98e-2eb48e090479                                  84.5K   199G  84.5K  /var/lib/flynn/volumes-0/zfs/mnt/data/0a56e34d-233a-4c15-b98e-2eb48e090479
flynn-default/data/11af63dc-1a00-4f46-99f7-8cd228638091                                  62.6M   199G  62.6M  /var/lib/flynn/volumes-0/zfs/mnt/data/11af63dc-1a00-4f46-99f7-8cd228638091
...
flynn-default/ext2                                                                       62.0M   199G    19K  none
flynn-default/ext2/host0-0222b3e1-4b7a-4b7f-b003-09cc601b8730                            3.64M   199G  3.64M  -
flynn-default/ext2/host0-11ad6619-340e-4345-a6e2-a693ce5b0722                            3.64M   199G  3.64M  -
...
flynn-default/squashfs                                                                    618M   199G    19K  none
flynn-default/squashfs/03597b9b04cd93f51d94876aa2421af872d110b4fc9aa19dcf3a8ba6e2c77bc6  42.6M   199G  41.5M  -
flynn-default/squashfs/069bfadbecec76a4faa0485d430d342a85f5cbff1a7056d570834fcfb9b6985b  9.62M   199G  9.15M  -
...
```