### PR TITLE
Fix UID in backups on Windows

### DIFF
--- a/pkg/backup/tar_writer.go
+++ b/pkg/backup/tar_writer.go
@@ -29,9 +29,13 @@ type TarWriter struct {
 }
 
 func NewTarWriter(name string, w io.Writer, progress ProgressBar) *TarWriter {
+	userid := syscall.Getuid()
+	if userid < 0 {
+		userid = 0
+	}
 	return &TarWriter{
 		Writer:   tar.NewWriter(w),
-		uid:      syscall.Getuid(),
+		uid:      userid,
 		name:     name,
 		progress: progress,
 	}


### PR DESCRIPTION
Fix for #4049.

When `syscall.Getuid()` returns a negative value zero is instead used as userid in the tar file.
This prevents userids like `00000-1` which are invalid.

Sorry for that new pull request, I previously fucked up with the branches on my fork.
