### PR TITLE
dashboard: Fix creating app releases in dashboard

### DIFF
--- a/dashboard/app/lib/javascripts/dashboard/actions/app-env.js
+++ b/dashboard/app/lib/javascripts/dashboard/actions/app-env.js
@@ -13,7 +13,7 @@ var updateAppEnv = function (appID, changedRelease, env, deployTimeout) {
 		}
 		return Promise.reject(args);
 	}).then(function (args) {
-		var release = extend({}, args[0]);
+		var release = extend({app_id: appID}, args[0]);
 		var envDiff = objectDiff(changedRelease.env || {}, env);
 		release.env = applyObjectDiff(envDiff, release.env || {});
 		delete release.id;

--- a/dashboard/app/lib/javascripts/dashboard/actions/providers.js
+++ b/dashboard/app/lib/javascripts/dashboard/actions/providers.js
@@ -24,7 +24,7 @@ var copyResourceEnvToApp = function (appID, resourceEnv) {
 		}
 		return Promise.reject(args);
 	}).then(function (args) {
-		var release = extend({}, args[0]);
+		var release = extend({app_id: appID}, args[0]);
 		release.env = release.env || {};
 		Object.keys(resourceEnv).forEach(function (k) {
 			if (release.env.hasOwnProperty(k) && release.env[k] !== resourceEnv[k]) {


### PR DESCRIPTION
Refs #3718 
Closes #3790

This fixes editing env and provisioning databases for an app when the app has no releases.