### PR TITLE
discoverd/server: Retry UDP test query on timeout

### DIFF
--- a/discoverd/server/dns_test.go
+++ b/discoverd/server/dns_test.go
@@ -477,6 +477,10 @@ func (s *DNSSuite) TestServiceLookup(c *C) {
 					addr = srv.TCPAddr
 				}
 				res, _, err := client.Exchange(req, addr)
+				if err != nil && strings.Contains(err.Error(), "i/o timeout") {
+					// retry once in case our UDP packet was dropped by the kernel
+					res, _, err = client.Exchange(req, addr)
+				}
 				c.Assert(err, IsNil)
 
 				if strings.Contains(t.name, "NXDOMAIN") {


### PR DESCRIPTION
The kernel provides no guarantees that a UDP packet will be delivered, and this test occasionally flakes with:

    read udp 127.0.0.1:43870->127.0.0.1:43733: i/o timeout