### PR TITLE
util/cloner: Add flynn-clone.sh script

### DIFF
--- a/cli/release.go
+++ b/cli/release.go
@@ -272,11 +272,23 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 		release.ID = ""
 	} else {
 		release.ID = ""
+
+		if len(updates.Env) > 0 && len(release.Env) == 0 {
+			release.Env = make(map[string]string, len(updates.Env))
+		}
 		for key, value := range updates.Env {
 			release.Env[key] = value
 		}
+
+		if len(updates.Meta) > 0 && len(release.Meta) == 0 {
+			release.Meta = make(map[string]string, len(updates.Meta))
+		}
 		for key, value := range updates.Meta {
 			release.Meta[key] = value
+		}
+
+		if len(updates.Processes) > 0 && len(release.Processes) == 0 {
+			release.Processes = make(map[string]ct.ProcessType, len(updates.Processes))
 		}
 		for procKey, procUpdate := range updates.Processes {
 			procRelease, ok := release.Processes[procKey]
@@ -288,9 +300,14 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 			if len(procUpdate.Args) > 0 {
 				procRelease.Args = procUpdate.Args
 			}
+
+			if len(procUpdate.Env) > 0 && len(procRelease.Env) == 0 {
+				procRelease.Env = make(map[string]string, len(procUpdate.Env))
+			}
 			for key, value := range procUpdate.Env {
 				procRelease.Env[key] = value
 			}
+
 			if len(procUpdate.Ports) > 0 {
 				procRelease.Ports = procUpdate.Ports
 			}

--- a/util/cloner/flynn-clone.sh
+++ b/util/cloner/flynn-clone.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# A script to clone a Flynn app.
+#
+# Typical usage would be:
+#
+#   flynn-clone.sh my-app my-app-staging
+#
+# This would create the my-app-staging app, copying the configuration
+# from my-app.
+#
+# If the apps exist in different clusters, pass the --src-cluster and
+# --dst-cluster flags:
+#
+#   flynn-clone.sh \
+#     --src-cluster "production" \
+#     --dst-cluster "staging" \
+#     my-app \
+#     my-app-staging
+#
+# It is recommended to only copy particular environment variables by
+# specifying --env-whitelist which is a file containing a list of
+# environment variables to copy, one per line:
+#
+#   # whitelist.env
+#   KEY1
+#   KEY2
+#   KEY3
+#
+#   flynn-clone.sh \
+#     --env-whitelist whitelist.env \
+#     my-app \
+#     my-app-staging
+
+set -e
+
+DEFAULT_SRC_CLUSTER="default"
+DEFAULT_DST_CLUSTER="default"
+
+usage() {
+  cat >&2 <<USAGE
+usage: $0 [options] SRC_APP DST_APP
+
+Clone a Flynn app from SRC_APP to DST_APP.
+
+OPTIONS:
+  --src-cluster CLUSTER   Source cluster name [default: ${DEFAULT_SRC_CLUSTER}]
+  --dst-cluster CLUSTER   Destination cluster name [default: ${DEFAULT_DST_CLUSTER}]
+  --env-whitelist FILE    Environment variable whitelist file (whitespace separated list)
+  -h, --help              Show this message
+USAGE
+}
+
+main() {
+  if ! which jq &>/dev/null; then
+    fail "jq >= 1.5 is required: see https://stedolan.github.io/jq/download/"
+  fi
+
+  local src_app=""
+  local dst_app=""
+  local src_cluster="${DEFAULT_SRC_CLUSTER}"
+  local dst_cluster="${DEFAULT_DST_CLUSTER}"
+  local env_whitelist=""
+
+  parse_args "$@"
+
+  info "cloning source app \"${src_app}\" from \"${src_cluster}\" cluster to destination app \"${dst_app}\" in \"${dst_cluster}\" cluster"
+
+  tmp="$(mktemp -d)"
+  trap "rm -rf ${tmp}" EXIT
+
+  info "getting source app"
+  flynn -c "${src_cluster}" -a "${src_app}" release show --json > "${tmp}/src.json"
+
+  info "generating destination release configuration"
+  if [[ -n "${env_whitelist}" ]]; then
+    info "filtering environment variables using whitelist:"
+    cat "${env_whitelist}"
+
+    # generate a whitelist JSON object like {key1: true, key2: true, ...}
+    # and use it to filter both the release env and the individual process env
+    jq \
+      --raw-output \
+      --argjson whitelist "$(jq --raw-input --slurp '[scan("\\S+")] | reduce .[] as $env ({}; .[$env] = true)' < "${env_whitelist}")" \
+      '
+        .env = (if(.env) then .env | with_entries(select(.key | in($whitelist))) else null end) |
+        .processes |= (map_values(.env = (if(.env) then with_entries(select(.key | in($whitelist))) else null end)))
+      ' \
+      < "${tmp}/src.json" \
+      > "${tmp}/dst.json"
+  else
+    cp "${tmp}/src.json" "${tmp}/dst.json"
+  fi
+
+  info "creating destination app"
+  flynn -c "${dst_cluster}" -a "${dst_app}" create --remote "" "${dst_app}"
+
+  info "creating destination release"
+  # set an env var to create an inital release which can then be updated
+  flynn -c "${dst_cluster}" -a "${dst_app}" env set "CLONE=true"
+  flynn -c "${dst_cluster}" -a "${dst_app}" release update "${tmp}/dst.json"
+
+  cat <<INFO
+
+========================
+Cloning finished at $(date +%H:%M:%S).
+
+Database appliances have not been cloned, provision them now if
+necessary with 'flynn -a ${dst_app} resource add ...'.
+
+Run 'flynn -a ${dst_app} remote add <remote>' to add a git remote for
+the new app and then 'git push <remote> master' to deploy the app.
+========================
+
+INFO
+}
+
+parse_args() {
+  while true; do
+    case "$1" in
+      -h | --help)
+        usage
+        exit
+        ;;
+      --src-cluster)
+        if [[ -z "$2" ]]; then
+          usage
+          fail "--src-cluster requires an argument"
+        fi
+        src_cluster="$2"
+        shift 2
+        ;;
+      --dst-cluster)
+        if [[ -z "$2" ]]; then
+          usage
+          fail "--dst-cluster requires an argument"
+        fi
+        dst_cluster="$2"
+        shift 2
+        ;;
+      --env-whitelist)
+        if [[ -z "$2" ]]; then
+          usage
+          fail "--env-whitelist requires an argument"
+        fi
+        env_whitelist="$2"
+        shift 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [[ $# -ne 2 ]]; then
+    usage
+    fail "invalid arguments"
+  fi
+
+  src_app="$1"
+  dst_app="$2"
+}
+
+info() {
+  echo "===> $(date +%H:%M:%S) $@"
+}
+
+fail() {
+  echo "ERROR: $@" >&2
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
`flynn-clone.sh` clones a Flynn app by copying the release configuration, optionally using an environment variable whitelist file.

Example cloning an app which has `FOO` and `TOKEN` set:

```
$ flynn -a my-app env
FOO=bar
TOKEN=s3cr3t

$ echo FOO > whitelist.env

$ util/cloner/flynn-clone.sh --env-whitelist whitelist.env my-app my-app-staging
===> 02:01:10 cloning source app "my-app" from "default" cluster to destination app "my-app-staging" in "default" cluster
===> 02:01:10 getting source app
===> 02:01:10 generating destination release configuration
===> 02:01:10 filtering environment variables using whitelist:
FOO
===> 02:01:10 creating destination app
Created my-app-staging
===> 02:01:10 creating destination release
Created release 51f7e44b-0146-4c91-873e-957f9bffcbac.
Created release 9bbd7fa6-7f48-4bf4-83cc-3f001c31318d.

========================
Cloning finished at 02:01:10.

Database appliances have not been cloned, provision them now if
necessary with 'flynn -a my-app-staging resource add ...'.

Run 'flynn -a my-app-staging remote add <remote>' to add a git remote for
the new app and then 'git push <remote> master' to deploy the app.
========================


$ flynn -a my-app-staging env
CLONE=true
FOO=bar
```