### PR TITLE
scheduler: Don't exit at startup whilst waiting for events

### DIFF
--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -45,8 +45,8 @@ type fakeDiscoverd struct {
 	leader      chan bool
 }
 
-func (d *fakeDiscoverd) Register() (bool, error) {
-	return d.firstLeader, nil
+func (d *fakeDiscoverd) Register() bool {
+	return d.firstLeader
 }
 
 func (d *fakeDiscoverd) LeaderCh() chan bool {


### PR DESCRIPTION
Exiting may leave the cluster without a scheduler, it is better to just wait for the events to happen.