### PR TITLE
test/runner: Boot multi node default cluster

### DIFF
--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -148,6 +148,7 @@ main() {
     --log-dir "${log_dir}" \
     --flynn-init "${bin_dir}/flynn-init" \
     --init-log-level "debug" \
+    --tags "host_id=${id}" \
     ${peer_ips} \
     &>"${log}"
 

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -290,20 +290,18 @@ func (c *Cluster) startVMs(typ ClusterType, rootFS string, count int, initial bo
 }
 
 func (c *Cluster) startFlynnHost(inst *Instance, peerInstances []*Instance) error {
+	peers := make([]string, 0, len(peerInstances))
+	for _, inst := range peerInstances {
+		if !inst.initial {
+			continue
+		}
+		peers = append(peers, inst.IP)
+	}
 	var script bytes.Buffer
 	data := hostScriptData{
-		ID: inst.ID,
-		IP: inst.IP,
-	}
-	if len(peerInstances) > 1 {
-		peers := make([]string, 0, len(peerInstances))
-		for _, inst := range peerInstances {
-			if !inst.initial {
-				continue
-			}
-			peers = append(peers, inst.IP)
-		}
-		data.Peers = strings.Join(peers, ",")
+		ID:    inst.ID,
+		IP:    inst.IP,
+		Peers: strings.Join(peers, ","),
 	}
 	flynnHostScript.Execute(&script, data)
 	c.logf("Starting flynn-host on %s [id: %s]\n", inst.IP, inst.ID)
@@ -471,7 +469,7 @@ sudo start-stop-daemon \
   --external-ip {{ .IP }} \
   --listen-ip {{ .IP }} \
   --force \
-  {{ if .Peers }} --peer-ips {{ .Peers }} {{ end }} \
+  --peer-ips {{ .Peers }} \
   --max-job-concurrency 8 \
   --init-log-level debug \
   --tags "host_id={{ .ID }}" \

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -254,17 +254,17 @@ func (c *Cluster) startVMs(typ ClusterType, rootFS string, count int, initial bo
 	instances := make([]*Instance, count)
 	for i := 0; i < count; i++ {
 		memory := "8192"
-		cores := 2
-		if typ == ClusterTypeDefault {
-			memory = "32768"
-			cores = 12
+		if initial && i == 0 {
+			// give the first instance more memory as that is where
+			// the test binary runs, and the tests use a lot of memory
+			memory = "16384"
 		}
 		inst, err := c.vm.NewInstance(&VMConfig{
 			Kernel: c.bc.Kernel,
 			User:   uid,
 			Group:  gid,
 			Memory: memory,
-			Cores:  cores,
+			Cores:  2,
 			Drives: map[string]*VMDrive{
 				"hda": {FS: rootFS, COW: true, Temp: true},
 			},

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -474,6 +474,7 @@ sudo start-stop-daemon \
   {{ if .Peers }} --peer-ips {{ .Peers }} {{ end }} \
   --max-job-concurrency 8 \
   --init-log-level debug \
+  --tags "host_id={{ .ID }}" \
   &>/tmp/flynn-host.log
 `[1:]))
 

--- a/test/rootfs/build.sh
+++ b/test/rootfs/build.sh
@@ -4,7 +4,7 @@ set -e -x
 src_dir="$(cd "$(dirname "$0")" && pwd)"
 build_dir=${1:-.}
 
-truncate -s 150G ${build_dir}/rootfs.img
+truncate -s 70G ${build_dir}/rootfs.img
 mkfs.ext4 -FqL rootfs ${build_dir}/rootfs.img
 
 dir=$(mktemp -d)

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -456,7 +456,7 @@ func (r *Runner) build(b *Build) (err error) {
 		return fmt.Errorf("could not build flynn: %s", err)
 	}
 
-	if _, err := c.Boot(cluster.ClusterTypeDefault, 1, buildLog, false); err != nil {
+	if _, err := c.Boot(cluster.ClusterTypeDefault, 3, buildLog, false); err != nil {
 		return fmt.Errorf("could not boot cluster: %s", err)
 	}
 

--- a/util/flynn-in-flynn/boot.go
+++ b/util/flynn-in-flynn/boot.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	_, err := cluster2.Boot(&cluster2.BootConfig{
-		Size:         1,
+		Size:         3,
 		ImagesPath:   "images.json",
 		ManifestPath: "bootstrap/bin/manifest.json",
 	})


### PR DESCRIPTION
This updates `test/cluster2` to boot clusters on a single host using tags and reverts CI back to using multiple VMs which should hopefully make it more reliable.