### PR TITLE
host/logmux: Ensure the DB is open when persisting sinks

### DIFF
--- a/host/logmux/sink.go
+++ b/host/logmux/sink.go
@@ -208,7 +208,12 @@ func (sm *SinkManager) newSink(s *SinkInfo) (Sink, error) {
 	}
 }
 
+var ErrDBClosed = errors.New("sink DB closed")
+
 func (sm *SinkManager) persistSink(id string) error {
+	if sm.db == nil {
+		return ErrDBClosed
+	}
 	if err := sm.db.Update(func(tx *bolt.Tx) error {
 		sinkBucket := tx.Bucket([]byte("sinks"))
 		k := []byte(id)


### PR DESCRIPTION
This was causing flynn-host to panic on shutdown when it had closed the DB but then tried to persist the logaggregator sink once it was stopped.