### PR TITLE
util/cedarish: Update apt sources

### DIFF
--- a/util/cedarish/Dockerfile
+++ b/util/cedarish/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:trusty-20160217
 
 # Derived from https://github.com/heroku/stack-images/blob/master/bin/cedar-14.sh
 
-RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main' >/etc/apt/sources.list &&\
-    echo 'deb http://archive.ubuntu.com/ubuntu trusty-security main' >>/etc/apt/sources.list &&\
-    echo 'deb http://archive.ubuntu.com/ubuntu trusty-updates main' >>/etc/apt/sources.list &&\
+RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main restricted' >/etc/apt/sources.list &&\
+    echo 'deb http://archive.ubuntu.com/ubuntu trusty-updates main restricted' >>/etc/apt/sources.list &&\
     echo 'deb http://archive.ubuntu.com/ubuntu trusty universe' >>/etc/apt/sources.list &&\
+    echo 'deb http://archive.ubuntu.com/ubuntu trusty-updates universe' >>/etc/apt/sources.list &&\
+    echo 'deb http://archive.ubuntu.com/ubuntu trusty-security main restricted' >>/etc/apt/sources.list &&\
+    echo 'deb http://archive.ubuntu.com/ubuntu trusty-security universe' >>/etc/apt/sources.list &&\
 
     apt-get update &&\
     apt-get dist-upgrade -y &&\


### PR DESCRIPTION
This is the list of sources used by the Ubuntu Core image with the universe lines uncommented.

Check with:

```
$ URL="https://partner-images.canonical.com/core/trusty/20170330/ubuntu-trusty-core-cloudimg-amd64-root.tar.gz"

$ curl -fsSL "${URL}" | tar xzO etc/apt/sources.list | grep -oP 'deb .*$' | grep -vP '(backports|multiverse)'
deb http://archive.ubuntu.com/ubuntu/ trusty main restricted
deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted
deb http://archive.ubuntu.com/ubuntu/ trusty universe
deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted
deb http://archive.ubuntu.com/ubuntu/ trusty-security universe
```

Fixes #4062.