### PR TITLE
test: Use a longer shutdown delay in host update tests

### DIFF
--- a/host/http.go
+++ b/host/http.go
@@ -535,11 +535,15 @@ func (h *jobAPI) Update(w http.ResponseWriter, req *http.Request, _ httprouter.P
 		return
 	}
 
-	// send an ok response and then shutdown after 1s to give the response
-	// chance to reach the client.
+	// send an ok response and then shutdown after a short delay to give
+	// the response chance to reach the client.
 	httphelper.JSON(w, http.StatusOK, cmd)
-	log.Info("shutting down in 1s")
-	time.AfterFunc(time.Second, func() {
+	delay := time.Second
+	if cmd.ShutdownDelay != nil {
+		delay = *cmd.ShutdownDelay
+	}
+	log.Info(fmt.Sprintf("shutting down in %s", delay))
+	time.AfterFunc(delay, func() {
 		log.Info("exiting")
 		os.Exit(0)
 	})

--- a/host/types/types.go
+++ b/host/types/types.go
@@ -330,9 +330,10 @@ type ResourceCheck struct {
 }
 
 type Command struct {
-	Path string   `json:"path"`
-	Args []string `json:"args"`
-	PID  int      `json:"pid"`
+	Path          string         `json:"path"`
+	Args          []string       `json:"args"`
+	PID           int            `json:"pid"`
+	ShutdownDelay *time.Duration `json:"shutdown_delay,omitempty"`
 }
 
 type LogBuffers map[string]LogBuffer

--- a/pkg/cluster/host.go
+++ b/pkg/cluster/host.go
@@ -225,7 +225,21 @@ func (c *Host) ResourceCheck(request host.ResourceCheck) error {
 }
 
 func (c *Host) Update(name string, args ...string) (pid int, err error) {
-	cmd := &host.Command{Path: name, Args: args}
+	return c.update(&host.Command{
+		Path: name,
+		Args: args,
+	})
+}
+
+func (c *Host) UpdateWithShutdownDelay(name string, delay time.Duration, args ...string) (pid int, err error) {
+	return c.update(&host.Command{
+		Path:          name,
+		Args:          args,
+		ShutdownDelay: &delay,
+	})
+}
+
+func (c *Host) update(cmd *host.Command) (pid int, err error) {
 	return cmd.PID, c.c.Post("/host/update", cmd, cmd)
 }
 

--- a/test/test_host_update.go
+++ b/test/test_host_update.go
@@ -51,7 +51,11 @@ func (s *HostUpdateSuite) TestUpdateLogs(t *c.C) {
 	// update flynn-host using the same flags
 	status, err := hosts[0].GetStatus()
 	t.Assert(err, c.IsNil)
-	_, err = hosts[0].Update("/usr/local/bin/flynn-host", append([]string{"daemon"}, status.Flags...)...)
+	_, err = hosts[0].UpdateWithShutdownDelay(
+		"/usr/local/bin/flynn-host",
+		10*time.Second,
+		append([]string{"daemon"}, status.Flags...)...,
+	)
 	t.Assert(err, c.IsNil)
 
 	// stream the log


### PR DESCRIPTION
When updating a host running in a nested cluster, the whole host dies when the original flynn-host daemon exits (because it is PID 1 in the container) so all jobs on that host also die, leading to test failures like "unexpected EOF".

The delay before exiting can now be specified by the client to give the tests more time to make assertions.