### PR TITLE
host: Force memory overcommitment

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -85,6 +85,10 @@ func NewLibcontainerBackend(config *LibcontainerConfig) (Backend, error) {
 		return nil, err
 	}
 
+	if err := forceMemoryOvercommit(); err != nil {
+		return nil, err
+	}
+
 	defaultTmpfs, err := createTmpfs(resource.DefaultTempDiskSize)
 	if err != nil {
 		return nil, err
@@ -1605,4 +1609,11 @@ func createTmpfs(size int64) (*Tmpfs, error) {
 	}
 
 	return &Tmpfs{Path: f.Name(), Size: size}, nil
+}
+
+func forceMemoryOvercommit() error {
+	if err := ioutil.WriteFile("/proc/sys/vm/overcommit_memory", []byte("1"), 0640); err != nil {
+		return fmt.Errorf("error forcing overcommit: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
This patch sets `/proc/sys/vm/overcommit_memory` to 1, which enables virtual memory overcommit and disables heuristic based denial of memory allocations (using these heuristics is the default setting of 0).

Due to the large virtual memory allocations that Go uses, and the fact that flynn-host frequently forks, the default heuristics can cause errors like this:

    fork/exec /sbin/zfs: cannot allocate memory

Since we rely on the OOM killer anyway, there's no need to arbitrarily cause memory allocations to fail and we can turn off the heuristics entirely.