### PR TITLE
vendor: Update go-p9p

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/flynn/flynn",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.8",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
@@ -666,11 +666,11 @@
 		},
 		{
 			"ImportPath": "github.com/flynn/go-p9p",
-			"Rev": "701321e87d2fd13b7a8240eb1ec0c66d7867d1cd"
+			"Rev": "42f7901ca21a2449fe239b33d84fdf916b8ea859"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-p9p/ufs",
-			"Rev": "701321e87d2fd13b7a8240eb1ec0c66d7867d1cd"
+			"Rev": "42f7901ca21a2449fe239b33d84fdf916b8ea859"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-tuf",

--- a/vendor/github.com/flynn/go-p9p/server.go
+++ b/vendor/github.com/flynn/go-p9p/server.go
@@ -2,6 +2,7 @@ package p9p
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"sync"
@@ -188,7 +189,11 @@ func (c *conn) read(requests chan *Fcall) {
 				}
 			}
 
-			c.CloseWithError(fmt.Errorf("error reading fcall: %v", err))
+			if err == io.EOF {
+				c.CloseWithError(err)
+			} else {
+				c.CloseWithError(fmt.Errorf("error reading fcall: %v", err))
+			}
 			return
 		}
 


### PR DESCRIPTION
This fixes the `error serving conn: error reading fcall: EOF` logspam during builds.