### PR TITLE
script/lib: Don't use magic for S3 upload MIME types

### DIFF
--- a/script/lib/aws.sh
+++ b/script/lib/aws.sh
@@ -17,6 +17,7 @@ sync_cloudfront() {
     --cf-invalidate \
     --no-preserve \
     --follow-symlinks \
+    --no-mime-magic \
     "${src}" "${dst}" \
     | tee /dev/stderr \
     | grep -oP "s3cmd cfinvalinfo cf://\w+/\w+")


### PR DESCRIPTION
s3cmd uses python-magic by default to figure out the MIME type of a file. Some version combinations return `text/plain` for JSON files instead of `application/json`, which breaks the Vagrant box manifest download.

Setting `--no-mime-magic` falls back to using the file extension, which is what we want.

Closes #4051