### PR TITLE
Update Makefile

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,13 +1,13 @@
 
 # Providers: virtualbox, vmware_fusion, aws
-PROVIDER := virtualbox
+PROVIDER ?= virtualbox
 
 # Domain to use when starting flynn
-CLUSTER_DOMAIN := demo.localflynn.com
-CLUSTER := demo-${PROVIDER}
+CLUSTER_DOMAIN ?= demo.localflynn.com
+CLUSTER ?= demo-${PROVIDER}
 
 # Location to install flynn CLI bin
-CLI_INSTALL_BIN := /usr/local/bin/flynn
+CLI_INSTALL_BIN ?= /usr/local/bin/flynn
 
 # ENV to set when running vagrant
 # See https://github.com/mitchellh/vagrant/issues/4367 for use of SSH_AUTH_SOCK=''


### PR DESCRIPTION
This (small) PR allows a developer to override the basic variables:

- `PROVIDER` (default: `virtualbox`)
- `CLUSTER_DOMAIN` (default: `demo.localflynn.com`)
- `CLUSTER` (default: `demo-${PROVIDER}`)
- `CLI_INSTALL_BIN` (default: `/usr/local/bin/flynn`)

One might even go as far as to change the `VAGRANT_ENV` to `PROVIDER_ENV` ?

(fixes issue #4084)