### PR TITLE
appliance/redis: Set a password in TestMain_Discoverd

### DIFF
--- a/appliance/redis/cmd/flynn-redis/main_test.go
+++ b/appliance/redis/cmd/flynn-redis/main_test.go
@@ -41,6 +41,9 @@ func TestMain_Discoverd(t *testing.T) {
 		return hb, nil
 	}
 
+	// set a password
+	m.Process.Password = "test"
+
 	// Execute program.
 	if err := m.Run(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
CI runs an old version of Redis which seems to handle empty passwords differently than newer versions (e.g. the version used in vagrant).

We have an outstanding task to bring CI up to date which would reveal this, but we are waiting on #3817 before doing that (I have a local branch refactoring CI based off that work).