### PR TITLE
docs: Fix command for updating controller AUTH_KEY

### DIFF
--- a/docs/content/production.html.md
+++ b/docs/content/production.html.md
@@ -436,7 +436,7 @@ and new keys can be added. Keys are stored in the environment variable
     NEW_KEY=$(openssl rand -hex 16)
 
     # Add the new key alongside the existing key
-    flynn -a controller env set AUTH_KEY=$NEW_KEY,$(flynn -a controller env get AUTH_KEY)
+    flynn -a controller env set -t web AUTH_KEY=$NEW_KEY,$(flynn -a controller env get AUTH_KEY)
 
 To rotate an authentication key:
 


### PR DESCRIPTION
Setting the `AUTH_KEY` for all controller types at once doesn't work because the scheduler gets deployed first and will not be able to access the web process with the new key.

/cc @temujin9 