### PR TITLE
installer: Fix DigitalOcean

### DIFF
--- a/installer/cluster.go
+++ b/installer/cluster.go
@@ -898,6 +898,7 @@ func (c *BaseCluster) genStartScript(nodes int64, dataDisk string) (string, stri
 
 var iptablesConfigScript = template.Must(template.New("iptables.sh").Parse(`
 export DEBIAN_FRONTEND=noninteractive
+apt-get update
 apt-get install -y iptables-persistent
 iptables -F INPUT
 {{ range $i, $ip := .InstanceIPs }}

--- a/installer/digital_ocean_cluster.go
+++ b/installer/digital_ocean_cluster.go
@@ -422,7 +422,7 @@ func (c *DigitalOceanCluster) instanceInstallFlynn(sshConfig *ssh.ClientConfig, 
 	attemptsRemaining := 3
 	for {
 		c.base.SendLog(fmt.Sprintf("Installing flynn on %s", ipAddress))
-		cmd := "curl -fsSL -o /tmp/install-flynn https://dl.flynn.io/install-flynn && sudo bash /tmp/install-flynn"
+		cmd := "curl -fsSL -o /tmp/install-flynn https://dl.flynn.io/install-flynn && sudo bash /tmp/install-flynn --clean"
 		err := c.base.instanceRunCmd(cmd, sshConfig, ipAddress)
 		if err != nil {
 			if attemptsRemaining > 0 {


### PR DESCRIPTION
- Running `apt-get update` before installing `iptables-persistent` fixes an issue where the package isn't found.
- The install script errors out due a false-positive for flynn already being installed. Passing in the `--clean` flag is a work around.

Closes #4046