### PR TITLE
test: Fix race in RouterSuite.TestAdditionalHttpPorts

### DIFF
--- a/test/test_router.go
+++ b/test/test_router.go
@@ -34,7 +34,6 @@ func (s *RouterSuite) TestAdditionalHttpPorts(t *c.C) {
 	// check a non-routed HTTP request to an additional port fails
 	req, err := http.NewRequest("GET", "http://dashboard."+x.Domain+":8080", nil)
 	t.Assert(err, c.IsNil)
-	req.SetBasicAuth("", x.Key)
 	res, err := http.DefaultClient.Do(req)
 	t.Assert(err, c.IsNil)
 	t.Assert(res.StatusCode, c.Equals, http.StatusNotFound)
@@ -60,7 +59,6 @@ func (s *RouterSuite) TestAdditionalHttpPorts(t *c.C) {
 	// check that a HTTP request to the default port succeeds
 	req, err = http.NewRequest("GET", "http://dashboard."+x.Domain, nil)
 	t.Assert(err, c.IsNil)
-	req.SetBasicAuth("", x.Key)
 	res, err = http.DefaultClient.Do(req)
 	t.Assert(err, c.IsNil)
 	t.Assert(res.StatusCode, c.Equals, http.StatusOK)
@@ -94,7 +92,6 @@ func (s *RouterSuite) TestAdditionalHttpPorts(t *c.C) {
 	// check a routed HTTP request succeeds
 	req, err = http.NewRequest("GET", "https://dashboard."+x.Domain+":8081", nil)
 	t.Assert(err, c.IsNil)
-	req.SetBasicAuth("", x.Key)
 	res, err = client.Do(req)
 	t.Assert(err, c.IsNil)
 	t.Assert(res.StatusCode, c.Equals, http.StatusOK)
@@ -103,7 +100,6 @@ func (s *RouterSuite) TestAdditionalHttpPorts(t *c.C) {
 	// check that a HTTPS request to the default port succeeds
 	req, err = http.NewRequest("GET", "https://dashboard."+x.Domain, nil)
 	t.Assert(err, c.IsNil)
-	req.SetBasicAuth("", x.Key)
 	res, err = client.Do(req)
 	t.Assert(err, c.IsNil)
 	t.Assert(res.StatusCode, c.Equals, http.StatusOK)


### PR DESCRIPTION
Ensure that the configuration change is applied to the router before moving forward, by watching for the up/down job events from the deployment.

This fixes a test failure that looks like:

```
++ 17:30:41.803 /go/src/github.com/flynn/flynn/build/bin/flynn-linux-amd64.4698f835b92d4d66342307a6dfede31b9a7d8bfc6b98001b79e04842a3587658 -a dashboard route add http -s dashboard-web -p 8080 dashboard.063ab384872a5776cad013a88d0e1b71.local
unknown_error: Something went wrong
```