### PR TITLE
docker-receive: Mount tmp volume at /tmp rather than /data

### DIFF
--- a/docker-receive/artifact/main.go
+++ b/docker-receive/artifact/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/pinkerton"
@@ -19,6 +20,7 @@ import (
 
 func main() {
 	log.SetFlags(0)
+	logrus.SetLevel(logrus.ErrorLevel)
 
 	if len(os.Args) != 2 {
 		log.Fatalf("usage: %s URL", os.Args[0])
@@ -34,7 +36,7 @@ func run(url string) error {
 		return err
 	}
 
-	context, err := pinkerton.BuildContext("flynn", "/data")
+	context, err := pinkerton.BuildContext("flynn", "/tmp/docker")
 	if err != nil {
 		return err
 	}

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -733,7 +733,7 @@ WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
 			"PGDATABASE":     data.Controller.Release.Env["PGDATABASE"],
 			"PGPASSWORD":     data.Controller.Release.Env["PGPASSWORD"],
 		}
-		cmd.Volumes = []*ct.VolumeReq{{Path: "/data", DeleteOnStop: true}}
+		cmd.Volumes = []*ct.VolumeReq{{Path: "/tmp", DeleteOnStop: true}}
 		if err := runMigrator(cmd); err != nil {
 			ch <- &bootstrap.StepInfo{
 				StepMeta:  meta,

--- a/host/cli/destroy-volumes.go
+++ b/host/cli/destroy-volumes.go
@@ -18,8 +18,9 @@ func init() {
 usage: flynn-host destroy-volumes [options]
 
 options:
-  --volpath=PATH     directory to create volumes in [default: /var/lib/flynn/volumes]
-  --include-data     actually destroy data in backends *this is dangerous* [default: false]
+  --volpath=PATH         directory to create volumes in [default: /var/lib/flynn/volumes]
+  --include-data         actually destroy data in backends *this is dangerous* [default: false]
+  --keep-system-images   don't destroy system images
 
 Destroys all data volumes on this host.  This is a dangerous operation: data
 may be permanently discarded.
@@ -33,6 +34,9 @@ it will simply be removed.  In this case, data will remain behind in the backend
 storage engines (and eventually require manual cleanup), but the flynn-host
 daemon's next launch will still be like a fresh launch.
 
+If '--keep-system-images' is set, system image volumes are not destroyed and
+the volume database is not removed.
+
 Major features of backends will not be adjusted (i.e., zfs datasets will be
 destroyed, but zpools will not be touched).`)
 }
@@ -45,6 +49,7 @@ func runVolumeDestroy(args *docopt.Args) error {
 
 	volPath := args.String["--volpath"]
 	includeData := args.Bool["--include-data"]
+	keepSystemImages := args.Bool["--keep-system-images"]
 
 	volumeDBPath := filepath.Join(volPath, "volumes.bolt")
 
@@ -64,18 +69,20 @@ func runVolumeDestroy(args *docopt.Args) error {
 	} else if includeData == false {
 		fmt.Println("'--include-data' not specified; leaving backend data storage intact.")
 	} else {
-		if err := destroyVolumes(vman); err != nil {
+		if err := destroyVolumes(vman, keepSystemImages); err != nil {
 			fmt.Printf("%s\n", err)
 			allVolumesDestroyed = false
 		}
 	}
 
-	// remove db file
-	if err := os.Remove(volumeDBPath); err != nil {
-		fmt.Printf("could not remove volume state db file %q: %s.\n", volumeDBPath, err)
-		shutdown.ExitWithCode(5)
+	if !keepSystemImages {
+		// remove db file
+		if err := os.Remove(volumeDBPath); err != nil {
+			fmt.Printf("could not remove volume state db file %q: %s.\n", volumeDBPath, err)
+			shutdown.ExitWithCode(5)
+		}
+		fmt.Printf("state db file %q removed.\n", volumeDBPath)
 	}
-	fmt.Printf("state db file %q removed.\n", volumeDBPath)
 
 	// exit code depends on if all volumes were destroyed successfully or not
 	if includeData && !allVolumesDestroyed {
@@ -106,24 +113,30 @@ func loadVolumeState(volumeDBPath string) (*volumemanager.Manager, error) {
 	return vman, nil
 }
 
-func destroyVolumes(vman *volumemanager.Manager) error {
+func destroyVolumes(vman *volumemanager.Manager, keepSystemImages bool) error {
 	someVolumesNotDestroyed := false
 	var secondPass []string
-	for volID := range vman.Volumes() {
-		fmt.Printf("removing volume id=%q... ", volID)
-		if err := vman.DestroyVolume(volID); err == nil {
+	for id, vol := range vman.Volumes() {
+		if keepSystemImages && vol.Info().Meta["flynn.system-image"] == "true" {
+			continue
+		}
+		fmt.Printf("removing volume id=%q... ", id)
+		if err := vman.DestroyVolume(id); err == nil {
 			fmt.Println("success")
 		} else if zfs.IsDatasetHasChildrenError(err) {
 			fmt.Println("has children, coming back to it later")
-			secondPass = append(secondPass, volID)
+			secondPass = append(secondPass, id)
 		} else {
 			fmt.Printf("error: %s\n", err)
 			someVolumesNotDestroyed = true
 		}
 	}
-	for volID := range vman.Volumes() {
-		fmt.Printf("removing volume id=%q... ", volID)
-		if err := vman.DestroyVolume(volID); err == nil {
+	for id, vol := range vman.Volumes() {
+		if keepSystemImages && vol.Info().Meta["flynn.system-image"] == "true" {
+			continue
+		}
+		fmt.Printf("removing volume id=%q... ", id)
+		if err := vman.DestroyVolume(id); err == nil {
 			fmt.Println("success")
 		} else {
 			fmt.Printf("error: %s\n", err)

--- a/script/generate-backups
+++ b/script/generate-backups
@@ -71,6 +71,8 @@ main() {
   backup_mysql_cluster
 
   backup_mongodb_cluster
+
+  backup_docker_cluster
 }
 
 clone_app() {
@@ -114,6 +116,22 @@ backup_mongodb_cluster() {
   backup_cluster "${out}"
 }
 
+backup_docker_cluster() {
+  local version="v20161017.1"
+  local name="${version}-nodejs-docker.tar"
+  local out="${dir}/${name}"
+
+  info "generating ${name}"
+  if [[ -e "${out}" ]] && ! $force; then
+    info "backup ${name} already exists"
+    return
+  fi
+
+  bootstrap_cluster "${version}"
+  docker_deploy_app
+  backup_cluster "${out}"
+}
+
 bootstrap_cluster() {
   local version=$1
 
@@ -152,6 +170,21 @@ git_deploy_app() {
   fi
 
   popd >/dev/null
+}
+
+docker_deploy_app() {
+  info "deploying app using 'flynn docker push'"
+
+  docker build -t "${app}" "${src}"
+
+  flynn create --remote "" --yes "${app}"
+
+  local out="${tmp}/docker-push-${version}.txt"
+  if ! flynn -a "${app}" docker push "${app}" &> "${out}"; then
+    warn "docker push failed:"
+    cat "${out}"
+    fail "docker push failed"
+  fi
 }
 
 add_redis_resource() {

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -97,7 +97,10 @@ main() {
   fi
 
   if $destroy_vols; then
-    sudo "${flynn_host}" destroy-volumes --volpath="${vol_path}" --include-data
+    sudo "${flynn_host}" destroy-volumes \
+      --volpath="${vol_path}" \
+      --include-data \
+      --keep-system-images
   fi
 
   # create IP on eth0 interface


### PR DESCRIPTION
The Docker library creates temporary files in `/tmp` for verifying layer digests which don't always fit on the ext2 tmpfs.

I've also added a docker-receive deploy backup to CI (and updated `script/generate-backups`), and updated the bootstrap scripts so we don't delete system image volumes every time we run `script/bootstrap-flynn`.