### PR TITLE
bootstrap: Just wait for mariadb / mongodb API

### DIFF
--- a/bootstrap/manifest_template.json
+++ b/bootstrap/manifest_template.json
@@ -727,12 +727,14 @@
   {
     "id": "mariadb-wait",
     "action": "wait",
-    "url": "http://mariadb-api.discoverd/ping"
+    "url": "http://mariadb-api.discoverd",
+    "status": 404
   },
   {
     "id": "mongodb-wait",
     "action": "wait",
-    "url": "http://mongodb-api.discoverd/ping"
+    "url": "http://mongodb-api.discoverd",
+    "status": 404
   },
   {
     "id": "blobstore-wait",


### PR DESCRIPTION
The /ping endpoint tries to determine the status of the sirenia cluster, which is not running for either mariadb or mongodb at bootstrap time, so the request times out.

This used to fail immediately, but now fails after 30s since switching HTTP transports in #3698 (which is a correct fix, if you want to know the status of the sirenia cluster, you should be retrying dial errors).