### PR TITLE
scheduler: Watch service events and mark formations as complete

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -496,7 +496,8 @@
               "proto": "tcp",
               "service": {
                 "name": "gitreceive",
-                "create": true
+                "create": true,
+                "check": {"type": "tcp"}
               }
             }
           ],
@@ -701,7 +702,8 @@
             "proto": "tcp",
             "service": {
               "name": "status-web",
-              "create": true
+              "create": true,
+              "check": {"type": "tcp"}
             }
           }]
         }

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	PutResource(resource *ct.Resource) error
 	DeleteResource(providerID, resourceID string) (*ct.Resource, error)
 	PutFormation(formation *ct.Formation) error
+	PutScaleRequest(req *ct.ScaleRequest) error
 	PutJob(job *ct.Job) error
 	DeleteJob(appID, jobID string) error
 	SetAppRelease(appID, releaseID string) error
@@ -67,6 +68,7 @@ type Client interface {
 	DeploymentList(appID string) ([]*ct.Deployment, error)
 	StreamDeployment(d *ct.Deployment, output chan *ct.DeploymentEvent) (stream.Stream, error)
 	DeployAppRelease(appID, releaseID string, stopWait <-chan struct{}) error
+	ScaleAppRelease(appID, releaseID string, opts ct.ScaleOptions) error
 	StreamJobEvents(appID string, output chan *ct.Job) (stream.Stream, error)
 	WatchJobEvents(appID, releaseID string) (ct.JobWatcher, error)
 	StreamEvents(opts ct.StreamEventsOptions, output chan *ct.Event) (stream.Stream, error)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -273,6 +273,8 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.GET("/apps/:apps_id/formations", httphelper.WrapHandler(api.appLookup(api.ListFormations)))
 	httpRouter.GET("/formations", httphelper.WrapHandler(api.GetFormations))
 
+	httpRouter.PUT("/apps/:apps_id/scale/:releases_id", httphelper.WrapHandler(api.appLookup(api.PutScaleRequest)))
+
 	httpRouter.POST("/apps/:apps_id/jobs", httphelper.WrapHandler(api.appLookup(api.RunJob)))
 	httpRouter.GET("/apps/:apps_id/jobs/:jobs_id", httphelper.WrapHandler(api.appLookup(api.GetJob)))
 	httpRouter.PUT("/apps/:apps_id/jobs/:jobs_id", httphelper.WrapHandler(api.appLookup(api.PutJob)))

--- a/controller/scheduler/job.go
+++ b/controller/scheduler/job.go
@@ -99,6 +99,8 @@ type Job struct {
 
 	// hostError is the error from the host if the job fails to start
 	hostError *string
+
+	serviceFirstSeen *time.Time
 }
 
 // Tags returns the tags for the job's process type from the formation
@@ -125,6 +127,13 @@ func (j *Job) Volumes() []ct.VolumeReq {
 		return []ct.VolumeReq{{Path: "/data"}}
 	}
 	return nil
+}
+
+func (j *Job) Service() string {
+	if j.Formation == nil {
+		return ""
+	}
+	return j.Formation.Release.Processes[j.Type].Service
 }
 
 func (j *Job) IsRunning() bool {

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	eventBufferSize      = 1000
-	defaultMaxHostChecks = 10
-	routerDrainTimeout   = 10 * time.Second
+	eventBufferSize        = 1000
+	defaultMaxHostChecks   = 10
+	routerDrainTimeout     = 10 * time.Second
+	routerBackendUpTimeout = 10 * time.Second
 )
 
 var (
@@ -57,6 +58,8 @@ type Scheduler struct {
 	hosts      map[string]*Host
 	routers    map[string]*Router
 	jobs       Jobs
+	routes     map[string]map[string]struct{}
+	services   map[string]*Service
 
 	jobEvents chan *host.Event
 
@@ -71,8 +74,9 @@ type Scheduler struct {
 	rectify               chan struct{}
 	sendTelemetry         chan struct{}
 	hostEvents            chan *discoverd.Event
+	serviceEvents         chan *discoverd.Event
 	routerServiceEvents   chan *discoverd.Event
-	routerBackendEvents   chan *RouterEvent
+	routerStreamEvents    chan *RouterEvent
 	formationEvents       chan *ct.ExpandedFormation
 	sinkEvents            chan *ct.Sink
 	putJobs               chan *ct.Job
@@ -114,6 +118,8 @@ func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient, disc D
 		hosts:                 make(map[string]*Host),
 		routers:               make(map[string]*Router),
 		jobs:                  make(map[string]*Job),
+		services:              make(map[string]*Service),
+		routes:                make(map[string]map[string]struct{}),
 		formations:            make(Formations),
 		sinks:                 make(map[string]*ct.Sink),
 		jobEvents:             make(chan *host.Event, eventBufferSize),
@@ -128,8 +134,9 @@ func NewScheduler(cluster utils.ClusterClient, cc utils.ControllerClient, disc D
 		sendTelemetry:         make(chan struct{}, 1),
 		formationEvents:       make(chan *ct.ExpandedFormation, eventBufferSize),
 		hostEvents:            make(chan *discoverd.Event, eventBufferSize),
+		serviceEvents:         make(chan *discoverd.Event, eventBufferSize),
 		routerServiceEvents:   make(chan *discoverd.Event, eventBufferSize),
-		routerBackendEvents:   make(chan *RouterEvent, eventBufferSize),
+		routerStreamEvents:    make(chan *RouterEvent, eventBufferSize),
 		sinkEvents:            make(chan *ct.Sink, eventBufferSize),
 		putJobs:               make(chan *ct.Job, eventBufferSize),
 		placementRequests:     make(chan *PlacementRequest, eventBufferSize),
@@ -410,11 +417,14 @@ func (s *Scheduler) Run() {
 		case e := <-s.hostEvents:
 			s.HandleHostEvent(e)
 			continue
+		case e := <-s.serviceEvents:
+			s.HandleServiceEvent(e)
+			continue
 		case e := <-s.routerServiceEvents:
 			s.HandleRouterServiceEvent(e)
 			continue
-		case e := <-s.routerBackendEvents:
-			s.HandleRouterBackendEvent(e)
+		case e := <-s.routerStreamEvents:
+			s.HandleRouterStreamEvent(e)
 			continue
 		case <-s.hostChecks:
 			s.PerformHostChecks()
@@ -461,10 +471,12 @@ func (s *Scheduler) Run() {
 			s.HandleInternalStateRequest(req)
 		case e := <-s.hostEvents:
 			s.HandleHostEvent(e)
+		case e := <-s.serviceEvents:
+			s.HandleServiceEvent(e)
 		case e := <-s.routerServiceEvents:
 			s.HandleRouterServiceEvent(e)
-		case e := <-s.routerBackendEvents:
-			s.HandleRouterBackendEvent(e)
+		case e := <-s.routerStreamEvents:
+			s.HandleRouterStreamEvent(e)
 		case <-s.hostChecks:
 			s.PerformHostChecks()
 		case e := <-s.jobEvents:
@@ -1376,13 +1388,76 @@ func (s *Scheduler) HandleHostEvent(e *discoverd.Event) {
 	}
 }
 
+func (s *Scheduler) HandleServiceEvent(e *discoverd.Event) {
+	if e.Instance == nil {
+		return
+	}
+
+	jobID := e.Instance.Meta["FLYNN_JOB_ID"]
+	jobType := e.Instance.Meta["FLYNN_PROCESS_TYPE"]
+	log := s.logger.New("fn", "HandleServiceEvent", "service", e.Service, "kind", e.Kind, "job.id", jobID, "job.type", jobType)
+	log.Info("handling service event")
+
+	id, err := cluster.ExtractUUID(jobID)
+	if err != nil {
+		log.Error("error handling service event, invalid job ID")
+		return
+	}
+
+	job, ok := s.jobs[id]
+	if !ok {
+		log.Error("error handling service event, unknown job")
+		return
+	}
+
+	if job.serviceFirstSeen == nil {
+		now := time.Now()
+		job.serviceFirstSeen = &now
+	}
+
+	if job.State != JobStatePending && job.State != JobStateStarting {
+		return
+	}
+
+	shouldWaitForRouterBackends := func() bool {
+		// don't wait if there are no routes for the service
+		routes, ok := s.routes[job.Service()]
+		if !ok {
+			return false
+		}
+
+		// don't wait if the service was first seen more than
+		// routerBackendUpTimeout ago
+		if time.Since(*job.serviceFirstSeen) > routerBackendUpTimeout {
+			return false
+		}
+
+		// don't wait if the job is up in all the routers which
+		// have a route for the service
+		if backend, ok := s.routerBackends[jobID]; ok && len(backend.Routers) >= len(routes) {
+			return false
+		}
+
+		return true
+	}
+
+	if shouldWaitForRouterBackends() {
+		log.Info("waiting for router backend events")
+		time.AfterFunc(routerBackendUpTimeout, func() {
+			s.serviceEvents <- e
+		})
+	} else {
+		s.handleJobStatus(job, host.StatusRunning)
+	}
+}
+
 func (s *Scheduler) HandleRouterServiceEvent(e *discoverd.Event) {
 	switch e.Kind {
 	case discoverd.EventKindUp, discoverd.EventKindUpdate:
 		id := e.Instance.Meta["FLYNN_JOB_ID"]
 		if _, ok := s.routers[id]; !ok {
 			s.logger.Info("adding router", "router.id", id)
-			s.routers[id] = NewRouter(id, e.Instance.Addr, s.routerBackendEvents, s.logger)
+			s.routers[id] = NewRouter(id, e.Instance.Addr, s.routerStreamEvents, s.logger)
 		}
 	case discoverd.EventKindDown:
 		id := e.Instance.Meta["FLYNN_JOB_ID"]
@@ -1392,7 +1467,7 @@ func (s *Scheduler) HandleRouterServiceEvent(e *discoverd.Event) {
 			delete(s.routers, id)
 		}
 		for _, b := range s.routerBackends {
-			s.HandleRouterBackendEvent(&RouterEvent{
+			s.HandleRouterStreamEvent(&RouterEvent{
 				RouterID: id,
 				Type:     router.EventTypeBackendDrained,
 				Backend:  b.Backend,
@@ -1401,10 +1476,34 @@ func (s *Scheduler) HandleRouterServiceEvent(e *discoverd.Event) {
 	}
 }
 
-func (s *Scheduler) HandleRouterBackendEvent(e *RouterEvent) {
-	log := s.logger.New("job.id", e.Backend.JobID, "job.service", e.Backend.Service, "router.id", e.RouterID)
+func (s *Scheduler) HandleRouterStreamEvent(e *RouterEvent) {
+	log := s.logger.New("router.id", e.RouterID)
+	if e.Backend != nil {
+		log = log.New("job.id", e.Backend.JobID, "job.service", e.Backend.Service)
+	}
+	if e.Route != nil {
+		log = log.New("route.service", e.Route.Service)
+	}
 
 	switch e.Type {
+	case router.EventTypeRouteSet:
+		routes, ok := s.routes[e.Route.Service]
+		if !ok {
+			routes = make(map[string]struct{})
+			s.routes[e.Route.Service] = routes
+		}
+		routes[e.RouterID] = struct{}{}
+		log.Info("route added", "router.count", len(routes))
+	case router.EventTypeRouteRemove:
+		routes, ok := s.routes[e.Route.Service]
+		if !ok {
+			return
+		}
+		delete(routes, e.RouterID)
+		log.Info("route removed", "router.count", len(routes))
+		if len(routes) == 0 {
+			delete(s.routes, e.Route.Service)
+		}
 	case router.EventTypeBackendUp:
 		backend, ok := s.routerBackends[e.Backend.JobID]
 		if !ok {
@@ -1413,6 +1512,12 @@ func (s *Scheduler) HandleRouterBackendEvent(e *RouterEvent) {
 		}
 		backend.Routers[e.RouterID] = struct{}{}
 		log.Info("router backend is up", "router.count", len(backend.Routers))
+
+		// if the backend is up in all the routers which have a route
+		// for the service, mark it as running
+		if len(backend.Routers) >= len(s.routes[e.Backend.Service]) {
+			s.markRouterBackendUp(backend)
+		}
 	case router.EventTypeBackendDrained:
 		backend, ok := s.routerBackends[e.Backend.JobID]
 		if !ok {
@@ -1424,6 +1529,20 @@ func (s *Scheduler) HandleRouterBackendEvent(e *RouterEvent) {
 			close(backend.Drained)
 			delete(s.routerBackends, e.Backend.JobID)
 		}
+	}
+}
+
+func (s *Scheduler) markRouterBackendUp(b *RouterBackend) {
+	id, err := cluster.ExtractUUID(b.Backend.JobID)
+	if err != nil {
+		return
+	}
+	job, ok := s.jobs[id]
+	if !ok {
+		return
+	}
+	if job.State == JobStatePending || job.State == JobStateStarting {
+		s.handleJobStatus(job, host.StatusRunning)
 	}
 }
 
@@ -1567,6 +1686,14 @@ func (s *Scheduler) handleActiveJob(activeJob *host.ActiveJob) *Job {
 	job.exitStatus = activeJob.ExitStatus
 	job.hostError = activeJob.Error
 
+	// if the host job is running but has a service, wait for either
+	// service or router events before marking the job as running
+	if activeJob.Status == host.StatusRunning && job.Service() != "" {
+		// TODO: consider adding a hard timeout to mark the job
+		//	 as running in case we never get any events
+		return job
+	}
+
 	s.handleJobStatus(job, activeJob.Status)
 
 	return job
@@ -1671,6 +1798,32 @@ func (s *Scheduler) handleFormation(ef *ct.ExpandedFormation) (formation *Format
 	log := s.logger.New("fn", "handleFormation", "app.id", ef.App.ID, "release.id", ef.Release.ID)
 
 	defer func() {
+		// subscribe to any release services so we know when to mark
+		// service jobs as running
+		processes := Processes(ef.Processes)
+		for _, proc := range ef.Release.Processes {
+			if proc.Service == "" {
+				continue
+			}
+			service, ok := s.services[proc.Service]
+			if !ok {
+				if processes.IsEmpty() {
+					continue
+				}
+				service = NewService(proc.Service, s.serviceEvents, s.logger)
+				s.services[proc.Service] = service
+			}
+			if processes.IsEmpty() {
+				delete(service.Formations, formation.key())
+				if len(service.Formations) == 0 {
+					service.Close()
+					delete(s.services, proc.Service)
+				}
+			} else {
+				service.Formations[formation.key()] = struct{}{}
+			}
+		}
+
 		// ensure the formation has the correct omni job counts
 		if formation.RectifyOmni(s.activeHostCount()) {
 			s.triggerRectify(formation.key())

--- a/controller/scheduler/scheduler.go
+++ b/controller/scheduler/scheduler.go
@@ -1773,7 +1773,10 @@ func (s *Scheduler) handleJobStatus(job *Job, status host.JobStatus) {
 	previousState := job.State
 	switch status {
 	case host.StatusStarting:
-		if job.State != JobStateStopping {
+		// only transition from pending -> starting (avoids
+		// out of order events marking jobs as starting which
+		// are actually running / stopped)
+		if job.State == "" || job.State == JobStatePending {
 			job.State = JobStateStarting
 		}
 	case host.StatusRunning:

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -587,10 +587,10 @@ func (TestSuite) TestMultipleSchedulers(c *C) {
 }
 
 func (TestSuite) TestStopJob(c *C) {
-	s := &Scheduler{putJobs: make(chan *ct.Job)}
-	defer close(s.putJobs)
+	s := &Scheduler{controllerPersist: make(chan interface{})}
+	defer close(s.controllerPersist)
 	go func() {
-		for range s.putJobs {
+		for range s.controllerPersist {
 		}
 	}()
 	formation := NewFormation(&ct.ExpandedFormation{

--- a/controller/scheduler/service.go
+++ b/controller/scheduler/service.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/flynn/flynn/controller/utils"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/pkg/stream"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+type Service struct {
+	Formations map[utils.FormationKey]struct{}
+
+	name     string
+	events   chan *discoverd.Event
+	logger   log15.Logger
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+func NewService(name string, events chan *discoverd.Event, logger log15.Logger) *Service {
+	s := &Service{
+		Formations: make(map[utils.FormationKey]struct{}),
+		name:       name,
+		events:     events,
+		logger:     logger,
+		stop:       make(chan struct{}),
+	}
+	go s.watchEvents()
+	return s
+}
+
+func (s *Service) Close() {
+	s.stopOnce.Do(func() { close(s.stop) })
+}
+
+func (s *Service) watchEvents() {
+	log := s.logger.New("fn", "service.watchEvents", "service", s.name)
+	var events chan *discoverd.Event
+	var stream stream.Stream
+	connect := func() (err error) {
+		log.Info("connecting service event stream")
+		events = make(chan *discoverd.Event)
+		stream, err = discoverd.NewService(s.name).Watch(events)
+		if err != nil {
+			log.Error("error connecting service event stream", "err", err)
+		}
+		return
+	}
+
+	// make initial connection
+	for {
+		if err := connect(); err == nil {
+			defer stream.Close()
+			break
+		}
+		select {
+		case <-s.stop:
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	for {
+	eventLoop:
+		for {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					break eventLoop
+				}
+				if event.Kind.Any(discoverd.EventKindUp, discoverd.EventKindUpdate) {
+					select {
+					case s.events <- event:
+					case <-s.stop:
+						return
+					}
+				}
+			case <-s.stop:
+				return
+			}
+		}
+		log.Warn("service event stream disconnected", "err", stream.Err())
+		// keep trying to reconnect, unless we are told to stop
+	retryLoop:
+		for {
+			select {
+			case <-s.stop:
+				return
+			default:
+			}
+
+			if err := connect(); err == nil {
+				break retryLoop
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -487,6 +487,23 @@ $$ LANGUAGE plpgsql`,
 	migrations.Add(29,
 		`ALTER TABLE deployments ADD COLUMN tags jsonb`,
 	)
+	migrations.Add(30,
+		`INSERT INTO event_types (name) VALUES ('scale_request')`,
+		`CREATE TABLE scale_request_states (name text PRIMARY KEY)`,
+		`INSERT INTO scale_request_states (name) VALUES ('pending'), ('cancelled'), ('complete')`,
+		`CREATE TABLE scale_requests (
+			scale_request_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+			app_id           uuid NOT NULL REFERENCES apps (app_id),
+			release_id       uuid NOT NULL REFERENCES releases (release_id),
+			state            text NOT NULL REFERENCES scale_request_states (name),
+			old_processes    jsonb,
+			new_processes    jsonb,
+			old_tags         jsonb,
+			new_tags         jsonb,
+			created_at       timestamptz NOT NULL DEFAULT now(),
+			updated_at       timestamptz NOT NULL DEFAULT now()
+		)`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/schema.go
+++ b/controller/schema/schema.go
@@ -57,6 +57,9 @@ func schemaForType(thing interface{}) *jsonschema.Schema {
 	if name == "newjob" {
 		name = "new_job"
 	}
+	if name == "scalerequest" {
+		name = "scale_request"
+	}
 	if name == "appupdate" {
 		name = "app"
 	}

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -164,6 +164,10 @@ func (c *FakeControllerClient) PutFormation(formation *ct.Formation) error {
 	return nil
 }
 
+func (c *FakeControllerClient) PutScaleRequest(req *ct.ScaleRequest) error {
+	return nil
+}
+
 func (c *FakeControllerClient) AppList() ([]*ct.App, error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -21,14 +21,17 @@ import (
 
 const RouteParentRefPrefix = "controller/apps/"
 
+var ErrScalingStopped = errors.New("controller: scaling was stopped")
+
 type ExpandedFormation struct {
-	App       *App                         `json:"app,omitempty"`
-	Release   *Release                     `json:"release,omitempty"`
-	Artifacts []*Artifact                  `json:"artifacts,omitempty"`
-	Processes map[string]int               `json:"processes,omitempty"`
-	Tags      map[string]map[string]string `json:"tags,omitempty"`
-	UpdatedAt time.Time                    `json:"updated_at,omitempty"`
-	Deleted   bool                         `json:"deleted,omitempty"`
+	App                 *App                         `json:"app,omitempty"`
+	Release             *Release                     `json:"release,omitempty"`
+	Artifacts           []*Artifact                  `json:"artifacts,omitempty"`
+	Processes           map[string]int               `json:"processes,omitempty"`
+	Tags                map[string]map[string]string `json:"tags,omitempty"`
+	UpdatedAt           time.Time                    `json:"updated_at,omitempty"`
+	Deleted             bool                         `json:"deleted,omitempty"`
+	PendingScaleRequest *ScaleRequest                `json:"pending_scale_request,omitempty"`
 
 	// DeprecatedImageArtifact is for creating backwards compatible cluster
 	// backups (the restore process used to require the ImageArtifact field
@@ -409,7 +412,7 @@ const (
 	EventTypeAppRelease           EventType = "app_release"
 	EventTypeDeployment           EventType = "deployment"
 	EventTypeJob                  EventType = "job"
-	EventTypeScale                EventType = "scale"
+	EventTypeScaleRequest         EventType = "scale_request"
 	EventTypeRelease              EventType = "release"
 	EventTypeReleaseDeletion      EventType = "release_deletion"
 	EventTypeArtifact             EventType = "artifact"
@@ -426,6 +429,11 @@ const (
 	EventTypeAppGarbageCollection EventType = "app_garbage_collection"
 	EventTypeSink                 EventType = "sink"
 	EventTypeSinkDeletion         EventType = "sink_deletion"
+
+	// EventTypeDeprecatedScale is a deprecated event which is emitted for
+	// old clients waiting for formations to be scaled (new clients should
+	// create and wait for scale requests)
+	EventTypeDeprecatedScale EventType = "scale"
 )
 
 type Event struct {
@@ -438,11 +446,44 @@ type Event struct {
 	CreatedAt  *time.Time      `json:"created_at,omitempty"`
 }
 
-type Scale struct {
+type ScaleRequest struct {
+	ID           string                        `json:"id"`
+	AppID        string                        `json:"app"`
+	ReleaseID    string                        `json:"release"`
+	State        ScaleRequestState             `json:"state"`
+	OldProcesses map[string]int                `json:"old_processes,omitempty"`
+	NewProcesses *map[string]int               `json:"new_processes,omitempty"`
+	OldTags      map[string]map[string]string  `json:"old_tags,omitempty"`
+	NewTags      *map[string]map[string]string `json:"new_tags,omitempty"`
+	CreatedAt    *time.Time                    `json:"created_at"`
+	UpdatedAt    *time.Time                    `json:"updated_at"`
+}
+
+type ScaleRequestState string
+
+const (
+	ScaleRequestStatePending   ScaleRequestState = "pending"
+	ScaleRequestStateCancelled ScaleRequestState = "cancelled"
+	ScaleRequestStateComplete  ScaleRequestState = "complete"
+)
+
+type DeprecatedScale struct {
 	PrevProcesses map[string]int `json:"prev_processes,omitempty"`
 	Processes     map[string]int `json:"processes"`
 	ReleaseID     string         `json:"release"`
 }
+
+type ScaleOptions struct {
+	Processes            map[string]int
+	Tags                 map[string]map[string]string
+	Timeout              *time.Duration
+	Stop                 chan struct{}
+	NoWait               bool
+	ScaleRequestCallback func(*ScaleRequest)
+	JobEventCallback     func(*Job) error
+}
+
+var DefaultScaleTimeout = 30 * time.Second
 
 type AppRelease struct {
 	PrevRelease *Release `json:"prev_release,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -279,6 +279,7 @@ type ControllerClient interface {
 	CreateRelease(appID string, release *ct.Release) error
 	CreateArtifact(artifact *ct.Artifact) error
 	PutFormation(formation *ct.Formation) error
+	PutScaleRequest(req *ct.ScaleRequest) error
 	StreamFormations(since *time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	AppList() ([]*ct.App, error)
 	FormationListActive() ([]*ct.ExpandedFormation, error)

--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -1,67 +1,31 @@
 package deployment
 
-import ct "github.com/flynn/flynn/controller/types"
-
 func (d *DeployJob) deployAllAtOnce() error {
 	log := d.logger.New("fn", "deployAllAtOnce")
 	log.Info("starting all-at-once deployment")
 
-	expected := make(ct.JobEvents)
-	newProcs := make(map[string]int, len(d.Processes))
-	for typ, n := range d.Processes {
-		// ignore processes which no longer exist in the new
-		// release
-		if _, ok := d.newRelease.Processes[typ]; !ok {
-			continue
-		}
-		newProcs[typ] = n
-		total := n
-		if d.isOmni(typ) {
-			total *= d.hostCount
-		}
-		existing := d.newReleaseState[typ]
-		if total > existing {
-			expected[typ] = ct.JobUpEvents(total - existing)
+	d.newFormation.Processes = make(map[string]int, len(d.oldFormation.Processes))
+	for typ, count := range d.oldFormation.Processes {
+		// only scale new processes which still exist
+		if _, ok := d.newRelease.Processes[typ]; ok {
+			d.newFormation.Processes[typ] = count
 		}
 	}
-	if expected.Count() > 0 {
-		log := log.New("release_id", d.NewReleaseID)
-		log.Info("creating new formation", "processes", newProcs)
-		if err := d.client.PutFormation(&ct.Formation{
-			AppID:     d.AppID,
-			ReleaseID: d.NewReleaseID,
-			Processes: newProcs,
-			Tags:      d.Tags,
-		}); err != nil {
-			log.Error("error creating new formation", "err", err)
-			return err
-		}
-
-		log.Info("waiting for job events", "expected", expected)
-		if err := d.waitForJobEvents(d.NewReleaseID, expected, log); err != nil {
-			log.Error("error waiting for job events", "err", err)
-			return err
-		}
+	log.Info("scaling up new formation", "release.id", d.NewReleaseID, "processes", d.newFormation.Processes)
+	if err := d.scaleNewRelease(); err != nil {
+		log.Error("error scaling up new formation", "release.id", d.NewReleaseID, "err", err)
+		return err
 	}
 
-	expected = make(ct.JobEvents)
-	for typ := range d.Processes {
-		if existing := d.oldReleaseState[typ]; existing > 0 {
-			expected[typ] = ct.JobDownEvents(existing)
-		}
+	log.Info("scaling old formation to zero", "release.id", d.OldReleaseID)
+	for typ := range d.oldRelease.Processes {
+		d.oldFormation.Processes[typ] = 0
 	}
-
-	log = log.New("release_id", d.OldReleaseID)
-	log.Info("scaling old formation to zero")
-	if err := d.client.PutFormation(&ct.Formation{
-		AppID:     d.AppID,
-		ReleaseID: d.OldReleaseID,
-		Tags:      d.Tags,
-	}); err != nil {
+	if err := d.scaleOldRelease(false); err != nil {
 		// the new jobs have now started and they are up, so return
 		// ErrSkipRollback (rolling back doesn't make a ton of sense
 		// because it involves stopping the new working jobs).
-		log.Error("error scaling old formation to zero", "err", err)
+		log.Error("error scaling old formation to zero", "release.id", d.OldReleaseID, "err", err)
 		return ErrSkipRollback{err.Error()}
 	}
 

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -1,104 +1,26 @@
 package deployment
 
 import (
-	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/controller/worker/types"
-	"github.com/flynn/flynn/discoverd/client"
-	"github.com/flynn/flynn/pkg/cluster"
 	"gopkg.in/inconshreveable/log15.v2"
 )
-
-type jobIDState struct {
-	jobID string
-	state ct.JobState
-}
-
-type JobEventType int
-
-const (
-	JobEventTypeDiscoverd JobEventType = iota
-	JobEventTypeController
-	JobEventTypeError
-)
-
-// JobEvent is a wrapper around either a discoverd service event, a controller
-// job event or a stream error, and helps the deploy to have a separate
-// channel per release when waiting for job events
-type JobEvent struct {
-	Type           JobEventType
-	DiscoverdEvent *discoverd.Event
-	JobEvent       *ct.Job
-	Error          error
-}
 
 type DeployJob struct {
 	*ct.Deployment
 	client       controller.Client
 	deployEvents chan<- ct.DeploymentEvent
-
-	// jobEvents is a map of release IDs to channels which receive job
-	// events for that particular release, and is used rather than just
-	// one channel for all events so that events received whilst waiting
-	// for one release to scale aren't dropped if they are for another
-	// release which may be scaled in the future
-	jobEvents    map[string]chan *JobEvent
-	jobEventsMtx sync.Mutex
-
-	serviceNames    map[string]string
-	serviceMeta     *discoverd.ServiceMeta
-	useJobEvents    map[string]struct{}
-	logger          log15.Logger
-	oldRelease      *ct.Release
-	newRelease      *ct.Release
-	oldReleaseState map[string]int
-	newReleaseState map[string]int
-	knownJobStates  map[jobIDState]struct{}
-	omni            map[string]struct{}
-	hostCount       int
-	stop            chan struct{}
-}
-
-// ReleaseJobEvents lazily creates and returns a channel of job events for the
-// given release
-func (d *DeployJob) ReleaseJobEvents(releaseID string) chan *JobEvent {
-	d.jobEventsMtx.Lock()
-	defer d.jobEventsMtx.Unlock()
-	if ch, ok := d.jobEvents[releaseID]; ok {
-		return ch
-	}
-	// give the channel a buffer so events for a release not being waited
-	// on do not block events for releases being waited on
-	ch := make(chan *JobEvent, 100)
-	d.jobEvents[releaseID] = ch
-	return ch
-}
-
-// JobEventErr sends the given error on job event channels for all releases.
-//
-// It does not close the channels because there are multiple publishers which
-// could break (i.e. controller job events and discoverd service events), but
-// everything will ultimately be closed when this error is received and the
-// deferred stream closes kick in.
-func (d *DeployJob) JobEventErr(err error) {
-	d.jobEventsMtx.Lock()
-	defer d.jobEventsMtx.Unlock()
-	for _, ch := range d.jobEvents {
-		ch <- &JobEvent{
-			Type:  JobEventTypeError,
-			Error: err,
-		}
-	}
-}
-
-func (d *DeployJob) isOmni(typ string) bool {
-	_, ok := d.omni[typ]
-	return ok
+	logger       log15.Logger
+	oldRelease   *ct.Release
+	newRelease   *ct.Release
+	oldFormation *ct.Formation
+	newFormation *ct.Formation
+	timeout      time.Duration
+	stop         chan struct{}
 }
 
 func (d *DeployJob) Perform() error {
@@ -121,249 +43,161 @@ func (d *DeployJob) Perform() error {
 		return err
 	}
 
-	log.Info("determining cluster size")
-	hosts, err := cluster.NewClient().Hosts()
+	log.Info("getting old release", "release.id", d.OldReleaseID)
+	var err error
+	d.oldRelease, err = d.client.GetRelease(d.OldReleaseID)
 	if err != nil {
-		log.Error("error listing cluster hosts", "err", err)
+		log.Error("error getting old release", "release.id", d.OldReleaseID, "err", err)
 		return err
 	}
-	d.hostCount = len(hosts)
-
-	log.Info("determining current release state")
-	oldRelease, err := d.client.GetRelease(d.OldReleaseID)
+	d.oldFormation, err = d.client.GetFormation(d.AppID, d.OldReleaseID)
 	if err != nil {
-		log.Error("error getting new release", "release_id", d.NewReleaseID, "err", err)
+		log.Error("error getting old formation", "release.id", d.OldReleaseID, "err", err)
 		return err
 	}
-	d.oldRelease = oldRelease
 
-	log.Info("determining release services and deployment state")
-	release, err := d.client.GetRelease(d.NewReleaseID)
+	log.Info("getting new release", "release.id", d.NewReleaseID)
+	d.newRelease, err = d.client.GetRelease(d.NewReleaseID)
 	if err != nil {
-		log.Error("error getting new release", "release_id", d.NewReleaseID, "err", err)
+		log.Error("error getting new release", "release.id", d.NewReleaseID, "err", err)
 		return err
 	}
-	d.newRelease = release
-	for typ, proc := range release.Processes {
-		if proc.Omni {
-			d.omni[typ] = struct{}{}
+	d.newFormation, err = d.client.GetFormation(d.AppID, d.NewReleaseID)
+	if err == controller.ErrNotFound {
+		d.newFormation = &ct.Formation{
+			AppID:     d.AppID,
+			ReleaseID: d.NewReleaseID,
+			Tags:      d.Tags,
 		}
-		if proc.Service == "" {
-			log.Info(fmt.Sprintf("using job events for %s process type, no service defined", typ))
-			d.useJobEvents[typ] = struct{}{}
-			continue
-		}
-
-		d.serviceNames[typ] = proc.Service
-
-		log.Info(fmt.Sprintf("using service discovery for %s process type", typ), "service", proc.Service)
-		events := make(chan *discoverd.Event)
-		stream, err := discoverd.NewService(proc.Service).Watch(events)
-		if err != nil {
-			log.Error("error creating service discovery watcher", "service", proc.Service, "err", err)
-			return err
-		}
-		defer stream.Close()
-
-	outer:
-		for {
-			select {
-			case <-d.stop:
-				return worker.ErrStopped
-			case event, ok := <-events:
-				if !ok {
-					log.Error("error creating service discovery watcher, channel closed", "service", proc.Service)
-					return fmt.Errorf("deployer: could not create watcher for service: %s", proc.Service)
-				}
-				switch event.Kind {
-				case discoverd.EventKindCurrent:
-					break outer
-				case discoverd.EventKindServiceMeta:
-					d.serviceMeta = event.ServiceMeta
-				case discoverd.EventKindUp:
-					releaseID, ok := event.Instance.Meta["FLYNN_RELEASE_ID"]
-					if !ok {
-						continue
-					}
-					switch releaseID {
-					case d.OldReleaseID:
-						d.oldReleaseState[typ]++
-					case d.NewReleaseID:
-						d.newReleaseState[typ]++
-					}
-				}
-			case <-time.After(5 * time.Second):
-				log.Error("error creating service discovery watcher, timeout reached", "service", proc.Service)
-				return fmt.Errorf("deployer: could not create watcher for service: %s", proc.Service)
-			}
-		}
-		go func() {
-			for {
-				event, ok := <-events
-				if !ok {
-					// this usually means deferred cleanup is in progress, but send an error
-					// in case the deploy is still waiting for an event which will now not come.
-					d.JobEventErr(errors.New("unexpected close of service event stream"))
-					return
-				}
-				if event.Instance == nil {
-					continue
-				}
-				if id, ok := event.Instance.Meta["FLYNN_APP_ID"]; !ok || id != d.AppID {
-					continue
-				}
-				releaseID, ok := event.Instance.Meta["FLYNN_RELEASE_ID"]
-				if !ok {
-					continue
-				}
-				d.ReleaseJobEvents(releaseID) <- &JobEvent{
-					Type:           JobEventTypeDiscoverd,
-					DiscoverdEvent: event,
-				}
-			}
-		}()
-	}
-
-	log.Info("getting job event stream")
-	jobEvents := make(chan *ct.Job)
-	stream, err := d.client.StreamJobEvents(d.AppID, jobEvents)
-	if err != nil {
-		log.Error("error getting job event stream", "err", err)
+	} else if err != nil {
 		return err
 	}
-	defer stream.Close()
-	go func() {
-		for {
-			event, ok := <-jobEvents
-			if !ok {
-				d.JobEventErr(errors.New("unexpected close of job event stream"))
-				return
-			}
-			d.ReleaseJobEvents(event.ReleaseID) <- &JobEvent{
-				Type:     JobEventTypeController,
-				JobEvent: event,
-			}
-		}
-	}()
-
-	log.Info("getting current jobs")
-	jobs, err := d.client.JobList(d.AppID)
-	if err != nil {
-		log.Error("error getting current jobs", "err", err)
-		return err
+	if d.newFormation.Processes == nil {
+		d.newFormation.Processes = make(map[string]int)
 	}
-	for _, job := range jobs {
-		if job.State != ct.JobStateUp {
-			continue
-		}
-		if _, ok := d.useJobEvents[job.Type]; !ok {
-			continue
-		}
 
-		// track the jobs so we can drop any events received between
-		// connecting the job stream and getting the list of jobs
-		d.knownJobStates[jobIDState{job.ID, ct.JobStateUp}] = struct{}{}
-
-		switch job.ReleaseID {
-		case d.OldReleaseID:
-			d.oldReleaseState[job.Type]++
-		case d.NewReleaseID:
-			d.newReleaseState[job.Type]++
-		}
+	if processesEqual(d.newFormation.Processes, d.Processes) {
+		log.Info("deployment already completed, nothing to do")
+		return nil
 	}
+
+	d.timeout = time.Duration(d.DeployTimeout) * time.Second
 
 	log.Info(
 		"determined deployment state",
 		"original", d.Processes,
-		"old_release", d.oldReleaseState,
-		"new_release", d.newReleaseState,
+		"old_release", d.oldFormation.Processes,
+		"new_release", d.newFormation.Processes,
 	)
 	return deployFunc()
 }
 
-func (d *DeployJob) waitForJobEvents(releaseID string, expected ct.JobEvents, log log15.Logger) error {
-	actual := make(ct.JobEvents)
-
-	handleEvent := func(jobID, typ string, state ct.JobState) {
-		// ignore pending events
-		if state == ct.JobStatePending {
-			return
-		}
-
-		// ignore duplicate events
-		if _, ok := d.knownJobStates[jobIDState{jobID, state}]; ok {
-			return
-		}
-		d.knownJobStates[jobIDState{jobID, state}] = struct{}{}
-
-		if _, ok := actual[typ]; !ok {
-			actual[typ] = make(map[ct.JobState]int)
-		}
-		actual[typ][state] += 1
+func (d *DeployJob) scaleOldRelease(wait bool) error {
+	opts := ct.ScaleOptions{
+		Processes:        d.oldFormation.Processes,
+		Timeout:          &d.timeout,
+		Stop:             d.stop,
+		NoWait:           !wait,
+		JobEventCallback: d.logJobEvent,
 	}
+	err := d.client.ScaleAppRelease(d.AppID, d.OldReleaseID, opts)
+	if err == ct.ErrScalingStopped {
+		err = worker.ErrStopped
+	}
+	return err
+}
 
-	jobEvents := d.ReleaseJobEvents(releaseID)
-	timeout := time.After(time.Duration(d.DeployTimeout) * time.Second)
-	for {
-		select {
-		case <-d.stop:
-			return worker.ErrStopped
-		case e := <-jobEvents:
-			switch e.Type {
-			case JobEventTypeDiscoverd:
-				event := e.DiscoverdEvent
-				if !event.Kind.Any(discoverd.EventKindUp, discoverd.EventKindUpdate) {
-					continue
+func (d *DeployJob) scaleNewRelease() error {
+	opts := ct.ScaleOptions{
+		Processes: d.newFormation.Processes,
+		Tags:      d.newFormation.Tags,
+		Timeout:   &d.timeout,
+		Stop:      d.stop,
+		JobEventCallback: func(job *ct.Job) error {
+			d.logJobEvent(job)
+			// return an error if we get a down job event when
+			// scaling the new formation up
+			if job.State == ct.JobStateDown {
+				msg := "got down job event"
+				if job.HostError != nil {
+					msg = *job.HostError
 				}
-				typ, ok := event.Instance.Meta["FLYNN_PROCESS_TYPE"]
-				if !ok {
-					continue
-				}
-				if _, ok := d.useJobEvents[typ]; ok {
-					continue
-				}
-				jobID, ok := event.Instance.Meta["FLYNN_JOB_ID"]
-				if !ok {
-					continue
-				}
-				log.Info("got service event", "job.id", jobID, "job.type", typ, "job.state", event.Kind)
-				handleEvent(jobID, typ, ct.JobStateUp)
-				if expected.Equals(actual) {
-					return nil
-				}
-			case JobEventTypeController:
-				event := e.JobEvent
-				// if service discovery is being used for the job's type, ignore up events and fail
-				// the deployment if we get a down event when waiting for the job to come up.
-				if _, ok := d.useJobEvents[event.Type]; !ok {
-					if event.State == ct.JobStateUp {
-						continue
-					}
-					if expected[event.Type][ct.JobStateUp] > 0 && event.IsDown() {
-						handleEvent(event.ID, event.Type, ct.JobStateDown)
-						return fmt.Errorf("%s process type failed to start, got %s job event", event.Type, event.State)
-					}
-				}
-
-				log.Info("got job event", "job.id", event.ID, "job.type", event.Type, "job.state", event.State)
-				if event.State == ct.JobStateStarting {
-					continue
-				}
-				if _, ok := actual[event.Type]; !ok {
-					actual[event.Type] = make(map[ct.JobState]int)
-				}
-				handleEvent(event.ID, event.Type, event.State)
-				if event.HostError != nil {
-					return fmt.Errorf("deployer: %s job failed to start: %s", event.Type, *event.HostError)
-				}
-				if expected.Equals(actual) {
-					return nil
-				}
-			case JobEventTypeError:
-				return e.Error
+				return fmt.Errorf("%s job failed to start: %s", job.Type, msg)
 			}
-		case <-timeout:
-			return fmt.Errorf("timed out waiting for job events: %v", expected)
+			return nil
+		},
+	}
+	err := d.client.ScaleAppRelease(d.AppID, d.NewReleaseID, opts)
+	if err == ct.ErrScalingStopped {
+		err = worker.ErrStopped
+	}
+	return err
+}
+
+func (d *DeployJob) logJobEvent(job *ct.Job) error {
+	d.logger.Info(
+		"got job event",
+		"release.id", job.ReleaseID,
+		"job.id", job.ID,
+		"job.type", job.Type,
+		"job.state", job.State,
+	)
+	return nil
+}
+
+func (d *DeployJob) scaleOneByOne(typ string, log log15.Logger) error {
+	for i := 0; i < d.Processes[typ]; i++ {
+		if err := d.scaleNewFormationUpByOne(typ, log); err != nil {
+			return err
+		}
+
+		if err := d.scaleOldFormationDownByOne(typ, log); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func (d *DeployJob) scaleNewFormationUpByOne(typ string, log log15.Logger) error {
+	// only scale new processes which still exist
+	if _, ok := d.newRelease.Processes[typ]; !ok {
+		return nil
+	}
+	// don't scale higher than d.Processes
+	if d.newFormation.Processes[typ] == d.Processes[typ] {
+		return nil
+	}
+	log.Info("scaling new formation up by one", "release.id", d.NewReleaseID, "job.type", typ)
+	d.newFormation.Processes[typ]++
+	if err := d.scaleNewRelease(); err != nil {
+		log.Error("error scaling new formation up by one", "release.id", d.NewReleaseID, "job.type", typ, "err", err)
+		return err
+	}
+	return nil
+}
+
+func (d *DeployJob) scaleOldFormationDownByOne(typ string, log log15.Logger) error {
+	// don't scale lower than zero
+	if d.oldFormation.Processes[typ] == 0 {
+		return nil
+	}
+	log.Info("scaling old formation down by one", "release.id", d.OldReleaseID, "job.type", typ)
+	d.oldFormation.Processes[typ]--
+	if err := d.scaleOldRelease(true); err != nil {
+		log.Error("error scaling old formation down by one", "release.id", d.OldReleaseID, "job.type", typ, "err", err)
+		return err
+	}
+	return nil
+}
+
+func processesEqual(a map[string]int, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for typ, countA := range a {
+		if countB, ok := b[typ]; !ok || countA != countB {
+			return false
+		}
+	}
+	return true
 }

--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -1,38 +1,10 @@
 package deployment
 
-import (
-	"fmt"
-	"sort"
-
-	ct "github.com/flynn/flynn/controller/types"
-	"gopkg.in/inconshreveable/log15.v2"
-)
-
-type WaitJobsFn func(releaseID string, expected ct.JobEvents, log log15.Logger) error
+import "sort"
 
 func (d *DeployJob) deployOneByOne() error {
-	return d.deployOneByOneWithWaitFn(d.waitForJobEvents)
-}
-
-func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 	log := d.logger.New("fn", "deployOneByOne")
 	log.Info("starting one-by-one deployment")
-
-	oldScale := make(map[string]int, len(d.oldReleaseState))
-	for typ, count := range d.oldReleaseState {
-		oldScale[typ] = count
-		if d.isOmni(typ) {
-			oldScale[typ] /= d.hostCount
-		}
-	}
-
-	newScale := make(map[string]int, len(d.newReleaseState))
-	for typ, count := range d.newReleaseState {
-		newScale[typ] = count
-		if d.isOmni(typ) {
-			newScale[typ] /= d.hostCount
-		}
-	}
 
 	processTypes := make([]string, 0, len(d.Processes))
 	for typ := range d.Processes {
@@ -40,82 +12,12 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 	}
 	sort.Sort(sort.StringSlice(processTypes))
 
-	olog := log.New("release_id", d.OldReleaseID)
-	nlog := log.New("release_id", d.NewReleaseID)
 	for _, typ := range processTypes {
-		num := d.Processes[typ]
-		// don't scale processes which no longer exist in the new release
-		if _, ok := d.newRelease.Processes[typ]; !ok {
-			num = 0
-		}
-		diff := 1
-		if d.isOmni(typ) {
-			diff = d.hostCount
-		}
-
-		for i := newScale[typ]; i < num; i++ {
-			nlog.Info("scaling new formation up by one", "type", typ)
-			newScale[typ]++
-			if err := d.client.PutFormation(&ct.Formation{
-				AppID:     d.AppID,
-				ReleaseID: d.NewReleaseID,
-				Processes: newScale,
-				Tags:      d.Tags,
-			}); err != nil {
-				nlog.Error("error scaling new formation up by one", "type", typ, "err", err)
-				return err
-			}
-			nlog.Info(fmt.Sprintf("waiting for %d job up event(s)", diff), "type", typ)
-			if err := waitJobs(d.NewReleaseID, ct.JobEvents{typ: ct.JobUpEvents(diff)}, nlog); err != nil {
-				nlog.Error("error waiting for job up events", "err", err)
-				return err
-			}
-
-			olog.Info("scaling old formation down by one", "type", typ)
-			oldScale[typ]--
-			if err := d.client.PutFormation(&ct.Formation{
-				AppID:     d.AppID,
-				ReleaseID: d.OldReleaseID,
-				Processes: oldScale,
-				Tags:      d.Tags,
-			}); err != nil {
-				olog.Error("error scaling old formation down by one", "type", typ, "err", err)
-				return err
-			}
-
-			olog.Info(fmt.Sprintf("waiting for %d job down event(s)", diff), "type", typ)
-			if err := waitJobs(d.OldReleaseID, ct.JobEvents{typ: ct.JobDownEvents(diff)}, olog); err != nil {
-				olog.Error("error waiting for job down events", "err", err)
-				return err
-			}
+		if err := d.scaleOneByOne(typ, log); err != nil {
+			return err
 		}
 	}
 
-	// ensure any old leftover jobs are stopped (this can happen when new
-	// workers continue deployments from old workers and still see the
-	// old worker running even though it has been scaled down), returning
-	// ErrSkipRollback if an error occurs (rolling back doesn't make a ton
-	// of sense because it involves stopping the new working jobs).
-	log.Info("ensuring old formation is scaled down to zero")
-	diff := make(ct.JobEvents, len(oldScale))
-	for typ, count := range oldScale {
-		if count > 0 {
-			diff[typ] = ct.JobDownEvents(count)
-		}
-	}
-	if err := d.client.PutFormation(&ct.Formation{
-		AppID:     d.AppID,
-		ReleaseID: d.OldReleaseID,
-		Tags:      d.Tags,
-	}); err != nil {
-		log.Error("error scaling old formation down to zero", "err", err)
-		return ErrSkipRollback{err.Error()}
-	}
-
-	// treat the deployment as finished now (rather than potentially
-	// waiting for the jobs to actually stop) as we can trust that the
-	// scheduler will actually kill the jobs, so no need to delay the
-	// deployment.
 	log.Info("finished one-by-one deployment")
 	return nil
 }

--- a/controller/worker/deployment/sirenia.go
+++ b/controller/worker/deployment/sirenia.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/controller/worker/types"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/sirenia/client"
 	"github.com/flynn/flynn/pkg/sirenia/state"
@@ -22,7 +23,8 @@ func (d *DeployJob) deploySirenia() (err error) {
 		}
 	}()
 
-	loggedErr := func(e string) error {
+	loggedErr := func(format string, v ...interface{}) error {
+		e := fmt.Sprintf(format, v...)
 		log.Error(e)
 		return errors.New(e)
 	}
@@ -34,7 +36,11 @@ func (d *DeployJob) deploySirenia() (err error) {
 	}
 	// if it's still not set we have a problem.
 	if processType == "" {
-		return fmt.Errorf("unable to determine sirenia process type")
+		return errors.New("unable to determine sirenia process type")
+	}
+	proc, ok := d.newRelease.Processes[processType]
+	if !ok {
+		return errors.New("sirenia process type not present in new release")
 	}
 
 	// if sirenia process type is scaled to 0, skip and deploy non-sirenia processes
@@ -43,13 +49,47 @@ func (d *DeployJob) deploySirenia() (err error) {
 		return d.deployOneByOne()
 	}
 
-	if d.serviceMeta == nil {
+	events := make(chan *discoverd.Event)
+	stream, err := discoverd.NewService(proc.Service).Watch(events)
+	if err != nil {
+		log.Error("error creating service discovery watcher", "service", processType, "err", err)
+		return err
+	}
+	defer stream.Close()
+
+	var serviceMeta *discoverd.ServiceMeta
+	timeout := time.After(d.timeout)
+loop:
+	for {
+		select {
+		case <-d.stop:
+			return worker.ErrStopped
+		case event, ok := <-events:
+			if !ok {
+				return loggedErr("service event stream closed unexpectedly: %s", stream.Err())
+			}
+			switch event.Kind {
+			case discoverd.EventKindCurrent:
+				break loop
+			case discoverd.EventKindServiceMeta:
+				serviceMeta = event.ServiceMeta
+			case discoverd.EventKindUp:
+				if event.Instance.Meta["FLYNN_RELEASE_ID"] == d.NewReleaseID {
+					return loggedErr("sirenia cluster in unexpected state")
+				}
+			}
+		case <-timeout:
+			return loggedErr("timed out waiting for current service event")
+		}
+	}
+
+	if serviceMeta == nil {
 		return loggedErr("missing sirenia cluster state")
 	}
 
 	var state state.State
 	log.Info("decoding sirenia cluster state")
-	if err := json.Unmarshal(d.serviceMeta.Data, &state); err != nil {
+	if err := json.Unmarshal(serviceMeta.Data, &state); err != nil {
 		log.Error("error decoding sirenia cluster state", "err", err)
 		return err
 	}
@@ -62,14 +102,7 @@ func (d *DeployJob) deploySirenia() (err error) {
 		return loggedErr("sirenia cluster in unhealthy state (has no asyncs)")
 	}
 	if 2+len(state.Async) != d.Processes[processType] {
-		return loggedErr(fmt.Sprintf("sirenia cluster in unhealthy state (too few asyncs)"))
-	}
-	if processesEqual(d.newReleaseState, d.Processes) {
-		log.Info("deployment already completed, nothing to do")
-		return nil
-	}
-	if d.newReleaseState[processType] > 0 {
-		return loggedErr("sirenia cluster in unexpected state")
+		return loggedErr("sirenia cluster in unhealthy state (too few asyncs)")
 	}
 
 	stopInstance := func(inst *discoverd.Instance) error {
@@ -87,18 +120,13 @@ func (d *DeployJob) deploySirenia() (err error) {
 			return err
 		}
 		log.Info("waiting for peer to stop")
-		jobEvents := d.ReleaseJobEvents(d.OldReleaseID)
-		timeout := time.After(time.Duration(d.DeployTimeout) * time.Second)
+		timeout := time.After(d.timeout)
 		for {
 			select {
-			case e := <-jobEvents:
-				if e.Type == JobEventTypeError {
-					return e.Error
+			case event, ok := <-events:
+				if !ok {
+					return loggedErr("service event stream closed unexpectedly: %s", stream.Err())
 				}
-				if e.Type != JobEventTypeDiscoverd {
-					continue
-				}
-				event := e.DiscoverdEvent
 				if event.Kind == discoverd.EventKindDown && event.Instance.ID == inst.ID {
 					d.deployEvents <- ct.DeploymentEvent{
 						ReleaseID: d.OldReleaseID,
@@ -122,31 +150,23 @@ func (d *DeployJob) deploySirenia() (err error) {
 			JobState:  ct.JobStateStarting,
 			JobType:   processType,
 		}
-		d.newReleaseState[processType]++
-		if err := d.client.PutFormation(&ct.Formation{
-			AppID:     d.AppID,
-			ReleaseID: d.NewReleaseID,
-			Processes: d.newReleaseState,
-			Tags:      d.Tags,
-		}); err != nil {
-			log.Error("error scaling formation up by one", "err", err)
+		d.newFormation.Processes[processType]++
+		// use PutFormation rather than ScaleAppRelease so we can use a
+		// custom wait loop below
+		if err := d.client.PutFormation(d.newFormation); err != nil {
+			log.Error("error scaling new formation up by one", "err", err)
 			return nil, err
 		}
 		log.Info("waiting for new instance to come up")
 		var inst *discoverd.Instance
-		jobEvents := d.ReleaseJobEvents(d.NewReleaseID)
-		timeout := time.After(time.Duration(d.DeployTimeout) * time.Second)
+		timeout := time.After(d.timeout)
 	loop:
 		for {
 			select {
-			case e := <-jobEvents:
-				if e.Type == JobEventTypeError {
-					return nil, e.Error
+			case event, ok := <-events:
+				if !ok {
+					return nil, loggedErr("service event stream closed unexpectedly: %s", stream.Err())
 				}
-				if e.Type != JobEventTypeDiscoverd {
-					continue
-				}
-				event := e.DiscoverdEvent
 				if event.Kind == discoverd.EventKindUp &&
 					event.Instance.Meta != nil &&
 					event.Instance.Meta["FLYNN_RELEASE_ID"] == d.NewReleaseID &&
@@ -243,56 +263,12 @@ func (d *DeployJob) deploySirenia() (err error) {
 	}
 
 	log.Info("stopping old jobs")
-	d.oldReleaseState[processType] = 0
-	if err := d.client.PutFormation(&ct.Formation{
-		AppID:     d.AppID,
-		ReleaseID: d.OldReleaseID,
-		Processes: d.oldReleaseState,
-		Tags:      d.Tags,
-	}); err != nil {
+	d.oldFormation.Processes[processType] = 0
+	if err := d.scaleOldRelease(true); err != nil {
 		log.Error("error scaling old formation", "err", err)
 		return err
 	}
 
-	log.Info(fmt.Sprintf("waiting for %d job down events", d.Processes[processType]))
-	actual := 0
-	jobEvents := d.ReleaseJobEvents(d.OldReleaseID)
-	timeout := time.After(time.Duration(d.DeployTimeout) * time.Second)
-loop:
-	for {
-		select {
-		case e := <-jobEvents:
-			if e.Type == JobEventTypeError {
-				return loggedErr(e.Error.Error())
-			}
-			if e.Type != JobEventTypeController {
-				continue
-			}
-			event := e.JobEvent
-			log.Info("got job event", "job_id", event.ID, "type", event.Type, "state", event.State)
-			if event.State == ct.JobStateDown && event.Type == processType {
-				actual++
-				if actual == d.Processes[processType] {
-					break loop
-				}
-			}
-		case <-timeout:
-			return loggedErr("timed out waiting for job events")
-		}
-	}
-
 	// do a one-by-one deploy for the other process types
 	return d.deployOneByOne()
-}
-
-func processesEqual(a map[string]int, b map[string]int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for typ, countA := range a {
-		if countB, ok := b[typ]; !ok || countA != countB {
-			return false
-		}
-	}
-	return true
 }

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
-	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/resource"
 	"github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/exec"
@@ -234,58 +233,24 @@ Options:
 	if needsDefaultScale(app.ID, prevRelease.ID, procs, client) {
 		fmt.Println("=====> Scaling initial release to web=1")
 
-		formation := &ct.Formation{
-			AppID:     app.ID,
-			ReleaseID: release.ID,
+		timeout := time.Duration(app.DeployTimeout) * time.Second
+		opts := ct.ScaleOptions{
 			Processes: map[string]int{"web": 1},
-		}
-
-		jobEvents := make(chan *ct.Job)
-		jobStream, err := client.StreamJobEvents(app.ID, jobEvents)
-		if err != nil {
-			return fmt.Errorf("Error streaming job events: %s", err)
-		}
-		defer jobStream.Close()
-
-		serviceEvents := make(chan *discoverd.Event)
-		serviceStream, err := discoverd.NewService(app.Name + "-web").Watch(serviceEvents)
-		if err != nil {
-			return fmt.Errorf("Error streaming service events: %s", err)
-		}
-		defer serviceStream.Close()
-
-		if err := client.PutFormation(formation); err != nil {
-			return fmt.Errorf("Error putting formation: %s", err)
+			Timeout:   &timeout,
+			JobEventCallback: func(job *ct.Job) error {
+				switch job.State {
+				case ct.JobStateUp:
+					fmt.Println("=====> Initial web job started")
+				case ct.JobStateDown:
+					return errors.New("Initial web job failed to start")
+				}
+				return nil
+			},
 		}
 		fmt.Println("-----> Waiting for initial web job to start...")
-
-		err = func() error {
-			for {
-				select {
-				case e, ok := <-serviceEvents:
-					if !ok {
-						return fmt.Errorf("Service stream closed unexpectedly: %s", serviceStream.Err())
-					}
-					if e.Kind == discoverd.EventKindUp && e.Instance.Meta["FLYNN_RELEASE_ID"] == release.ID {
-						fmt.Println("=====> Initial web job started")
-						return nil
-					}
-				case e, ok := <-jobEvents:
-					if !ok {
-						return fmt.Errorf("Job stream closed unexpectedly: %s", jobStream.Err())
-					}
-					if e.State == ct.JobStateDown {
-						return errors.New("Initial web job failed to start")
-					}
-				case <-time.After(time.Duration(app.DeployTimeout) * time.Second):
-					return errors.New("Timed out waiting for initial web job to start")
-				}
-			}
-		}()
-		if err != nil {
+		if err := client.ScaleAppRelease(app.ID, release.ID, opts); err != nil {
 			fmt.Println("-----> WARN: scaling initial release down to web=0 due to error")
-			formation.Processes["web"] = 0
-			if err := client.PutFormation(formation); err != nil {
+			if err := client.DeleteFormation(app.ID, release.ID); err != nil {
 				// just print this error and return the original error
 				fmt.Println("-----> WARN: could not scale the initial release down (it may continue to run):", err)
 			}

--- a/schema/controller/event.json
+++ b/schema/controller/event.json
@@ -35,7 +35,8 @@
         "route_deletion",
         "sink",
         "sink_deletion",
-        "scale"
+        "scale",
+        "scale_request"
       ]
     }
   },

--- a/schema/controller/expanded_formation.json
+++ b/schema/controller/expanded_formation.json
@@ -35,6 +35,10 @@
       "description": "process tags",
       "type": "object"
     },
+    "pending_scale_request": {
+      "description": "pending scale request",
+      "type": "object"
+    },
     "updated_at": {
       "$ref": "/schema/controller/common#/definitions/updated_at"
     }

--- a/schema/controller/scale_request.json
+++ b/schema/controller/scale_request.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://flynn.io/schema/controller/scale_request#",
+  "title": "Scale Request",
+  "description": "A scale request initiates a formation update",
+  "sortIndex": 21,
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "app": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "release": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "state": {
+      "type": "string",
+      "enum": ["pending", "cancelled", "complete"]
+    },
+    "old_processes": {
+      "description": "the formation's old processes",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "new_processes": {
+      "description": "the formation's new processes",
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "old_tags": {
+      "description": "the formation's old tags",
+      "type": "object"
+    },
+    "new_tags": {
+      "description": "the formation's new tags",
+      "type": "object"
+    },
+    "created_at": {
+      "$ref": "/schema/controller/common#/definitions/created_at"
+    },
+    "updated_at": {
+      "$ref": "/schema/controller/common#/definitions/updated_at"
+    }
+  }
+}

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -257,7 +257,7 @@ func (s *DeployerSuite) TestRollbackFailedJob(t *c.C) {
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	event := s.waitForDeploymentStatus(t, events, "failed")
-	t.Assert(event.Error, c.Equals, `deployer: printer job failed to start: exec: "this-is-gonna-fail": executable file not found in $PATH`)
+	t.Assert(event.Error, c.Equals, `printer job failed to start: exec: "this-is-gonna-fail": executable file not found in $PATH`)
 
 	s.assertRolledBack(t, deployment, map[string]int{"printer": 2})
 }
@@ -297,7 +297,7 @@ func (s *DeployerSuite) TestRollbackNoService(t *c.C) {
 	t.Assert(err, c.IsNil)
 	defer stream.Close()
 	event := s.waitForDeploymentStatus(t, events, "failed")
-	t.Assert(event.Error, c.Equals, "printer process type failed to start, got down job event")
+	t.Assert(event.Error, c.Equals, "printer job failed to start: got down job event")
 
 	s.assertRolledBack(t, deployment, map[string]int{"printer": 2})
 

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/term"
+	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/pkg/attempt"
 	c "github.com/flynn/go-check"
@@ -317,13 +318,12 @@ func (s *GitDeploySuite) TestCrashingApp(t *c.C) {
 	t.Assert(push, c.Not(Succeeds))
 	t.Assert(push, OutputContains, "web job failed to start")
 
-	// check the formation was scaled down
+	// check the formation was deleted
 	client := s.controllerClient(t)
 	release, err := client.GetAppRelease(app)
 	t.Assert(err, c.IsNil)
-	formation, err := client.GetFormation(app, release.ID)
-	t.Assert(err, c.IsNil)
-	t.Assert(formation.Processes["web"], c.Equals, 0)
+	_, err = client.GetFormation(app, release.ID)
+	t.Assert(err, c.Equals, controller.ErrNotFound)
 }
 
 func (s *GitDeploySuite) TestSlugignore(t *c.C) {


### PR DESCRIPTION
Summary:

* the scheduler now waits for service events for any process types with a configured service before marking jobs as running
* if the service is being routed to, the scheduler waits for all the routers to emit a backend up event before marking the job as running (with a 10s timeout after first seeing the service)
* formations now have a state which is either `pending` or `complete`, with any calls to `PutFormation` marking the formation as `pending`, and the scheduler marking as `complete` once it determines the correct number of jobs are running for that formation
* a scale event is emitted once a formation is marked as complete, meaning clients no longer need to calculate how many job / service events to wait for when scaling a formation, instead just waiting for the `complete` event (I have added a `Scale` method to the controller client which does exactly this)
* lots of code has been simplified by using scale events rather than job / service events (mainly the deploy worker)

Fixes #3621 
Fixes #3518
Fixes #2043
Fixes #3144
Fixes #2895
Fixes #2705
Fixes #3699