### PR TITLE
host,cli: Add newline delimited option for syslog sink

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -627,12 +627,20 @@ type Sink struct {
 	UpdatedAt   *time.Time      `json:"updated_at,omitempty"`
 }
 
+type SyslogFormat string
+
+const (
+	SyslogFormatRFC6587 SyslogFormat = "rfc6587"
+	SyslogFormatNewline SyslogFormat = "newline"
+)
+
 type SyslogSinkConfig struct {
-	URL            string `json:"url"`
-	Prefix         string `json:"template,omitempty"`
-	UseIDs         bool   `json:"use_ids,omitempty"`
-	Insecure       bool   `json:"insecure,omitempty"`
-	StructuredData bool   `json:"structured_data,omitempty"`
+	URL            string       `json:"url"`
+	Prefix         string       `json:"template,omitempty"`
+	UseIDs         bool         `json:"use_ids,omitempty"`
+	Insecure       bool         `json:"insecure,omitempty"`
+	StructuredData bool         `json:"structured_data,omitempty"`
+	Format         SyslogFormat `json:"format,omitempty"`
 }
 
 type LogAggregatorSinkConfig struct {


### PR DESCRIPTION
Add option to support non-RFC6587 compliant sinks that expect syslog lines delimited by newlines.

Fixes #3858