### PR TITLE
host/fixer: Reprovision temporary volumes

### DIFF
--- a/controller/release.go
+++ b/controller/release.go
@@ -219,6 +219,11 @@ func (r *ReleaseRepo) Delete(app *ct.App, release *ct.Release) error {
 			return err
 		}
 
+		// don't delete system images
+		if artifact.Meta["flynn.system-image"] == "true" {
+			continue
+		}
+
 		// only delete artifacts which aren't still referenced by other releases
 		var count int64
 		if err := tx.QueryRow("artifact_release_count", artifact.ID).Scan(&count); err != nil {


### PR DESCRIPTION
I've also updated release deletion so it doesn't delete system images.

Tested manually with:

```
script/kill-flynn
script/start-flynn-host --no-destroy-state --no-destroy-vols 0
```

We should have tests for this, I have a plan...

Fixes #3686.