### PR TITLE
test/runner: Only run builds for relevant PR events

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -838,7 +838,7 @@ func (r *Runner) explainBuild(w http.ResponseWriter, req *http.Request, ps httpr
 }
 
 func needsBuild(event Event) bool {
-	if e, ok := event.(*PullRequestEvent); ok && e.Action == "closed" {
+	if e, ok := event.(*PullRequestEvent); ok && e.Action != "opened" && e.Action != "synchronize" {
 		return false
 	}
 	if e, ok := event.(*PushEvent); ok && (e.Deleted || e.Ref != "refs/heads/master") {


### PR DESCRIPTION
This change ensures that builds are only triggered by new pull requests and pushes to open pull requests. Other events like requesting a review, editing the description, and labeling should not trigger a build.