### PR TITLE
pkg/syslog: Truncate fractional seconds to comply with RFC

### DIFF
--- a/logaggregator/api_test.go
+++ b/logaggregator/api_test.go
@@ -187,7 +187,7 @@ func (s *LogAggregatorTestSuite) TestAPIGetLogFollow(c *C) {
 }
 
 func (s *LogAggregatorTestSuite) TestNewMessageFromSyslog(c *C) {
-	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123450789Z")
+	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123456Z")
 	c.Assert(err, IsNil)
 	m := NewMessageFromSyslog(rfc5424.NewMessage(
 		&rfc5424.Header{
@@ -208,7 +208,7 @@ func (s *LogAggregatorTestSuite) TestNewMessageFromSyslog(c *C) {
 }
 
 func (s *LogAggregatorTestSuite) TestMessageMarshalJSON(c *C) {
-	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123450789Z")
+	timestamp, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00.123456Z")
 	c.Assert(err, IsNil)
 
 	m := client.Message{
@@ -220,7 +220,7 @@ func (s *LogAggregatorTestSuite) TestMessageMarshalJSON(c *C) {
 		Stream:      "stderr",
 		Timestamp:   timestamp,
 	}
-	expected := `{"host_id":"my.flynn.local","job_id":"deadbeef1234","msg":"a log message","process_type":"web","source":"app","stream":"stderr","timestamp":"2009-11-10T23:00:00.123450789Z"}`
+	expected := `{"host_id":"my.flynn.local","job_id":"deadbeef1234","msg":"a log message","process_type":"web","source":"app","stream":"stderr","timestamp":"2009-11-10T23:00:00.123456Z"}`
 
 	b, err := json.Marshal(m)
 	c.Assert(err, IsNil)

--- a/logaggregator/iterator_test.go
+++ b/logaggregator/iterator_test.go
@@ -259,7 +259,7 @@ func (s *LogAggregatorTestSuite) TestReadLastNAndSubscribe(c *C) {
 	}
 }
 
-var timeNow = time.Now()
+var timeNow = time.Now().UTC().Truncate(time.Millisecond)
 var msgIdx int
 
 func buildTestData(n int, hdr *rfc5424.Header) []*rfc5424.Message {

--- a/pkg/syslog/rfc5424/message.go
+++ b/pkg/syslog/rfc5424/message.go
@@ -71,6 +71,8 @@ type Header struct {
 	MsgID     []byte
 }
 
+const syslogTimestamp = "2006-01-02T15:04:05.999999Z07:00"
+
 func (h Header) Bytes() []byte {
 	hostname := h.Hostname
 	if len(hostname) == 0 {
@@ -96,7 +98,7 @@ func (h Header) Bytes() []byte {
 	fmt.Fprintf(buf, "<%d>%d %s %s %s %s %s",
 		h.PriVal(),
 		1,
-		h.Timestamp.Format(time.RFC3339Nano),
+		h.Timestamp.Format(syslogTimestamp),
 		hostname,
 		appName,
 		procID,

--- a/pkg/syslog/rfc5424/message_test.go
+++ b/pkg/syslog/rfc5424/message_test.go
@@ -17,8 +17,8 @@ type S struct {
 var _ = Suite(&S{})
 
 func (s *S) TestNewMessage(c *C) {
-	ts := time.Now().UTC()
-	tss := ts.Format(time.RFC3339Nano)
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	tss := ts.Format(syslogTimestamp)
 
 	table := []struct {
 		hdr Header

--- a/pkg/syslog/rfc5424/parser_test.go
+++ b/pkg/syslog/rfc5424/parser_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func (s *S) TestParse(c *C) {
-	ts := time.Now().UTC()
-	tss := ts.Format(time.RFC3339Nano)
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	tss := ts.Format(syslogTimestamp)
 
 	table := []struct {
 		msg  string


### PR DESCRIPTION
The `TIME-SECFRAC` production in RFC 5424 only allows six digits, this patch ensures that we comply with that.