### PR TITLE
host/volume: Don't error on restore if a volume no longer exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-unit: test-unit-deps
 	@$(GO_ENV) PATH=${PWD}/discoverd/bin:${PATH} util/_toolchain/go/bin/go test -race -cover ./...
 
 test-unit-root: test-unit
-	@$(GO_ENV) util/_toolchain/go/bin/go test -race -cover ./host/volume/zfs ./pinkerton
+	@sudo -E $(GO_ENV) util/_toolchain/go/bin/go test -race -cover ./host/volume/...
 
 test-integration: toolchain
 	script/run-integration-tests

--- a/host/cli/destroy-volumes.go
+++ b/host/cli/destroy-volumes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flynn/flynn/host/volume/zfs"
 	"github.com/flynn/flynn/pkg/shutdown"
 	"github.com/flynn/go-docopt"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 func init() {
@@ -98,6 +99,7 @@ func loadVolumeState(volumeDBPath string) (*volumemanager.Manager, error) {
 	fmt.Println("opening volume state db...")
 	vman := volumemanager.New(
 		volumeDBPath,
+		log15.New(),
 		func() (volume.Provider, error) {
 			return nil, nil
 		},

--- a/host/cli/download.go
+++ b/host/cli/download.go
@@ -45,7 +45,7 @@ func runDownload(args *docopt.Args) error {
 	log.Info("initializing ZFS volumes")
 	volPath := args.String["--volpath"]
 	volDB := filepath.Join(volPath, "volumes.bolt")
-	volMan := volumemanager.New(volDB, func() (volume.Provider, error) {
+	volMan := volumemanager.New(volDB, log, func() (volume.Provider, error) {
 		return zfs.NewProvider(&zfs.ProviderConfig{
 			DatasetName: zfs.DefaultDatasetName,
 			Make:        zfs.DefaultMakeDev(volPath, log),

--- a/host/host.go
+++ b/host/host.go
@@ -276,6 +276,7 @@ func runDaemon(args *docopt.Args) {
 	}
 	vman := volumemanager.New(
 		filepath.Join(volPath, "volumes.bolt"),
+		logger.New("component", "volumemanager"),
 		newVolProvider,
 	)
 	shutdown.BeforeExit(func() { vman.CloseDB() })

--- a/host/volume/api/http.go
+++ b/host/volume/api/http.go
@@ -123,7 +123,7 @@ func (api *HTTPAPI) Destroy(w http.ResponseWriter, r *http.Request, ps httproute
 	err := api.vman.DestroyVolume(volumeID)
 	if err != nil {
 		switch err {
-		case volumemanager.ErrNoSuchVolume:
+		case volume.ErrNoSuchVolume:
 			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:
@@ -140,7 +140,7 @@ func (api *HTTPAPI) Snapshot(w http.ResponseWriter, r *http.Request, ps httprout
 	snap, err := api.vman.CreateSnapshot(volumeID)
 	if err != nil {
 		switch err {
-		case volumemanager.ErrNoSuchVolume:
+		case volume.ErrNoSuchVolume:
 			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:
@@ -212,7 +212,7 @@ func (api *HTTPAPI) Send(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	err := api.vman.SendSnapshot(volumeID, haves, w)
 	if err != nil {
 		switch err {
-		case volumemanager.ErrNoSuchVolume:
+		case volume.ErrNoSuchVolume:
 			httphelper.ObjectNotFoundError(w, fmt.Sprintf("no volume with id %q", volumeID))
 			return
 		default:

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -1,9 +1,12 @@
 package volume
 
 import (
+	"errors"
 	"io"
 	"time"
 )
+
+var ErrNoSuchVolume = errors.New("no such volume")
 
 /*
 	A Volume is a persistent and sharable filesystem.  Unlike most of the filesystem in a job's

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -624,6 +624,9 @@ func (p *Provider) RestoreVolumeState(volInfo *volume.Info, data json.RawMessage
 	}
 	dataset, err := zfs.GetDataset(record.Dataset)
 	if err != nil {
+		if isDatasetNotExistsError(err) {
+			return nil, volume.ErrNoSuchVolume
+		}
 		return nil, fmt.Errorf("cannot restore volume %q: %s", volInfo.ID, err)
 	}
 	v := &zfsVolume{


### PR DESCRIPTION
We don't seem to be running the volume tests in CI, so I have fixed that too.