### PR TITLE
worker: Maintain formation tags through deployments

### DIFF
--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -40,7 +40,7 @@ func (r *DeploymentRepo) Add(data interface{}) (*ct.Deployment, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.QueryRow("deployment_insert", d.ID, d.AppID, oldReleaseID, d.NewReleaseID, d.Strategy, d.Processes, d.DeployTimeout).Scan(&d.CreatedAt); err != nil {
+	if err := tx.QueryRow("deployment_insert", d.ID, d.AppID, oldReleaseID, d.NewReleaseID, d.Strategy, d.Processes, d.Tags, d.DeployTimeout).Scan(&d.CreatedAt); err != nil {
 		tx.Rollback()
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func scanDeployment(s postgres.Scanner) (*ct.Deployment, error) {
 	d := &ct.Deployment{}
 	var oldReleaseID *string
 	var status *string
-	err := s.Scan(&d.ID, &d.AppID, &oldReleaseID, &d.NewReleaseID, &d.Strategy, &status, &d.Processes, &d.DeployTimeout, &d.CreatedAt, &d.FinishedAt)
+	err := s.Scan(&d.ID, &d.AppID, &oldReleaseID, &d.NewReleaseID, &d.Strategy, &status, &d.Processes, &d.Tags, &d.DeployTimeout, &d.CreatedAt, &d.FinishedAt)
 	if err == pgx.ErrNoRows {
 		err = ErrNotFound
 	}
@@ -183,6 +183,7 @@ func (c *controllerAPI) CreateDeployment(ctx context.Context, w http.ResponseWri
 		Strategy:      app.Strategy,
 		OldReleaseID:  oldRelease.ID,
 		Processes:     oldFormation.Processes,
+		Tags:          oldFormation.Tags,
 		DeployTimeout: app.DeployTimeout,
 	}
 

--- a/controller/schema.go
+++ b/controller/schema.go
@@ -475,6 +475,9 @@ $$ LANGUAGE plpgsql`,
 			deleted_at timestamptz
 		)`,
 	)
+	migrations.Add(29,
+		`ALTER TABLE deployments ADD COLUMN tags jsonb`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/schema/queries.go
+++ b/controller/schema/queries.go
@@ -190,8 +190,8 @@ UPDATE artifacts SET deleted_at = now() WHERE artifact_id = $1 AND deleted_at IS
 	artifactReleaseCountQuery = `
 SELECT COUNT(*) FROM release_artifacts WHERE artifact_id = $1 AND deleted_at IS NULL`
 	deploymentInsertQuery = `
-INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes, deploy_timeout)
-VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING created_at`
+INSERT INTO deployments (deployment_id, app_id, old_release_id, new_release_id, strategy, processes, tags, deploy_timeout)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING created_at`
 	deploymentUpdateFinishedAtQuery = `
 UPDATE deployments SET finished_at = $2 WHERE deployment_id = $1`
 	deploymentUpdateFinishedAtNowQuery = `
@@ -202,7 +202,7 @@ DELETE FROM deployments WHERE deployment_id = $1`
 WITH deployment_events AS (SELECT * FROM events WHERE object_type = 'deployment')
 SELECT d.deployment_id, d.app_id, d.old_release_id, d.new_release_id,
   strategy, e1.data->>'status' AS status,
-  processes, deploy_timeout, d.created_at, d.finished_at
+  processes, tags, deploy_timeout, d.created_at, d.finished_at
 FROM deployments d
 LEFT JOIN deployment_events e1
   ON d.deployment_id = e1.object_id::uuid
@@ -213,7 +213,7 @@ WHERE e2.created_at IS NULL AND d.deployment_id = $1`
 WITH deployment_events AS (SELECT * FROM events WHERE object_type = 'deployment')
 SELECT d.deployment_id, d.app_id, d.old_release_id, d.new_release_id,
   strategy, e1.data->>'status' AS status,
-  processes, deploy_timeout, d.created_at, d.finished_at
+  processes, tags, deploy_timeout, d.created_at, d.finished_at
 FROM deployments d
 LEFT JOIN deployment_events e1
   ON d.deployment_id = e1.object_id::uuid

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -320,16 +320,17 @@ type NewJob struct {
 const DefaultDeployTimeout = 120 // seconds
 
 type Deployment struct {
-	ID            string         `json:"id,omitempty"`
-	AppID         string         `json:"app,omitempty"`
-	OldReleaseID  string         `json:"old_release,omitempty"`
-	NewReleaseID  string         `json:"new_release,omitempty"`
-	Strategy      string         `json:"strategy,omitempty"`
-	Status        string         `json:"status,omitempty"`
-	Processes     map[string]int `json:"processes,omitempty"`
-	DeployTimeout int32          `json:"deploy_timeout,omitempty"`
-	CreatedAt     *time.Time     `json:"created_at,omitempty"`
-	FinishedAt    *time.Time     `json:"finished_at,omitempty"`
+	ID            string                       `json:"id,omitempty"`
+	AppID         string                       `json:"app,omitempty"`
+	OldReleaseID  string                       `json:"old_release,omitempty"`
+	NewReleaseID  string                       `json:"new_release,omitempty"`
+	Strategy      string                       `json:"strategy,omitempty"`
+	Status        string                       `json:"status,omitempty"`
+	Processes     map[string]int               `json:"processes,omitempty"`
+	Tags          map[string]map[string]string `json:"tags,omitempty"`
+	DeployTimeout int32                        `json:"deploy_timeout,omitempty"`
+	CreatedAt     *time.Time                   `json:"created_at,omitempty"`
+	FinishedAt    *time.Time                   `json:"finished_at,omitempty"`
 }
 
 type DeployID struct {

--- a/controller/worker/deployment/all_at_once.go
+++ b/controller/worker/deployment/all_at_once.go
@@ -31,6 +31,7 @@ func (d *DeployJob) deployAllAtOnce() error {
 			AppID:     d.AppID,
 			ReleaseID: d.NewReleaseID,
 			Processes: newProcs,
+			Tags:      d.Tags,
 		}); err != nil {
 			log.Error("error creating new formation", "err", err)
 			return err
@@ -55,6 +56,7 @@ func (d *DeployJob) deployAllAtOnce() error {
 	if err := d.client.PutFormation(&ct.Formation{
 		AppID:     d.AppID,
 		ReleaseID: d.OldReleaseID,
+		Tags:      d.Tags,
 	}); err != nil {
 		// the new jobs have now started and they are up, so return
 		// ErrSkipRollback (rolling back doesn't make a ton of sense

--- a/controller/worker/deployment/one_by_one.go
+++ b/controller/worker/deployment/one_by_one.go
@@ -60,6 +60,7 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 				AppID:     d.AppID,
 				ReleaseID: d.NewReleaseID,
 				Processes: newScale,
+				Tags:      d.Tags,
 			}); err != nil {
 				nlog.Error("error scaling new formation up by one", "type", typ, "err", err)
 				return err
@@ -76,6 +77,7 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 				AppID:     d.AppID,
 				ReleaseID: d.OldReleaseID,
 				Processes: oldScale,
+				Tags:      d.Tags,
 			}); err != nil {
 				olog.Error("error scaling old formation down by one", "type", typ, "err", err)
 				return err
@@ -104,6 +106,7 @@ func (d *DeployJob) deployOneByOneWithWaitFn(waitJobs WaitJobsFn) error {
 	if err := d.client.PutFormation(&ct.Formation{
 		AppID:     d.AppID,
 		ReleaseID: d.OldReleaseID,
+		Tags:      d.Tags,
 	}); err != nil {
 		log.Error("error scaling old formation down to zero", "err", err)
 		return ErrSkipRollback{err.Error()}

--- a/controller/worker/deployment/sirenia.go
+++ b/controller/worker/deployment/sirenia.go
@@ -127,6 +127,7 @@ func (d *DeployJob) deploySirenia() (err error) {
 			AppID:     d.AppID,
 			ReleaseID: d.NewReleaseID,
 			Processes: d.newReleaseState,
+			Tags:      d.Tags,
 		}); err != nil {
 			log.Error("error scaling formation up by one", "err", err)
 			return nil, err
@@ -247,6 +248,7 @@ func (d *DeployJob) deploySirenia() (err error) {
 		AppID:     d.AppID,
 		ReleaseID: d.OldReleaseID,
 		Processes: d.oldReleaseState,
+		Tags:      d.Tags,
 	}); err != nil {
 		log.Error("error scaling old formation", "err", err)
 		return err

--- a/schema/controller/deployment.json
+++ b/schema/controller/deployment.json
@@ -38,6 +38,10 @@
         "type": "integer"
       }
     },
+    "tags": {
+      "description": "process tags",
+      "type": "object"
+    },
     "deploy_timeout": {
       "$ref": "/schema/controller/common#/definitions/deploy_timeout"
     },


### PR DESCRIPTION
This is also fixed in #3667, but I would like to get this fix into the next stable release, and I don't think #3667 is ready to be merged just yet.

Fixes #3699.