### PR TITLE
all: Reuse HTTP client transports

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/flynn/flynn/controller/client/v1"
 	ct "github.com/flynn/flynn/controller/types"
 	logagg "github.com/flynn/flynn/logaggregator/types"
-	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/pinned"
 	"github.com/flynn/flynn/pkg/status"
 	"github.com/flynn/flynn/pkg/stream"
@@ -114,8 +114,7 @@ func newClient(key string, url string, http *http.Client) *v1controller.Client {
 // NewClient creates a new Client pointing at uri and using key for
 // authentication.
 func NewClient(uri, key string) (Client, error) {
-	httpClient := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	return NewClientWithHTTP(uri, key, httpClient)
+	return NewClientWithHTTP(uri, key, httphelper.RetryClient)
 }
 
 func NewClientWithHTTP(uri, key string, httpClient *http.Client) (Client, error) {

--- a/docker-receive/artifact/main.go
+++ b/docker-receive/artifact/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
 	"github.com/flynn/flynn/pinkerton"
-	"github.com/flynn/flynn/pkg/dialer"
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/imagebuilder"
 )
 
@@ -100,8 +100,7 @@ func upload(data io.Reader, url string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	res, err := client.Do(req)
+	res, err := httphelper.RetryClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/logaggregator/client/client.go
+++ b/logaggregator/client/client.go
@@ -10,8 +10,8 @@ import (
 
 	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/logaggregator/utils"
-	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
+	"github.com/flynn/flynn/pkg/httphelper"
 )
 
 // ErrNotFound is returned when a resource is not found (HTTP status 404).
@@ -35,8 +35,7 @@ func newClient(url string, http *http.Client) *Client {
 
 // NewClient creates a new Client pointing at uri.
 func New(uri string) (*Client, error) {
-	httpClient := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	return NewWithHTTP(uri, httpClient)
+	return NewWithHTTP(uri, httphelper.RetryClient)
 }
 
 // NewClient creates a new Client pointing at uri with the specified http client.

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
-	"github.com/flynn/flynn/pkg/dialer"
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/stream"
 )
 
@@ -26,8 +26,7 @@ type ServiceFunc func(name string) discoverd.Service
 // NewClientWithServices uses the provided services to find cluster members. If
 // services is nil, the default discoverd client is used.
 func NewClientWithServices(services ServiceFunc) *Client {
-	hc := &http.Client{Transport: &http.Transport{Dial: dialer.Retry.Dial}}
-	return NewClientWithHTTP(services, hc)
+	return NewClientWithHTTP(services, httphelper.RetryClient)
 }
 
 func NewClientWithHTTP(services ServiceFunc, hc *http.Client) *Client {

--- a/pkg/sirenia/client/client.go
+++ b/pkg/sirenia/client/client.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/discoverd/client"
-	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sirenia/state"
 )
 
@@ -34,6 +34,11 @@ type Client struct {
 	c *httpclient.Client
 }
 
+var httpClient = &http.Client{
+	Timeout:   3 * time.Minute, // client operation timeout
+	Transport: httphelper.RetryClient.Transport,
+}
+
 func NewClient(addr string) *Client {
 	// remove port, if any
 	host, p, _ := net.SplitHostPort(addr)
@@ -41,11 +46,8 @@ func NewClient(addr string) *Client {
 
 	return &Client{
 		c: &httpclient.Client{
-			URL: fmt.Sprintf("http://%s:%d", host, port+1),
-			HTTP: &http.Client{
-				Timeout:   3 * time.Minute, // client operation timeout
-				Transport: &http.Transport{Dial: dialer.Default.Dial},
-			},
+			URL:  fmt.Sprintf("http://%s:%d", host, port+1),
+			HTTP: httpClient,
 		},
 	}
 }

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/flynn/flynn/pkg/dialer"
 	"github.com/flynn/flynn/pkg/httpclient"
+	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/stream"
 	"github.com/flynn/flynn/router/types"
 )
@@ -38,9 +38,7 @@ func newRouterClient() *client {
 	return &client{Client: &httpclient.Client{
 		ErrNotFound: ErrNotFound,
 		URL:         "http://router-api.discoverd:5000",
-		HTTP: &http.Client{
-			Transport: &http.Transport{Dial: dialer.Retry.Dial},
-		},
+		HTTP:        httphelper.RetryClient,
 	}}
 }
 


### PR DESCRIPTION
This fixes a connection leak in the cluster-monitor fixer, which creates new clients for some phases. These new clients were not subsequently re-used and the established connections in the HTTP connection pool were leaking.

The solution is to reuse the same HTTP transport across all instances of all clients, which this change implements.