### PR TITLE
cli: Better support for custom mounts

### DIFF
--- a/cli/release.go
+++ b/cli/release.go
@@ -314,6 +314,9 @@ func runReleaseUpdate(args *docopt.Args, client controller.Client) error {
 			if len(procUpdate.Volumes) > 0 {
 				procRelease.Volumes = procUpdate.Volumes
 			}
+			if len(procUpdate.Mounts) > 0 {
+				procRelease.Mounts = procUpdate.Mounts
+			}
 			if procUpdate.DeprecatedData {
 				fmt.Fprintln(os.Stderr, `WARN: ProcessType.Data is deprecated and will be removed in future versions, populate ProcessType.Volumes instead e.g. "volumes": [{"path": "/data"}]`)
 				procRelease.DeprecatedData = true

--- a/controller/jobs.go
+++ b/controller/jobs.go
@@ -344,6 +344,9 @@ func (c *controllerAPI) RunJob(ctx context.Context, w http.ResponseWriter, req *
 	if len(newJob.Args) > 0 {
 		job.Config.Args = newJob.Args
 	}
+	if typ := newJob.MountsFrom; typ != "" {
+		job.Config.Mounts = release.Processes[typ].Mounts
+	}
 	utils.SetupMountspecs(job, artifacts)
 
 	// provision data volume if required

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -341,6 +341,9 @@ type NewJob struct {
 	Data        bool               `json:"data,omitempty"`
 	Partition   PartitionType      `json:"partition,omitempty"`
 
+	// MountsFrom is a process type to copy mounts from
+	MountsFrom string `json:"mounts_from,omitempty"`
+
 	// Entrypoint and Cmd are DEPRECATED: use Args instead
 	DeprecatedCmd        []string `json:"cmd,omitempty"`
 	DeprecatedEntrypoint []string `json:"entrypoint,omitempty"`

--- a/schema/controller/new_job.json
+++ b/schema/controller/new_job.json
@@ -67,6 +67,10 @@
     },
     "partition": {
       "$ref": "/schema/controller/common#/definitions/partition"
+    },
+    "mounts_from": {
+      "description": "process type to copy mounts from",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
This allows process mounts to be updated with `flynn release update` and also allows one-off jobs to use mounts from a process type with `flynn run --mounts-from web`.