### PR TITLE
sirenia: Clone volumes to new release on deploy

### DIFF
--- a/appliance/mongodb/cmd/flynn-mongodb/main.go
+++ b/appliance/mongodb/cmd/flynn-mongodb/main.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/flynn/flynn/appliance/mongodb"
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/volume"
+	"github.com/flynn/flynn/pkg/cluster"
 	"github.com/flynn/flynn/pkg/httphelper"
-	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/pkg/shutdown"
 	sd "github.com/flynn/flynn/pkg/sirenia/discoverd"
 	"github.com/flynn/flynn/pkg/sirenia/state"
@@ -37,17 +38,15 @@ func main() {
 	serverId := ipToId(net.ParseIP(ip))
 
 	const dataDir = "/data"
-	idFile := filepath.Join(dataDir, "instance_id")
-	idBytes, err := ioutil.ReadFile(idFile)
-	if err != nil && !os.IsNotExist(err) {
-		shutdown.Fatalf("error reading instance ID: %s", err)
+	volID := os.Getenv("VOLUME_0")
+	if volID == "" {
+		shutdown.Fatalf("error getting primary volume ID, VOLUME_0 not set")
 	}
-	id := string(idBytes)
-	if len(id) == 0 {
-		id = random.UUID()
-		if err := ioutil.WriteFile(idFile, []byte(id), 0644); err != nil {
-			shutdown.Fatalf("error writing instance ID: %s", err)
-		}
+
+	hostID, _ := cluster.ExtractHostID(os.Getenv("FLYNN_JOB_ID"))
+	host, err := cluster.NewClient().Host(hostID)
+	if err != nil {
+		shutdown.Fatal(err)
 	}
 
 	keyFile := filepath.Join(dataDir, "Keyfile")
@@ -63,7 +62,7 @@ func main() {
 	}
 	inst := &discoverd.Instance{
 		Addr: ":" + mongodb.DefaultPort,
-		Meta: map[string]string{mongoIdKey: id},
+		Meta: map[string]string{mongoIdKey: volID},
 	}
 	hb, err := discoverd.DefaultClient.RegisterInstance(serviceName, inst)
 	if err != nil {
@@ -74,6 +73,7 @@ func main() {
 	log := log15.New("app", "mongodb")
 
 	process := mongodb.NewProcess()
+	process.ID = volID
 	process.Password = password
 	process.Singleton = singleton
 	process.ServerID = serverId
@@ -81,7 +81,7 @@ func main() {
 
 	dd := sd.NewDiscoverd(discoverd.DefaultClient.Service(serviceName), log.New("component", "discoverd"))
 
-	peer := state.NewPeer(inst, id, mongoIdKey, singleton, dd, process, log.New("component", "peer"))
+	peer := state.NewPeer(inst, volID, mongoIdKey, singleton, dd, process, log.New("component", "peer"))
 	shutdown.BeforeExit(func() { peer.Close() })
 
 	go peer.Run()
@@ -91,6 +91,7 @@ func main() {
 	handler.Peer = peer
 	handler.Heartbeater = hb
 	handler.Logger = log.New("component", "http")
+	handler.Snapshot = func() (*volume.Info, error) { return host.CreateSnapshot(volID) }
 
 	shutdown.Fatal(http.ListenAndServe(":"+httpPort, handler))
 }

--- a/appliance/mongodb/handler.go
+++ b/appliance/mongodb/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/flynn/flynn/discoverd/client"
+	"github.com/flynn/flynn/host/volume"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sirenia/client"
 	"github.com/flynn/flynn/pkg/sirenia/state"
@@ -20,6 +21,7 @@ type Handler struct {
 	Peer        *state.Peer
 	Heartbeater discoverd.Heartbeater
 	Logger      log15.Logger
+	Snapshot    func() (*volume.Info, error)
 }
 
 // NewHandler returns a new instance of Handler.
@@ -31,6 +33,7 @@ func NewHandler() *Handler {
 	h.router.Handler("GET", status.Path, status.Handler(h.healthStatus))
 	h.router.GET("/status", h.handleGetStatus)
 	h.router.POST("/stop", h.handlePostStop)
+	h.router.POST("/snapshot", h.handleSnapshot)
 	return h
 }
 
@@ -91,4 +94,25 @@ func (h *Handler) handlePostStop(w http.ResponseWriter, req *http.Request, _ htt
 		return
 	}
 	w.WriteHeader(200)
+}
+
+func (h *Handler) handleSnapshot(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	if h.Snapshot == nil {
+		httphelper.ServiceUnavailableError(w, "snapshot unavailable")
+		return
+	}
+	snap, err := h.Snapshot()
+	if err != nil {
+		httphelper.Error(w, err)
+		return
+	}
+	xlog, err := h.Process.XLogPosition()
+	if err != nil {
+		httphelper.Error(w, err)
+		return
+	}
+	httphelper.JSON(w, 200, &client.SnapshotResponse{
+		Snap: snap,
+		XLog: xlog,
+	})
 }

--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -567,6 +567,9 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 	if job.Config.Env == nil {
 		job.Config.Env = make(map[string]string)
 	}
+	for i, v := range job.Config.Volumes {
+		job.Config.Env[fmt.Sprintf("VOLUME_%d", i)] = v.VolumeID
+	}
 	for i, p := range job.Config.Ports {
 		if p.Proto != "tcp" && p.Proto != "udp" {
 			err := fmt.Errorf("unknown port proto %q", p.Proto)

--- a/host/volume/backend.go
+++ b/host/volume/backend.go
@@ -20,7 +20,7 @@ type Provider interface {
 	ImportFilesystem(*Filesystem) (Volume, error)
 	DestroyVolume(Volume) error
 	CreateSnapshot(Volume) (Volume, error)
-	ForkVolume(Volume) (Volume, error)
+	ForkVolume(Volume, *Info) (Volume, error)
 
 	ListHaves(Volume) ([]json.RawMessage, error) // Report known data addresses; this can be given to `SendSnapshot` to attempt deduplicated/incrememntal transport.
 	SendSnapshot(vol Volume, haves []json.RawMessage, stream io.Writer) error

--- a/host/volume/volume.go
+++ b/host/volume/volume.go
@@ -6,7 +6,11 @@ import (
 	"time"
 )
 
-var ErrNoSuchVolume = errors.New("no such volume")
+var (
+	ErrNoSuchVolume   = errors.New("no such volume")
+	ErrNoSuchSnapshot = errors.New("no such snapshot")
+	ErrNotASnapshot   = errors.New("not a snapshot")
+)
 
 /*
 	A Volume is a persistent and sharable filesystem.  Unlike most of the filesystem in a job's
@@ -39,10 +43,11 @@ type Volume interface {
 	It is a serializable structure intended for API use.
 */
 type Info struct {
-	ID        string            `json:"id"`
-	Type      VolumeType        `json:"type"`
-	Meta      map[string]string `json:"meta,omitempty"`
-	CreatedAt time.Time         `json:"created_at"`
+	ID         string            `json:"id"`
+	Type       VolumeType        `json:"type"`
+	SnapshotID string            `json:"snapshot_id,omitempty"`
+	Meta       map[string]string `json:"meta,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
 }
 
 type VolumeType string

--- a/host/volume/zfs/zfs_snapshots_test.go
+++ b/host/volume/zfs/zfs_snapshots_test.go
@@ -116,7 +116,7 @@ func (s *ZfsSnapshotTests) TestForkedSnapshotShouldIsolateNewChangesToFork(c *C)
 
 	snap, err := s.VolProv.CreateSnapshot(v)
 	c.Assert(err, IsNil)
-	v2, err := s.VolProv.ForkVolume(snap)
+	v2, err := s.VolProv.ForkVolume(snap, nil)
 	c.Assert(err, IsNil)
 
 	// write another file to the fork

--- a/test/sirenia.go
+++ b/test/sirenia.go
@@ -205,6 +205,13 @@ func testSireniaDeploy(client controller.Client, disc *discoverd.Client, t *c.C,
 	// check currently writeable
 	d.db.assertWriteable(t, release, d)
 
+	// wait for the async to have some data to test volume snapshotting
+	debug(t, "waiting for async to have some data")
+	sireniaClient = sc.NewClient(sireniaState.Async[0].Addr)
+	t.Assert(sireniaClient.WaitForStatus(func(status *sc.Status) bool {
+		return status.Database.XLog != ""
+	}, time.Minute), c.IsNil)
+
 	// check a deploy completes with expected cluster state changes
 	release.ID = ""
 	t.Assert(client.CreateRelease(app.ID, release), c.IsNil)


### PR DESCRIPTION
This is a proposal for improving sirenia deployments by creating snapshots of existing volumes and cloning them to the new release during a deployment.

The deployer makes a snapshot request to the process about to be replaced (giving it chance to do tasks pre / post snapshot), and then creates a new volume from that snapshot on the same host, tagging it with the new release so that the scheduler will use it when starting the replacement process. 

Volume IDs are now used as the sirenia process IDs, so during a deployment the new nodes come up with new IDs (as they have distinct, cloned volumes), although the cluster fixer will end up creating nodes with existing IDs (as the volume ID will be the same).

TODO:

- [x] decide whether each appliance needs pre / post snapshot tasks
- [x] check using the volume ID as the process ID works in all cases
- [ ] convince ourselves that this is reliable (either with an integration test or manually testing with real data)