### PR TITLE
host/logmux: Don't attempt to close nil conn on Close

### DIFF
--- a/host/logmux/sink.go
+++ b/host/logmux/sink.go
@@ -419,7 +419,9 @@ func (s *LogAggregatorSink) Connect() error {
 }
 
 func (s *LogAggregatorSink) Close() {
-	s.conn.Close()
+	if s.conn != nil {
+		s.conn.Close()
+	}
 }
 
 func (s *LogAggregatorSink) GetCursor(hostID string) (*utils.HostCursor, error) {


### PR DESCRIPTION
Fixes #3895 