### PR TITLE
slugbuilder: Determine process types in Go

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -223,7 +223,8 @@ cp "/etc/group" "${build_root}/etc/group"
 /bin/create-artifact \
   --dir "${build_root}" \
   --uid "${USER_UID}" \
-  --gid "${USER_GID}"
+  --gid "${USER_GID}" \
+  | ensure_indent
 
 if [[ -n "${BUILD_CACHE_URL}" ]]; then
   tar \


### PR DESCRIPTION
This avoids potentially matching unrelated buildpack output as the configured process types.