### PR TITLE
installer: Allow selecting version to install

### DIFF
--- a/installer/app/src/base-cluster.js
+++ b/installer/app/src/base-cluster.js
@@ -1,6 +1,12 @@
 import { extend, createClass } from 'marbles/utils';
 import State from 'marbles/state';
 import Dispatcher from './dispatcher';
+import Config from './config';
+
+var releaseChannels = Config.release_channels || [];
+if (releaseChannels.length === 0) {
+	releaseChannels = [{name: null, version: null}];
+}
 
 var BaseCluster = createClass({
 	mixins: [State],
@@ -24,6 +30,8 @@ var BaseCluster = createClass({
 
 	getInitialState: function () {
 		return {
+			releaseChannel: releaseChannels[0].name,
+			releaseVersion: releaseChannels[0].version,
 			selectedCloud: this.constructor.type,
 			selectedRegionSlug: null,
 			logEvents: [],
@@ -75,6 +83,17 @@ var BaseCluster = createClass({
 
 			__allCredentials: attrs.credentials || prevState.__allCredentials
 		};
+
+		if (attrs.hasOwnProperty('releaseChannel') && attrs.releaseChannel !== prevState.releaseChannel) {
+			state.releaseChannel = attrs.releaseChannel;
+		} else {
+			state.releaseChannel = prevState.releaseChannel;
+		}
+		if (attrs.hasOwnProperty('releaseVersion') && attrs.releaseVersion !== prevState.releaseVersion) {
+			state.releaseVersion = attrs.releaseVersion;
+		} else {
+			state.releaseVersion = prevState.releaseVersion;
+		}
 
 		var credentialIDExists = false;
 		state.credentials = state.__allCredentials.filter(function (creds) {
@@ -267,6 +286,20 @@ var BaseCluster = createClass({
 			}));
 			break;
 
+		case 'SELECT_RELEASE_CHANNEL':
+			this.setState(this.__computeState({
+				releaseChannel: event.releaseChannel,
+				releaseVersion: event.releaseVersion
+			}));
+			break;
+
+		case 'SELECT_RELEASE_VERSION':
+			this.setState(this.__computeState({
+				releaseChannel: event.releaseChannel,
+				releaseVersion: event.releaseVersion
+			}));
+			break;
+
 		case 'SELECT_BACKUP':
 			this.setState(this.__computeState({
 				backupFile: event.file
@@ -291,6 +324,8 @@ var BaseCluster = createClass({
 });
 
 BaseCluster.prototype.setState = function (newState, shouldDelay) {
+	this.attrs.releaseChannel = newState.releaseChannel;
+	this.attrs.releaseVersion = newState.releaseVersion;
 	this.attrs.credentialID = newState.credentialID;
 	this.attrs.numInstances = newState.numInstances;
 	this.attrs.region = newState.selectedRegionSlug;
@@ -306,6 +341,8 @@ BaseCluster.prototype.setState = function (newState, shouldDelay) {
 BaseCluster.jsonFields = {
 	id: 'ID',
 	type: 'type',
+	release_channel: 'releaseChannel',
+	release_version: 'releaseVersion',
 	state: 'state',
 	region: 'region',
 	num_instances: 'numInstances',

--- a/installer/app/src/views/advanced-options.js.jsx
+++ b/installer/app/src/views/advanced-options.js.jsx
@@ -1,4 +1,5 @@
 import BackupSelector from './backup-selector';
+import ReleaseChannelSelector from './release-channel-selector';
 
 var AdvancedOptions = React.createClass({
 	render: function () {
@@ -12,6 +13,9 @@ var AdvancedOptions = React.createClass({
 					<div style={{
 						marginTop: 20
 					}}>
+						<ReleaseChannelSelector state={state} />
+						<br />
+						<br />
 						<BackupSelector state={state} />
 						<br />
 						<br />

--- a/installer/app/src/views/release-channel-selector.js.jsx
+++ b/installer/app/src/views/release-channel-selector.js.jsx
@@ -1,0 +1,85 @@
+import Dispatcher from '../dispatcher';
+import Config from '../config';
+import ExternalLink from './external-link';
+
+var ReleaseChannelSelector = React.createClass({
+	render: function () {
+		var clusterState = this.props.state;
+		var releaseChannels = Config.release_channels || [];
+		var selectedReleaseChannel = (clusterState.releaseChannel ? (releaseChannels.find(function (ch) {
+			return ch.name === clusterState.releaseChannel;
+		})) : null) || null;
+		var selectedReleaseVersion = clusterState.releaseVersion;
+
+		var ec2Versions = Config.ec2_versions;
+		if (clusterState.selectedCloud === 'aws') {
+			selectedReleaseChannel = {
+				name: 'stable',
+				version: (ec2Versions[0] || {}).version || null,
+				history: ec2Versions.map(function (v) {
+					return { version: v.version };
+				})
+			};
+			releaseChannels = [selectedReleaseChannel];
+		}
+
+		return (
+			<div style={this.props.style}>
+				<label>
+					<span>Select version to install:&nbsp;&nbsp;</span>
+					<select value={clusterState.releaseChannel} onChange={this.__handleReleaseChannelChange}>
+						{releaseChannels.map(function (c) {
+							return (
+								<option key={c.name} value={c.name}>{c.name}</option>
+							);
+						}.bind(this))}
+					</select>
+					{selectedReleaseChannel !== null ? (
+						<select value={selectedReleaseVersion || selectedReleaseChannel.version} onChange={function (e) {
+							this.__handleReleaseVersionChange(selectedReleaseChannel, e.target.value);
+						}.bind(this)}>
+							{selectedReleaseChannel.history.map(function (h) {
+								return (
+									<option key={h.version} value={h.version}>{h.version}</option>
+								);
+							}.bind(this))}
+						</select>
+					) : null}
+					{selectedReleaseVersion ? (
+						<span>
+							&nbsp;&nbsp;
+							<ExternalLink href={'https://releases.flynn.io/'+ selectedReleaseChannel.name +'/'+ clusterState.releaseVersion}>More info</ExternalLink>
+						</span>
+					) : null}
+					{clusterState.selectedCloud === 'aws' ? (
+						<p>EC2 images are pre-built and include a subset of all available releases. You'll have to use the <ExternalLink href="https://flynn.io/docs/installation/manual">manual install process</ExternalLink> or a different cloud provider if you want to use a version which isn't listed above.</p>
+					) : null}
+				</label>
+			</div>
+		);
+	},
+
+	__handleReleaseChannelChange: function (e) {
+		var name = e.target.value;
+		var channel = (Config.release_channels || []).find(function (ch) {
+			return ch.name === name;
+		});
+		Dispatcher.dispatch({
+			clusterID: 'new',
+			name: 'SELECT_RELEASE_CHANNEL',
+			releaseChannel: channel.name,
+			releaseVersion: channel.version
+		});
+	},
+
+	__handleReleaseVersionChange: function (channel, version) {
+		Dispatcher.dispatch({
+			clusterID: 'new',
+			name: 'SELECT_RELEASE_VERSION',
+			releaseChannel: channel.name,
+			releaseVersion: version
+		});
+	}
+});
+
+export default ReleaseChannelSelector;

--- a/installer/aws_cluster.go
+++ b/installer/aws_cluster.go
@@ -242,6 +242,9 @@ func (c *AWSCluster) loadKeyPair(name string) error {
 		}
 	}
 	c.base.SSHKeyName = *res.KeyPairs[0].KeyName
+	if err := c.base.saveField("SSHKeyName", c.base.SSHKeyName); err != nil {
+		return err
+	}
 	return saveSSHKey(c.base.SSHKeyName, keypair)
 }
 

--- a/installer/aws_cluster.go
+++ b/installer/aws_cluster.go
@@ -381,7 +381,15 @@ func (c *AWSCluster) fetchLatestEC2Images() ([]*release.EC2Image, error) {
 	if len(manifest.Versions) == 0 {
 		return nil, errors.New("No versions in manifest")
 	}
-	return manifest.Versions[0].Images, nil
+	if c.base.ReleaseVersion == "" {
+		return manifest.Versions[0].Images, nil
+	}
+	for _, v := range manifest.Versions {
+		if v.Version == c.base.ReleaseVersion {
+			return v.Images, nil
+		}
+	}
+	return nil, fmt.Errorf("No images found for version %s", c.base.ReleaseVersion)
 }
 
 type stackTemplateData struct {

--- a/installer/azure_cluster.go
+++ b/installer/azure_cluster.go
@@ -138,6 +138,9 @@ func (c *AzureCluster) createKeyPair() error {
 	}
 	c.base.SSHKey = keypair
 	c.base.SSHKeyName = keypairName
+	if err := c.base.saveField("SSHKeyName", c.base.SSHKeyName); err != nil {
+		return err
+	}
 	return saveSSHKey(keypairName, keypair)
 }
 

--- a/installer/bare_cluster.go
+++ b/installer/bare_cluster.go
@@ -50,6 +50,12 @@ func (c *BareCluster) instanceInstallFlynn(t *TargetServer) error {
 	for {
 		c.Base.SendLog(fmt.Sprintf("Installing flynn on %s", t.IP))
 		cmd := "curl -fsSL -o /tmp/install-flynn https://dl.flynn.io/install-flynn && sudo bash /tmp/install-flynn"
+		if c.Base.ReleaseChannel != "" {
+			cmd = fmt.Sprintf("%s --channel %s", cmd, c.Base.ReleaseChannel)
+		}
+		if c.Base.ReleaseVersion != "" {
+			cmd = fmt.Sprintf("%s --version %s", cmd, c.Base.ReleaseVersion)
+		}
 		if c.Base.Type == "ssh" {
 			cmd = cmd + " --clean"
 		}

--- a/installer/digital_ocean_cluster.go
+++ b/installer/digital_ocean_cluster.go
@@ -153,6 +153,10 @@ func (c *DigitalOceanCluster) createKeyPair() error {
 		return err
 	}
 
+	if err := c.base.saveField("SSHKeyName", c.base.SSHKeyName); err != nil {
+		return err
+	}
+
 	err = saveSSHKey(keypairName, keypair)
 	if err != nil {
 		return err

--- a/installer/digital_ocean_cluster.go
+++ b/installer/digital_ocean_cluster.go
@@ -427,6 +427,12 @@ func (c *DigitalOceanCluster) instanceInstallFlynn(sshConfig *ssh.ClientConfig, 
 	for {
 		c.base.SendLog(fmt.Sprintf("Installing flynn on %s", ipAddress))
 		cmd := "curl -fsSL -o /tmp/install-flynn https://dl.flynn.io/install-flynn && sudo bash /tmp/install-flynn --clean"
+		if c.base.ReleaseChannel != "" {
+			cmd = fmt.Sprintf("%s --channel %s", cmd, c.base.ReleaseChannel)
+		}
+		if c.base.ReleaseVersion != "" {
+			cmd = fmt.Sprintf("%s --version %s", cmd, c.base.ReleaseVersion)
+		}
 		err := c.base.instanceRunCmd(cmd, sshConfig, ipAddress)
 		if err != nil {
 			if attemptsRemaining > 0 {

--- a/installer/http.go
+++ b/installer/http.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flynn/flynn/pkg/cors"
 	"github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/sse"
+	"github.com/flynn/flynn/util/release/types"
 	"github.com/flynn/oauth2"
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/browser"
@@ -38,9 +39,11 @@ type htmlTemplateData struct {
 }
 
 type installerJSConfig struct {
-	Endpoints            map[string]string `json:"endpoints"`
-	HasAWSEnvCredentials bool              `json:"has_aws_env_credentials"`
-	AWSEnvCredentialsID  string            `json:"aws_env_credentials_id,omitempty"`
+	ReleaseChannels      []*ReleaseChannel     `json:"release_channels"`
+	EC2Versions          []*release.EC2Version `json:"ec2_versions"`
+	Endpoints            map[string]string     `json:"endpoints"`
+	HasAWSEnvCredentials bool                  `json:"has_aws_env_credentials"`
+	AWSEnvCredentialsID  string                `json:"aws_env_credentials_id,omitempty"`
 }
 
 type httpAPI struct {
@@ -58,6 +61,8 @@ func ServeHTTP() error {
 		Installer: installer,
 		logger:    logger,
 		clientConfig: installerJSConfig{
+			ReleaseChannels: installer.releaseChannels,
+			EC2Versions:     installer.ec2Versions,
 			Endpoints: map[string]string{
 				"clusters":           "/clusters",
 				"cluster":            "/clusters/:id",

--- a/installer/schema.go
+++ b/installer/schema.go
@@ -122,6 +122,8 @@ type BaseCluster struct {
 	State               string            `json:"state" ql:"index xState"` // enum(starting, error, running, deleting)
 	Name                string            `json:"name" ql:"-"`
 	NumInstances        int64             `json:"num_instances"`
+	ReleaseChannel      string            `json:"release_channel,omitempty"`
+	ReleaseVersion      string            `json:"release_version,omitempty"`
 	ControllerKey       string            `json:"controller_key,omitempty"`
 	ControllerPin       string            `json:"controller_pin,omitempty"`
 	DashboardLoginToken string            `json:"dashboard_login_token,omitempty"`


### PR DESCRIPTION
Adds option under "Advanced options" for release channel and version. The "More info" link opens the [releases.flynn.io](https://releases.flynn.io) page for the selected channel/version. Only versions for which there is an EC2 image available are listed for AWS (all other launchers use the install script).

<img width="530" alt="screen shot 2017-04-21 at 9 42 28 pm" src="https://cloud.githubusercontent.com/assets/171040/25300353/0448bcc6-26fd-11e7-948f-7da3e5ea6f12.png">


Closes #2287