### PR TITLE
scheduler: Prevent race persisting volumes

### DIFF
--- a/controller/scheduler/volume.go
+++ b/controller/scheduler/volume.go
@@ -36,6 +36,13 @@ func (v *Volume) Info() *volume.Info {
 	}
 }
 
+func (v *Volume) ControllerVolume() *ct.Volume {
+	v.stateMtx.Lock()
+	defer v.stateMtx.Unlock()
+	vol := v.Volume
+	return &vol
+}
+
 func NewVolume(info *volume.Info, state ct.VolumeState, hostID string) *Volume {
 	return &Volume{
 		Volume: ct.Volume{


### PR DESCRIPTION
This avoids a race where two goroutines can persist a volume and try to decode the response into the volume struct concurrently.

Observed in a CI build where the scheduler crashed with `fatal error: concurrent map writes`.