### PR TITLE
Updated supported python runtimes as per the github link

### DIFF
--- a/docs/content/languages/python.md
+++ b/docs/content/languages/python.md
@@ -33,8 +33,8 @@ python-2.7.8
 
 ### Supported Runtimes
 
-The latest `python-2.7` and `python-3.4` are officially supported, but any
-runtime between 2.4.4–3.4.1 can be used, including PyPy runtimes. See
+The latest `python-2.7` and `python-3.6` are officially supported, but any
+runtime between 2.4.4–3.6.1 can be used, including PyPy runtimes. See
 [the buildpack's GitHub page](https://github.com/heroku/heroku-buildpack-python/tree/master/builds/runtimes)
 for a full list.
 


### PR DESCRIPTION
Was looking through docs when it said python3.4 was last available runtime. Checked given buildpacks link and saw python3.6. This PR updates the docs and specifies a runtime range up to 3.6.1.

Signed-off-by: Jay Nagpaul <jaynagpaul@gmail.com>