### PR TITLE
host: Prevent deadlock when restoring state

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -1354,13 +1354,11 @@ func (l *LibcontainerBackend) UnmarshalState(jobs map[string]*host.ActiveJob, jo
 	}
 	// gather connection attempts and finish reconstruction if success.  failures will time out.
 	for _, j := range jobs {
-		container, ok := containers[j.Job.ID]
-		if !ok {
+		if _, ok := containers[j.Job.ID]; !ok {
 			continue
 		}
 		if err := <-readySignals[j.Job.ID]; err != nil {
 			// log error
-			container.cleanup()
 			delete(readySignals, j.Job.ID)
 			continue
 		}


### PR DESCRIPTION
Container cleanup emits a cleanup event which attempts to persist to the state database, but the state database is open for reading when restoring state during startup, so running cleanup can deadlock.

`Container.Watch` (which is run [in a goroutine during restore](https://github.com/flynn/flynn/blob/v20161114.0p1/host/libcontainer_backend.go#L1381)) runs the cleanup in a deferred call [here](https://github.com/flynn/flynn/blob/v20161114.0p1/host/libcontainer_backend.go#L883-L890), so there is no need to run the cleanup directly in `UnmarshalState`, thus preventing the deadlock.