### PR TITLE
scheduler: Only sync active jobs from hosts

### DIFF
--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -65,6 +65,18 @@ func (c *FakeHostClient) ListJobs() (map[string]host.ActiveJob, error) {
 	return jobs, nil
 }
 
+func (c *FakeHostClient) ListActiveJobs() (map[string]host.ActiveJob, error) {
+	c.jobsMtx.RLock()
+	defer c.jobsMtx.RUnlock()
+	jobs := make(map[string]host.ActiveJob)
+	for id, j := range c.Jobs {
+		if j.Status == host.StatusStarting || j.Status == host.StatusRunning {
+			jobs[id] = j
+		}
+	}
+	return jobs, nil
+}
+
 func (c *FakeHostClient) AddJob(job *host.Job) error {
 	c.jobsMtx.Lock()
 	defer c.jobsMtx.Unlock()

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -255,6 +255,7 @@ type HostClient interface {
 	StopJob(string) error
 	DiscoverdDeregisterJob(string) error
 	ListJobs() (map[string]host.ActiveJob, error)
+	ListActiveJobs() (map[string]host.ActiveJob, error)
 	StreamEvents(id string, ch chan *host.Event) (stream.Stream, error)
 	GetStatus() (*host.HostStatus, error)
 }

--- a/host/http.go
+++ b/host/http.go
@@ -190,9 +190,13 @@ func (h *jobAPI) ListJobs(w http.ResponseWriter, r *http.Request, ps httprouter.
 		}
 		return
 	}
-	res := h.host.state.Get()
-
-	httphelper.JSON(w, 200, res)
+	var jobs map[string]*host.ActiveJob
+	if r.FormValue("active") == "true" {
+		jobs = h.host.state.GetActive()
+	} else {
+		jobs = h.host.state.Get()
+	}
+	httphelper.JSON(w, 200, jobs)
 }
 
 func (h *jobAPI) GetJob(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/host/state.go
+++ b/host/state.go
@@ -333,6 +333,18 @@ func (s *State) Get() map[string]*host.ActiveJob {
 	return res
 }
 
+func (s *State) GetActive() map[string]*host.ActiveJob {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	res := make(map[string]*host.ActiveJob)
+	for id, job := range s.jobs {
+		if job.Status == host.StatusStarting || job.Status == host.StatusRunning {
+			res[id] = job.Dup()
+		}
+	}
+	return res
+}
+
 func (s *State) ClusterJobs() []*host.Job {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -88,10 +88,17 @@ func WaitForHostStatus(hostIP string, desired func(*host.HostStatus) bool) (*hos
 	}
 }
 
-// ListJobs lists the jobs running on the host.
+// ListJobs lists all jobs on the host.
 func (c *Host) ListJobs() (map[string]host.ActiveJob, error) {
 	var jobs map[string]host.ActiveJob
 	err := c.c.Get("/host/jobs", &jobs)
+	return jobs, err
+}
+
+// ListActiveJobs lists starting or running jobs on the host.
+func (c *Host) ListActiveJobs() (map[string]host.ActiveJob, error) {
+	var jobs map[string]host.ActiveJob
+	err := c.c.Get("/host/jobs?active=true", &jobs)
 	return jobs, err
 }
 


### PR DESCRIPTION
Loading all jobs from each host in the cluster leads to ever increasing network i/o and load in the cluster as the number of stopped jobs increases.

Once the scheduler knows a job has stopped, there is no need to sync it again, so the scheduler has been updated to just sync the starting / running jobs from each host (which should be a small number of jobs) and determine which jobs have stopped by their absence from that list.