### PR TITLE
cli: Don't scale down app before deleting it

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -124,11 +124,6 @@ func runDelete(args *docopt.Args, client controller.Client) error {
 		}
 	}
 
-	// scale formation down to 0
-	if err := scaleToZero(appName, client); err != nil {
-		return err
-	}
-
 	res, err := client.DeleteApp(appName)
 	if err != nil {
 		return err
@@ -194,18 +189,4 @@ func runInfo(_ *docopt.Args, client controller.Client) error {
 	}
 
 	return nil
-}
-
-func scaleToZero(appName string, client controller.Client) error {
-	release, err := client.GetAppRelease(appName)
-	if err == controller.ErrNotFound {
-		return nil
-	} else if err != nil {
-		return err
-	}
-	opts := ct.ScaleOptions{Processes: make(map[string]int, len(release.Processes))}
-	for typ := range release.Processes {
-		opts.Processes[typ] = 0
-	}
-	return client.ScaleAppRelease(appName, release.ID, opts)
 }


### PR DESCRIPTION
The app deletion will lead to associated releases being deleted, which will subsequently scale the formations down, so there is no need to do it explicitly in the CLI.

Fixes #3991.