### PR TITLE
script: Automatically set --nightly if releasing master

### DIFF
--- a/script/release-flynn
+++ b/script/release-flynn
@@ -62,9 +62,6 @@ main() {
           fail "$1 requires an argument"
         fi
         branch="$2"
-        if [[ "${branch}" = "master" ]]; then
-          nightly=true
-        fi
         shift 2
         ;;
       -v | --version)
@@ -119,6 +116,10 @@ main() {
   if [[ $# -ne 0 ]]; then
     usage
     exit 1
+  fi
+
+  if [[ "${branch}" = "master" ]]; then
+    nightly=true
   fi
 
   check_aws_keys


### PR DESCRIPTION
I believe this restores the original behavior so that if `release-flynn` is run without `--branch` or `--nightly` that the master branch will be released on the `nightly` channel.