### PR TITLE
cli: Fix pre-ScaleRequest formation scaling

### DIFF
--- a/cli/scale.go
+++ b/cli/scale.go
@@ -204,6 +204,13 @@ func runScaleWithJobEvents(client controller.Client, app string, release *ct.Rel
 
 	currentProcs := formation.Processes
 	currentTags := formation.Tags
+
+	for k, v := range currentProcs {
+		if _, ok := processes[k]; !ok {
+			processes[k] = v
+		}
+	}
+
 	formation.Processes = processes
 	formation.Tags = tags
 


### PR DESCRIPTION
In an effort to fix #3983, a bug that affected versions older than v20170309.0, 6a298e8d64fb2818e6704f85d542576c2e593175 was committed which introduced a new bug for the same Flynn versions where process types that are not specified in the `flynn scale` command are scaled to zero because the existing formation map is not copied over.

This patch fixes the issue by ensuring that unspecified process types are copied over properly and not modified by `flynn scale`.

Closes #4016 

```text
# broken behavior
$ flynn scale worker=1
scaling web: 1=>0, worker: 0=>1

17:10:02.910 ==> worker 422bca30-25ad-4aee-8202-1300e90800bf pending
17:10:02.918 ==> web host0-afdef0f0-82c5-4398-a751-87f9f3f93fc6 stopping
17:10:02.938 ==> web host0-afdef0f0-82c5-4398-a751-87f9f3f93fc6 down
17:10:02.938 ==> worker host0-422bca30-25ad-4aee-8202-1300e90800bf starting
17:10:03.348 ==> worker host0-422bca30-25ad-4aee-8202-1300e90800bf up

scale completed in 452.633562ms

# fixed behavior
$ ../../flynn/flynn/cli/bin/flynn-darwin-amd64 scale web=1
scaling web: 0=>1

17:10:36.239 ==> web 0a9714fc-c779-43f8-aa3d-efdd30987662 pending
17:10:36.275 ==> web host0-0a9714fc-c779-43f8-aa3d-efdd30987662 starting
17:10:36.614 ==> web host0-0a9714fc-c779-43f8-aa3d-efdd30987662 up

scale completed in 393.059139ms
$ ../../flynn/flynn/cli/bin/flynn-darwin-amd64 scale worker=1
requested scale equals current scale, nothing to do!
$ ../../flynn/flynn/cli/bin/flynn-darwin-amd64 scale web=0
scaling web: 1=>0

17:10:46.566 ==> web host0-0a9714fc-c779-43f8-aa3d-efdd30987662 stopping
17:10:46.575 ==> web host0-0a9714fc-c779-43f8-aa3d-efdd30987662 down

scale completed in 32.8476ms
$ ../../flynn/flynn/cli/bin/flynn-darwin-amd64 scale web=1
scaling web: 0=>1

17:10:53.259 ==> web 3e2bb671-593a-438f-a336-fde433e09106 pending
17:10:53.286 ==> web host0-3e2bb671-593a-438f-a336-fde433e09106 starting
17:10:53.587 ==> web host0-3e2bb671-593a-438f-a336-fde433e09106 up

scale completed in 347.556399ms
```