### PR TITLE
test: Bump unit test timeout to 20 minutes

### DIFF
--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -431,7 +431,7 @@ flynn=$GOPATH/src/github.com/flynn/flynn
 cd $flynn
 
 if [[ -f test/scripts/test-unit.sh ]]; then
-  timeout --signal=QUIT --kill-after=10 5m test/scripts/test-unit.sh
+  timeout --signal=QUIT --kill-after=25 20m test/scripts/test-unit.sh
 fi
 `[1:]
 


### PR DESCRIPTION
The unit tests rarely hang and under some circumstances trigger a rebuild of Flynn, which can take more than five minutes.