### PR TITLE
test: Mount backups dir on all VMs

### DIFF
--- a/schema/controller/expanded_formation.json
+++ b/schema/controller/expanded_formation.json
@@ -31,6 +31,10 @@
         "type": "integer"
       }
     },
+    "tags": {
+      "description": "process tags",
+      "type": "object"
+    },
     "updated_at": {
       "$ref": "/schema/controller/common#/definitions/updated_at"
     }

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -455,6 +455,10 @@ if [[ -f /usr/local/bin/debug-info.sh ]]; then
   /usr/local/bin/debug-info.sh &>/tmp/debug-info.log &
 fi
 
+# mount the backups dir
+sudo mkdir -p /mnt/backups
+sudo mount -t 9p -o trans=virtio backupsfs /mnt/backups
+
 sudo start-stop-daemon \
   --start \
   --background \

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -354,10 +354,6 @@ git config --global user.name "CI"
 
 cd test
 
-# mount the backups dir
-sudo mkdir -p /mnt/backups
-sudo mount -t 9p -o trans=virtio backupsfs /mnt/backups
-
 cmd="bin/flynn-test \
   --flynnrc $HOME/.flynnrc \
   --cluster-api https://{{ .Cluster.BridgeIP }}:{{ .ListenPort }}/cluster/{{ .Cluster.ID }} \


### PR DESCRIPTION
I've also added a fix for `ControllerSuite.TestExampleOutput` now that we have formations with tags (i.e. the flynn-in-flynn clusters).