### PR TITLE
bootstrap: Fix restoring from recent MongoDB / MariaDB backups

### DIFF
--- a/script/bootstrap-flynn
+++ b/script/bootstrap-flynn
@@ -99,7 +99,16 @@ main() {
     mkdir -p "${dir}"
 
     info "downloading ${version} into ${dir}"
-    sudo FLYNN_VERSION="${version}" "${flynn_host}" download --config-dir "${dir}" --bin-dir "${dir}"
+    local args=(
+      --config-dir "${dir}"
+      --bin-dir    "${dir}"
+    )
+    if [[ "${version:1:8}" -ge "20161106" ]]; then
+      args+=(
+        --volpath "/var/lib/flynn/volumes-0"
+      )
+    fi
+    sudo FLYNN_VERSION="${version}" "${flynn_host}" download ${args[@]}
     flynn_host="${dir}/flynn-host"
     bin_dir="${dir}"
     manifest="${dir}/bootstrap-manifest.json"

--- a/script/generate-backups
+++ b/script/generate-backups
@@ -53,7 +53,15 @@ main() {
   export FLYNNRC="${tmp}/flynnrc"
   local app="nodejs"
 
-  for version in "v20160309.0" "v20160423.0" "v20160624.1" "v20160721.2" "v20160814.0"; do
+  local versions=(
+    "v20160309.0"
+    "v20160423.0"
+    "v20160624.1"
+    "v20160721.2"
+    "v20160814.0"
+    "v20161114.0p1"
+  )
+  for version in ${versions[@]}; do
     local name="${version}-nodejs-redis.tar"
     local out="${dir}/${name}"
 
@@ -141,6 +149,7 @@ bootstrap_cluster() {
   info "bootstrapping ${version} cluster"
   export CLUSTER_DOMAIN="$(openssl rand -hex 16).local"
   echo "192.0.2.200 ${CLUSTER_DOMAIN} controller.${CLUSTER_DOMAIN} git.${CLUSTER_DOMAIN} docker.${CLUSTER_DOMAIN}" | sudo tee -a /etc/hosts
+  "${ROOT}/script/kill-flynn"
   local cluster_add=$("${ROOT}/script/bootstrap-flynn" --version "${version}" &> >(tee "${out}") | tail -3 | head -1)
 
   if [[ "${cluster_add:0:17}" != "flynn cluster add" ]]; then

--- a/test/test_backup.go
+++ b/test/test_backup.go
@@ -50,6 +50,10 @@ func (s *BackupSuite) Test_v20161017_1_nodejs_docker(t *c.C) {
 	s.testClusterBackup(t, "v20161017.1-nodejs-docker.tar")
 }
 
+func (s *BackupSuite) Test_v20161114_0p1_nodejs_redis(t *c.C) {
+	s.testClusterBackup(t, "v20161114.0p1-nodejs-redis.tar")
+}
+
 func (s *BackupSuite) testClusterBackup(t *c.C, name string) {
 	if args.BootConfig.BackupsDir == "" {
 		t.Skip("--backups-dir not set")


### PR DESCRIPTION
Restoring backups from cluster versions >= `v20161026.0` (i.e. since [this commit](https://github.com/flynn/flynn/commit/00cb6e0)) will fail to start the MongoDB / MariaDB appliances because `Release.Processes` will get set to `null` by [these SQL commands](https://github.com/flynn/flynn/blob/v20170116.0/host/cli/bootstrap.go#L356-L372) (since the `env` key no longer exists on the db type).

I've wrapped those SQL commands with a conditional, and added a test for restoring a `v20161114.0p1` backup (which fails without this change).

We need to improve our testing of backups, at the very least test that backing up a cluster with the current code can then be restored, but we need to merge this as it is affecting users.

Fixes #3816
Fixes #3843