### PR TITLE
Fix issue with ADDITIONAL_HTTPS_PORTS

### DIFF
--- a/router/http.go
+++ b/router/http.go
@@ -203,7 +203,7 @@ func (s *HTTPListener) AddRoute(r *router.Route) error {
 	// If not using default ports, check that the port is reserved, first
 	addrs := s.Addrs
 	err := ErrUnreservedHTTP
-	if r.Certificate != nil {
+	if r.LegacyTLSCert != "" {
 		addrs = s.TLSAddrs
 		err = ErrUnreservedHTTPS
 	}


### PR DESCRIPTION
I made an assumption that turned out to be incorrect, about the router.Route member which gets populated for an HTTPS route. This fixes the issue, and wraps it in an integration test.