### PR TITLE
host: Repair MongoDB cluster before the controller

### DIFF
--- a/host/monitor.go
+++ b/host/monitor.go
@@ -198,7 +198,7 @@ func (m *Monitor) repairCluster() error {
 	f.KillSchedulers()
 
 	log.Info("checking status of sirenia databases")
-	for _, db := range []string{"postgres", "mariadb"} {
+	for _, db := range []string{"postgres", "mariadb", "mongodb"} {
 		log.Info("checking for database state", "db", db)
 		if _, err := discoverd.NewService(db).GetMeta(); err != nil {
 			if discoverd.IsNotFound(err) {


### PR DESCRIPTION
So that it is started with the volume from the previous primary when rebooting a single node cluster.

Fixes #3847.