### PR TITLE
pkg/syslog: Use a consistent number of secfrac digits

### DIFF
--- a/pkg/syslog/rfc5424/message.go
+++ b/pkg/syslog/rfc5424/message.go
@@ -71,7 +71,7 @@ type Header struct {
 	MsgID     []byte
 }
 
-const syslogTimestamp = "2006-01-02T15:04:05.999999Z07:00"
+const syslogTimestamp = "2006-01-02T15:04:05.000000Z07:00"
 
 func (h Header) Bytes() []byte {
 	hostname := h.Hostname


### PR DESCRIPTION
Some syslog timestamp parsers can't handle the variable number of fractional second digits, so always include trailing zeros.