### PR TITLE
host: Drop structured data when sending to syslog sink

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -628,10 +628,11 @@ type Sink struct {
 }
 
 type SyslogSinkConfig struct {
-	URL      string `json:"url"`
-	Prefix   string `json:"template"`
-	UseIDs   bool   `json:"use_ids"`
-	Insecure bool   `json:"insecure"`
+	URL            string `json:"url"`
+	Prefix         string `json:"template,omitempty"`
+	UseIDs         bool   `json:"use_ids,omitempty"`
+	Insecure       bool   `json:"insecure,omitempty"`
+	StructuredData bool   `json:"structured_data,omitempty"`
 }
 
 type LogAggregatorSinkConfig struct {

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -790,8 +790,9 @@ func (s *HostSuite) TestLogSinks(t *c.C) {
 
 	// add sink to controller
 	config, err := json.Marshal(&ct.SyslogSinkConfig{
-		URL:    fmt.Sprintf("syslog://%s", instances[0].Addr),
-		UseIDs: true,
+		URL:            fmt.Sprintf("syslog://%s", instances[0].Addr),
+		UseIDs:         true,
+		StructuredData: true,
 	})
 	t.Assert(err, c.IsNil)
 	sink := &ct.Sink{


### PR DESCRIPTION
Drops structured data as it's not of any use outside of the logaggregator API.

If users want to consume this they will probably also wish to implement the logaggregator HTTP cursor API in which case we can expose the ability to create logaggregator compatible sinks.