### PR TITLE
host: Expose container PID

### DIFF
--- a/host/cli/inspect.go
+++ b/host/cli/inspect.go
@@ -60,6 +60,10 @@ func printJobDesc(job *host.ActiveJob, out io.Writer, env bool, redactEnv []stri
 	if job.ExitStatus != nil {
 		exitStatus = strconv.Itoa(*job.ExitStatus)
 	}
+	var pid string
+	if job.PID != nil {
+		pid = strconv.Itoa(*job.PID)
+	}
 	var jobError string
 	if job.Error != nil {
 		jobError = *job.Error
@@ -71,6 +75,7 @@ func printJobDesc(job *host.ActiveJob, out io.Writer, env bool, redactEnv []stri
 	listRec(w, "CreatedAt", job.CreatedAt)
 	listRec(w, "StartedAt", job.StartedAt)
 	listRec(w, "EndedAt", displayTime(job.EndedAt))
+	listRec(w, "PID", pid)
 	listRec(w, "ExitStatus", exitStatus)
 	listRec(w, "Error", jobError)
 	listRec(w, "IP Address", job.InternalIP)

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -664,6 +664,13 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	}
 	go process.Wait()
 
+	pid, err := process.Pid()
+	if err != nil {
+		c.Destroy()
+		return err
+	}
+	l.State.SetContainerPID(job.ID, pid)
+
 	container.container = c
 
 	go container.watch(nil, nil)

--- a/host/state.go
+++ b/host/state.go
@@ -363,6 +363,13 @@ func (s *State) SetContainerIP(jobID string, ip net.IP) {
 	s.persist(jobID)
 }
 
+func (s *State) SetContainerPID(jobID string, pid int) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.jobs[jobID].PID = &pid
+	s.persist(jobID)
+}
+
 func (s *State) SetForceStop(jobID string) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -412,6 +419,7 @@ func (s *State) SetStatusDone(jobID string, exitStatus int) {
 	} else {
 		job.Status = host.StatusCrashed
 	}
+	job.PID = nil
 	s.sendEvent(job, host.JobEventStop)
 	if err := s.Acquire(); err == nil {
 		s.persist(job.Job.ID)
@@ -431,6 +439,7 @@ func (s *State) SetStatusFailed(jobID string, err error) {
 	job.EndedAt = time.Now().UTC()
 	errStr := err.Error()
 	job.Error = &errStr
+	job.PID = nil
 	s.sendEvent(job, host.JobEventError)
 	if err := s.Acquire(); err == nil {
 		s.persist(jobID)

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -216,6 +216,7 @@ type ActiveJob struct {
 	Job        *Job      `json:"job,omitempty"`
 	HostID     string    `json:"host_id,omitempty"`
 	InternalIP string    `json:"internal_ip,omitempty"`
+	PID        *int      `json:"pid,omitempty"`
 	ForceStop  bool      `json:"force_stop,omitempty"`
 	Status     JobStatus `json:"status,omitempty"`
 	CreatedAt  time.Time `json:"created_at,omitempty"`


### PR DESCRIPTION
This exposes the container PID via the host API.

Necessary for providing PID -> container mapping in tools such as Scope that need to join on the host namespace PID.