### PR TITLE
slugbuilder: Don't require metadata to convert slugs

### DIFF
--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -742,7 +742,7 @@ WHERE env->>'%[1]s_IMAGE_URI' IS NOT NULL;`,
 		return fmt.Errorf("error listing artifacts: %s", err)
 	}
 	for _, artifact := range artifactList {
-		if artifact.Type == ct.DeprecatedArtifactTypeFile && artifact.Meta["blobstore"] == "true" {
+		if artifact.Type == ct.DeprecatedArtifactTypeFile {
 			migrateSlugs = true
 		}
 		if artifact.Type == ct.DeprecatedArtifactTypeDocker && artifact.Meta["docker-receive.repository"] != "" {

--- a/slugbuilder/migrator/main.go
+++ b/slugbuilder/migrator/main.go
@@ -96,7 +96,6 @@ func getActiveSlugArtifacts(db *postgres.DB) ([]*ct.Artifact, error) {
 	sql := `
 SELECT artifact_id, uri FROM artifacts
 WHERE type = 'file'
-AND meta->>'blobstore' = 'true'
 AND deleted_at IS NULL
 AND artifact_id IN (
   SELECT artifact_id FROM release_artifacts


### PR DESCRIPTION
Some slugs have been seen which do not have the metadata, but if they belong to a release with `git=true`, then we can just assume they are stored in the blobstore.