### PR TITLE
test: Add debug logging to TestUpdateLogs

### DIFF
--- a/test/test_host_update.go
+++ b/test/test_host_update.go
@@ -60,7 +60,7 @@ func (s *HostUpdateSuite) TestUpdateLogs(t *c.C) {
 	t.Assert(err, c.IsNil)
 	_, err = hostClient.UpdateWithShutdownDelay(
 		"/usr/local/bin/flynn-host",
-		10*time.Second,
+		30*time.Second,
 		append([]string{"daemon"}, status.Flags...)...,
 	)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
To help investigate why the test keeps failing in CI.