### PR TITLE
test: Set GIT_TRACE to debug git push failures

### DIFF
--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -1027,7 +1027,7 @@ func (s *CLISuite) TestRemote(t *c.C) {
 	remoteApp := "remote-" + random.String(8)
 	customRemote := random.String(8)
 
-	r := s.newGitRepo(t, "http")
+	r := s.newGitRepoWithoutTrace(t, "http")
 	// create app without remote
 	t.Assert(r.flynn("create", remoteApp, "--remote", `""`), Succeeds)
 


### PR DESCRIPTION
This is to debug git push failures in CI like the following which have no output:

```
++ 20:12:08.770 /usr/bin/git push flynn master

test_git_deploy.go:67:
    t.Assert(r.git("push", "flynn", "master"), Succeeds)
... result *main.CmdResult = &main.CmdResult{Cmd:[]string{"git", "push", "flynn", "master"}, Output:"", OutputBuf:(*bytes.Buffer)(0xc42011f260), Err:(*exec.ExitError)(0xc42038a4c0)}
```