### PR TITLE
gitreceive: Fix restoring submodules from cache

### DIFF
--- a/gitreceive/server.go
+++ b/gitreceive/server.go
@@ -301,7 +301,7 @@ git-archive-all() {
 	GIT_DIR="$(pwd)"
 	cd ..
 	git checkout --force --quiet $1
-	git submodule --quiet update --init --recursive
+	git submodule --quiet update --force --init --checkout --recursive
 	tar --create --exclude-vcs .
 }
 

--- a/test/test_git_deploy.go
+++ b/test/test_git_deploy.go
@@ -247,6 +247,11 @@ func (s *GitDeploySuite) TestGitSubmodules(t *c.C) {
 	t.Assert(r.flynn("create"), Succeeds)
 	t.Assert(r.git("push", "flynn", "master"), Succeeds)
 	t.Assert(r.flynn("run", "ls", "go-flynn-example"), SuccessfulOutputContains, "main.go")
+
+	// deploy again to test cached repo
+	t.Assert(r.git("commit", "-m", "foo", "--allow-empty"), Succeeds)
+	t.Assert(r.git("push", "flynn", "master"), Succeeds)
+	t.Assert(r.flynn("run", "ls", "go-flynn-example"), SuccessfulOutputContains, "main.go")
 }
 
 func (s *GitDeploySuite) TestCancel(t *c.C) {


### PR DESCRIPTION
When gitreceive used a cached copy of the repo, it was not properly checking out submodules. Adding `--checkout` to the `git submodule update` command fixed this.