### PR TITLE
appliance/redis: Fix setting password in discoverd registration test

### DIFF
--- a/appliance/redis/cmd/flynn-redis/main_test.go
+++ b/appliance/redis/cmd/flynn-redis/main_test.go
@@ -41,6 +41,8 @@ func TestMain_Discoverd(t *testing.T) {
 		return hb, nil
 	}
 
+	m.Process.Password = "password"
+
 	// Execute program.
 	if err := m.Run(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Not having a password set was causing Redis tests to hang for quite some time locally (though eventually exiting with exit status 0).
I'm unsure if this effects CI, it probably does but is likely masked by the long run times of other unit tests.