### PR TITLE
docker-receive: Fix deleting image layers

### DIFF
--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -665,6 +665,7 @@ type ImageLayer struct {
 	Type   ImageLayerType    `json:"type,omitempty"`
 	Length int64             `json:"length,omitempty"`
 	Hashes map[string]string `json:"hashes,omitempty"`
+	Meta   map[string]string `json:"meta,omitempty"`
 }
 
 type ImagePullInfo struct {

--- a/controller/worker/release_cleanup/handler.go
+++ b/controller/worker/release_cleanup/handler.go
@@ -63,7 +63,7 @@ func deleteFile(uri string) error {
 		return err
 	}
 	res.Body.Close()
-	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotFound {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted && res.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("unexpected status %d", res.StatusCode)
 	}
 	return nil

--- a/docker-receive/utils/utils.go
+++ b/docker-receive/utils/utils.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"fmt"
+
+	ct "github.com/flynn/flynn/controller/types"
+)
+
+func ConfigURL(id string) string {
+	return fmt.Sprintf("http://blobstore.discoverd/docker-receive/layers/%s.json", id)
+}
+
+const LayerURLTemplate = "http://blobstore.discoverd/docker-receive/layers/{id}.squashfs"
+
+func LayerURL(layer *ct.ImageLayer) string {
+	return fmt.Sprintf("http://blobstore.discoverd/docker-receive/layers/%s.squashfs", layer.ID)
+}

--- a/pinkerton/ref.go
+++ b/pinkerton/ref.go
@@ -77,3 +77,15 @@ func (r *Ref) DockerRef() string {
 	}
 	return r.DockerRepo() + delim + r.Tag()
 }
+
+func (r *Ref) ImageURI() string {
+	u := &url.URL{
+		Scheme: r.scheme,
+		Host:   r.host,
+		Path:   fmt.Sprintf("/v2/%s/manifests/%s", r.repo, r.Tag()),
+	}
+	if r.username != "" || r.password != "" {
+		u.User = url.UserPassword(r.username, r.password)
+	}
+	return u.String()
+}

--- a/pkg/imagebuilder/builder.go
+++ b/pkg/imagebuilder/builder.go
@@ -204,6 +204,9 @@ func (b *Builder) createLayer(ids []string) (*ct.ImageLayer, error) {
 	if err != nil {
 		return nil, err
 	}
+	layer.Meta = map[string]string{
+		"docker.layer_id": imageID,
+	}
 
 	return layer, b.Store.Save(imageID, path, layer)
 }

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -174,4 +174,12 @@ func (s *DockerReceiveSuite) TestReleaseDeleteImageLayers(t *c.C) {
 	t.Assert(flynn(t, "/", "-a", app1, "delete", "--yes"), Succeeds)
 	assertNotExist(distinctLayers)
 	assertExist(commonLayers)
+
+	// delete app2 and check we can push app1's image to a new app and have
+	// the layers regenerated (which checks docker-receive cache invalidation)
+	t.Assert(flynn(t, "/", "-a", app2, "delete", "--yes"), Succeeds)
+	app3 := "docker-receive-test-delete-layers-3"
+	t.Assert(flynn(t, "/", "create", "--remote", "", app3), Succeeds)
+	t.Assert(flynn(t, "/", "-a", app3, "docker", "push", app1), Succeeds)
+	t.Assert(flynn(t, "/", "-a", app3, "run", "test", "-f", "/app1.txt"), Succeeds)
 }


### PR DESCRIPTION
Deleting a layer from the blobstore did not previously invalidate the docker-receive cache, so pushing the same image would not regenerate the layer, now it does :smile:.

Addresses the issue from [this comment](https://github.com/flynn/flynn/issues/4011#issuecomment-289174300).

/cc @temujin9 