### PR TITLE
Add Canada Central to AWSRegionPicker

### DIFF
--- a/installer/app/src/views/aws-region-picker.js.jsx
+++ b/installer/app/src/views/aws-region-picker.js.jsx
@@ -15,6 +15,7 @@ var AWSRegionPicker = React.createClass({
 					<option value="ap-southeast-2">Asia Pacific (Sydney)</option>
 					<option value="ap-northeast-1">Asia Pacific (Tokyo)</option>
 					<option value="sa-east-1">South America (Sao Paulo)</option>
+					<option value="ca-central-1">Canada Central (Montreal)</option>
 				</PrettySelect>
 			</label>
 		);

--- a/util/packer/ubuntu.json
+++ b/util/packer/ubuntu.json
@@ -101,6 +101,7 @@
         "ap-northeast-1",
         "ap-southeast-1",
         "ap-southeast-2",
+        "ca-central-1",
         "eu-central-1",
         "eu-west-1",
         "sa-east-1",


### PR DESCRIPTION
Allows for new Canada region to be selected as an option via installer.
Need to confirm this region doesn't require any additional changes to the installer etc to fully function.