### PR TITLE
host: Updated usage to show 'volume' command

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -111,6 +111,7 @@ Commands:
   demote                     Demotes a Flynn node, removing it from the consensus cluster
   log-sink                   Manage host log sinks
   cli-add-command            Get the 'flynn cluster add' command to manage this cluster
+  volume                     Manage volumes on the Flynn node
 
 See 'flynn-host help <command>' for more information on a specific command.
 `


### PR DESCRIPTION
Just a small update to the help text to include the 'volume' option to flynn-host