### PR TITLE
router: Prevent race creating TLS certificates

### DIFF
--- a/router/data_store.go
+++ b/router/data_store.go
@@ -164,10 +164,8 @@ func (d *pgDataStore) addCertWithTx(tx *pgx.Tx, c *router.Certificate) error {
 	}
 
 	tlsCertSHA256 := sha256.Sum256([]byte(c.Cert))
-	if err := tx.QueryRow("select_certificate_by_sha", tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
-		if err := tx.QueryRow("insert_certificate", c.Cert, c.Key, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
-			return err
-		}
+	if err := tx.QueryRow("insert_certificate", c.Cert, c.Key, tlsCertSHA256[:]).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		return err
 	}
 	for _, rid := range c.Routes {
 		if _, err := tx.Exec("delete_route_certificate_by_route_id", rid); err != nil {

--- a/router/schema/queries.go
+++ b/router/schema/queries.go
@@ -121,6 +121,7 @@ const (
 	insertCertificate = `
 	INSERT INTO certificates (cert, key, cert_sha256)
 	VALUES ($1, $2, $3)
+	ON CONFLICT (cert_sha256) WHERE deleted_at IS NULL DO UPDATE SET cert_sha256 = $3
 	RETURNING id, created_at, updated_at`
 
 	deleteCertificate = `UPDATE certificates SET deleted_at = now() WHERE id = $1`


### PR DESCRIPTION
This sometimes manifests itself when migrating a domain when we add new routes with the same certificate in parallel.