### PR TITLE
dashboard: Reduce github/provision button padding

### DIFF
--- a/dashboard/app/lib/stylesheets/dashboard/panel.scss
+++ b/dashboard/app/lib/stylesheets/dashboard/panel.scss
@@ -24,7 +24,7 @@
   box-shadow: 0px 1px 2px $grayBlueColor;
 
   > section {
-    padding: 2rem;
+    padding: 1.5rem;
     border-bottom: 2px solid $grayBlueColor;
 
     &:last-of-type {


### PR DESCRIPTION
When the app-list is long enough to cause a scrollbar on the middle
panel, there's not quite enough width for the github and provision
database buttons and this causes them to appear one above the other
instead of side by side.

This commit has the side-effect of reducing the padding by 0.5rem in
right-hand panel too.

Signed-off-by: Simon Amor <simon@leaky.org>