### PR TITLE
router: Add request logging for debugging

### DIFF
--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -138,6 +138,7 @@ func (p *ReverseProxy) ServeHTTP(ctx context.Context, rw http.ResponseWriter, re
 
 	prepareResponseHeaders(res)
 	p.writeResponse(rw, res)
+	l.Debug("request complete", "status", res.StatusCode, "location", res.Header.Get("Location"), "backend", backend)
 }
 
 // ServeConn takes an inbound conn and proxies it to a backend.

--- a/router/server.go
+++ b/router/server.go
@@ -22,6 +22,13 @@ import (
 
 var logger = log15.New("app", "router")
 
+func init() {
+	if os.Getenv("DEBUG") == "" {
+		// filter debug log messages if DEBUG is not set
+		logger.SetHandler(log15.LvlFilterHandler(log15.LvlInfo, log15.StdoutHandler))
+	}
+}
+
 type Listener interface {
 	Start() error
 	Close() error


### PR DESCRIPTION
When the `DEBUG` env var is set, the router will log details about each request/response that it routes to a backend.

Example log message:

> t=2017-11-27T21:44:14+0000 lvl=dbug msg="request complete" app=router request_id=7d48d1a6-9174-4eb4-8cdb-49b768cfbb0e client_addr=192.0.2.200:38846 host=controller.1.localflynn.com path=/apps/router/log method=GET status=200 location= backend=100.100.60.4:80