### PR TITLE
test: Support booting Flynn in Flynn!

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -21,6 +21,7 @@ import (
 )
 
 type Client interface {
+	SetKey(newKey string)
 	GetCACert() ([]byte, error)
 	StreamFormations(since *time.Time, output chan<- *ct.ExpandedFormation) (stream.Stream, error)
 	PutDomain(dm *ct.DomainMigration) error

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -28,6 +28,10 @@ type Client struct {
 	*httpclient.Client
 }
 
+func (c *Client) SetKey(newKey string) {
+	c.Key = newKey
+}
+
 type jobWatcher struct {
 	events    chan *ct.Job
 	stream    stream.Stream

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -677,7 +677,10 @@ func (c *Client) ProviderList() ([]*ct.Provider, error) {
 // Backup takes a backup of the cluster
 func (c *Client) Backup() (io.ReadCloser, error) {
 	res, err := c.RawReq("GET", "/backup", nil, nil, nil)
-	return res.Body, err
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, nil
 }
 
 // GetBackupMeta returns metadata for latest backup

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -102,6 +102,7 @@ type ProcessType struct {
 	Service     string             `json:"service,omitempty"`
 	Resurrect   bool               `json:"resurrect,omitempty"`
 	Resources   resource.Resources `json:"resources,omitempty"`
+	Mounts      []host.Mount       `json:"mounts,omitempty"`
 
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/flynn/pkg/tlscert"
 	"github.com/flynn/flynn/router/types"
 	"github.com/jtacoma/uritemplates"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/tent/canonical-json-go"
 )
 
@@ -93,16 +94,19 @@ func (r *Release) IsDockerReceiveDeploy() bool {
 }
 
 type ProcessType struct {
-	Args        []string           `json:"args,omitempty"`
-	Env         map[string]string  `json:"env,omitempty"`
-	Ports       []Port             `json:"ports,omitempty"`
-	Volumes     []VolumeReq        `json:"volumes,omitempty"`
-	Omni        bool               `json:"omni,omitempty"` // omnipresent - present on all hosts
-	HostNetwork bool               `json:"host_network,omitempty"`
-	Service     string             `json:"service,omitempty"`
-	Resurrect   bool               `json:"resurrect,omitempty"`
-	Resources   resource.Resources `json:"resources,omitempty"`
-	Mounts      []host.Mount       `json:"mounts,omitempty"`
+	Args              []string           `json:"args,omitempty"`
+	Env               map[string]string  `json:"env,omitempty"`
+	Ports             []Port             `json:"ports,omitempty"`
+	Volumes           []VolumeReq        `json:"volumes,omitempty"`
+	Omni              bool               `json:"omni,omitempty"` // omnipresent - present on all hosts
+	HostNetwork       bool               `json:"host_network,omitempty"`
+	Service           string             `json:"service,omitempty"`
+	Resurrect         bool               `json:"resurrect,omitempty"`
+	Resources         resource.Resources `json:"resources,omitempty"`
+	Mounts            []host.Mount       `json:"mounts,omitempty"`
+	LinuxCapabilities []string           `json:"linux_capabilities,omitempty"`
+	AllowedDevices    []*configs.Device  `json:"allowed_devices,omitempty"`
+	WriteableCgroups  bool               `json:"writeable_cgroups,omitempty"`
 
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -57,6 +57,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 			Uid:         entrypoint.Uid,
 			Gid:         entrypoint.Gid,
 			HostNetwork: t.HostNetwork,
+			Mounts:      t.Mounts,
 		},
 		Resurrect: t.Resurrect,
 		Resources: t.Resources,

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -51,19 +51,26 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 		ID:       id,
 		Metadata: metadata,
 		Config: host.ContainerConfig{
-			Args:        entrypoint.Args,
-			Env:         env,
-			WorkingDir:  entrypoint.WorkingDir,
-			Uid:         entrypoint.Uid,
-			Gid:         entrypoint.Gid,
-			HostNetwork: t.HostNetwork,
-			Mounts:      t.Mounts,
+			Args:             entrypoint.Args,
+			Env:              env,
+			WorkingDir:       entrypoint.WorkingDir,
+			Uid:              entrypoint.Uid,
+			Gid:              entrypoint.Gid,
+			HostNetwork:      t.HostNetwork,
+			Mounts:           t.Mounts,
+			WriteableCgroups: t.WriteableCgroups,
 		},
 		Resurrect: t.Resurrect,
 		Resources: t.Resources,
 	}
 	if len(t.Args) > 0 {
 		job.Config.Args = t.Args
+	}
+	if len(t.LinuxCapabilities) > 0 {
+		job.Config.LinuxCapabilities = &t.LinuxCapabilities
+	}
+	if len(t.AllowedDevices) > 0 {
+		job.Config.AllowedDevices = &t.AllowedDevices
 	}
 
 	// job.Config.Args may be empty if restoring from an old backup which

--- a/host/Dockerfile
+++ b/host/Dockerfile
@@ -3,13 +3,14 @@ FROM ubuntu:xenial
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install --yes zfsutils-linux iptables udev && \
+    apt-get install --yes zfsutils-linux iptables udev net-tools iproute2 && \
     apt-get clean
 
-ADD bin/flynn-host /usr/local/bin/flynn-host
-ADD bin/flynn-init /usr/local/bin/flynn-init
-ADD zfs-mknod.sh   /usr/local/bin/zfs-mknod
-ADD udev.rules     /lib/udev/rules.d/10-local.rules
-ADD start.sh       /usr/local/bin/start-flynn-host.sh
+ADD bin/ca-certs.pem /etc/ssl/certs/ca-certs.pem
+ADD bin/flynn-host   /usr/local/bin/flynn-host
+ADD bin/flynn-init   /usr/local/bin/flynn-init
+ADD zfs-mknod.sh     /usr/local/bin/zfs-mknod
+ADD udev.rules       /lib/udev/rules.d/10-local.rules
+ADD start.sh         /usr/local/bin/start-flynn-host.sh
 
 CMD ["/usr/local/bin/start-flynn-host.sh"]

--- a/host/Dockerfile
+++ b/host/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:xenial
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install --yes zfsutils-linux iptables udev && \
+    apt-get clean
+
+ADD bin/flynn-host /usr/local/bin/flynn-host
+ADD bin/flynn-init /usr/local/bin/flynn-init
+ADD zfs-mknod.sh   /usr/local/bin/zfs-mknod
+ADD udev.rules     /lib/udev/rules.d/10-local.rules
+ADD start.sh       /usr/local/bin/start-flynn-host.sh
+
+CMD ["/usr/local/bin/start-flynn-host.sh"]

--- a/host/Tupfile
+++ b/host/Tupfile
@@ -4,3 +4,4 @@ include_rules
 : bin/flynn-host |> gzip -9 --keep bin/flynn-host |> bin/flynn-host.gz
 : |> !go ./flynn-init |> bin/flynn-init
 : bin/flynn-host.gz $(ROOT)/script/install-flynn.tmpl |> sed "s/{{FLYNN-HOST-CHECKSUM}}/\$(sha512sum bin/flynn-host.gz | cut -d " " -f 1)/g" $(ROOT)/script/install-flynn.tmpl > %o |> $(ROOT)/script/install-flynn
+: bin/* |> !image-bootstrapped |>

--- a/host/Tupfile
+++ b/host/Tupfile
@@ -4,4 +4,5 @@ include_rules
 : bin/flynn-host |> gzip -9 --keep bin/flynn-host |> bin/flynn-host.gz
 : |> !go ./flynn-init |> bin/flynn-init
 : bin/flynn-host.gz $(ROOT)/script/install-flynn.tmpl |> sed "s/{{FLYNN-HOST-CHECKSUM}}/\$(sha512sum bin/flynn-host.gz | cut -d " " -f 1)/g" $(ROOT)/script/install-flynn.tmpl > %o |> $(ROOT)/script/install-flynn
+: $(ROOT)/util/ca-certs/ca-certs.pem |> !cp |> bin/ca-certs.pem
 : bin/* |> !image-bootstrapped |>

--- a/host/cli/run.go
+++ b/host/cli/run.go
@@ -26,6 +26,7 @@ Run an interactive job.
 Options:
 	--host=<host>        run on a specific host
 	--bind=<mountspecs>  bind mount a directory into the job (ex: /foo:/data,/bar:/baz)
+	--volume=<path>      mount a temporary volume at <path>
 
 Example:
 	$ flynn-host run <(jq '.mongodb' images.json) mongo --version
@@ -77,6 +78,12 @@ func runRun(args *docopt.Args, client *cluster.Client) error {
 				Writeable: true,
 			}
 		}
+	}
+	if path := args.String["--volume"]; path != "" {
+		cmd.Volumes = []*ct.VolumeReq{{
+			Path:         path,
+			DeleteOnStop: true,
+		}}
 	}
 
 	var termState *term.State

--- a/host/host.go
+++ b/host/host.go
@@ -57,6 +57,7 @@ options:
   --max-job-concurrency=NUM  maximum number of jobs to start concurrently
   --partitions=PARTITIONS    specify resource partitions for host [default: system=cpu_shares:4096 background=cpu_shares:4096 user=cpu_shares:8192]
   --init-log-level=LEVEL     containerinit log level [default: info]
+  --zpool-name=NAME          zpool name
 	`)
 }
 
@@ -199,6 +200,11 @@ func runDaemon(args *docopt.Args) {
 		maxJobConcurrency = m
 	}
 
+	zpoolName := args.String["--zpool-name"]
+	if zpoolName == "" {
+		zpoolName = zfsVolume.DefaultDatasetName
+	}
+
 	if path, err := filepath.Abs(flynnInit); err == nil {
 		flynnInit = path
 	}
@@ -264,7 +270,7 @@ func runDaemon(args *docopt.Args) {
 	case "zfs":
 		newVolProvider = func() (volume.Provider, error) {
 			return zfsVolume.NewProvider(&zfsVolume.ProviderConfig{
-				DatasetName: zfsVolume.DefaultDatasetName,
+				DatasetName: zpoolName,
 				Make:        zfsVolume.DefaultMakeDev(volPath, log),
 				WorkingDir:  filepath.Join(volPath, "zfs"),
 			})

--- a/host/host.go
+++ b/host/host.go
@@ -321,11 +321,9 @@ func runDaemon(args *docopt.Args) {
 		id:  hostID,
 		url: publishURL,
 		status: &host.HostStatus{
-			ID:      hostID,
-			PID:     os.Getpid(),
-			URL:     publishURL,
-			Tags:    tags,
-			Version: version.String(),
+			ID:   hostID,
+			URL:  publishURL,
+			Tags: tags,
 		},
 		state:   state,
 		backend: backend,
@@ -345,11 +343,15 @@ func runDaemon(args *docopt.Args) {
 			log.Error("error restoring host status from parent", "err", err)
 			shutdown.Fatal(err)
 		}
-		pid := os.Getpid()
-		log.Info("setting status PID", "pid", pid)
-		host.status.PID = pid
 		// keep the same tags as the parent
 		discoverdManager.UpdateTags(host.status.Tags)
+	}
+	pid := os.Getpid()
+	log.Info("setting host status PID", "pid", pid)
+	host.status.PID = pid
+	host.status.Version = version.String()
+	if len(os.Args) > 2 {
+		host.status.Flags = os.Args[2:]
 	}
 
 	log.Info("creating HTTP listener")

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -269,8 +269,11 @@ func (l *LibcontainerBackend) ConfigureNetworking(config *host.NetworkConfig) er
 	}
 
 	// enable IP forwarding
-	if err := ioutil.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1\n"), 0644); err != nil {
-		return err
+	ipFwd := "/proc/sys/net/ipv4/ip_forward"
+	if data, err := ioutil.ReadFile(ipFwd); err != nil && !bytes.HasPrefix(data, []byte("1")) {
+		if err := ioutil.WriteFile(ipFwd, []byte("1\n"), 0644); err != nil {
+			return err
+		}
 	}
 
 	// Set up iptables for outbound traffic masquerading from containers to the

--- a/host/start.sh
+++ b/host/start.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# A script to start flynn-host inside a container.
+
+# exit on error
+set -e
+
+# create /dev/zfs
+mknod -m 0600 /dev/zfs c $(sed 's|:| |' /sys/class/misc/zfs/dev)
+
+# create /etc/mtab to keep ZFS happy
+ln -nfs /proc/mounts /etc/mtab
+
+# start udevd so that ZFS device nodes and symlinks are created in our mount
+# namespace
+/lib/systemd/systemd-udevd --daemon
+
+# use a unique directory in /var/lib/flynn (which is bind mounted from the
+# host)
+DIR="/var/lib/flynn/${FLYNN_JOB_ID}"
+mkdir -p "${DIR}"
+
+# create a tmpdir in /var/lib/flynn to avoid ENOSPC when downloading image
+# layers
+export TMPDIR="${DIR}/tmp"
+mkdir -p "${TMPDIR}"
+
+# use a unique zpool to avoid conflicts with other daemons
+ZPOOL="flynn-${FLYNN_JOB_ID}"
+
+# start flynn-host
+exec /usr/local/bin/flynn-host daemon \
+  --state      "${DIR}/host-state.bolt" \
+  --volpath    "${DIR}/volumes" \
+  --log-dir    "${DIR}/logs" \
+  --zpool-name "${ZPOOL}" \
+  --no-resurrect

--- a/host/start.sh
+++ b/host/start.sh
@@ -28,10 +28,19 @@ mkdir -p "${TMPDIR}"
 # use a unique zpool to avoid conflicts with other daemons
 ZPOOL="flynn-${FLYNN_JOB_ID}"
 
-# start flynn-host
-exec /usr/local/bin/flynn-host daemon \
-  --state      "${DIR}/host-state.bolt" \
-  --volpath    "${DIR}/volumes" \
-  --log-dir    "${DIR}/logs" \
-  --zpool-name "${ZPOOL}" \
+ARGS=(
+  --state      "${DIR}/host-state.bolt"
+  --volpath    "${DIR}/volumes"
+  --log-dir    "${DIR}/logs"
+  --zpool-name "${ZPOOL}"
   --no-resurrect
+)
+
+if [[ -n "${DISCOVERY_SERVICE}" ]]; then
+  ARGS+=(
+    --discovery-service "${DISCOVERY_SERVICE}"
+  )
+fi
+
+# start flynn-host
+exec /usr/local/bin/flynn-host daemon ${ARGS[@]}

--- a/host/start.sh
+++ b/host/start.sh
@@ -42,5 +42,15 @@ if [[ -n "${DISCOVERY_SERVICE}" ]]; then
   )
 fi
 
-# start flynn-host
-exec /usr/local/bin/flynn-host daemon ${ARGS[@]}
+# start flynn-host in the background and just block so that the container
+# doesn't exit if flynn-host is updated in-place
+start-stop-daemon \
+  --start \
+  --background \
+  --no-close \
+  --exec "/usr/local/bin/flynn-host" \
+  -- \
+  "daemon" \
+  ${ARGS[@]}
+
+sleep infinity

--- a/host/start.sh
+++ b/host/start.sh
@@ -44,13 +44,37 @@ fi
 
 # start flynn-host in the background and just block so that the container
 # doesn't exit if flynn-host is updated in-place
+PIDFILE="/tmp/flynn-host.pid"
 start-stop-daemon \
   --start \
   --background \
   --no-close \
+  --pidfile "${PIDFILE}" \
+  --make-pidfile \
   --exec "/usr/local/bin/flynn-host" \
   -- \
   "daemon" \
   ${ARGS[@]}
 
-sleep infinity
+cleanup() {
+  set -x
+
+  start-stop-daemon \
+    --stop \
+    --oknodo \
+    --retry 5 \
+    --pidfile "${PIDFILE}"
+
+  flynn-host destroy-volumes --volpath "${DIR}/volumes" --include-data
+
+  zpool destroy "${ZPOOL}"
+
+  rm -rf "${DIR}"
+
+  exit
+}
+trap cleanup TERM
+
+# sleep in the background so we can catch the SIGTERM
+sleep infinity &
+wait

--- a/host/types/defaults.go
+++ b/host/types/defaults.go
@@ -1,0 +1,28 @@
+// +build linux freebsd
+
+package host
+
+import "github.com/opencontainers/runc/libcontainer/configs"
+
+// DefaultCapabilities is the default list of capabilities which are set inside
+// a container, taken from:
+// https://github.com/opencontainers/runc/blob/v1.0.0-rc1/libcontainer/SPEC.md#security
+var DefaultCapabilities = []string{
+	"CAP_NET_RAW",
+	"CAP_NET_BIND_SERVICE",
+	"CAP_DAC_OVERRIDE",
+	"CAP_SETFCAP",
+	"CAP_SETPCAP",
+	"CAP_SETGID",
+	"CAP_SETUID",
+	"CAP_MKNOD",
+	"CAP_CHOWN",
+	"CAP_FOWNER",
+	"CAP_FSETID",
+	"CAP_KILL",
+	"CAP_SYS_CHROOT",
+}
+
+// DefaultAllowedDevices is the default list of devices containers are allowed
+// to access
+var DefaultAllowedDevices = configs.DefaultAllowedDevices

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -5,29 +5,11 @@ import (
 	"time"
 
 	"github.com/flynn/flynn/host/resource"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 // TagPrefix is the prefix added to tags in discoverd instance metadata
 const TagPrefix = "tag:"
-
-// DefaultCapabilities is the default list of capabilities which are set inside
-// a container, taken from:
-// https://github.com/opencontainers/runc/blob/v1.0.0-rc1/libcontainer/SPEC.md#security
-var DefaultCapabilities = []string{
-	"CAP_NET_RAW",
-	"CAP_NET_BIND_SERVICE",
-	"CAP_DAC_OVERRIDE",
-	"CAP_SETFCAP",
-	"CAP_SETPCAP",
-	"CAP_SETGID",
-	"CAP_SETUID",
-	"CAP_MKNOD",
-	"CAP_CHOWN",
-	"CAP_FOWNER",
-	"CAP_FSETID",
-	"CAP_KILL",
-	"CAP_SYS_CHROOT",
-}
 
 type Job struct {
 	ID string `json:"id,omitempty"`
@@ -104,20 +86,22 @@ type JobResources struct {
 }
 
 type ContainerConfig struct {
-	Args              []string          `json:"args,omitempty"`
-	TTY               bool              `json:"tty,omitempty"`
-	Stdin             bool              `json:"stdin,omitempty"`
-	Data              bool              `json:"data,omitempty"`
-	Env               map[string]string `json:"env,omitempty"`
-	Mounts            []Mount           `json:"mounts,omitempty"`
-	Volumes           []VolumeBinding   `json:"volumes,omitempty"`
-	Ports             []Port            `json:"ports,omitempty"`
-	WorkingDir        string            `json:"working_dir,omitempty"`
-	Uid               *uint32           `json:"uid,omitempty"`
-	Gid               *uint32           `json:"gid,omitempty"`
-	HostNetwork       bool              `json:"host_network,omitempty"`
-	DisableLog        bool              `json:"disable_log,omitempty"`
-	LinuxCapabilities *[]string         `json:"linux_capabilities,omitempty"`
+	Args              []string           `json:"args,omitempty"`
+	TTY               bool               `json:"tty,omitempty"`
+	Stdin             bool               `json:"stdin,omitempty"`
+	Data              bool               `json:"data,omitempty"`
+	Env               map[string]string  `json:"env,omitempty"`
+	Mounts            []Mount            `json:"mounts,omitempty"`
+	Volumes           []VolumeBinding    `json:"volumes,omitempty"`
+	Ports             []Port             `json:"ports,omitempty"`
+	WorkingDir        string             `json:"working_dir,omitempty"`
+	Uid               *uint32            `json:"uid,omitempty"`
+	Gid               *uint32            `json:"gid,omitempty"`
+	HostNetwork       bool               `json:"host_network,omitempty"`
+	DisableLog        bool               `json:"disable_log,omitempty"`
+	LinuxCapabilities *[]string          `json:"linux_capabilities,omitempty"`
+	AllowedDevices    *[]*configs.Device `json:"allowed_devices,omitempty"`
+	WriteableCgroups  bool               `json:"writeable_cgroups,omitempty"`
 }
 
 // Apply 'y' to 'x', returning a new structure.  'y' trumps.

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -309,6 +309,7 @@ type HostStatus struct {
 	Discoverd *DiscoverdConfig  `json:"discoverd,omitempty"`
 	Network   *NetworkConfig    `json:"network,omitempty"`
 	Version   string            `json:"version"`
+	Flags     []string          `json:"flags"`
 }
 
 type JobEventType string

--- a/host/udev.rules
+++ b/host/udev.rules
@@ -1,0 +1,2 @@
+# A udev rule to run a custom script when ZFS zvols are added
+KERNEL=="zd*" RUN+="/usr/local/bin/zfs-mknod"

--- a/host/zfs-mknod.sh
+++ b/host/zfs-mknod.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# A script to create ZFS device nodes
+# (expected to be called by udevd inside a container)
+
+set -e
+
+if ! [[ -e "${DEVNAME}" ]]; then
+  mknod "${DEVNAME}" "b" "${MAJOR}" "${MINOR}"
+fi

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -108,6 +108,13 @@ func CommandUsingCluster(c ClusterClient, artifact *ct.Artifact, args ...string)
 	return command
 }
 
+func CommandUsingHost(h *cluster.Host, artifact *ct.Artifact, args ...string) *Cmd {
+	command := Command(artifact, args...)
+	command.HostID = h.ID()
+	command.host = h
+	return command
+}
+
 func JobUsingCluster(c ClusterClient, artifact *ct.Artifact, job *host.Job) *Cmd {
 	command := Job(artifact, job)
 	command.cluster = c

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -30,6 +30,8 @@ type Cmd struct {
 
 	Volumes []*ct.VolumeReq
 
+	HostNetwork bool
+
 	Stdin io.Reader
 
 	Stdout io.Writer
@@ -188,10 +190,11 @@ func (c *Cmd) Start() error {
 	if c.Job == nil {
 		c.Job = &host.Job{
 			Config: host.ContainerConfig{
-				Args:  c.Args,
-				TTY:   c.TTY,
-				Env:   c.Env,
-				Stdin: c.Stdin != nil || c.stdinPipe != nil,
+				Args:        c.Args,
+				TTY:         c.TTY,
+				Env:         c.Env,
+				Stdin:       c.Stdin != nil || c.stdinPipe != nil,
+				HostNetwork: c.HostNetwork,
 			},
 			Metadata: c.Meta,
 		}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -29,6 +29,7 @@ type Cmd struct {
 	Env map[string]string
 
 	Volumes []*ct.VolumeReq
+	Mounts  []host.Mount
 
 	HostNetwork bool
 
@@ -195,6 +196,7 @@ func (c *Cmd) Start() error {
 				Env:         c.Env,
 				Stdin:       c.Stdin != nil || c.stdinPipe != nil,
 				HostNetwork: c.HostNetwork,
+				Mounts:      c.Mounts,
 			},
 			Metadata: c.Meta,
 		}

--- a/pkg/sirenia/client/client.go
+++ b/pkg/sirenia/client/client.go
@@ -40,6 +40,10 @@ var httpClient = &http.Client{
 }
 
 func NewClient(addr string) *Client {
+	return NewClientWithHTTP(addr, httpClient)
+}
+
+func NewClientWithHTTP(addr string, httpClient *http.Client) *Client {
 	// remove port, if any
 	host, p, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(p)

--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -124,7 +124,7 @@ main() {
   done
 
   info "bootstrapping Flynn"
-  export CLUSTER_DOMAIN="${size}.localflynn.com"
+  export CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-"${size}.localflynn.com"}"
   export DISCOVERD="$(join "," ${ips[@]/%/:1111})"
   local flags=(
     "--min-hosts=${size}"

--- a/script/generate-backups
+++ b/script/generate-backups
@@ -138,6 +138,7 @@ bootstrap_cluster() {
   local out="${tmp}/bootstrap-${version}.txt"
 
   info "bootstrapping ${version} cluster"
+  export CLUSTER_DOMAIN="$(openssl rand -hex 16).1.localflynn.com"
   local cluster_add=$("${ROOT}/script/bootstrap-flynn" --version "${version}" &> >(tee "${out}") | tail -3 | head -1)
 
   if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then
@@ -149,6 +150,7 @@ bootstrap_cluster() {
   flynn cluster remove default
 
   if [[ "${version:1:8}" -ge "20160609" ]]; then
+    "${ROOT}/script/configure-docker" "${CLUSTER_DOMAIN}"
     flynn cluster add --docker ${cluster_add:18}
   else
     flynn cluster add ${cluster_add:18}

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -107,6 +107,7 @@ main() {
   local mounts=(
     "${ROOT}:${ROOT}"
     "/var/run/docker.sock:/var/run/docker.sock"
+    "/var/lib/flynn:/var/lib/flynn"
   )
 
   local image="$(${ROOT}/util/release/flynn-release manifest --image-dir "${ROOT}/image" - <<< '$image_artifact[test]')"

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -3,6 +3,7 @@
 set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${ROOT}/script/lib/util.sh"
 
 usage() {
   cat <<USAGE >&2
@@ -74,8 +75,6 @@ main() {
   make
   popd >/dev/null
 
-  export BACKOFF_PERIOD="5s"
-
   local boot_flags=(
     "--size" "${size}"
   )
@@ -89,23 +88,10 @@ main() {
     exit 1
   fi
 
-  sudo mv /etc/resolv.conf{,.backup}
-  trap 'sudo mv /etc/resolv.conf{.backup,}' EXIT
-  echo "nameserver $(ifconfig flynnbr0 | grep -oP 'inet addr:\S+' | cut -d: -f2)" | sudo tee /etc/resolv.conf
-
   "${ROOT}/script/configure-docker" "${CLUSTER_DOMAIN:-"${size}.localflynn.com"}"
-
-  export FLYNNRC=/tmp/flynnrc
-  "${flynn}" cluster remove default
-  "${flynn}" cluster add --docker ${cluster_add:18}
-
-  cd "${ROOT}/test"
 
   local args=(
     "--concurrency 1"
-    "--flynnrc ${FLYNNRC}"
-    "--cli ${flynn}"
-    "--flynn-host ${flynn_host}"
     "--backups-dir" "${ROOT}/backups"
     "--debug"
   )
@@ -118,7 +104,20 @@ main() {
   fi
   args+=("--router-ip=192.0.2.200")
 
-  bin/flynn-test ${args[@]}
+  local mounts=(
+    "${ROOT}:${ROOT}"
+    "/var/run/docker.sock:/var/run/docker.sock"
+  )
+
+  local image="$(${ROOT}/util/release/flynn-release manifest --image-dir "${ROOT}/image" - <<< '$image_artifact[test]')"
+  "${flynn_host}" run \
+    --bind "$(join "," ${mounts[@]})" \
+    <(echo "${image}") \
+    /usr/bin/env \
+    ROOT="${ROOT}" \
+    CLUSTER_ADD_ARGS="${cluster_add:18}" \
+    /bin/run-flynn-test.sh \
+    ${args[@]}
 }
 
 main $@

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -113,6 +113,7 @@ main() {
   local image="$(${ROOT}/util/release/flynn-release manifest --image-dir "${ROOT}/image" - <<< '$image_artifact[test]')"
   "${flynn_host}" run \
     --bind "$(join "," ${mounts[@]})" \
+    --volume "/tmp" \
     <(echo "${image}") \
     /usr/bin/env \
     ROOT="${ROOT}" \

--- a/test/Tupfile
+++ b/test/Tupfile
@@ -1,4 +1,6 @@
 include_rules
-: |> !cgo |> bin/flynn-test
+# use an 'image' directory so docker only reads the files it needs
+: |> !cgo |> image/bin/flynn-test
 : |> !cgo ./runner |> bin/flynn-test-runner
-: |> !cgo ./util/file-server |> bin/flynn-test-file-server
+: |> !cgo ./util/file-server |> image/bin/flynn-test-file-server
+: image/bin/* | $(ROOT)/util/imagebuilder/build-image |> ^ build-image test^ $(BUILDIMAGE) --dir image test > %o |> $(ROOT)/image/test.json

--- a/test/bin/flynn-test
+++ b/test/bin/flynn-test
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# A script to start flynn-test in Flynn.
+#
+# TODO: Remove once the CI runner does this directly
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "${ROOT}/script/lib/util.sh"
+
+main() {
+  local mounts=(
+    "${ROOT}:${ROOT}"
+    "/var/run/docker.sock:/var/run/docker.sock"
+    "/var/lib/flynn:/var/lib/flynn"
+    "/mnt/backups:/mnt/backups"
+  )
+
+  local tlspin="$(grep -F "TLSPin =" ~/.flynnrc | sed 's|  TLSPin = "\(.*\)"|\1|')"
+  local domain="$(grep -F "ControllerURL =" ~/.flynnrc | sed 's|  ControllerURL = "https://controller.\(.*\)"|\1|')"
+  local key="$(grep -F "Key =" ~/.flynnrc | sed 's|  Key = "\(.*\)"|\1|')"
+
+  local ip="$(ifconfig eth0 | grep -oP 'inet addr:\S+' | cut -d: -f2)"
+  export DISCOVERD="http://${ip}:1111"
+
+  local host="$(curl -s http://${ip}:1113/host/status | jq -r .id)"
+
+  local image="$(${ROOT}/util/release/flynn-release manifest --image-dir "${ROOT}/image" - <<< '$image_artifact[test]')"
+  "${ROOT}/host/bin/flynn-host" run \
+    --host "${host}" \
+    --bind "$(join "," ${mounts[@]})" \
+    <(echo "${image}") \
+    /usr/bin/env \
+    ROOT="${ROOT}" \
+    CLUSTER_ADD_ARGS="-p ${tlspin} default ${domain} ${key}" \
+    ROUTER_IP="${ip}" \
+    DOMAIN="${domain}" \
+    TEST_RUNNER_AUTH_KEY="${TEST_RUNNER_AUTH_KEY}" \
+    BLOBSTORE_S3_CONFIG="${BLOBSTORE_S3_CONFIG}" \
+    BLOBSTORE_GCS_CONFIG="${BLOBSTORE_GCS_CONFIG}" \
+    BLOBSTORE_AZURE_CONFIG="${BLOBSTORE_AZURE_CONFIG}" \
+    /bin/run-flynn-test.sh \
+    $@
+}
+
+main "$@"

--- a/test/bin/flynn-test
+++ b/test/bin/flynn-test
@@ -30,6 +30,7 @@ main() {
   "${ROOT}/host/bin/flynn-host" run \
     --host "${host}" \
     --bind "$(join "," ${mounts[@]})" \
+    --volume "/tmp" \
     <(echo "${image}") \
     /usr/bin/env \
     ROOT="${ROOT}" \

--- a/test/cluster2/cluster.go
+++ b/test/cluster2/cluster.go
@@ -1,0 +1,346 @@
+package cluster2
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/flynn/pkg/exec"
+	hh "github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/random"
+	"github.com/flynn/flynn/pkg/tlscert"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+type BootConfig struct {
+	Size         int
+	ImagesPath   string
+	ManifestPath string
+	Logger       log15.Logger
+	Client       controller.Client
+	HostTimeout  *time.Duration
+	Key          string
+	Domain       string
+}
+
+type Cluster struct {
+	App     *ct.App
+	Release *ct.Release
+	IP      string
+	Domain  string
+	Key     string
+	Pin     string
+
+	config *BootConfig
+}
+
+func Boot(c *BootConfig) (*Cluster, error) {
+	if c.Size <= 0 || c.Size == 2 {
+		return nil, errors.New("size must be either 1 or >= 3")
+	}
+
+	if c.ImagesPath == "" {
+		return nil, errors.New("missing images path")
+	}
+
+	if c.ManifestPath == "" {
+		return nil, errors.New("missing manifest path")
+	}
+
+	log := c.Logger
+	if log == nil {
+		log = log15.New()
+	}
+	log.Info("booting cluster", "size", c.Size)
+
+	manifest, err := os.Open(c.ManifestPath)
+	if err != nil {
+		log.Error("error loading bootstrap manifest", "err", err)
+		return nil, err
+	}
+	defer manifest.Close()
+
+	if c.Client == nil {
+		var err error
+		client, err := controllerClient()
+		if err != nil {
+			log.Error("error creating controller client", "err", err)
+			return nil, err
+		}
+		c.Client = client
+	}
+
+	hostImage, err := loadHostImage(c.ImagesPath)
+	if err != nil {
+		log.Error("error loading host image", "err", err)
+		return nil, err
+	}
+	if err := c.Client.CreateArtifact(hostImage); err != nil {
+		log.Error("error creating host image", "err", err)
+		return nil, err
+	}
+
+	app := &ct.App{Name: "flynn-" + random.String(4)}
+	log.Info("creating app", "name", app.Name)
+	if err := c.Client.CreateApp(app); err != nil {
+		log.Error("error creating app", "err", err)
+		return nil, err
+	}
+
+	zfsDev, err := zfsDev()
+	if err != nil {
+		log.Error("error loading zfs device details", "err", err)
+		return nil, err
+	}
+
+	release := &ct.Release{
+		ArtifactIDs: []string{hostImage.ID},
+		Processes: map[string]ct.ProcessType{
+			"host": {
+				Mounts: []host.Mount{
+					{
+						Location:  "/var/lib/flynn",
+						Target:    "/var/lib/flynn",
+						Writeable: true,
+					},
+					{
+						Location: "/dev/zvol",
+						Target:   "/dev/zvol",
+					},
+				},
+				Ports: []ct.Port{{
+					Port:  1113,
+					Proto: "tcp",
+					Service: &host.Service{
+						Name:   app.Name,
+						Create: true,
+						Check:  &host.HealthCheck{Type: "tcp"},
+					},
+				}},
+				LinuxCapabilities: append(host.DefaultCapabilities, []string{
+					"CAP_SYS_ADMIN",
+					"CAP_NET_ADMIN",
+				}...),
+				AllowedDevices: append(host.DefaultAllowedDevices, []*configs.Device{
+					{
+						Path:        "/dev/zfs",
+						Type:        'c',
+						Major:       zfsDev.Major,
+						Minor:       zfsDev.Minor,
+						Permissions: "rwm",
+					},
+					{
+						Type:        'b',
+						Major:       230,
+						Minor:       configs.Wildcard,
+						Permissions: "rwm",
+					},
+				}...),
+				WriteableCgroups: true,
+			},
+		},
+	}
+	if err := c.Client.CreateRelease(release); err != nil {
+		log.Error("error creating release", "err", err)
+		return nil, err
+	}
+	if err := c.Client.SetAppRelease(app.ID, release.ID); err != nil {
+		log.Error("error setting app release", "err", err)
+		return nil, err
+	}
+
+	formation := &ct.Formation{
+		AppID:     app.ID,
+		ReleaseID: release.ID,
+		Processes: map[string]int{"host": c.Size},
+	}
+	if err := c.Client.PutFormation(formation); err != nil {
+		log.Error("error scaling hosts", "err", err)
+		return nil, err
+	}
+
+	log.Info("waiting for hosts", "count", c.Size)
+	events := make(chan *discoverd.Event)
+	stream, err := discoverd.NewService(app.Name).Watch(events)
+	if err != nil {
+		log.Error("error streaming service events", "err", err)
+		return nil, err
+	}
+	defer stream.Close()
+
+	if c.HostTimeout == nil {
+		t := 60 * time.Second
+		c.HostTimeout = &t
+	}
+	timeout := time.After(*c.HostTimeout)
+
+	hosts := make([]*cluster.Host, 0, c.Size)
+loop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return nil, stream.Err()
+			}
+			switch event.Kind {
+			case discoverd.EventKindUp:
+				id, _ := cluster.ExtractUUID(event.Instance.Meta["FLYNN_JOB_ID"])
+				id = strings.Replace(id, "-", "", -1)
+				addr := event.Instance.Addr
+				log.Info("host is up", "addr", addr, "id", id)
+				hosts = append(hosts, cluster.NewHost(id, addr, hh.RetryClient, nil))
+				if len(hosts) == c.Size {
+					break loop
+				}
+			case discoverd.EventKindDown:
+				log.Info("host is down", "addr", event.Instance.Addr, "id", event.Instance.Meta["FLYNN_JOB_ID"])
+				return nil, fmt.Errorf("a host failed to start: %v", event.Instance)
+			}
+		case <-timeout:
+			log.Error("timed out waiting for hosts to start")
+			return nil, errors.New("timed out waiting for hosts to start")
+		}
+	}
+
+	domain := c.Domain
+	if domain == "" {
+		domain = random.String(32) + ".local"
+	}
+	cert, err := tlscert.Generate([]string{domain, "*." + domain})
+	if err != nil {
+		log.Error("error generating TLS certs", "err", err)
+		return nil, err
+	}
+
+	peerIPs := make([]string, len(hosts))
+	for i, host := range hosts {
+		ip, _, _ := net.SplitHostPort(host.Addr())
+		peerIPs[i] = ip
+	}
+	log.Info("bootstrapping cluster", "size", c.Size, "domain", domain, "peers", peerIPs)
+	cmd := exec.CommandUsingHost(
+		hosts[0],
+		hostImage,
+		"flynn-host",
+		"bootstrap",
+		"--min-hosts="+strconv.Itoa(c.Size),
+		"--peer-ips="+strings.Join(peerIPs, ","),
+		"-",
+	)
+	key := c.Key
+	if key == "" {
+		key = random.String(32)
+	}
+	discURL := fmt.Sprintf("http://%s:1111", peerIPs[0])
+	cmd.Env = map[string]string{
+		"CLUSTER_DOMAIN":  domain,
+		"CONTROLLER_KEY":  key,
+		"DISCOVERD":       discURL,
+		"FLANNEL_NETWORK": "100.64.0.0/16",
+		"TLS_CA":          cert.CACert,
+		"TLS_KEY":         cert.PrivateKey,
+		"TLS_CERT":        cert.Cert,
+	}
+	cmd.HostNetwork = true
+	cmd.Stdin = manifest
+	// stream output to the log
+	logR, logW := io.Pipe()
+	go func() {
+		buf := bufio.NewReader(logR)
+		for {
+			line, err := buf.ReadString('\n')
+			if err != nil {
+				return
+			}
+			log.Info(line[0 : len(line)-1])
+		}
+	}()
+	cmd.Stdout = logW
+	cmd.Stderr = logW
+	if err := cmd.Run(); err != nil {
+		log.Error("error bootstrapping cluster", "err", err)
+		return nil, err
+	}
+
+	log.Info("successfully bootstrapped cluster", "app", app.Name, "size", c.Size, "peers", peerIPs)
+	return &Cluster{
+		App:     app,
+		Release: release,
+		IP:      peerIPs[0],
+		Domain:  domain,
+		Key:     key,
+		Pin:     cert.Pin,
+		config:  c,
+	}, nil
+}
+
+func (c *Cluster) Destroy() error {
+	_, err := c.config.Client.DeleteApp(c.App.ID)
+	return err
+}
+
+func controllerClient() (controller.Client, error) {
+	instances, err := discoverd.NewService("controller").Instances()
+	if err != nil {
+		return nil, err
+	}
+	inst := instances[0]
+	return controller.NewClient("http://"+inst.Addr, inst.Meta["AUTH_KEY"])
+}
+
+func loadHostImage(path string) (*ct.Artifact, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var artifacts map[string]*ct.Artifact
+	if err := json.NewDecoder(f).Decode(&artifacts); err != nil {
+		return nil, err
+	}
+	artifact, ok := artifacts["host"]
+	if !ok {
+		return nil, errors.New("missing host image from images.json")
+	}
+	return artifact, nil
+}
+
+type ZFSDev struct {
+	Major int64
+	Minor int64
+}
+
+func zfsDev() (*ZFSDev, error) {
+	data, err := ioutil.ReadFile("/sys/class/misc/zfs/dev")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.SplitN(strings.TrimSpace(string(data)), ":", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf("unexpected data in /sys/class/misc/zfs/dev: %q", data)
+	}
+	dev := &ZFSDev{}
+	dev.Major, err = strconv.ParseInt(s[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing zfs major from %q: %s", data, err)
+	}
+	dev.Minor, err = strconv.ParseInt(s[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing zfs minor from %q: %s", data, err)
+	}
+	return dev, nil
+}

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty-20160217
+
+RUN apt-get update && \
+    apt-get -qy install git curl squashfs-tools && \
+    apt-get clean
+
+RUN curl -fsSLo "/usr/local/bin/docker" "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1" && \
+    chmod +x "/usr/local/bin/docker"
+
+RUN git config --global "user.email" "test@flynn.io" &&\
+    git config --global "user.name"  "Flynn Test"
+
+ADD bin/flynn-test /bin/flynn-test
+ADD bin/flynn-test-file-server /bin/flynn-test-file-server
+ADD run.sh /bin/run-flynn-test.sh
+
+CMD ["/bin/run-flynn-test.sh"]

--- a/test/image/run.sh
+++ b/test/image/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+export HOME="/root"
+export PATH="${ROOT}/cli/bin:${ROOT}/host/bin:${PATH}"
+export BACKOFF_PERIOD="5s"
+
+main() {
+  if [[ -n "${ROUTER_IP}" ]] && [[ -n "${DOMAIN}" ]]; then
+    echo "${ROUTER_IP}" \
+      "${DOMAIN}" \
+      "controller.${DOMAIN}" \
+      "git.${DOMAIN}" \
+      "dashboard.${DOMAIN}" \
+      "docker.${DOMAIN}" \
+      >> /etc/hosts
+  fi
+
+  flynn cluster add --docker ${CLUSTER_ADD_ARGS}
+
+  cd "${ROOT}/test"
+
+  # remove --flynnrc from $@
+  # TODO: remove once the CI runner no longer passes --flynnrc
+  local args=()
+  while [[ -n "$1" ]]; do
+    if [[ "$1" = "--flynnrc" ]]; then
+      shift 2
+      continue
+    fi
+    args+=("$1")
+    shift
+  done
+
+  exec /bin/flynn-test --flynnrc "${HOME}/.flynnrc" ${args[@]}
+}
+
+main "$@"

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -456,7 +456,7 @@ func (r *Runner) build(b *Build) (err error) {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 
-	if _, err := c.Boot(cluster.ClusterTypeDefault, 3, buildLog, false); err != nil {
+	if _, err := c.Boot(cluster.ClusterTypeDefault, 1, buildLog, false); err != nil {
 		return fmt.Errorf("could not boot cluster: %s", err)
 	}
 

--- a/test/test_blobstore.go
+++ b/test/test_blobstore.go
@@ -123,8 +123,8 @@ func (s *BlobstoreSuite) testBlobstoreBackend(t *c.C, name, redirectPattern stri
 	t.Assert(r.flynn("run", "echo", "1"), Succeeds)
 
 	// test a docker push
-	repo := "s3-test"
-	s.buildDockerImage(t, repo, "RUN echo foo > /foo.txt")
+	repo := name + "-test"
+	s.buildDockerImage(t, repo, fmt.Sprintf("RUN echo %s > /foo.txt", name))
 	u, err = url.Parse(s.clusterConf(t).DockerPushURL)
 	t.Assert(err, c.IsNil)
 	tag := fmt.Sprintf("%s/%s:latest", u.Host, repo)

--- a/test/test_controller.go
+++ b/test/test_controller.go
@@ -28,7 +28,7 @@ type ControllerSuite struct {
 	Helper
 }
 
-var _ = c.Suite(&ControllerSuite{})
+var _ = c.ConcurrentSuite(&ControllerSuite{})
 
 func (s *ControllerSuite) SetUpSuite(t *c.C) {
 	var schemaPaths []string
@@ -539,8 +539,10 @@ func (s *ControllerSuite) TestAppEvents(t *c.C) {
 }
 
 func (s *ControllerSuite) TestBackup(t *c.C) {
-	client := s.controllerClient(t)
-	out, err := client.Backup()
+	x := s.bootCluster(t, 1)
+	defer x.Destroy()
+
+	out, err := x.controller.Backup()
 	t.Assert(err, c.IsNil)
 	defer out.Close()
 	data := make(map[string][]byte)

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -307,15 +307,15 @@ func (s *DeployerSuite) TestRollbackNoService(t *c.C) {
 }
 
 func (s *DeployerSuite) TestOmniProcess(t *c.C) {
-	if testCluster == nil {
-		t.Skip("cannot determine test cluster size")
-	}
+	clusterSize := 3
+	x := s.bootCluster(t, clusterSize)
+	defer x.Destroy()
 
 	// create and scale an omni release
 	omniScale := 2
-	totalJobs := omniScale * testCluster.Size()
-	client := s.controllerClient(t)
-	app, release := s.createApp(t)
+	totalJobs := omniScale * clusterSize
+	client := x.controller
+	app, release := s.createAppWithClient(t, client)
 
 	watcher, err := client.WatchJobEvents(app.Name, release.ID)
 	t.Assert(err, c.IsNil)
@@ -372,9 +372,9 @@ func (s *DeployerSuite) TestOmniProcess(t *c.C) {
 	stream, err = client.StreamDeployment(deployment, events)
 	t.Assert(err, c.IsNil)
 	expected = make([]*ct.Job, 0, 4*totalJobs+1)
-	appendEvents(deployment.NewReleaseID, ct.JobStateUp, testCluster.Size())
-	appendEvents(deployment.OldReleaseID, ct.JobStateDown, testCluster.Size())
-	appendEvents(deployment.NewReleaseID, ct.JobStateUp, testCluster.Size())
-	appendEvents(deployment.OldReleaseID, ct.JobStateDown, testCluster.Size())
+	appendEvents(deployment.NewReleaseID, ct.JobStateUp, clusterSize)
+	appendEvents(deployment.OldReleaseID, ct.JobStateDown, clusterSize)
+	appendEvents(deployment.NewReleaseID, ct.JobStateUp, clusterSize)
+	appendEvents(deployment.OldReleaseID, ct.JobStateDown, clusterSize)
 	s.waitForDeploymentStatus(t, events, "complete")
 }

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -15,7 +15,7 @@ type DockerReceiveSuite struct {
 	Helper
 }
 
-var _ = c.Suite(&DockerReceiveSuite{})
+var _ = c.ConcurrentSuite(&DockerReceiveSuite{})
 
 func (s *DockerReceiveSuite) TestPushImage(t *c.C) {
 	// build a Docker image

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -57,7 +57,7 @@ func (s *GitDeploySuite) TestEmptyRelease(t *c.C) {
 }
 
 func (s *GitDeploySuite) TestBuildCaching(t *c.C) {
-	s.testBuildCaching(t)
+	s.testBuildCaching(t, nil)
 }
 
 func (s *GitDeploySuite) TestAppRecreation(t *c.C) {

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -79,7 +79,7 @@ src="${GOPATH}/src/github.com/flynn/flynn"
     --start \
     --background \
     --chdir "${dir}" \
-    --exec "${src}/test/bin/flynn-test-file-server"
+    --exec "${src}/test/image/bin/flynn-test-file-server"
 ) >&2
 
 cat "${src}/images.json"

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
@@ -108,18 +107,7 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	}
 
 	// stream script output to t.Log
-	logReader, logWriter := io.Pipe()
-	defer logWriter.Close()
-	go func() {
-		buf := bufio.NewReader(logReader)
-		for {
-			line, err := buf.ReadString('\n')
-			if err != nil {
-				return
-			}
-			debug(t, line[0:len(line)-1])
-		}
-	}()
+	logWriter := debugLogWriter(t)
 
 	// boot the release cluster, release components to a blobstore and output the new images.json
 	releaseCluster := s.addReleaseHosts(t)

--- a/test/test_zz_backup.go
+++ b/test/test_zz_backup.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"time"
 
-	"github.com/flynn/flynn/cli/config"
-	"github.com/flynn/flynn/controller/client"
-	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/attempt"
 	c "github.com/flynn/go-check"
 )
@@ -47,94 +38,17 @@ func (s *ZZBackupSuite) TestClusterBackups(t *c.C) {
 func (s *ZZBackupSuite) testClusterBackup(t *c.C, index int, path string) {
 	debugf(t, "restoring cluster backup %s", filepath.Base(path))
 
-	// boot the cluster using an RFC 5737 TEST-NET IP, avoiding conflicts
-	// with those used by script/bootstrap-flynn so the test can be run in
-	// development
-	ip := fmt.Sprintf("192.0.2.%d", index+100)
-	device := fmt.Sprintf("eth0:%d", index+10)
-	t.Assert(run(t, exec.Command("sudo", "ifconfig", device, ip)), Succeeds)
-
-	dir := t.MkDir()
-	debugf(t, "using tempdir %s", dir)
-
-	debug(t, "starting flynn-host")
-	cmd := exec.Command(
-		"sudo",
-		"../host/bin/flynn-host",
-		"daemon",
-		"--id", fmt.Sprintf("backup%d", index),
-		"--external-ip", ip,
-		"--listen-ip", ip,
-		"--bridge-name", fmt.Sprintf("backupbr%d", index),
-		"--state", filepath.Join(dir, "host-state.bolt"),
-		"--volpath", filepath.Join(dir, "volumes"),
-		"--log-dir", filepath.Join(dir, "logs"),
-		"--flynn-init", "../host/bin/flynn-init",
-	)
-	out, err := os.Create(filepath.Join(dir, "flynn-host.log"))
-	t.Assert(err, c.IsNil)
-	defer out.Close()
-	cmd.Stdout = out
-	cmd.Stderr = out
-	t.Assert(cmd.Start(), c.IsNil)
-	go cmd.Process.Wait()
-
-	defer func() {
-		// collect-debug-info if the tests failed then kill flynn-host
-		if t.Failed() {
-			cmd := exec.Command(
-				"sudo",
-				"-E",
-				"../host/bin/flynn-host",
-				"collect-debug-info",
-				"--log-dir", filepath.Join(dir, "logs"),
-			)
-			cmd.Env = []string{fmt.Sprintf("DISCOVERD=%s:1111", ip)}
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Run()
-		}
-		exec.Command("sudo", "kill", strconv.Itoa(cmd.Process.Pid)).Run()
-	}()
-
-	debugf(t, "bootstrapping flynn from backup")
-	cmd = exec.Command(
-		"../host/bin/flynn-host",
-		"bootstrap",
-		"--peer-ips", ip,
-		"--from-backup", path,
-		"../bootstrap/bin/manifest.json",
-	)
-	cmd.Env = []string{
-		"CLUSTER_DOMAIN=1.localflynn.com",
-		fmt.Sprintf("DISCOVERD=%s:1111", ip),
-		fmt.Sprintf("FLANNEL_NETWORK=100.%d.0.0/16", index+101),
-	}
-	logR, logW := io.Pipe()
-	defer logW.Close()
-	go func() {
-		buf := bufio.NewReader(logR)
-		for {
-			line, err := buf.ReadString('\n')
-			if err != nil {
-				return
-			}
-			debug(t, line[0:len(line)-1])
-		}
-	}()
-	cmd.Stdout = logW
-	cmd.Stderr = logW
-	t.Assert(cmd.Run(), c.IsNil)
+	x := s.bootClusterFromBackup(t, path)
+	defer x.Destroy()
 
 	debug(t, "waiting for nodejs-web service")
-	disc := discoverd.NewClientWithURL(fmt.Sprintf("http://%s:1111", ip))
-	_, err = disc.Instances("nodejs-web", 30*time.Second)
+	_, err := x.discoverd.Instances("nodejs-web", 30*time.Second)
 	t.Assert(err, c.IsNil)
 
 	debug(t, "checking HTTP requests")
-	req, err := http.NewRequest("GET", "http://"+ip, nil)
+	req, err := http.NewRequest("GET", "http://"+x.IP, nil)
 	t.Assert(err, c.IsNil)
-	req.Host = "nodejs.1.localflynn.com"
+	req.Host = "nodejs." + x.Domain
 	var res *http.Response
 	// try multiple times in case we get a 503 from the router as it has
 	// not seen the service yet
@@ -151,29 +65,11 @@ func (s *ZZBackupSuite) testClusterBackup(t *c.C, index int, path string) {
 	t.Assert(res.StatusCode, c.Equals, http.StatusOK)
 
 	debug(t, "getting app release")
-	controllerInstances, err := disc.Instances("controller", 30*time.Second)
-	t.Assert(err, c.IsNil)
-	controllerURL := "http://" + controllerInstances[0].Addr
-	controllerKey := controllerInstances[0].Meta["AUTH_KEY"]
-	client, err := controller.NewClient(controllerURL, controllerKey)
-	t.Assert(err, c.IsNil)
-	release, err := client.GetAppRelease("nodejs")
+	release, err := x.controller.GetAppRelease("nodejs")
 	t.Assert(err, c.IsNil)
 
-	debug(t, "configuring flynn CLI")
-	flynnrc := filepath.Join(dir, ".flynnrc")
-	conf := &config.Config{}
-	t.Assert(conf.Add(&config.Cluster{
-		Name:          "default",
-		ControllerURL: controllerURL,
-		Key:           controllerKey,
-	}, true), c.IsNil)
-	t.Assert(conf.SaveTo(flynnrc), c.IsNil)
 	flynn := func(cmdArgs ...string) *CmdResult {
-		cmd := exec.Command(args.CLI, cmdArgs...)
-		cmd.Env = flynnEnv(flynnrc)
-		cmd.Env = append(cmd.Env, "FLYNN_APP=nodejs")
-		return run(t, cmd)
+		return x.flynn("/", append([]string{"-a", "nodejs"}, cmdArgs...)...)
 	}
 
 	if _, ok := release.Env["FLYNN_REDIS"]; ok {
@@ -203,9 +99,9 @@ func (s *ZZBackupSuite) testClusterBackup(t *c.C, index int, path string) {
 	}
 
 	debug(t, "checking dashboard STATUS_KEY matches status AUTH_KEY")
-	dashboardStatusKeyResult := flynn("-a", "dashboard", "env", "get", "STATUS_KEY")
+	dashboardStatusKeyResult := x.flynn("/", "-a", "dashboard", "env", "get", "STATUS_KEY")
 	t.Assert(dashboardStatusKeyResult, Succeeds)
-	statusAuthKeyResult := flynn("-a", "status", "env", "get", "AUTH_KEY")
+	statusAuthKeyResult := x.flynn("/", "-a", "status", "env", "get", "AUTH_KEY")
 	t.Assert(statusAuthKeyResult, Succeeds)
 	t.Assert(dashboardStatusKeyResult.Output, c.Equals, statusAuthKeyResult.Output)
 }

--- a/util/flynn-in-flynn/boot.go
+++ b/util/flynn-in-flynn/boot.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+
+	"github.com/flynn/flynn/test/cluster2"
+)
+
+func main() {
+	_, err := cluster2.Boot(&cluster2.BootConfig{
+		Size:         1,
+		ImagesPath:   "images.json",
+		ManifestPath: "bootstrap/bin/manifest.json",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/util/imagebuilder/main.go
+++ b/util/imagebuilder/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -14,21 +15,24 @@ import (
 	"github.com/flynn/flynn/pkg/imagebuilder"
 )
 
+var dir = flag.String("dir", ".", "directory to build")
+
 func main() {
 	log.SetFlags(0)
+	flag.Parse()
 
-	if len(os.Args) != 2 {
-		log.Fatalf("usage: %s NAME", os.Args[0])
+	if len(flag.Args()) != 1 {
+		log.Fatalf("usage: %s [--dir DIR] NAME", os.Args[0])
 	}
-	if err := build(os.Args[1]); err != nil {
+	if err := build(flag.Args()[0], *dir); err != nil {
 		log.Fatalln("ERROR:", err)
 	}
 }
 
-func build(name string) error {
+func build(name, dir string) error {
 	name = "flynn/" + name
 
-	cmd := exec.Command("docker", "build", "-t", name, ".")
+	cmd := exec.Command("docker", "build", "-t", name, dir)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/util/release/images_template.json
+++ b/util/release/images_template.json
@@ -1,4 +1,5 @@
 {
+  "host":           $image_artifact[host],
   "flannel":        $image_artifact[flannel],
   "discoverd":      $image_artifact[discoverd],
   "postgres":       $image_artifact[postgres],


### PR DESCRIPTION
This adds support for booting Flynn clusters inside Flynn clusters :smile:.

Summary:

* the `test/cluster2` package (which will eventually replace `test/cluster`) boots Flynn clusters by creating a flynn-host app, scaling it up, then running the bootstrapper once the hosts have started
* flynn-test now has a `bootCluster` function which boots a cluster and returns an object which can be used to run commands against the cluster
* flynn-test now runs in a Flynn job, which means it can happily change `/etc/hosts` at will, and also use discoverd for DNS without [hacking /etc/resolv.conf](https://github.com/flynn/flynn/blob/v20161114.0p1/script/run-integration-tests#L92-L94)
* flynn-host needs extra Linux capabilities (`CAP_SYS_ADMIN` and `CAP_NET_ADMIN`), needs to access `/dev/zfs` and `/dev/zd*`, and needs write access to `cgroupfs`, so I've added support for customising these through `ct.ProcessType` and `host.ContainerConfig`
* I've added a xenial based `host` image which has the `zfsutils-linux` package and a custom udev rule to create ZFS device nodes in the host's mount namespace
* flynn-host jobs have `/var/lib/flynn` mounted from the host and create volumes in `/var/lib/flynn/JOB_ID/volumes` (`zfs` doesn't like the sparse vdev file being in the container's filesystem, it needs to be available at the same path both inside and outside the container)
* some disruptive tests have been updated to boot their own clusters

This is a first step in refactoring CI (see #2970). I have some grand plans, but one step at a time :wink:.

Lets make CI great again!