### PR TITLE
Don't output headers in quiet mode

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -59,11 +59,13 @@ func runPs(args *docopt.Args, client controller.Client) error {
 	sort.Sort(sortJobs(jobs))
 	w := tabWriter()
 	defer w.Flush()
-	headers := []interface{}{"ID", "TYPE", "STATE", "CREATED", "RELEASE"}
-	if args.Bool["--command"] {
-		headers = append(headers, "COMMAND")
+	if !args.Bool["--quiet"] {
+		headers := []interface{}{"ID", "TYPE", "STATE", "CREATED", "RELEASE"}
+		if args.Bool["--command"] {
+			headers = append(headers, "COMMAND")
+		}
+		listRec(w, headers...)
 	}
-	listRec(w, headers...)
 	for _, j := range jobs {
 		if !args.Bool["--all"] && j.State != ct.JobStateUp && j.State != ct.JobStatePending {
 			continue


### PR DESCRIPTION
Currently the header list is output in quiet mode, which results in the following:
```
flynn02-15630c66-d3a3-44ca-809c-ca2599ff1cc1
flynn01-3b8ef01b-4d25-4f1c-89ef-d2483f7a75a1
ID  TYPE  STATE  CREATED  RELEASE
```

Which results in the following:
```sh
# flynn -c cluster2 -a app ps -q | xargs flynn -c cluster2 -a app kill
Job flynn02-15630c66-d3a3-44ca-809c-ca2599ff1cc1 killed.
Job flynn01-3b8ef01b-4d25-4f1c-89ef-d2483f7a75a1 killed.
ERROR: could not kill job ID: controller: resource not found
ERROR: could not kill job TYPE: controller: resource not found
ERROR: could not kill job STATE: controller: resource not found
ERROR: could not kill job CREATED: controller: resource not found
ERROR: could not kill job RELEASE: controller: resource not found
Could not kill all jobs.
```

This simply skips all header assembly and output if quiet is enabled.