### PR TITLE
cli: allow specifying limits for run jobs

### DIFF
--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 
+	units "github.com/docker/go-units"
 	"github.com/flynn/flynn/cli/config"
 	"github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
@@ -929,6 +930,13 @@ func (s *CLISuite) TestRunLimits(t *c.C) {
 	t.Assert(limits[0], c.Equals, strconv.FormatInt(*defaults[resource.TypeMemory].Limit, 10))
 	t.Assert(limits[1], c.Equals, strconv.FormatInt(1024, 10))
 	t.Assert(limits[2], c.Equals, strconv.FormatInt(*defaults[resource.TypeMaxFD].Limit, 10))
+	cmd = app.flynn("run", "--limits", "memory=200MB,max_fd=9000", "sh", "-c", resourceCmd)
+	t.Assert(cmd, Succeeds)
+	limits = strings.Split(strings.TrimSpace(cmd.Output), "\n")
+	t.Assert(limits, c.HasLen, 3)
+	t.Assert(limits[0], c.Equals, strconv.FormatInt(200*units.MiB, 10))
+	t.Assert(limits[1], c.Equals, strconv.FormatInt(1024, 10))
+	t.Assert(limits[2], c.Equals, strconv.FormatInt(9000, 10))
 }
 
 func assertExportContains(t *c.C, file string, paths ...string) {


### PR DESCRIPTION
closes #3707 

```
$ flynn -a postgres run --limits temp_disk=3G bash
root@b025e6c0-d24a-431c-abff-b59c2c51bed6:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         3.0G  4.6M  3.0G   1% /
tmpfs           2.0G     0  2.0G   0% /dev
shm              64M     0   64M   0% /dev/shm
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/sda1        40G   29G  8.9G  77% /.containerinit
root@b025e6c0-d24a-431c-abff-b59c2c51bed6:/# exit
exit
$ flynn -a postgres run --limits temp_disk=2G bash
root@0d48eb90-b55a-4eb9-9558-9c8dd863546e:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         2.0G  3.1M  2.0G   1% /
tmpfs           2.0G     0  2.0G   0% /dev
shm              64M     0   64M   0% /dev/shm
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/sda1        40G   29G  8.9G  77% /.containerinit
root@0d48eb90-b55a-4eb9-9558-9c8dd863546e:/# exit
exit
$ flynn -a postgres run --limits temp_disk=1G bash
root@607491b4-d76c-47de-9e23-3105ef63d8fd:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay        1008M  1.3M 1007M   1% /
tmpfs           2.0G     0  2.0G   0% /dev
shm              64M     0   64M   0% /dev/shm
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/sda1        40G   29G  8.9G  77% /.containerinit
root@607491b4-d76c-47de-9e23-3105ef63d8fd:/# exit
exit
$ flynn -a postgres run --limits memory=2G,temp_disk=3G bash
root@2f72b64f-bade-4fb4-8b0e-23f86dacb869:/# cat /sys/fs/cgroup/memory/memory.limit_in_bytes
2147483648
root@2f72b64f-bade-4fb4-8b0e-23f86dacb869:/# exit
exit
```