### PR TITLE
host,controller: Allow jobs to be launched in host PID namespace

### DIFF
--- a/cli/release.go
+++ b/cli/release.go
@@ -307,6 +307,9 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 			if procUpdate.HostNetwork {
 				procRelease.HostNetwork = true
 			}
+			if procUpdate.HostPIDNamespace {
+				procRelease.HostPIDNamespace = true
+			}
 			if len(procUpdate.Service) > 0 {
 				procRelease.Service = procUpdate.Service
 			}

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -101,6 +101,7 @@ type ProcessType struct {
 	Volumes           []VolumeReq        `json:"volumes,omitempty"`
 	Omni              bool               `json:"omni,omitempty"` // omnipresent - present on all hosts
 	HostNetwork       bool               `json:"host_network,omitempty"`
+	HostPIDNamespace  bool               `json:"host_pid_namespace,omitempty"`
 	Service           string             `json:"service,omitempty"`
 	Resurrect         bool               `json:"resurrect,omitempty"`
 	Resources         resource.Resources `json:"resources,omitempty"`

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -58,6 +58,7 @@ func JobConfig(f *ct.ExpandedFormation, name, hostID string, uuid string) *host.
 			Uid:              entrypoint.Uid,
 			Gid:              entrypoint.Gid,
 			HostNetwork:      t.HostNetwork,
+			HostPIDNamespace: t.HostPIDNamespace,
 			Mounts:           t.Mounts,
 			WriteableCgroups: t.WriteableCgroups,
 		},

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -424,7 +424,6 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 			{Type: configs.NEWNS},
 			{Type: configs.NEWUTS},
 			{Type: configs.NEWIPC},
-			{Type: configs.NEWPID},
 		}),
 		Cgroups: &configs.Cgroup{
 			Path: filepath.Join("/flynn", job.Partition, job.ID),
@@ -480,6 +479,10 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 				Flags:       cgroupMountFlags,
 			},
 		}...),
+	}
+
+	if !job.Config.HostPIDNamespace {
+		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWPID})
 	}
 
 	if spec, ok := job.Resources[resource.TypeMaxFD]; ok && spec.Limit != nil && spec.Request != nil {

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -98,6 +98,7 @@ type ContainerConfig struct {
 	Uid               *uint32            `json:"uid,omitempty"`
 	Gid               *uint32            `json:"gid,omitempty"`
 	HostNetwork       bool               `json:"host_network,omitempty"`
+	HostPIDNamespace  bool               `json:"host_pid_namespace,omitempty"`
 	DisableLog        bool               `json:"disable_log,omitempty"`
 	LinuxCapabilities *[]string          `json:"linux_capabilities,omitempty"`
 	AllowedDevices    *[]*configs.Device `json:"allowed_devices,omitempty"`
@@ -142,6 +143,7 @@ func (x ContainerConfig) Merge(y ContainerConfig) ContainerConfig {
 		x.Gid = y.Gid
 	}
 	x.HostNetwork = x.HostNetwork || y.HostNetwork
+	x.HostPIDNamespace = x.HostPIDNamespace || y.HostPIDNamespace
 	return x
 }
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -32,7 +32,8 @@ type Cmd struct {
 	Volumes []*ct.VolumeReq
 	Mounts  []host.Mount
 
-	HostNetwork bool
+	HostNetwork      bool
+	HostPIDNamespace bool
 
 	Stdin io.Reader
 
@@ -200,12 +201,13 @@ func (c *Cmd) Start() error {
 	if c.Job == nil {
 		c.Job = &host.Job{
 			Config: host.ContainerConfig{
-				Args:        c.Args,
-				TTY:         c.TTY,
-				Env:         c.Env,
-				Stdin:       c.Stdin != nil || c.stdinPipe != nil,
-				HostNetwork: c.HostNetwork,
-				Mounts:      c.Mounts,
+				Args:             c.Args,
+				TTY:              c.TTY,
+				Env:              c.Env,
+				Stdin:            c.Stdin != nil || c.stdinPipe != nil,
+				HostNetwork:      c.HostNetwork,
+				HostPIDNamespace: c.HostPIDNamespace,
+				Mounts:           c.Mounts,
 			},
 			Metadata: c.Meta,
 		}


### PR DESCRIPTION
This allows processes that require access to the host PID namespace for monitoring purposes etc to be run as Flynn jobs rather than being managed outside of Flynn.

Ideal for agents like Scope/Sysdig/CollectD etc.