### PR TITLE
Implement Persistent Volumes

### DIFF
--- a/appliance/redis/cmd/flynn-redis-api/main.go
+++ b/appliance/redis/cmd/flynn-redis-api/main.go
@@ -241,7 +241,14 @@ func (h *Handler) servePostCluster(w http.ResponseWriter, req *http.Request, _ h
 		return
 	}
 
-	host := fmt.Sprintf("leader.%s.discoverd", app.Name)
+	h.Logger.Info("waiting for Redis to start", "service", serviceName)
+	if _, err := discoverd.GetInstances(serviceName, 5*time.Minute); err != nil {
+		h.Logger.Error("error waiting for Redis to start", "err", err)
+		httphelper.Error(w, err)
+		return
+	}
+
+	host := "leader." + serviceName
 	u := url.URL{
 		Scheme: "redis",
 		Host:   host + ":6379",

--- a/cli/main.go
+++ b/cli/main.go
@@ -65,6 +65,7 @@ Commands:
 	resource    provision a new resource
 	release     manage app releases
 	deployment  list deployments
+	volume      manage volumes
 	export      export app data
 	import      create app from exported data
 	version     show flynn version

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/flynn/flynn/controller/client"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/cluster"
+	"github.com/flynn/go-docopt"
+)
+
+func init() {
+	register("volume", runVolume, `
+usage: flynn volume
+       flynn volume show [--json] <id>
+       flynn volume decommission <id>
+
+Manage cluster volumes.
+
+Commands:
+    With no arguments, displays current volumes.
+
+    show
+	    Show information about a volume.
+
+    decommission
+	    Decommission a volume.
+
+	    A decommissioned volume will continue to exist but will no longer
+	    be attached to new jobs by the scheduler.
+`)
+}
+
+func runVolume(args *docopt.Args, client controller.Client) error {
+	if args.Bool["show"] {
+		return runVolumeShow(args, client)
+	} else if args.Bool["decommission"] {
+		return runVolumeDecommission(args, client)
+	}
+	return runVolumeList(args, client)
+}
+
+func runVolumeList(args *docopt.Args, client controller.Client) error {
+	volumes, err := client.AppVolumeList(mustApp())
+	if err != nil {
+		return err
+	}
+
+	w := tabWriter()
+	defer w.Flush()
+
+	listRec(w, "ID", "HOST", "STATE", "ATTACHED JOB", "CREATED", "DECOMMISSIONED")
+	for _, v := range volumes {
+		var jobID string
+		if v.JobID != nil {
+			jobID = cluster.GenerateJobID(v.HostID, *v.JobID)
+		}
+		var created string
+		if v.CreatedAt != nil {
+			created = units.HumanDuration(time.Now().UTC().Sub(*v.CreatedAt)) + " ago"
+		}
+		listRec(w, v.ID, v.HostID, v.State, jobID, created, v.DecommissionedAt != nil)
+	}
+
+	return nil
+}
+
+func runVolumeShow(args *docopt.Args, client controller.Client) error {
+	vol, err := client.GetVolume(mustApp(), args.String["<id>"])
+	if err != nil {
+		return err
+	}
+	if args.Bool["--json"] {
+		return json.NewEncoder(os.Stdout).Encode(vol)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	listRec(w, "ID:", vol.ID)
+	listRec(w, "State:", vol.State)
+	listRec(w, "HostID:", vol.HostID)
+	listRec(w, "AppID:", vol.AppID)
+	listRec(w, "ReleaseID:", vol.ReleaseID)
+	var jobID string
+	if vol.JobID != nil {
+		jobID = cluster.GenerateJobID(vol.HostID, *vol.JobID)
+	}
+	listRec(w, "JobID:", jobID)
+	listRec(w, "JobType:", vol.JobType)
+	listRec(w, "CreatedAt:", vol.CreatedAt)
+	listRec(w, "UpdatedAt:", vol.UpdatedAt)
+	listRec(w, "DecommissionedAt:", vol.DecommissionedAt)
+	return nil
+}
+
+func runVolumeDecommission(args *docopt.Args, client controller.Client) error {
+	vol := &ct.Volume{ID: args.String["<id>"]}
+	if err := client.DecommissionVolume(mustApp(), vol); err != nil {
+		return err
+	}
+	fmt.Printf("volume %s successfully decommissioned at %s\n", vol.ID, vol.DecommissionedAt)
+	return nil
+}

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -85,6 +85,12 @@ type Client interface {
 	ReleaseList() ([]*ct.Release, error)
 	AppReleaseList(appID string) ([]*ct.Release, error)
 	ProviderList() ([]*ct.Provider, error)
+	VolumeList() ([]*ct.Volume, error)
+	AppVolumeList(appID string) ([]*ct.Volume, error)
+	GetVolume(appID, volID string) (*ct.Volume, error)
+	PutVolume(vol *ct.Volume) error
+	DecommissionVolume(appID string, vol *ct.Volume) error
+	StreamVolumes(since *time.Time, output chan *ct.Volume) (stream.Stream, error)
 	Backup() (io.ReadCloser, error)
 	GetBackupMeta() (*ct.ClusterBackup, error)
 	DeleteRelease(appID, releaseID string) (*ct.ReleaseDeletion, error)

--- a/controller/client/v1/client.go
+++ b/controller/client/v1/client.go
@@ -780,6 +780,63 @@ func (c *Client) ProviderList() ([]*ct.Provider, error) {
 	return providers, c.Get("/providers", &providers)
 }
 
+// GetVolume returns a Volume for the given volume ID
+func (c *Client) GetVolume(appID, id string) (*ct.Volume, error) {
+	if appID == "" {
+		return nil, errors.New("controller: missing app ID")
+	}
+	if id == "" {
+		return nil, errors.New("controller: missing id")
+	}
+	vol := &ct.Volume{}
+	return vol, c.Get(fmt.Sprintf("/apps/%s/volumes/%s", appID, id), vol)
+}
+
+// PutVolume updates an existing volume.
+func (c *Client) PutVolume(vol *ct.Volume) error {
+	if vol.ID == "" {
+		return errors.New("controller: missing id")
+	}
+	return c.Put(fmt.Sprintf("/volumes/%s", vol.ID), vol, vol)
+}
+
+// VolumeList returns a list of all volumes.
+func (c *Client) VolumeList() ([]*ct.Volume, error) {
+	var volumes []*ct.Volume
+	return volumes, c.Get("/volumes", &volumes)
+}
+
+// AppVolumeList returns a list of all volumes for an app.
+func (c *Client) AppVolumeList(appID string) ([]*ct.Volume, error) {
+	if appID == "" {
+		return nil, errors.New("controller: missing app ID")
+	}
+	var volumes []*ct.Volume
+	return volumes, c.Get(fmt.Sprintf("/apps/%s/volumes", appID), &volumes)
+}
+
+// DecommissionVolume decommissions a volume
+func (c *Client) DecommissionVolume(appID string, vol *ct.Volume) error {
+	if appID == "" {
+		return errors.New("controller: missing app ID")
+	}
+	if vol.ID == "" {
+		return errors.New("controller: missing id")
+	}
+	return c.Put(fmt.Sprintf("/apps/%s/volumes/%s/decommission", appID, vol.ID), &vol, &vol)
+}
+
+// StreamVolumes sends a series of Volume into the provided channel.
+// If since is not nil, only retrieves volume updates since the specified time.
+func (c *Client) StreamVolumes(since *time.Time, output chan *ct.Volume) (stream.Stream, error) {
+	if since == nil {
+		s := time.Unix(0, 0)
+		since = &s
+	}
+	t := since.UTC().Format(time.RFC3339Nano)
+	return c.Stream("GET", "/volumes?since="+t, nil, output)
+}
+
 // Backup takes a backup of the cluster
 func (c *Client) Backup() (io.ReadCloser, error) {
 	res, err := c.RawReq("GET", "/backup", nil, nil, nil)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -217,6 +217,7 @@ func appHandler(c handlerConfig) http.Handler {
 	eventRepo := NewEventRepo(c.db)
 	backupRepo := NewBackupRepo(c.db)
 	sinkRepo := NewSinkRepo(c.db)
+	volumeRepo := NewVolumeRepo(c.db)
 
 	api := controllerAPI{
 		domainMigrationRepo: domainMigrationRepo,
@@ -231,6 +232,7 @@ func appHandler(c handlerConfig) http.Handler {
 		eventRepo:           eventRepo,
 		backupRepo:          backupRepo,
 		sinkRepo:            sinkRepo,
+		volumeRepo:          volumeRepo,
 		clusterClient:       c.cc,
 		logaggc:             c.lc,
 		routerc:             c.rc,
@@ -311,6 +313,12 @@ func appHandler(c handlerConfig) http.Handler {
 	httpRouter.GET("/events", httphelper.WrapHandler(api.Events))
 	httpRouter.GET("/events/:id", httphelper.WrapHandler(api.GetEvent))
 
+	httpRouter.GET("/volumes", httphelper.WrapHandler(api.GetVolumes))
+	httpRouter.PUT("/volumes/:volume_id", httphelper.WrapHandler(api.PutVolume))
+	httpRouter.GET("/apps/:apps_id/volumes", httphelper.WrapHandler(api.appLookup(api.GetAppVolumes)))
+	httpRouter.GET("/apps/:apps_id/volumes/:volume_id", httphelper.WrapHandler(api.appLookup(api.GetVolume)))
+	httpRouter.PUT("/apps/:apps_id/volumes/:volume_id/decommission", httphelper.WrapHandler(api.appLookup(api.DecommissionVolume)))
+
 	httpRouter.POST("/sinks", httphelper.WrapHandler(api.CreateSink))
 	httpRouter.GET("/sinks", httphelper.WrapHandler(api.GetSinks))
 	httpRouter.GET("/sinks/:sink_id", httphelper.WrapHandler(api.GetSink))
@@ -367,6 +375,7 @@ type controllerAPI struct {
 	eventRepo           *EventRepo
 	backupRepo          *BackupRepo
 	sinkRepo            *SinkRepo
+	volumeRepo          *VolumeRepo
 	clusterClient       utils.ClusterClient
 	logaggc             logClient
 	routerc             routerc.Client

--- a/controller/scheduler/volume.go
+++ b/controller/scheduler/volume.go
@@ -1,30 +1,70 @@
 package main
 
-import "github.com/flynn/flynn/host/volume"
+import (
+	"sync"
+
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/volume"
+)
 
 type Volume struct {
-	*volume.Info
+	ct.Volume
 
-	AppID     string
-	ReleaseID string
-	JobType   string
-	Path      string
-	HostID    string
-	JobID     string
+	// stateMtx protects the State field from concurrent access by both
+	// the main scheduler loop and the StartJob goroutine which is
+	// potentially creating the volume on the host
+	stateMtx sync.RWMutex
 }
 
-func NewVolume(info *volume.Info, hostID string) *Volume {
+func (v *Volume) GetState() ct.VolumeState {
+	v.stateMtx.RLock()
+	defer v.stateMtx.RUnlock()
+	return v.State
+}
+
+func (v *Volume) SetState(state ct.VolumeState) {
+	v.stateMtx.Lock()
+	defer v.stateMtx.Unlock()
+	v.State = state
+}
+
+func (v *Volume) Info() *volume.Info {
+	return &volume.Info{
+		ID:   v.ID,
+		Type: v.Type,
+		Meta: v.Meta,
+	}
+}
+
+func NewVolume(info *volume.Info, state ct.VolumeState, hostID string) *Volume {
 	return &Volume{
-		Info:      info,
-		AppID:     info.Meta["flynn-controller.app"],
-		ReleaseID: info.Meta["flynn-controller.release"],
-		JobType:   info.Meta["flynn-controller.type"],
-		Path:      info.Meta["flynn-controller.path"],
-		HostID:    hostID,
+		Volume: ct.Volume{
+			VolumeReq: ct.VolumeReq{
+				Path:         info.Meta["flynn-controller.path"],
+				DeleteOnStop: info.Meta["flynn-controller.delete_on_stop"] == "true",
+			},
+			ID:        info.ID,
+			HostID:    hostID,
+			Type:      info.Type,
+			State:     state,
+			AppID:     info.Meta["flynn-controller.app"],
+			ReleaseID: info.Meta["flynn-controller.release"],
+			JobType:   info.Meta["flynn-controller.type"],
+			Meta:      info.Meta,
+			CreatedAt: &info.CreatedAt,
+		},
 	}
 }
 
 type VolumeEvent struct {
-	Type   volume.EventType
+	Type   VolumeEventType
 	Volume *Volume
 }
+
+type VolumeEventType string
+
+const (
+	VolumeEventTypeCreate     VolumeEventType = "create"
+	VolumeEventTypeDestroy    VolumeEventType = "destroy"
+	VolumeEventTypeController VolumeEventType = "controller"
+)

--- a/controller/scheduler/volume.go
+++ b/controller/scheduler/volume.go
@@ -1,0 +1,30 @@
+package main
+
+import "github.com/flynn/flynn/host/volume"
+
+type Volume struct {
+	*volume.Info
+
+	AppID     string
+	ReleaseID string
+	JobType   string
+	Path      string
+	HostID    string
+	JobID     string
+}
+
+func NewVolume(info *volume.Info, hostID string) *Volume {
+	return &Volume{
+		Info:      info,
+		AppID:     info.Meta["flynn-controller.app"],
+		ReleaseID: info.Meta["flynn-controller.release"],
+		JobType:   info.Meta["flynn-controller.type"],
+		Path:      info.Meta["flynn-controller.path"],
+		HostID:    hostID,
+	}
+}
+
+type VolumeEvent struct {
+	Type   volume.EventType
+	Volume *Volume
+}

--- a/controller/testutils/fake_controller_client.go
+++ b/controller/testutils/fake_controller_client.go
@@ -271,6 +271,19 @@ func (c *FakeControllerClient) StreamSinks(*time.Time, chan *ct.Sink) (stream.St
 	return nil, nil
 }
 
+func (c *FakeControllerClient) VolumeList() ([]*ct.Volume, error) {
+	return nil, nil
+}
+
+func (c *FakeControllerClient) PutVolume(*ct.Volume) error {
+	return nil
+}
+
+func (c *FakeControllerClient) StreamVolumes(since *time.Time, ch chan *ct.Volume) (stream.Stream, error) {
+	ch <- &ct.Volume{}
+	return nil, nil
+}
+
 func NewRelease(id string, artifact *ct.Artifact, processes map[string]int) *ct.Release {
 	return NewReleaseOmni(id, artifact, processes, false)
 }

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -217,6 +217,14 @@ func (c *FakeHostClient) StreamEvents(id string, ch chan *host.Event) (stream.St
 	return &HostStream{host: c, ch: ch}, nil
 }
 
+func (c *FakeHostClient) ListVolumes() ([]*volume.Info, error) {
+	return nil, nil
+}
+
+func (c *FakeHostClient) StreamVolumes(ch chan *volume.Event) (stream.Stream, error) {
+	return stream.New(), nil
+}
+
 func (c *FakeHostClient) GetStatus() (*host.HostStatus, error) {
 	if !c.Healthy {
 		return nil, errors.New("unhealthy")

--- a/controller/testutils/fake_host_client.go
+++ b/controller/testutils/fake_host_client.go
@@ -190,11 +190,10 @@ func (c *FakeHostClient) SetAttachFunc(id string, f attachFunc) {
 	c.attach[id] = f
 }
 
-func (c *FakeHostClient) CreateVolume(providerID string) (*volume.Info, error) {
-	id := random.UUID()
-	volume := &volume.Info{ID: id}
-	c.volumes[id] = volume
-	return volume, nil
+func (c *FakeHostClient) CreateVolume(providerID string, info *volume.Info) error {
+	info.ID = random.UUID()
+	c.volumes[info.ID] = info
+	return nil
 }
 
 func (c *FakeHostClient) StreamEvents(id string, ch chan *host.Event) (stream.Stream, error) {

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -256,6 +256,7 @@ type JobState string
 
 const (
 	JobStatePending  JobState = "pending"
+	JobStateBlocked  JobState = "blocked"
 	JobStateStarting JobState = "starting"
 	JobStateUp       JobState = "up"
 	JobStateStopping JobState = "stopping"

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -258,6 +258,8 @@ type HostClient interface {
 	ListJobs() (map[string]host.ActiveJob, error)
 	ListActiveJobs() (map[string]host.ActiveJob, error)
 	StreamEvents(id string, ch chan *host.Event) (stream.Stream, error)
+	ListVolumes() ([]*volume.Info, error)
+	StreamVolumes(ch chan *volume.Event) (stream.Stream, error)
 	GetStatus() (*host.HostStatus, error)
 	GetSinks() ([]*ct.Sink, error)
 	AddSink(*ct.Sink) error

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -171,12 +171,12 @@ func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) (*volume
 	if err != nil {
 		return nil, err
 	}
-	job.Config.Volumes = []host.VolumeBinding{{
+	job.Config.Volumes = append(job.Config.Volumes, host.VolumeBinding{
 		Target:       req.Path,
 		VolumeID:     vol.ID,
 		Writeable:    true,
 		DeleteOnStop: req.DeleteOnStop,
-	}}
+	})
 	return vol, nil
 }
 

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -161,7 +162,15 @@ var provisionVolumeAttempts = attempt.Strategy{
 }
 
 func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) (*volume.Info, error) {
-	vol := &volume.Info{}
+	vol := &volume.Info{
+		Meta: map[string]string{
+			"flynn-controller.app":            job.Metadata["flynn-controller.app"],
+			"flynn-controller.release":        job.Metadata["flynn-controller.release"],
+			"flynn-controller.type":           job.Metadata["flynn-controller.type"],
+			"flynn-controller.path":           req.Path,
+			"flynn-controller.delete_on_stop": strconv.FormatBool(req.DeleteOnStop),
+		},
+	}
 	// this potentially leaks volumes on the host, but we'll leave it up
 	// to the volume garbage collector to clean up
 	err := provisionVolumeAttempts.Run(func() error {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -161,12 +161,11 @@ var provisionVolumeAttempts = attempt.Strategy{
 }
 
 func ProvisionVolume(req *ct.VolumeReq, h VolumeCreator, job *host.Job) (*volume.Info, error) {
-	var vol *volume.Info
+	vol := &volume.Info{}
 	// this potentially leaks volumes on the host, but we'll leave it up
 	// to the volume garbage collector to clean up
-	err := provisionVolumeAttempts.Run(func() (err error) {
-		vol, err = h.CreateVolume("default")
-		return
+	err := provisionVolumeAttempts.Run(func() error {
+		return h.CreateVolume("default", vol)
 	})
 	if err != nil {
 		return nil, err
@@ -243,7 +242,7 @@ func ExpandFormation(c ControllerClient, f *ct.Formation) (*ct.ExpandedFormation
 }
 
 type VolumeCreator interface {
-	CreateVolume(string) (*volume.Info, error)
+	CreateVolume(string, *volume.Info) error
 }
 
 type HostClient interface {

--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -288,6 +288,9 @@ type ControllerClient interface {
 	JobListActive() ([]*ct.Job, error)
 	StreamSinks(since *time.Time, ch chan *ct.Sink) (stream.Stream, error)
 	ListSinks() ([]*ct.Sink, error)
+	VolumeList() ([]*ct.Volume, error)
+	PutVolume(*ct.Volume) error
+	StreamVolumes(since *time.Time, ch chan *ct.Volume) (stream.Stream, error)
 }
 
 func ClusterClientWrapper(c *cluster.Client) clusterClientWrapper {

--- a/controller/volume.go
+++ b/controller/volume.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/flynn/flynn/controller/schema"
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/pkg/ctxhelper"
+	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/pkg/postgres"
+	"github.com/flynn/flynn/pkg/sse"
+	"github.com/jackc/pgx"
+	"golang.org/x/net/context"
+)
+
+type VolumeRepo struct {
+	db *postgres.DB
+}
+
+func NewVolumeRepo(db *postgres.DB) *VolumeRepo {
+	return &VolumeRepo{db}
+}
+
+func (r *VolumeRepo) Get(appID, volID string) (*ct.Volume, error) {
+	row := r.db.QueryRow("volume_select", appID, volID)
+	return scanVolume(row)
+}
+
+func (r *VolumeRepo) Add(vol *ct.Volume) error {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	err = tx.QueryRow("volume_insert",
+		vol.ID,
+		vol.HostID,
+		string(vol.Type),
+		string(vol.State),
+		vol.AppID,
+		vol.ReleaseID,
+		vol.JobID,
+		vol.JobType,
+		vol.Path,
+		vol.DeleteOnStop,
+		vol.Meta,
+	).Scan(&vol.CreatedAt, &vol.UpdatedAt)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	if err := createEvent(tx.Exec, &ct.Event{
+		AppID:      vol.AppID,
+		ObjectID:   vol.ID,
+		ObjectType: ct.EventTypeVolume,
+	}, vol); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func scanVolume(s postgres.Scanner) (*ct.Volume, error) {
+	vol := &ct.Volume{}
+	var typ, state string
+	err := s.Scan(
+		&vol.ID,
+		&vol.HostID,
+		&typ,
+		&state,
+		&vol.AppID,
+		&vol.ReleaseID,
+		&vol.JobID,
+		&vol.JobType,
+		&vol.Path,
+		&vol.DeleteOnStop,
+		&vol.Meta,
+		&vol.CreatedAt,
+		&vol.UpdatedAt,
+		&vol.DecommissionedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			err = ErrNotFound
+		}
+		return nil, err
+	}
+	vol.Type = volume.VolumeType(typ)
+	vol.State = ct.VolumeState(state)
+	return vol, nil
+}
+
+func (r *VolumeRepo) List() ([]*ct.Volume, error) {
+	rows, err := r.db.Query("volume_list")
+	if err != nil {
+		return nil, err
+	}
+	return scanVolumes(rows)
+}
+
+func (r *VolumeRepo) AppList(appID string) ([]*ct.Volume, error) {
+	rows, err := r.db.Query("volume_app_list", appID)
+	if err != nil {
+		return nil, err
+	}
+	return scanVolumes(rows)
+}
+
+func (r *VolumeRepo) ListSince(since time.Time) ([]*ct.Volume, error) {
+	rows, err := r.db.Query("volume_list_since", since)
+	if err != nil {
+		return nil, err
+	}
+	return scanVolumes(rows)
+}
+
+func scanVolumes(rows *pgx.Rows) ([]*ct.Volume, error) {
+	var volumes []*ct.Volume
+	for rows.Next() {
+		volume, err := scanVolume(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		volumes = append(volumes, volume)
+	}
+	return volumes, rows.Err()
+}
+
+func (r *VolumeRepo) Decommission(appID string, vol *ct.Volume) error {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	err = tx.QueryRow("volume_decommission", appID, vol.ID).Scan(&vol.UpdatedAt, &vol.DecommissionedAt)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	if err := createEvent(tx.Exec, &ct.Event{
+		AppID:      appID,
+		ObjectID:   vol.ID,
+		ObjectType: ct.EventTypeVolume,
+	}, vol); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (c *controllerAPI) GetVolumes(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		c.streamVolumes(ctx, w, req)
+		return
+	}
+
+	list, err := c.volumeRepo.List()
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, list)
+}
+
+func (c *controllerAPI) GetAppVolumes(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	list, err := c.volumeRepo.AppList(c.getApp(ctx).ID)
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, list)
+}
+
+func (c *controllerAPI) GetVolume(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	params, _ := ctxhelper.ParamsFromContext(ctx)
+	volume, err := c.volumeRepo.Get(c.getApp(ctx).ID, params.ByName("volume_id"))
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, volume)
+}
+
+func (c *controllerAPI) PutVolume(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	var volume ct.Volume
+	if err := httphelper.DecodeJSON(req, &volume); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if err := schema.Validate(volume); err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	if err := c.volumeRepo.Add(&volume); err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, &volume)
+}
+
+func (c *controllerAPI) DecommissionVolume(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	var volume ct.Volume
+	if err := httphelper.DecodeJSON(req, &volume); err != nil {
+		respondWithError(w, err)
+		return
+	}
+	if err := c.volumeRepo.Decommission(c.getApp(ctx).ID, &volume); err != nil {
+		respondWithError(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, &volume)
+}
+
+func (c *controllerAPI) streamVolumes(ctx context.Context, w http.ResponseWriter, req *http.Request) (err error) {
+	l, _ := ctxhelper.LoggerFromContext(ctx)
+	ch := make(chan *ct.Volume)
+	stream := sse.NewStream(w, ch, l)
+	stream.Serve()
+	defer func() {
+		if err == nil {
+			stream.Close()
+		} else {
+			stream.CloseWithError(err)
+		}
+	}()
+
+	since, err := time.Parse(time.RFC3339Nano, req.FormValue("since"))
+	if err != nil {
+		return err
+	}
+
+	eventListener, err := c.maybeStartEventListener()
+	if err != nil {
+		l.Error("error starting event listener")
+		return err
+	}
+
+	sub, err := eventListener.Subscribe("", []string{string(ct.EventTypeVolume)}, "")
+	if err != nil {
+		return err
+	}
+	defer sub.Close()
+
+	vols, err := c.volumeRepo.ListSince(since)
+	if err != nil {
+		return err
+	}
+	currentUpdatedAt := since
+	for _, vol := range vols {
+		select {
+		case <-stream.Done:
+			return nil
+		case ch <- vol:
+			if vol.UpdatedAt.After(currentUpdatedAt) {
+				currentUpdatedAt = *vol.UpdatedAt
+			}
+		}
+	}
+
+	select {
+	case <-stream.Done:
+		return nil
+	case ch <- &ct.Volume{}:
+	}
+
+	for {
+		select {
+		case <-stream.Done:
+			return
+		case event, ok := <-sub.Events:
+			if !ok {
+				return sub.Err
+			}
+			var vol ct.Volume
+			if err := json.Unmarshal(event.Data, &vol); err != nil {
+				l.Error("error deserializing volume event", "event.id", event.ID, "err", err)
+				continue
+			}
+			if vol.UpdatedAt.Before(currentUpdatedAt) {
+				continue
+			}
+			select {
+			case <-stream.Done:
+				return nil
+			case ch <- &vol:
+			}
+		}
+	}
+}

--- a/host/cli/volume.go
+++ b/host/cli/volume.go
@@ -171,12 +171,12 @@ func runVolumeCreate(args *docopt.Args, client *cluster.Client) error {
 	if args.String["--provider"] != "" {
 		provider = args.String["--provider"]
 	}
-	v, err := hostClient.CreateVolume(provider)
-	if err != nil {
+	vol := &volume.Info{}
+	if err := hostClient.CreateVolume(provider, vol); err != nil {
 		fmt.Printf("could not create volume: %s\n", err)
 		return err
 	}
-	fmt.Printf("created volume %s on %s\n", v.ID, hostId)
+	fmt.Printf("created volume %s on %s\n", vol.ID, hostId)
 	return nil
 }
 

--- a/host/fixer/fixer.go
+++ b/host/fixer/fixer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/go-docopt"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -181,8 +182,8 @@ func (f *ClusterFixer) StartAppJob(app, typ, service string) ([]*discoverd.Insta
 	for i, v := range job.Config.Volumes {
 		if v.DeleteOnStop {
 			f.l.Info(fmt.Sprintf("provisioning volume for %s %s job", app, typ), "job.id", job.ID, "release", job.Metadata["flynn-controller.release"])
-			vol, err := host.CreateVolume("default")
-			if err != nil {
+			vol := &volume.Info{}
+			if err := host.CreateVolume("default", vol); err != nil {
 				return nil, fmt.Errorf("error provisioning volume for %s %s job: %s", app, typ, err)
 			}
 			job.Config.Volumes[i].VolumeID = vol.ID

--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -16,7 +16,7 @@ import (
 type Provider interface {
 	Kind() string
 
-	NewVolume() (Volume, error)
+	NewVolume(info *Info) (Volume, error)
 	ImportFilesystem(*Filesystem) (Volume, error)
 	DestroyVolume(Volume) error
 	CreateSnapshot(Volume) (Volume, error)

--- a/host/volume/manager/persistence_test.go
+++ b/host/volume/manager/persistence_test.go
@@ -81,9 +81,9 @@ func (s *PersistenceTests) TestPersistence(c *C) {
 	c.Assert(vman.OpenDB(), IsNil)
 
 	// make two volumes
-	vol1, err := vman.NewVolume()
+	vol1, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
-	vol2, err := vman.NewVolume()
+	vol2, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// assert existence of filesystems; emplace some data
@@ -174,7 +174,7 @@ func (s *PersistenceTests) TestVolumeDeletion(c *C) {
 	c.Assert(vman.OpenDB(), IsNil)
 
 	// make a named volume
-	vol, err := vman.NewVolume()
+	vol, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// assert existence of filesystems; emplace some data
@@ -258,7 +258,7 @@ func (s *PersistenceTests) TestSnapshotPersistence(c *C) {
 	c.Assert(vman.OpenDB(), IsNil)
 
 	// make a volume
-	vol1, err := vman.NewVolume()
+	vol1, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// assert existence of filesystems; emplace some data
@@ -353,7 +353,7 @@ func (s *PersistenceTests) TestTransmittedSnapshotPersistence(c *C) {
 	c.Assert(vman.OpenDB(), IsNil)
 
 	// make a volume
-	vol1, err := vman.NewVolume()
+	vol1, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// assert existence of filesystems; emplace some data
@@ -363,7 +363,7 @@ func (s *PersistenceTests) TestTransmittedSnapshotPersistence(c *C) {
 
 	// make a snapshot, make a new volume to receive it, and do the transmit
 	snap, err := vman.CreateSnapshot(vol1.Info().ID)
-	vol2, err := vman.NewVolume()
+	vol2, err := vman.NewVolume(nil)
 	c.Assert(err, IsNil)
 	var buf bytes.Buffer
 	haves, err := vman.ListHaves(vol2.Info().ID)

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -59,6 +59,18 @@ var VolumeTypes = []VolumeType{
 	VolumeTypeExt2,
 }
 
+type Event struct {
+	Type   EventType `json:"type"`
+	Volume *Info     `json:"volume"`
+}
+
+type EventType string
+
+const (
+	EventTypeCreate  EventType = "create"
+	EventTypeDestroy EventType = "destroy"
+)
+
 type Filesystem struct {
 	ID         string            `json:"id"`
 	Data       io.Reader         `json:"-"`

--- a/host/volume/zfs/zfs.go
+++ b/host/volume/zfs/zfs.go
@@ -171,13 +171,15 @@ func (p *Provider) Kind() string {
 	return "zfs"
 }
 
-func (p *Provider) NewVolume() (volume.Volume, error) {
-	id := random.UUID()
-	info := &volume.Info{
-		ID:        id,
-		Type:      volume.VolumeTypeData,
-		CreatedAt: time.Now(),
+func (p *Provider) NewVolume(info *volume.Info) (volume.Volume, error) {
+	if info == nil {
+		info = &volume.Info{}
 	}
+	if info.ID == "" {
+		info.ID = random.UUID()
+	}
+	info.Type = volume.VolumeTypeData
+	info.CreatedAt = time.Now()
 	v := &zfsVolume{
 		info:      info,
 		provider:  p,
@@ -190,7 +192,7 @@ func (p *Provider) NewVolume() (volume.Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	p.volumes[id] = v
+	p.volumes[info.ID] = v
 	return v, nil
 }
 

--- a/host/volume/zfs/zfs_snapshots_test.go
+++ b/host/volume/zfs/zfs_snapshots_test.go
@@ -22,7 +22,7 @@ func (ZfsSnapshotTests) SetUpSuite(c *C) {
 }
 
 func (s *ZfsSnapshotTests) TestSnapshotShouldCarryFiles(c *C) {
-	v, err := s.VolProv.NewVolume()
+	v, err := s.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
@@ -48,7 +48,7 @@ func (s *ZfsSnapshotTests) TestSnapshotShouldCarryFiles(c *C) {
 }
 
 func (s *ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToSource(c *C) {
-	v, err := s.VolProv.NewVolume()
+	v, err := s.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
@@ -76,7 +76,7 @@ func (s *ZfsSnapshotTests) TestSnapshotShouldIsolateNewChangesToSource(c *C) {
 }
 
 func (s *ZfsSnapshotTests) TestSnapshotShouldBeReadOnly(c *C) {
-	v, err := s.VolProv.NewVolume()
+	v, err := s.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:
@@ -101,7 +101,7 @@ func (s *ZfsSnapshotTests) TestSnapshotShouldBeReadOnly(c *C) {
 }
 
 func (s *ZfsSnapshotTests) TestForkedSnapshotShouldIsolateNewChangesToFork(c *C) {
-	v, err := s.VolProv.NewVolume()
+	v, err := s.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 
 	// a new volume should start out empty:

--- a/host/volume/zfs/zfs_transmit_test.go
+++ b/host/volume/zfs/zfs_transmit_test.go
@@ -41,7 +41,7 @@ func (s *ZfsTransmitTests) TearDownTest(c *C) {
 func (s *ZfsTransmitTests) TestZfsSendRecvFull(c *C) {
 	// create volume; add content; snapshot it.
 	// note that 'zfs send' refuses anything but snapshots.
-	v, err := s.pool1.VolProv.NewVolume()
+	v, err := s.pool1.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 	f, err := os.Create(filepath.Join(v.Location(), "alpha"))
 	c.Assert(err, IsNil)
@@ -53,7 +53,7 @@ func (s *ZfsTransmitTests) TestZfsSendRecvFull(c *C) {
 	s.pool1.VolProv.SendSnapshot(snap, nil, &buf)
 
 	// send stream to this pool; should get a new snapshot volume
-	v2, err := s.pool1.VolProv.NewVolume()
+	v2, err := s.pool1.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 	snapRestored, err := s.pool1.VolProv.ReceiveSnapshot(v2, bytes.NewBuffer(buf.Bytes()))
 	c.Assert(err, IsNil)
@@ -64,7 +64,7 @@ func (s *ZfsTransmitTests) TestZfsSendRecvFull(c *C) {
 	c.Assert(v2.Location(), testutils.DirContains, []string{"alpha"})
 
 	// send stream to another pool; should get a new volume
-	v2, err = s.pool2.VolProv.NewVolume()
+	v2, err = s.pool2.VolProv.NewVolume(nil)
 	snapRestored, err = s.pool2.VolProv.ReceiveSnapshot(v2, bytes.NewBuffer(buf.Bytes()))
 	c.Assert(err, IsNil)
 	c.Assert(snapRestored.IsSnapshot(), Equals, true)
@@ -79,7 +79,7 @@ func (s *ZfsTransmitTests) TestZfsSendRecvFull(c *C) {
 */
 func (s *ZfsTransmitTests) TestZfsSendRecvIncremental(c *C) {
 	// create volume; add content; snapshot it.
-	v, err := s.pool1.VolProv.NewVolume()
+	v, err := s.pool1.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 	f, err := os.Create(filepath.Join(v.Location(), "alpha"))
 	c.Assert(err, IsNil)
@@ -92,7 +92,7 @@ func (s *ZfsTransmitTests) TestZfsSendRecvIncremental(c *C) {
 	fmt.Printf("note: size of snapshot stream is %d bytes\n", buf.Len()) // 41680
 
 	// send stream to another pool; should get a new snapshot volume
-	v2, err := s.pool2.VolProv.NewVolume()
+	v2, err := s.pool2.VolProv.NewVolume(nil)
 	c.Assert(err, IsNil)
 	snapRestored1, err := s.pool2.VolProv.ReceiveSnapshot(v2, bytes.NewBuffer(buf.Bytes()))
 	c.Assert(err, IsNil)

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -140,12 +140,10 @@ func (c *Host) StreamEvents(id string, ch chan *host.Event) (stream.Stream, erro
 	return c.c.ResumingStream("GET", r, ch)
 }
 
-// CreateVolume a new volume, returning its ID.
+// CreateVolume a new volume with the given configuration.
 // When in doubt, use a providerId of "default".
-func (c *Host) CreateVolume(providerId string) (*volume.Info, error) {
-	var res volume.Info
-	err := c.c.Post(fmt.Sprintf("/storage/providers/%s/volumes", providerId), nil, &res)
-	return &res, err
+func (c *Host) CreateVolume(providerId string, info *volume.Info) error {
+	return c.c.Post(fmt.Sprintf("/storage/providers/%s/volumes", providerId), info, info)
 }
 
 // GetVolume gets a volume by ID

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -160,6 +160,11 @@ func (c *Host) ListVolumes() ([]*volume.Info, error) {
 	return volumes, c.c.Get("/storage/volumes", &volumes)
 }
 
+// StreamVolumes streams volume events to the given channel
+func (c *Host) StreamVolumes(ch chan *volume.Event) (stream.Stream, error) {
+	return c.c.ResumingStream("GET", "/storage/volumes", ch)
+}
+
 // DestroyVolume deletes a volume by ID
 func (c *Host) DestroyVolume(volumeID string) error {
 	return c.c.Delete(fmt.Sprintf("/storage/volumes/%s", volumeID))

--- a/schema/controller/event.json
+++ b/schema/controller/event.json
@@ -36,7 +36,8 @@
         "sink",
         "sink_deletion",
         "scale",
-        "scale_request"
+        "scale_request",
+        "volume"
       ]
     }
   },

--- a/schema/controller/job.json
+++ b/schema/controller/job.json
@@ -44,6 +44,12 @@
     "args": {
       "$ref": "/schema/controller/common#/definitions/args"
     },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "$ref": "/schema/controller/common#/definitions/id"
+      }
+    },
     "meta": {
       "$ref": "/schema/controller/common#/definitions/meta"
     },

--- a/schema/controller/volume.json
+++ b/schema/controller/volume.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://flynn.io/schema/controller/volume#",
+  "title": "Volume",
+  "description": "A volume is a durable filesystem that can be attached to jobs.",
+  "sortIndex": 20,
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "host_id": {
+      "type": "string",
+      "description": "the ID of the host the volume is running on"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["data", "squashfs", "ext2"]
+    },
+    "state": {
+      "type": "string",
+      "enum": ["pending", "created", "destroyed"]
+    },
+    "app": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "release": {
+      "$ref": "/schema/controller/common#/definitions/id"
+    },
+    "job": {
+      "type": "string",
+      "description": "ID of the job the volume is currently attached to"
+    },
+    "job_type": {
+      "type": "string",
+      "description": "job process type"
+    },
+    "path": {
+      "type": "string",
+      "description": "mount path"
+    },
+    "delete_on_stop": {
+      "type": "boolean",
+      "description": "delete the volume when the job stops"
+    },
+    "meta": {
+      "$ref": "/schema/controller/common#/definitions/meta"
+    },
+    "created_at": {
+      "$ref": "/schema/controller/common#/definitions/created_at"
+    },
+    "updated_at": {
+      "$ref": "/schema/controller/common#/definitions/updated_at"
+    },
+    "decommissioned_at": {
+      "description": "volume decommission time",
+      "format": "date-time",
+      "type": "string"
+    }
+  }
+}

--- a/schema/controller/volume_req.json
+++ b/schema/controller/volume_req.json
@@ -10,6 +10,10 @@
   "properties": {
     "path": {
       "type": "string"
+    },
+    "delete_on_stop": {
+      "type": "boolean",
+      "description": "delete the volume when the job stops"
     }
   }
 }

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flynn/flynn/controller/utils"
 	"github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	logaggc "github.com/flynn/flynn/logaggregator/client"
 	logagg "github.com/flynn/flynn/logaggregator/types"
 	"github.com/flynn/flynn/pkg/attempt"
@@ -289,8 +290,8 @@ func (s *HostSuite) TestNetworkedPersistentJob(t *c.C) {
 func (s *HostSuite) TestVolumeCreation(t *c.C) {
 	h := s.anyHostClient(t)
 
-	vol, err := h.CreateVolume("default")
-	t.Assert(err, c.IsNil)
+	vol := &volume.Info{}
+	t.Assert(h.CreateVolume("default", vol), c.IsNil)
 	t.Assert(vol.ID, c.Not(c.Equals), "")
 	t.Assert(h.DestroyVolume(vol.ID), c.IsNil)
 }
@@ -298,8 +299,7 @@ func (s *HostSuite) TestVolumeCreation(t *c.C) {
 func (s *HostSuite) TestVolumeCreationFailsForNonexistentProvider(t *c.C) {
 	h := s.anyHostClient(t)
 
-	_, err := h.CreateVolume("non-existent")
-	t.Assert(err, c.NotNil)
+	t.Assert(h.CreateVolume("non-existent", &volume.Info{}), c.NotNil)
 }
 
 func (s *HostSuite) TestVolumePersistence(t *c.C) {
@@ -309,8 +309,8 @@ func (s *HostSuite) TestVolumePersistence(t *c.C) {
 	h := s.anyHostClient(t)
 
 	// create a volume!
-	vol, err := h.CreateVolume("default")
-	t.Assert(err, c.IsNil)
+	vol := &volume.Info{}
+	t.Assert(h.CreateVolume("default", vol), c.IsNil)
 	defer func() {
 		t.Assert(h.DestroyVolume(vol.ID), c.IsNil)
 	}()

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -331,6 +331,7 @@ func (s *HostSuite) TestVolumePersistence(t *c.C) {
 	t.Assert(resp, c.Equals, "0\n")
 
 	// start another one that mounts the same volume
+	ish.Cleanup()
 	ish, err = s.makeIshApp(t, &IshApp{host: h, extraConfig: host.ContainerConfig{
 		Volumes: []host.VolumeBinding{{
 			Target:    "/vol",

--- a/test/test_volume.go
+++ b/test/test_volume.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/flynn/flynn/host/types"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/cluster"
 	c "github.com/flynn/go-check"
 )
@@ -37,8 +38,8 @@ func (s *VolumeSuite) TestInterhostVolumeTransmitAPI(t *c.C) {
 
 func (s *VolumeSuite) doVolumeTransmitAPI(t *c.C, x *Cluster, h0, h1 *cluster.Host) {
 	// create a volume!
-	vol, err := h0.CreateVolume("default")
-	t.Assert(err, c.IsNil)
+	vol := &volume.Info{}
+	t.Assert(h0.CreateVolume("default", vol), c.IsNil)
 	defer func() {
 		t.Assert(h0.DestroyVolume(vol.ID), c.IsNil)
 	}()
@@ -63,8 +64,8 @@ func (s *VolumeSuite) doVolumeTransmitAPI(t *c.C, x *Cluster, h0, h1 *cluster.Ho
 		t.Assert(h0.DestroyVolume(snapInfo.ID), c.IsNil)
 	}()
 	// make a volume on another host to yank the snapshot content into
-	vol2, err := h1.CreateVolume("default")
-	t.Assert(err, c.IsNil)
+	vol2 := &volume.Info{}
+	t.Assert(h1.CreateVolume("default", vol2), c.IsNil)
 	defer func() {
 		t.Assert(h1.DestroyVolume(vol2.ID), c.IsNil)
 	}()


### PR DESCRIPTION
This pull request is a continuation of the work already done on the [persistent-volumes branch](https://github.com/flynn/flynn/compare/persistent-volumes) to implement persistent volumes as per #2438.

Summary:

* the scheduler syncs volumes from all hosts and persists them to the `volumes` and `job_volumes` tables in the controller database
* when placing a job which requires volumes, the scheduler first tries to locate existing, unassigned volumes for the job's app / release / type and the volume's path, and if it finds one then places the job on the same host as the volume whilst also assigning the volume to the job (i.e. setting `Volume.JobID`)
* volumes can be "decommissioned" via `flynn volume decommission ID` which causes the volume to not be attached to any new jobs
* if a host which has unassigned volumes is down, jobs are still scheduled on that host but enter a new `blocked` state waiting for either the host to come back up or the volume to be decommissioned. This then means if a host is rebooted which has data for a process type, the job just stays down until the host comes back rather than being restarted on a different host with an empty volume, but if the host has really gone away then it is up to the operator to decommission the volume and unblock the job to be scheduled on a different host

Things which need to be considered but not included in this PR:

* volumes won't be persisted through deployments, but the design allows for that to be added later (see [this comment](https://github.com/flynn/flynn/issues/2438#issuecomment-274272589))
* we should add `flynn volume backup` and `flynn volume restore` so that if a host is lost and volumes need to be decommissioned in order to move jobs to other hosts, operators can first restore volumes so that the unblocked job doesn't have to start with a completely empty volume