### PR TITLE
test: Start a bash shell to debug cluster test failures

### DIFF
--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -102,6 +102,9 @@ main() {
   if $stream; then
     args+=("--stream")
   fi
+  if [[ -t 0 ]]; then
+    args+=("--interactive")
+  fi
   args+=("--router-ip=192.0.2.200")
 
   local mounts=(

--- a/test/arg/arg.go
+++ b/test/arg/arg.go
@@ -28,6 +28,7 @@ type Args struct {
 	ClusterAPI       string
 	Concurrency      int
 	ConcurrentBuilds int
+	Interactive      bool
 }
 
 func Parse() *Args {
@@ -56,6 +57,7 @@ func Parse() *Args {
 	flag.BoolVar(&args.Kill, "kill", true, "kill the cluster after running the tests")
 	flag.BoolVar(&args.BuildRootFS, "build-rootfs", false, "just build the rootfs (leaving it behind for future use) without running tests")
 	flag.BoolVar(&args.Gist, "gist", false, "upload debug info to a gist")
+	flag.BoolVar(&args.Interactive, "interactive", false, "start an interactive bash shell when cluster tests fail")
 	flag.IntVar(&args.Concurrency, "concurrency", 5, "max number of concurrent tests")
 	flag.IntVar(&args.ConcurrentBuilds, "concurrent-builds", 5, "max number of concurrent builds")
 	flag.Parse()

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -860,12 +860,13 @@ func (s *HostSuite) TestLogSinks(t *c.C) {
 
 	// wait for syslog message from each host
 	received := make(map[string]struct{})
+loop:
 	for {
 		select {
 		case msg := <-msgs:
 			received[msg.HostID] = struct{}{}
 			if len(received) == len(hosts) {
-				return
+				break loop
 			}
 		case <-time.After(30 * time.Second):
 			t.Fatal("timed out waiting for log messages")


### PR DESCRIPTION
When tests fail in nested clusters, it is hard to debug what has gone wrong because the cluster is destroyed.

If the tests are being run in a terminal then a bash shell will now be started before destroying the cluster:

```
test_host.go:895:
    t.Fatal("fail")
... Error: fail

++ 15:24:48.545 

*****
starting bash shell with both 'flynn-host' and 'flynn' configured
to debug test failure in cluster "flynn-d84f"

run 'exit' when you're done
*****


test-debug@flynn-d84f# flynn-host list
ID                                ADDR               RAFT STATUS
29f4162630464647b001c441f9f712a1  100.100.3.18:1113  peer (leader)
3ff374e277724019825b613fa83a91f8  100.100.3.20:1113  peer
e49a510aca2b4e92875ea7e931790e8e  100.100.3.19:1113  peer

test-debug@flynn-d84f# flynn -a discoverd ps
ID                                                                     TYPE  STATE  CREATED             RELEASE
29f4162630464647b001c441f9f712a1-e56f3574-68ed-47f3-a49b-840e7ebd9e1a  app   up     About a minute ago  b87edacd-7ac6-4632-a0a1-b3e0a9af1bb2
3ff374e277724019825b613fa83a91f8-bc1fbcbb-18c8-4de3-84a7-aa0e3835325f  app   up     About a minute ago  b87edacd-7ac6-4632-a0a1-b3e0a9af1bb2
e49a510aca2b4e92875ea7e931790e8e-fecd0f3b-5e0a-4bd4-a678-8491810903ea  app   up     About a minute ago  b87edacd-7ac6-4632-a0a1-b3e0a9af1bb2

test-debug@flynn-d84f# exit
exit
++ 15:26:05.769 t=2017-01-26T15:26:05+0000 lvl=info msg="running host cleanup" fn=Destroy app=flynn-d84f job.id=host0-29f41626-3046-4647-b001-c441f9f712a1
++ 15:26:06.917 t=2017-01-26T15:26:06+0000 lvl=info msg="+ JOB_ID=host0-29f41626-3046-4647-b001-c441f9f712a1" fn=Destroy app=flynn-d84f
++ 15:26:06.917 t=2017-01-26T15:26:06+0000 lvl=info msg="++ sed 's|:| |' /sys/class/misc/zfs/dev" fn=Destroy app=flynn-d84f
++ 15:26:06.918 t=2017-01-26T15:26:06+0000 lvl=info msg="+ mknod -m 0600 /dev/zfs c 10 54" fn=Destroy app=flynn-d84f
++ 15:26:06.918 t=2017-01-26T15:26:06+0000 lvl=info msg="+ ln -nfs /proc/mounts /etc/mtab" fn=Destroy app=flynn-d84f
++ 15:26:06.919 t=2017-01-26T15:26:06+0000 lvl=info msg="+ zpool destroy flynn-host0-29f41626-3046-4647-b001-c441f9f712a1" fn=Destroy app=flynn-d84f
++ 15:26:07.622 t=2017-01-26T15:26:07+0000 lvl=info msg="+ rm -rf /var/lib/flynn/host0-29f41626-3046-4647-b001-c441f9f712a1" fn=Destroy app=flynn-d84f
++ 15:26:07.883 t=2017-01-26T15:26:07+0000 lvl=info msg="running host cleanup" fn=Destroy app=flynn-d84f job.id=host0-3ff374e2-7772-4019-825b-613fa83a91f8
++ 15:26:08.071 t=2017-01-26T15:26:08+0000 lvl=info msg="+ JOB_ID=host0-3ff374e2-7772-4019-825b-613fa83a91f8" fn=Destroy app=flynn-d84f
++ 15:26:08.071 t=2017-01-26T15:26:08+0000 lvl=info msg="++ sed 's|:| |' /sys/class/misc/zfs/dev" fn=Destroy app=flynn-d84f
++ 15:26:08.072 t=2017-01-26T15:26:08+0000 lvl=info msg="+ mknod -m 0600 /dev/zfs c 10 54" fn=Destroy app=flynn-d84f
++ 15:26:08.072 t=2017-01-26T15:26:08+0000 lvl=info msg="+ ln -nfs /proc/mounts /etc/mtab" fn=Destroy app=flynn-d84f
++ 15:26:08.073 t=2017-01-26T15:26:08+0000 lvl=info msg="+ zpool destroy flynn-host0-3ff374e2-7772-4019-825b-613fa83a91f8" fn=Destroy app=flynn-d84f
++ 15:26:08.765 t=2017-01-26T15:26:08+0000 lvl=info msg="+ rm -rf /var/lib/flynn/host0-3ff374e2-7772-4019-825b-613fa83a91f8" fn=Destroy app=flynn-d84f
++ 15:26:09.006 t=2017-01-26T15:26:09+0000 lvl=info msg="running host cleanup" fn=Destroy app=flynn-d84f job.id=host0-e49a510a-ca2b-4e92-875e-a7e931790e8e
++ 15:26:09.190 t=2017-01-26T15:26:09+0000 lvl=info msg="+ JOB_ID=host0-e49a510a-ca2b-4e92-875e-a7e931790e8e" fn=Destroy app=flynn-d84f
++ 15:26:09.191 t=2017-01-26T15:26:09+0000 lvl=info msg="++ sed 's|:| |' /sys/class/misc/zfs/dev" fn=Destroy app=flynn-d84f
++ 15:26:09.191 t=2017-01-26T15:26:09+0000 lvl=info msg="+ mknod -m 0600 /dev/zfs c 10 54" fn=Destroy app=flynn-d84f
++ 15:26:09.192 t=2017-01-26T15:26:09+0000 lvl=info msg="+ ln -nfs /proc/mounts /etc/mtab" fn=Destroy app=flynn-d84f
++ 15:26:09.193 t=2017-01-26T15:26:09+0000 lvl=info msg="+ zpool destroy flynn-host0-e49a510a-ca2b-4e92-875e-a7e931790e8e" fn=Destroy app=flynn-d84f
++ 15:26:10.084 t=2017-01-26T15:26:10+0000 lvl=info msg="+ rm -rf /var/lib/flynn/host0-e49a510a-ca2b-4e92-875e-a7e931790e8e" fn=Destroy app=flynn-d84f
15:26:10.395 FAIL: test_host.go:749: HostSuite.TestLogSinks
```