### PR TITLE
Fix pushing of docker images with tab characters in env

### DIFF
--- a/pkg/imagebuilder/builder.go
+++ b/pkg/imagebuilder/builder.go
@@ -65,7 +65,8 @@ func (b *Builder) Build(name string, groupByTags bool) (*ct.ImageManifest, error
 		if len(keyVal) != 2 {
 			continue
 		}
-		entrypoint.Env[keyVal[0]] = keyVal[1]
+		val := strings.Replace(keyVal[1], "\t", "\\t", -1)
+		entrypoint.Env[keyVal[0]] = val
 	}
 
 	return &ct.ImageManifest{

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -201,6 +201,6 @@ func (s *DockerReceiveSuite) TestTabsInEnv(t *c.C) {
 	// flynn docker push image
 	t.Assert(flynn(t, "/", "-a", app.Name, "docker", "push", repo), Succeeds)
 
-	// check the whiteouts are effective
+	// check the environment variable has the correct value
 	t.Assert(flynn(t, "/", "-a", app.Name, "run", "sh", "-c", "[[ \"$TAB\" = \"test\ttest\" ]]"), Succeeds)
 }

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -183,3 +183,24 @@ func (s *DockerReceiveSuite) TestReleaseDeleteImageLayers(t *c.C) {
 	t.Assert(flynn(t, "/", "-a", app3, "docker", "push", app1), Succeeds)
 	t.Assert(flynn(t, "/", "-a", app3, "run", "test", "-f", "/app1.txt"), Succeeds)
 }
+
+// TestTabsInEnv ensures that a docker container containing tabs 
+// in the environment variables can be imported.
+func (s *DockerReceiveSuite) TestTabsInEnv(t *c.C) {
+	// build a Docker image with tabs in env
+	repo := "docker-receive-test-tab-env"
+	s.buildDockerImage(t, repo,
+		"ENV TAB test\ttest",
+	)
+
+	// create app
+	client := s.controllerClient(t)
+	app := &ct.App{Name: repo}
+	t.Assert(client.CreateApp(app), c.IsNil)
+
+	// flynn docker push image
+	t.Assert(flynn(t, "/", "-a", app.Name, "docker", "push", repo), Succeeds)
+
+	// check the whiteouts are effective
+	t.Assert(flynn(t, "/", "-a", app.Name, "run", "sh", "-c", "[[ \"$TAB\" = \"test\ttest\" ]]" ), Succeeds)
+}

--- a/test/test_docker_receive.go
+++ b/test/test_docker_receive.go
@@ -184,7 +184,7 @@ func (s *DockerReceiveSuite) TestReleaseDeleteImageLayers(t *c.C) {
 	t.Assert(flynn(t, "/", "-a", app3, "run", "test", "-f", "/app1.txt"), Succeeds)
 }
 
-// TestTabsInEnv ensures that a docker container containing tabs 
+// TestTabsInEnv ensures that a docker container containing tabs
 // in the environment variables can be imported.
 func (s *DockerReceiveSuite) TestTabsInEnv(t *c.C) {
 	// build a Docker image with tabs in env
@@ -202,5 +202,5 @@ func (s *DockerReceiveSuite) TestTabsInEnv(t *c.C) {
 	t.Assert(flynn(t, "/", "-a", app.Name, "docker", "push", repo), Succeeds)
 
 	// check the whiteouts are effective
-	t.Assert(flynn(t, "/", "-a", app.Name, "run", "sh", "-c", "[[ \"$TAB\" = \"test\ttest\" ]]" ), Succeeds)
+	t.Assert(flynn(t, "/", "-a", app.Name, "run", "sh", "-c", "[[ \"$TAB\" = \"test\ttest\" ]]"), Succeeds)
 }


### PR DESCRIPTION
Replaces tab characters in Manifest with `\t` an prevents so the error mentioned in #3910 