### PR TITLE
cli: Fix usage for deprecated `flynn install` command

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	register("install", runInstaller, ``)
+	register("install", runInstaller, `usage: flynn install`)
 }
 
 func runInstaller(args *docopt.Args) error {


### PR DESCRIPTION
Without a `usage:` section in help, docopt blows up with:

    "usage:" (case-insensitive) not found.