### PR TITLE
discoverd: Use a low HTTP client timeout

### DIFF
--- a/discoverd/client/client.go
+++ b/discoverd/client/client.go
@@ -68,6 +68,10 @@ func NewClientWithConfig(config Config) *Client {
 	}
 	client.hc = &http.Client{
 		CheckRedirect: checkRedirect,
+		// use a low timeout so the client doesn't hang if any of the
+		// discoverd servers become unreachable (requests will be
+		// retried on fallback servers if they timeout, see client.Do)
+		Timeout: heartbeatInterval,
 	}
 	for _, e := range config.Endpoints {
 		client.servers[e] = client.httpClient(e)


### PR DESCRIPTION
Not having a timeout meant that, after a successful dial to a discoverd server, subsequent HTTP requests could hang indefinitely, which is particular problematic for heartbeats as then the service will get marked as down even though the job is still running, so apps will become unavailable.

Reduces the need for #3792 and #3766 as services should not flap like they used to when the network becomes unreliable.

Fixes #3953
Fixes #3748
Fixes #3680
Fixes #3313