### PR TITLE
controller: Add one-down-one-up deploy strategy

### DIFF
--- a/controller/schema.go
+++ b/controller/schema.go
@@ -534,6 +534,9 @@ $$ LANGUAGE plpgsql`,
 		)`,
 		`INSERT INTO job_states (name) VALUES ('blocked')`,
 	)
+	migrations.Add(32,
+		`INSERT INTO deployment_strategies (name) VALUES ('one-down-one-up')`,
+	)
 }
 
 func migrateDB(db *postgres.DB) error {

--- a/controller/worker/deployment/job.go
+++ b/controller/worker/deployment/job.go
@@ -31,6 +31,8 @@ func (d *DeployJob) Perform() error {
 	switch d.Strategy {
 	case "one-by-one":
 		deployFunc = d.deployOneByOne
+	case "one-down-one-up":
+		deployFunc = d.deployOneDownOneUp
 	case "all-at-once":
 		deployFunc = d.deployAllAtOnce
 	case "sirenia":
@@ -162,6 +164,18 @@ func (d *DeployJob) scaleOneByOne(typ string, log log15.Logger) error {
 		}
 
 		if err := d.scaleOldFormationDownByOne(typ, log); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DeployJob) scaleOneDownOneUp(typ string, log log15.Logger) error {
+	for i := 0; i < d.Processes[typ]; i++ {
+		if err := d.scaleOldFormationDownByOne(typ, log); err != nil {
+			return err
+		}
+		if err := d.scaleNewFormationUpByOne(typ, log); err != nil {
 			return err
 		}
 	}

--- a/controller/worker/deployment/one_down_one_up.go
+++ b/controller/worker/deployment/one_down_one_up.go
@@ -1,0 +1,23 @@
+package deployment
+
+import "sort"
+
+func (d *DeployJob) deployOneDownOneUp() error {
+	log := d.logger.New("fn", "deployOneDownOneUp")
+	log.Info("starting one-down-one-up deployment")
+
+	processTypes := make([]string, 0, len(d.Processes))
+	for typ := range d.Processes {
+		processTypes = append(processTypes, typ)
+	}
+	sort.Sort(sort.StringSlice(processTypes))
+
+	for _, typ := range processTypes {
+		if err := d.scaleOneDownOneUp(typ, log); err != nil {
+			return err
+		}
+	}
+
+	log.Info("finished one-down-one-up deployment")
+	return nil
+}

--- a/schema/controller/common.json
+++ b/schema/controller/common.json
@@ -43,7 +43,7 @@
     },
     "strategy": {
       "type": "string",
-      "enum": ["all-at-once", "one-by-one", "sirenia", "discoverd-meta"]
+      "enum": ["all-at-once", "one-by-one", "sirenia", "discoverd-meta", "one-down-one-up"]
     },
     "meta": {
       "description": "client-specified metadata",

--- a/test/test_deployer.go
+++ b/test/test_deployer.go
@@ -191,6 +191,21 @@ func (s *DeployerSuite) TestOneByOneStrategy(t *c.C) {
 	d.waitForDeploymentStatus("complete")
 }
 
+func (s *DeployerSuite) TestOneDownOneUpStrategy(t *c.C) {
+	d := s.createDeployment(t, "printer", "one-down-one-up", "")
+	defer d.cleanup()
+	releaseID := d.deployment.NewReleaseID
+	oldReleaseID := d.deployment.OldReleaseID
+
+	d.waitForJobEvents("printer", []*ct.Job{
+		{ReleaseID: oldReleaseID, State: ct.JobStateDown},
+		{ReleaseID: releaseID, State: ct.JobStateUp},
+		{ReleaseID: oldReleaseID, State: ct.JobStateDown},
+		{ReleaseID: releaseID, State: ct.JobStateUp},
+	})
+	d.waitForDeploymentStatus("complete")
+}
+
 func (s *DeployerSuite) TestAllAtOnceStrategy(t *c.C) {
 	d := s.createDeployment(t, "printer", "all-at-once", "")
 	defer d.cleanup()


### PR DESCRIPTION
This can be used by apps which mount external storage (e.g. NFS mounts) and are happy to sacrifice availability in favour of data consistency.