### PR TITLE
host,cli: Syslog sink insecure

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -75,7 +75,7 @@ Commands:
             --file=<backup-file>  file to write backup to (defaults to stdout)
 
     log-sink
-        With no arguments, prints a list of registerd log-sinks for this cluster
+        With no arguments, prints a list of registered log-sinks for this cluster
 
     log-sink add syslog
         Creates a new syslog log sink with specified <url> and optionally <prefix> template.

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -31,7 +31,7 @@ usage: flynn cluster
        flynn cluster migrate-domain <domain>
        flynn cluster backup [--file <file>]
        flynn cluster log-sink
-       flynn cluster log-sink add syslog [--use-ids] <url> [<prefix>]
+       flynn cluster log-sink add syslog [--use-ids] [--insecure] <url> [<prefix>]
        flynn cluster log-sink remove <id>
 
 Manage Flynn clusters.
@@ -82,10 +82,11 @@ Commands:
         Supported schemes are syslog and syslog+tls
 
         options:
-            --use-ids  Use app IDs instead of app names in the syslog APP-NAME field
+            --use-ids   Use app IDs instead of app names in the syslog APP-NAME field
+            --insecure  Don't verify servers certificate chain or hostname. Should only be used for testing.
 
         examples:
-			$ flynn cluster log-sink add syslog syslog+tls://rsyslog.host:514/
+            $ flynn cluster log-sink add syslog syslog+tls://rsyslog.host:514/
 
     log-sink remove
         Removes a log sink with <id>
@@ -482,9 +483,10 @@ func runLogSinkAddSyslog(args *docopt.Args, client controller.Client) error {
 	}
 
 	config, _ := json.Marshal(ct.SyslogSinkConfig{
-		Prefix: args.String["<prefix>"],
-		URL:    u.String(),
-		UseIDs: args.Bool["--use-ids"],
+		Prefix:   args.String["<prefix>"],
+		URL:      u.String(),
+		UseIDs:   args.Bool["--use-ids"],
+		Insecure: args.Bool["--insecure"],
 	})
 
 	sink := &ct.Sink{

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -628,9 +628,10 @@ type Sink struct {
 }
 
 type SyslogSinkConfig struct {
-	URL    string `json:"url"`
-	Prefix string `json:"template"`
-	UseIDs bool   `json:"use_ids"`
+	URL      string `json:"url"`
+	Prefix   string `json:"template"`
+	UseIDs   bool   `json:"use_ids"`
+	Insecure bool   `json:"insecure"`
 }
 
 type LogAggregatorSinkConfig struct {


### PR DESCRIPTION
Allows usage with self-signed or otherwise untrusted target syslog sinks.
Not recommended for production due to potential for man-in-the-middle attacks but very useful in development and testing environments.