### PR TITLE
Docker v17.06 fix - remove email from docker login

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -131,7 +131,7 @@ var ErrDockerTLSError = errors.New("docker TLS error")
 
 func dockerLogin(host, key string) error {
 	var out bytes.Buffer
-	cmd := exec.Command("docker", "login", "--email=user@"+host, "--username=user", "--password="+key, host)
+	cmd := exec.Command("docker", "login", "--username=user", "--password="+key, host)
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err := cmd.Run()


### PR DESCRIPTION
Fixes #4156

Docker v17.06 depreciated the `--email` flag from the docker login command, and it breaks flynn's docker login command.