### PR TITLE
router: Add support for inbound PROXY protocol v1

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -458,7 +458,8 @@
       "env": {
         "TLSCERT": "{{ (index .StepData \"controller-cert\").Cert }}",
         "TLSKEY": "{{ (index .StepData \"controller-cert\").PrivateKey }}",
-        "COOKIE_KEY": "{{ (index .StepData \"router-sticky-key\").Data }}"
+        "COOKIE_KEY": "{{ (index .StepData \"router-sticky-key\").Data }}",
+        "PROXY_PROTOCOL": "{{ getenv \"PROXY_PROTOCOL\" }}"
       },
       "processes": {
         "app": {

--- a/router/proxyproto/LICENSE
+++ b/router/proxyproto/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Prime Directive, Inc.
+Copyright (c) 2014 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/router/proxyproto/protocol.go
+++ b/router/proxyproto/protocol.go
@@ -1,0 +1,154 @@
+// Derived from https://github.com/bradfitz/go-proxyproto
+
+// Package proxyproto implements a net.Listener supporting HAProxy PROXY protocol.
+//
+// See http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt for details.
+package proxyproto
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// prefix is the string we look for at the start of a connection
+// to check if this connection is using the PROXY protocol.
+var prefix = []byte("PROXY ")
+
+// Listener wraps an underlying listener whose connections may be using the
+// HAProxy PROXY Protocol (version 1). If the connection is using the protocol,
+// RemoteAddr will return the correct client address.
+type Listener struct {
+	net.Listener
+}
+
+// conn is used to wrap an underlying connection which may be speaking the PROXY
+// Protocol. If it is, the RemoteAddr() will return the address of the client
+// instead of the proxy address.
+type conn struct {
+	net.Conn
+	connBuf  []byte
+	srcAddr  *net.TCPAddr
+	initOnce sync.Once
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (p Listener) Accept() (net.Conn, error) {
+	rawc, err := p.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return newConn(rawc), nil
+}
+
+func newConn(c net.Conn) *conn {
+	return &conn{Conn: c}
+}
+
+// Read checks for the PROXY protocol header when doing the initial scan. If
+// there is an error parsing the header, it is returned and the socket is
+// closed.
+func (p *conn) Read(b []byte) (int, error) {
+	var err error
+	p.initOnce.Do(func() { err = p.checkPrefix() })
+	if err != nil {
+		return 0, err
+	}
+	if p.connBuf != nil {
+		n := copy(b, p.connBuf)
+		p.connBuf = p.connBuf[n:]
+		if len(p.connBuf) == 0 {
+			p.connBuf = nil
+		}
+		if len(b) == n {
+			return n, nil
+		}
+		readN, err := p.Conn.Read(b[n:])
+		return readN + n, err
+	}
+	return p.Conn.Read(b)
+}
+
+// RemoteAddr returns the address of the client if the PROXY protocol is being
+// used, otherwise just returns the address of the socket peer. If there is an
+// error parsing the header, the address of the client is not returned, and the
+// socket is closed. One implication of this is that the call could block if the
+// client is slow. Using a Deadline is recommended if this is called before
+// Read().
+func (p *conn) RemoteAddr() net.Addr {
+	p.initOnce.Do(func() { p.checkPrefix() })
+	if p.srcAddr != nil {
+		return p.srcAddr
+	}
+	return p.Conn.RemoteAddr()
+}
+
+func (p *conn) checkPrefix() error {
+	buf := bufio.NewReaderSize(p.Conn, 107)
+
+	// Incrementally check each byte of the prefix
+	for i := 1; i <= len(prefix); i++ {
+		inp, err := buf.Peek(i)
+		if err != nil {
+			if remaining := buf.Buffered(); !bytes.Equal(inp, prefix[:i]) && remaining > 0 {
+				p.connBuf, _ = buf.Peek(remaining)
+				return nil
+			}
+			return err
+		}
+
+		// Check for a prefix mis-match, quit early
+		if !bytes.Equal(inp, prefix[:i]) {
+			if remaining := buf.Buffered(); remaining > 0 {
+				p.connBuf, _ = buf.Peek(remaining)
+			}
+			return nil
+		}
+	}
+
+	// Read the header line
+	header, err := buf.ReadString('\n')
+	if err != nil {
+		p.Conn.Close()
+		return err
+	}
+
+	// Strip the carriage return and new line
+	header = header[:len(header)-2]
+
+	// Split on spaces, should be (PROXY <type> <src addr> <dst addr> <src port> <dst port>)
+	parts := strings.Split(header, " ")
+	if len(parts) != 6 {
+		p.Conn.Close()
+		return fmt.Errorf("proxyconn: invalid header line: %q", header)
+	}
+
+	// Verify the type is known
+	if parts[1] != "TCP4" && parts[1] != "TCP6" {
+		p.Conn.Close()
+		return fmt.Errorf("proxyconn: unknown address type: %q", parts[1])
+	}
+
+	// Parse out the source address
+	ip := net.ParseIP(parts[2])
+	if ip == nil {
+		p.Conn.Close()
+		return fmt.Errorf("proxyconn: invalid source IP: %q", parts[2])
+	}
+	port, err := strconv.Atoi(parts[4])
+	if err != nil {
+		p.Conn.Close()
+		return fmt.Errorf("proxyconn: invalid source port: %q", parts[4])
+	}
+	p.srcAddr = &net.TCPAddr{IP: ip, Port: port}
+
+	if remaining := buf.Buffered(); remaining > 0 {
+		p.connBuf, _ = buf.Peek(remaining)
+	}
+
+	return nil
+}

--- a/router/proxyproto/protocol_test.go
+++ b/router/proxyproto/protocol_test.go
@@ -1,0 +1,220 @@
+package proxyproto
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+)
+
+func TestPassthrough(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestParse_ipv4(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP4 10.1.1.1 20.2.2.2 1000 2000\r\nfoo"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 7)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("fooping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the remote addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "10.1.1.1" {
+		t.Fatalf("bad: %v", addr)
+	}
+	if addr.Port != 1000 {
+		t.Fatalf("bad: %v", addr)
+	}
+}
+
+func TestParse_ipv6(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP6 ffff::ffff ffff::ffff 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !bytes.Equal(recv, []byte("pong")) {
+			t.Fatalf("bad: %v", recv)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(recv, []byte("ping")) {
+		t.Fatalf("bad: %v", recv)
+	}
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the remote addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "ffff::ffff" {
+		t.Fatalf("bad: %v", addr)
+	}
+	if addr.Port != 1000 {
+		t.Fatalf("bad: %v", addr)
+	}
+}
+
+func TestParse_BadHeader(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	pl := &Listener{Listener: l}
+	defer pl.Close()
+
+	go func() {
+		conn, err := net.Dial("tcp", pl.Addr().String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		// Write out the header!
+		header := "PROXY TCP4 what 127.0.0.1 1000 2000\r\n"
+		conn.Write([]byte(header))
+
+		conn.Write([]byte("ping"))
+
+		recv := make([]byte, 4)
+		_, err = conn.Read(recv)
+		if err != io.EOF {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+
+	conn, err := pl.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer conn.Close()
+
+	// Check the remote addr, should be the local addr
+	addr := conn.RemoteAddr().(*net.TCPAddr)
+	if addr.IP.String() != "127.0.0.1" {
+		t.Fatalf("bad: %v", addr)
+	}
+
+	// Read should fail
+	recv := make([]byte, 4)
+	_, err = conn.Read(recv)
+	if err == nil {
+		t.Fatalf("err: %v", err)
+	}
+}

--- a/router/server.go
+++ b/router/server.go
@@ -89,6 +89,8 @@ func main() {
 		shutdown.Fatal("Missing random 32 byte base64-encoded COOKIE_KEY")
 	}
 
+	proxyProtocol := os.Getenv("PROXY_PROTOCOL") == "true"
+
 	httpPort := flag.String("http-port", "8080", "http listen port")
 	httpsPort := flag.String("https-port", "4433", "https listen port")
 	tcpIP := flag.String("tcp-ip", os.Getenv("LISTEN_IP"), "tcp router listen ip")
@@ -148,12 +150,13 @@ func main() {
 			discoverd: discoverd.DefaultClient,
 		},
 		HTTP: &HTTPListener{
-			Addr:      httpAddr,
-			TLSAddr:   httpsAddr,
-			cookieKey: cookieKey,
-			keypair:   keypair,
-			ds:        NewPostgresDataStore("http", db.ConnPool),
-			discoverd: discoverd.DefaultClient,
+			Addr:          httpAddr,
+			TLSAddr:       httpsAddr,
+			cookieKey:     cookieKey,
+			keypair:       keypair,
+			ds:            NewPostgresDataStore("http", db.ConnPool),
+			discoverd:     discoverd.DefaultClient,
+			proxyProtocol: proxyProtocol,
 		},
 	}
 


### PR DESCRIPTION
This adds support for version 1 of the PROXY protocol to indicate the source IP for incoming HTTP and HTTPS connections.

http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt

The feature is off by default, and can be enabled by setting the environment variable `PROXY_PROTOCOL=true` while running a non-backup `flynn-host bootstrap` or configuring the router directly after bootstrap with the command:

    flynn -a router env set PROXY_PROTOCOL=true

This feature is useful to integrate external load balancers in TCP mode like the AWS Classic Load Balancer (previously called ELB) and HAProxy.

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html
https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#5.2-send-proxy

References #68

/cc @temujin9 @sleighter @blurrcat 