### PR TITLE
controller: Associate releases with a single app

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -219,7 +219,7 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 	}
 
 	h.Logger.Info("creating release", "artifact.id", h.RedisImageID)
-	if err := h.ControllerClient.CreateRelease(release); err != nil {
+	if err := h.ControllerClient.CreateRelease(app.ID, release); err != nil {
 		h.Logger.Error("error creating release", "err", err)
 		httphelper.Error(w, err)
 		return

--- a/bootstrap/add_app_action.go
+++ b/bootstrap/add_app_action.go
@@ -51,7 +51,7 @@ func (a *AddAppAction) Run(s *State) error {
 		}
 	}
 	as.Artifacts = data.Artifacts
-	if err := client.CreateRelease(data.Release); err != nil {
+	if err := client.CreateRelease(a.App.ID, data.Release); err != nil {
 		return err
 	}
 	as.Release = data.Release

--- a/bootstrap/deploy_app_action.go
+++ b/bootstrap/deploy_app_action.go
@@ -86,7 +86,7 @@ func (a *DeployAppAction) Run(s *State) error {
 	}
 	as.Artifacts = a.Artifacts
 
-	if err := client.CreateRelease(a.Release); err != nil {
+	if err := client.CreateRelease(a.App.ID, a.Release); err != nil {
 		return err
 	}
 	as.Release = a.Release

--- a/cli/env.go
+++ b/cli/env.go
@@ -149,7 +149,11 @@ func runEnvGet(args *docopt.Args, client controller.Client) error {
 }
 
 func setEnv(client controller.Client, proc string, env map[string]*string) (string, error) {
-	release, err := client.GetAppRelease(mustApp())
+	app, err := client.GetApp(mustApp())
+	if err != nil {
+		return "", err
+	}
+	release, err := client.GetAppRelease(app.ID)
 	if err == controller.ErrNotFound {
 		release = &ct.Release{}
 		if proc != "" {
@@ -186,10 +190,10 @@ func setEnv(client controller.Client, proc string, env map[string]*string) (stri
 	}
 
 	release.ID = ""
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		return "", err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		return "", err
 	}
 	return release.ID, nil

--- a/cli/export.go
+++ b/cli/export.go
@@ -757,7 +757,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			}
 			release.Processes[t] = proc
 		}
-		if err := client.CreateRelease(release); err != nil {
+		if err := client.CreateRelease(app.ID, release); err != nil {
 			return fmt.Errorf("error creating release: %s", err)
 		}
 		if err := client.SetAppRelease(app.ID, release.ID); err != nil {
@@ -795,7 +795,7 @@ func runImport(args *docopt.Args, client controller.Client) error {
 			release.Meta = make(map[string]string, 1)
 		}
 		release.Meta["git"] = "true"
-		if err := client.CreateRelease(release); err != nil {
+		if err := client.CreateRelease(app.ID, release); err != nil {
 			return fmt.Errorf("error creating release: %s", err)
 		}
 		if err := client.SetAppRelease(app.ID, release.ID); err != nil {

--- a/cli/limit.go
+++ b/cli/limit.go
@@ -94,7 +94,11 @@ func formatLimits(w io.Writer, s string, r resource.Resources) {
 
 func runLimitSet(args *docopt.Args, client controller.Client) error {
 	proc := args.String["<proc>"]
-	release, err := client.GetAppRelease(mustApp())
+	app, err := client.GetApp(mustApp())
+	if err != nil {
+		return err
+	}
+	release, err := client.GetAppRelease(app.ID)
 	if err == controller.ErrNotFound {
 		release = &ct.Release{}
 	} else if err != nil {
@@ -131,10 +135,10 @@ func runLimitSet(args *docopt.Args, client controller.Client) error {
 	release.Processes[proc] = t
 
 	release.ID = ""
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		return err
 	}
-	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		return err
 	}
 	fmt.Printf("Created release %s\n", release.ID)

--- a/cli/release.go
+++ b/cli/release.go
@@ -200,6 +200,10 @@ func runReleaseShow(args *docopt.Args, client controller.Client) error {
 func runReleaseAddDocker(args *docopt.Args, client controller.Client) error {
 	fmt.Fprintln(os.Stderr, "WARN: The 'release add' command is deprecated and only works on legacy clusters, use 'docker push' to push Docker images")
 
+	app, err := client.GetApp(mustApp())
+	if err != nil {
+		return err
+	}
 	release := &ct.Release{}
 	if args.String["--file"] != "" {
 		data, err := ioutil.ReadFile(args.String["--file"])
@@ -220,11 +224,11 @@ func runReleaseAddDocker(args *docopt.Args, client controller.Client) error {
 	}
 
 	release.ArtifactIDs = []string{artifact.ID}
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		return err
 	}
 
-	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		return err
 	}
 
@@ -234,12 +238,15 @@ func runReleaseAddDocker(args *docopt.Args, client controller.Client) error {
 }
 
 func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
+	app, err := client.GetApp(mustApp())
+	if err != nil {
+		return err
+	}
 	var release *ct.Release
-	var err error
 	if args.String["<id>"] != "" {
 		release, err = client.GetRelease(args.String["<id>"])
 	} else {
-		release, err = client.GetAppRelease(mustApp())
+		release, err = client.GetAppRelease(app.ID)
 	}
 	if err != nil {
 		return err
@@ -310,11 +317,11 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		return err
 	}
 
-	if err := client.DeployAppRelease(mustApp(), release.ID, nil); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		return err
 	}
 

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -26,7 +26,7 @@ type Client interface {
 	StreamFormations(since *time.Time, output chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	PutDomain(dm *ct.DomainMigration) error
 	CreateArtifact(artifact *ct.Artifact) error
-	CreateRelease(release *ct.Release) error
+	CreateRelease(appID string, release *ct.Release) error
 	CreateApp(app *ct.App) error
 	UpdateApp(app *ct.App) error
 	UpdateAppMeta(app *ct.App) error

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -150,7 +150,8 @@ func (c *Client) CreateArtifact(artifact *ct.Artifact) error {
 }
 
 // CreateRelease creates a new release.
-func (c *Client) CreateRelease(release *ct.Release) error {
+func (c *Client) CreateRelease(appID string, release *ct.Release) error {
+	release.AppID = appID
 	return c.Post("/releases", release, release)
 }
 

--- a/controller/deployment_test.go
+++ b/controller/deployment_test.go
@@ -11,7 +11,7 @@ import (
 
 func (s *S) TestCreateDeployment(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "create-deployment"})
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		Processes: map[string]ct.ProcessType{"web": {}},
 	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
@@ -29,7 +29,7 @@ func (s *S) TestCreateDeployment(c *C) {
 	gotRelease, err := s.c.GetAppRelease(app.ID)
 	c.Assert(release.ID, Equals, gotRelease.ID)
 
-	newRelease := s.createTestRelease(c, &ct.Release{})
+	newRelease := s.createTestRelease(c, app.ID, &ct.Release{})
 
 	d, err = s.c.CreateDeployment(app.ID, newRelease.ID)
 	c.Assert(err, IsNil)
@@ -47,7 +47,7 @@ func (s *S) TestCreateDeployment(c *C) {
 
 func (s *S) TestStreamDeployment(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "stream-deployment"})
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		Processes: map[string]ct.ProcessType{"web": {}},
 	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
@@ -58,7 +58,7 @@ func (s *S) TestStreamDeployment(c *C) {
 	defer s.c.DeleteFormation(app.ID, release.ID)
 	c.Assert(s.c.SetAppRelease(app.ID, release.ID), IsNil)
 
-	newRelease := s.createTestRelease(c, &ct.Release{})
+	newRelease := s.createTestRelease(c, app.ID, &ct.Release{})
 
 	d, err := s.c.CreateDeployment(app.ID, newRelease.ID)
 	c.Assert(err, IsNil)
@@ -92,7 +92,7 @@ func (s *S) TestStreamDeployment(c *C) {
 
 func (s *S) TestGetDeployment(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "get-deployment"})
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		Processes: map[string]ct.ProcessType{"web": {}},
 	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
@@ -106,7 +106,7 @@ func (s *S) TestGetDeployment(c *C) {
 	d, err := s.c.CreateDeployment(app.ID, release.ID)
 	c.Assert(err, IsNil)
 	c.Assert(d.Status, Equals, "complete")
-	newRelease := s.createTestRelease(c, &ct.Release{})
+	newRelease := s.createTestRelease(c, app.ID, &ct.Release{})
 
 	// create a second deployment
 	d, err = s.c.CreateDeployment(app.ID, newRelease.ID)
@@ -126,7 +126,7 @@ func (s *S) TestGetDeployment(c *C) {
 
 func (s *S) TestDeploymentList(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "list-deployment"})
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		Processes: map[string]ct.ProcessType{"web": {}},
 	})
 	c.Assert(s.c.PutFormation(&ct.Formation{
@@ -140,7 +140,7 @@ func (s *S) TestDeploymentList(c *C) {
 	initial, err := s.c.CreateDeployment(app.ID, release.ID)
 	c.Assert(err, IsNil)
 	c.Assert(initial.Status, Equals, "complete")
-	newRelease := s.createTestRelease(c, &ct.Release{})
+	newRelease := s.createTestRelease(c, app.ID, &ct.Release{})
 
 	// create a second deployment
 	second, err := s.c.CreateDeployment(app.ID, newRelease.ID)

--- a/controller/examples/examples.go
+++ b/controller/examples/examples.go
@@ -355,7 +355,7 @@ func (e *generator) createRelease() {
 			},
 		},
 	}
-	err := e.client.CreateRelease(release)
+	err := e.client.CreateRelease(e.resourceIds["app"], release)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/formation.go
+++ b/controller/formation.go
@@ -154,6 +154,7 @@ func scanExpandedFormation(s postgres.Scanner) (*ct.ExpandedFormation, error) {
 			f.Release.LegacyArtifactID = f.Release.ArtifactIDs[0]
 		}
 	}
+	f.Release.AppID = f.App.ID
 	return f, nil
 }
 

--- a/controller/jobs_test.go
+++ b/controller/jobs_test.go
@@ -18,7 +18,7 @@ func (s *S) createTestJob(c *C, in *ct.Job) *ct.Job {
 
 func (s *S) TestJobList(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-list"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, app.ID, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
 	id := random.UUID()
 	s.createTestJob(c, &ct.Job{UUID: id, AppID: app.ID, ReleaseID: release.ID, Type: "web", State: ct.JobStateStarting, Meta: map[string]string{"some": "info"}})
@@ -35,7 +35,7 @@ func (s *S) TestJobList(c *C) {
 
 func (s *S) TestJobListActive(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-list-active"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, app.ID, &ct.Release{})
 
 	// mark all existing jobs as down
 	c.Assert(s.hc.db.Exec("UPDATE job_cache SET state = 'down'"), IsNil)
@@ -78,7 +78,7 @@ func (s *S) TestJobListActive(c *C) {
 
 func (s *S) TestJobGet(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "job-get"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, app.ID, &ct.Release{})
 	s.createTestFormation(c, &ct.Formation{ReleaseID: release.ID, AppID: app.ID})
 	uuid := random.UUID()
 	hostID := "host0"
@@ -113,7 +113,7 @@ func fakeHostID() string {
 
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
-	release := s.createTestRelease(c, &ct.Release{})
+	release := s.createTestRelease(c, app.ID, &ct.Release{})
 	hostID := fakeHostID()
 	uuid := random.UUID()
 	jobID := cluster.GenerateJobID(hostID, uuid)
@@ -143,7 +143,7 @@ func (s *S) TestRunJobDetached(c *C) {
 	host := tu.NewFakeHostClient(hostID, false)
 	s.cc.AddHost(host)
 
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		ArtifactIDs: []string{artifact.ID},
 		Env:         map[string]string{"RELEASE": "true", "FOO": "bar"},
 	})
@@ -221,7 +221,7 @@ func (s *S) TestRunJobAttached(c *C) {
 	})
 
 	artifact := s.createTestArtifact(c, &ct.Artifact{})
-	release := s.createTestRelease(c, &ct.Release{
+	release := s.createTestRelease(c, app.ID, &ct.Release{
 		ArtifactIDs: []string{artifact.ID},
 		Env:         map[string]string{"RELEASE": "true", "FOO": "bar"},
 	})

--- a/controller/scheduler/scheduler_test.go
+++ b/controller/scheduler/scheduler_test.go
@@ -71,7 +71,7 @@ func createTestScheduler(cluster utils.ClusterClient, discoverd Discoverd, proce
 	cc := NewFakeControllerClient()
 	cc.CreateApp(app)
 	cc.CreateArtifact(artifact)
-	cc.CreateRelease(release)
+	cc.CreateRelease(app.ID, release)
 	cc.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	return NewScheduler(cluster, cc, discoverd, l)
 }
@@ -266,7 +266,7 @@ func (TestSuite) TestFormationChange(c *C) {
 	processes := map[string]int{testJobType: testJobCount}
 	release = NewRelease(random.UUID(), artifact, processes)
 	s.CreateArtifact(artifact)
-	s.CreateRelease(release)
+	s.CreateRelease(app.ID, release)
 	c.Assert(len(s.formations), Equals, 1)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	job := s.waitJobStart()
@@ -324,7 +324,7 @@ func (TestSuite) TestRectify(c *C) {
 	c.Log("Add the formation to the controller. Wait for formation change. Check the job has a formation and no new job was created")
 	s.CreateApp(app)
 	s.CreateArtifact(artifact)
-	s.CreateRelease(release)
+	s.CreateRelease(app.ID, release)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	s.waitFormationChange()
 	_, err := s.waitDurationForEvent("handled job start event", 1*time.Second, nil)
@@ -405,7 +405,7 @@ func (TestSuite) TestMultipleHosts(c *C) {
 	c.Log("Add the formation to the controller. Wait for formation change and job start on both hosts.")
 	s.CreateApp(app)
 	s.CreateArtifact(artifact)
-	s.CreateRelease(release)
+	s.CreateRelease(app.ID, release)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	s.waitJobStart()
 	s.waitJobStart()
@@ -778,7 +778,7 @@ func (TestSuite) TestScaleCriticalApp(c *C) {
 	release := NewRelease("critical-release-1", artifact, processes)
 	s.CreateApp(app)
 	s.CreateArtifact(artifact)
-	s.CreateRelease(release)
+	s.CreateRelease(app.ID, release)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: release.ID, Processes: processes})
 	s.waitJobStart()
 
@@ -790,7 +790,7 @@ func (TestSuite) TestScaleCriticalApp(c *C) {
 
 	// scale up another formation
 	newRelease := NewRelease("critical-release-2", artifact, processes)
-	s.CreateRelease(newRelease)
+	s.CreateRelease(app.ID, newRelease)
 	s.PutFormation(&ct.Formation{AppID: app.ID, ReleaseID: newRelease.ID, Processes: processes})
 	s.waitJobStart()
 

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -122,7 +122,7 @@ UPDATE apps SET deleted_at = now() WHERE app_id = $1 AND deleted_at IS NULL`
 	appNextNameIDQuery = `
 SELECT nextval('name_ids')`
 	appGetReleaseQuery = `
-SELECT r.release_id,
+SELECT r.release_id, r.app_id,
   ARRAY(
 	SELECT a.artifact_id
 	FROM release_artifacts a
@@ -132,7 +132,7 @@ SELECT r.release_id,
 FROM apps a JOIN releases r USING (release_id) WHERE a.app_id = $1 AND r.deleted_at IS NULL`
 
 	releaseListQuery = `
-SELECT r.release_id,
+SELECT r.release_id, r.app_id,
   ARRAY(
 	SELECT a.artifact_id
 	FROM release_artifacts a
@@ -141,7 +141,7 @@ SELECT r.release_id,
   ), r.env, r.processes, r.meta, r.created_at
 FROM releases r WHERE r.deleted_at IS NULL ORDER BY r.created_at DESC`
 	releaseSelectQuery = `
-SELECT r.release_id,
+SELECT r.release_id, r.app_id,
   ARRAY(
 	SELECT a.artifact_id
 	FROM release_artifacts a
@@ -150,18 +150,17 @@ SELECT r.release_id,
   ), r.env, r.processes, r.meta, r.created_at
 FROM releases r WHERE r.release_id = $1 AND r.deleted_at IS NULL`
 	releaseInsertQuery = `
-INSERT INTO releases (release_id, env, processes, meta)
-VALUES ($1, $2, $3, $4) RETURNING created_at`
+INSERT INTO releases (release_id, app_id, env, processes, meta)
+VALUES ($1, $2, $3, $4, $5) RETURNING created_at`
 	releaseAppListQuery = `
-SELECT DISTINCT(r.release_id),
+SELECT r.release_id, r.app_id,
   ARRAY(
 	SELECT a.artifact_id
 	FROM release_artifacts a
 	WHERE a.release_id = r.release_id AND a.deleted_at IS NULL
 	ORDER BY a.index
   ), r.env, r.processes, r.meta, r.created_at
-FROM releases r JOIN formations f USING (release_id)
-WHERE f.app_id = $1 AND r.deleted_at IS NULL ORDER BY r.created_at DESC`
+FROM releases r WHERE r.app_id = $1 AND r.deleted_at IS NULL ORDER BY r.created_at DESC`
 	releaseArtifactsInsertQuery = `
 INSERT INTO release_artifacts (release_id, artifact_id, index) VALUES ($1, $2, $3)`
 	releaseArtifactsDeleteQuery = `

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -121,7 +121,7 @@ func (c *FakeControllerClient) CreateApp(app *ct.App) error {
 	return nil
 }
 
-func (c *FakeControllerClient) CreateRelease(release *ct.Release) error {
+func (c *FakeControllerClient) CreateRelease(appID string, release *ct.Release) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -74,6 +74,7 @@ func (a *App) Critical() bool {
 
 type Release struct {
 	ID          string                 `json:"id,omitempty"`
+	AppID       string                 `json:"app_id,omitempty"`
 	ArtifactIDs []string               `json:"artifacts,omitempty"`
 	Env         map[string]string      `json:"env,omitempty"`
 	Meta        map[string]string      `json:"meta,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -271,7 +271,7 @@ type ControllerClient interface {
 	GetArtifact(artifactID string) (*ct.Artifact, error)
 	GetExpandedFormation(appID, releaseID string) (*ct.ExpandedFormation, error)
 	CreateApp(app *ct.App) error
-	CreateRelease(release *ct.Release) error
+	CreateRelease(appID string, release *ct.Release) error
 	CreateArtifact(artifact *ct.Artifact) error
 	PutFormation(formation *ct.Formation) error
 	StreamFormations(since *time.Time, ch chan<- *ct.ExpandedFormation) (stream.Stream, error)

--- a/controller/worker/domain_migration/domain_migration.go
+++ b/controller/worker/domain_migration/domain_migration.go
@@ -161,6 +161,7 @@ func (m *migration) generateTLSCert() (*tlscert.Cert, error) {
 
 func dupRelease(release *ct.Release) *ct.Release {
 	return &ct.Release{
+		AppID:       release.AppID,
 		ArtifactIDs: release.ArtifactIDs,
 		Env:         release.Env,
 		Meta:        release.Meta,
@@ -236,11 +237,11 @@ func (m *migration) maybeDeployController() error {
 	release = dupRelease(release)
 	release.Env["DEFAULT_ROUTE_DOMAIN"] = m.dm.Domain
 	release.Env["CA_CERT"] = m.dm.TLSCert.CACert
-	if err := m.client.CreateRelease(release); err != nil {
+	if err := m.client.CreateRelease(release.AppID, release); err != nil {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID, m.cancelDeploy()); err != nil {
+	if err := m.client.DeployAppRelease(release.AppID, release.ID, m.cancelDeploy()); err != nil {
 		log.Error("error deploying release", "error", err)
 		select {
 		case <-m.stop:
@@ -270,11 +271,11 @@ func (m *migration) maybeDeployRouter() error {
 	release = dupRelease(release)
 	release.Env["TLSCERT"] = m.dm.TLSCert.Cert
 	release.Env["TLSKEY"] = m.dm.TLSCert.PrivateKey
-	if err := m.client.CreateRelease(release); err != nil {
+	if err := m.client.CreateRelease(release.AppID, release); err != nil {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID, m.cancelDeploy()); err != nil {
+	if err := m.client.DeployAppRelease(release.AppID, release.ID, m.cancelDeploy()); err != nil {
 		log.Error("error deploying release", "error", err)
 		select {
 		case <-m.stop:
@@ -306,11 +307,11 @@ func (m *migration) maybeDeployDashboard() error {
 	release.Env["DEFAULT_ROUTE_DOMAIN"] = m.dm.Domain
 	release.Env["CONTROLLER_DOMAIN"] = fmt.Sprintf("controller.%s", m.dm.Domain)
 	release.Env["URL"] = fmt.Sprintf("https://dashboard.%s", m.dm.Domain)
-	if err := m.client.CreateRelease(release); err != nil {
+	if err := m.client.CreateRelease(release.AppID, release); err != nil {
 		log.Error("error creating release", "error", err)
 		return err
 	}
-	if err := m.client.DeployAppRelease(appName, release.ID, m.cancelDeploy()); err != nil {
+	if err := m.client.DeployAppRelease(release.AppID, release.ID, m.cancelDeploy()); err != nil {
 		log.Error("error deploying release", "error", err)
 		select {
 		case <-m.stop:

--- a/gitreceive/receiver/flynn-receive.go
+++ b/gitreceive/receiver/flynn-receive.go
@@ -219,10 +219,10 @@ Options:
 	}
 	release.Processes = procs
 
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		return fmt.Errorf("Error creating release: %s", err)
 	}
-	if err := client.DeployAppRelease(app.Name, release.ID, nil); err != nil {
+	if err := client.DeployAppRelease(app.ID, release.ID, nil); err != nil {
 		return fmt.Errorf("Error deploying app release: %s", err)
 	}
 

--- a/schema/controller/release.json
+++ b/schema/controller/release.json
@@ -18,6 +18,9 @@
     "id": {
       "$ref": "/schema/controller/common#/definitions/id"
     },
+    "app_id": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
     "artifact": {
       "description": "DEPRECATED: legacy artifact ID",
       "$ref": "/schema/controller/common#/definitions/id"

--- a/test/cluster2/cluster.go
+++ b/test/cluster2/cluster.go
@@ -183,7 +183,7 @@ func Boot(c *BootConfig) (*Cluster, error) {
 		})
 		release.Processes["host"] = proc
 	}
-	if err := c.Client.CreateRelease(release); err != nil {
+	if err := c.Client.CreateRelease(app.ID, release); err != nil {
 		log.Error("error creating release", "err", err)
 		return nil, err
 	}

--- a/test/helper.go
+++ b/test/helper.go
@@ -403,7 +403,7 @@ func (h *Helper) createAppWithClient(t *c.C, client controller.Client) (*ct.App,
 			},
 		},
 	}
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.ID, release.ID), c.IsNil)
 	return app, release
 }

--- a/test/sirenia.go
+++ b/test/sirenia.go
@@ -98,7 +98,7 @@ func testSireniaDeploy(client controller.Client, disc *discoverd.Client, t *c.C,
 	proc := release.Processes[procName]
 	proc.Service = d.name
 	release.Processes[procName] = proc
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.ID, release.ID), c.IsNil)
 	oldRelease := release.ID
 
@@ -207,7 +207,7 @@ func testSireniaDeploy(client controller.Client, disc *discoverd.Client, t *c.C,
 
 	// check a deploy completes with expected cluster state changes
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	newRelease := release.ID
 	deployment, err := client.CreateDeployment(app.ID, newRelease)
 	t.Assert(err, c.IsNil)

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -211,7 +211,7 @@ func (s *CLISuite) TestScaleAll(t *c.C) {
 		Meta:        release.Meta,
 		Processes:   release.Processes,
 	}
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.id, release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.id, release.ID), c.IsNil)
 
 	scale = app.flynn("scale", "echoer=2", "printer=1")
@@ -829,7 +829,7 @@ func (s *CLISuite) TestRelease(t *c.C) {
 		},
 	}
 	client := s.controllerClient(t)
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.id, release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.id, release.ID), c.IsNil)
 
 	updateFile := filepath.Join(t.MkDir(), "updates.json")
@@ -1251,7 +1251,7 @@ func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
 			},
 			Meta: map[string]string{"git": "true"},
 		}
-		t.Assert(client.CreateRelease(release), c.IsNil)
+		t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 		procs := map[string]int{"app": 0}
 		if r.active {
 			procs["app"] = 1
@@ -1291,7 +1291,7 @@ func (s *CLISuite) TestSlugReleaseGarbageCollection(t *c.C) {
 	time.AfterFunc(5*time.Minute, func() { close(timeoutCh) })
 	newRelease := *lastRelease
 	newRelease.ID = ""
-	t.Assert(client.CreateRelease(&newRelease), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, &newRelease), c.IsNil)
 	t.Assert(client.DeployAppRelease(app.ID, newRelease.ID, timeoutCh), c.IsNil)
 
 	// wait for garbage collection

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -96,7 +96,7 @@ func (s *DeployerSuite) createDeployment(t *c.C, process, strategy, service stri
 
 	// create a new release for the deployment
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
@@ -247,7 +247,7 @@ func (s *DeployerSuite) TestRollbackFailedJob(t *c.C) {
 	printer := release.Processes["printer"]
 	printer.Args = []string{"this-is-gonna-fail"}
 	release.Processes["printer"] = printer
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 
@@ -287,7 +287,7 @@ func (s *DeployerSuite) TestRollbackNoService(t *c.C) {
 		},
 	}}
 	release.Processes["printer"] = printer
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 
@@ -333,7 +333,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	app.Strategy = "all-at-once"
 	t.Assert(client.UpdateApp(app), c.IsNil)
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 	events := make(chan *ct.DeploymentEvent)
@@ -358,7 +358,7 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	app.Strategy = "one-by-one"
 	t.Assert(client.UpdateApp(app), c.IsNil)
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	// try creating the deployment multiple times to avoid getting a
 	// "Cannot create deploy, one is already in progress" error (there
 	// is no guarantee the previous deploy has finished yet)

--- a/test/test_discoverd.go
+++ b/test/test_discoverd.go
@@ -27,7 +27,7 @@ func (s *DiscoverdSuite) TestDeploy(t *c.C) {
 	release, err := client.GetAppRelease(app.ID)
 	t.Assert(err, c.IsNil)
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -60,7 +60,7 @@ loop:
 	app := &ct.App{}
 	t.Assert(client.CreateApp(app), c.IsNil)
 	release := &ct.Release{ArtifactIDs: []string{artifact.ID}}
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	t.Assert(client.SetAppRelease(app.ID, release.ID), c.IsNil)
 
 	// check running a job uses the image

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -373,17 +373,19 @@ func (s *GitDeploySuite) TestCustomPort(t *c.C) {
 
 	// Update release with a different port
 	cc := s.controllerClient(t)
+	app, err := cc.GetApp(name)
+	t.Assert(err, c.IsNil)
 	release, err := cc.GetAppRelease(name)
 	t.Assert(err, c.IsNil)
 	release.ID = ""
 	release.Processes["web"].Ports[0].Port = 9090
-	t.Assert(cc.CreateRelease(release), c.IsNil)
-	t.Assert(cc.DeployAppRelease(name, release.ID, nil), c.IsNil)
+	t.Assert(cc.CreateRelease(app.ID, release), c.IsNil)
+	t.Assert(cc.DeployAppRelease(app.ID, release.ID, nil), c.IsNil)
 
 	// Deploy again, check that port stays the same
 	t.Assert(r.git("commit", "-m", "foo", "--allow-empty"), Succeeds)
 	t.Assert(r.git("push", "flynn", "master"), Succeeds)
-	release, err = cc.GetAppRelease(name)
+	release, err = cc.GetAppRelease(app.ID)
 	t.Assert(err, c.IsNil)
 	t.Assert(release.Processes["web"].Ports[0].Port, c.Equals, 9090)
 }

--- a/test/test_healthcheck.go
+++ b/test/test_healthcheck.go
@@ -29,7 +29,7 @@ func (s *HealthcheckSuite) createAppWithService(t *c.C, process string, service 
 	}}
 	release.Processes[process] = proctype
 
-	t.Assert(s.controllerClient(t).CreateRelease(release), c.IsNil)
+	t.Assert(s.controllerClient(t).CreateRelease(app.ID, release), c.IsNil)
 	t.Assert(s.controllerClient(t).SetAppRelease(app.ID, release.ID), c.IsNil)
 	return app, release
 }

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -184,7 +184,7 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 		Meta:        map[string]string{"git": "true"},
 		Env:         resource.Env,
 	}
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(slugApp.ID, release), c.IsNil)
 	t.Assert(client.SetAppRelease(slugApp.ID, release.ID), c.IsNil)
 	watcher, err := client.WatchJobEvents(slugApp.ID, release.ID)
 	t.Assert(err, c.IsNil)

--- a/test/test_scheduler.go
+++ b/test/test_scheduler.go
@@ -571,7 +571,7 @@ func (s *SchedulerSuite) TestRollbackController(t *c.C) {
 	worker := release.Processes["worker"]
 	worker.Args = []string{"/i/dont/exist"}
 	release.Processes["worker"] = worker
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 
@@ -664,7 +664,7 @@ func (s *SchedulerSuite) TestDeployController(t *c.C) {
 
 	// create a controller deployment
 	release.ID = ""
-	t.Assert(client.CreateRelease(release), c.IsNil)
+	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)
 	deployment, err := client.CreateDeployment(app.ID, release.ID)
 	t.Assert(err, c.IsNil)
 

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -233,7 +233,7 @@ func deployApp(client controller.Client, app *ct.App, image *ct.Artifact, update
 	if updateFn != nil {
 		updateFn(release)
 	}
-	if err := client.CreateRelease(release); err != nil {
+	if err := client.CreateRelease(app.ID, release); err != nil {
 		log.Error("error creating new release", "err", err)
 		return err
 	}


### PR DESCRIPTION
Releases were previously related to apps indirectly via formations, but pretty much everywhere a release is created, there is an associated app that a formation is created for, so whilst associating a release with multiple apps via formations was possible, it was rarely done.

This commit adds an `app_id` column and makes it required if the release is not deleted. Old releases that can't reliably be associated with an app are marked as deleted.