### PR TITLE
host: Ensure mutex is unlocked in error case when adding job

### DIFF
--- a/host/libcontainer_backend.go
+++ b/host/libcontainer_backend.go
@@ -571,6 +571,7 @@ func (l *LibcontainerBackend) Run(job *host.Job, runConfig *RunConfig, rateLimit
 		if p.Proto != "tcp" && p.Proto != "udp" {
 			err := fmt.Errorf("unknown port proto %q", p.Proto)
 			log.Error("error allocating port", "proto", p.Proto, "err", err)
+			l.State.mtx.Unlock()
 			return err
 		}
 


### PR DESCRIPTION
Not unlocking this mutex causes all future API calls to hang.