### PR TITLE
open up ports used for external access to resources

### DIFF
--- a/installer/cluster.go
+++ b/installer/cluster.go
@@ -907,6 +907,7 @@ iptables -A INPUT -i eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i eth0 -p tcp --dport 80 -j ACCEPT
 iptables -A INPUT -i eth0 -p tcp --dport 443 -j ACCEPT
 iptables -A INPUT -i eth0 -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -i eth0 -p tcp -m multiport --dports 3000:3500 -j ACCEPT
 iptables -A INPUT -i eth0 -p icmp --icmp-type echo-request -j ACCEPT
 iptables -A INPUT -i eth0 -j DROP
 netfilter-persistent save


### PR DESCRIPTION
Brand new installs from the installer (at least on Digital Ocean) produce IP firewalls which do not allow external access to internal resources. ie generating external routes for db access wont work. Here is the rule change you need to open port range 3000-3500.