### PR TITLE
controller: Implement basic request audit logging

### DIFF
--- a/controller/audit_log.go
+++ b/controller/audit_log.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	ct "github.com/flynn/flynn/controller/types"
+	"github.com/flynn/flynn/pkg/httphelper"
+	"github.com/flynn/flynn/router/types"
+	log "gopkg.in/inconshreveable/log15.v2"
+)
+
+const maxAuditRequestBodySize = 1000000
+
+func handleRequestWithAuditBodyBuffer(h http.Handler, rw *httphelper.ResponseWriter, req *http.Request) *bytes.Buffer {
+	var buf *bytes.Buffer
+	if req.Body != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") {
+		buf = &bytes.Buffer{}
+		req.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			io.TeeReader(&limitedBodyReader{R: req.Body, N: maxAuditRequestBodySize}, buf),
+			req.Body,
+		}
+	}
+	h.ServeHTTP(rw, req)
+	maybeRedactBody(req, buf)
+	return buf
+}
+
+type limitedBodyReader struct {
+	R io.Reader // underlying reader
+	N int64     // max bytes remaining
+}
+
+const redactedPlaceholder = "[redacted]"
+
+func redactEnv(env map[string]string) {
+	for k, v := range env {
+		for _, s := range []string{"key", "token", "pass", "secret", "url"} {
+			if v != "" && strings.Contains(strings.ToLower(k), s) {
+				env[k] = redactedPlaceholder
+				break
+			}
+		}
+	}
+}
+
+func maybeRedactBody(req *http.Request, buf *bytes.Buffer) {
+	if buf == nil || buf.Len() == 0 {
+		return
+	}
+	var data interface{}
+	if req.Method == "POST" && req.URL.Path == "/releases" {
+		release := &ct.Release{}
+		if err := json.NewDecoder(buf).Decode(release); err != nil {
+			return
+		}
+		redactEnv(release.Env)
+		for _, proc := range release.Processes {
+			redactEnv(proc.Env)
+		}
+		data = release
+	} else if req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/jobs") {
+		job := &ct.NewJob{}
+		if err := json.NewDecoder(buf).Decode(job); err != nil {
+			return
+		}
+		redactEnv(job.Env)
+		data = job
+	} else if (req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/routes")) || (req.Method == "PUT" && strings.Contains(req.URL.Path, "/routes/")) {
+		route := &router.Route{}
+		if err := json.NewDecoder(buf).Decode(route); err != nil {
+			return
+		}
+		if route.Type != "http" {
+			return
+		}
+		if route.Certificate != nil && route.Certificate.Key != "" {
+			route.Certificate.Key = redactedPlaceholder
+		}
+		if route.LegacyTLSKey != "" {
+			route.LegacyTLSKey = redactedPlaceholder
+		}
+		data = route
+	}
+	if data != nil {
+		buf.Reset()
+		json.NewEncoder(buf).Encode(data)
+	}
+}
+
+func (l *limitedBodyReader) Read(p []byte) (n int, err error) {
+	if l.N <= 0 {
+		return 0, httphelper.ErrRequestBodyTooBig
+	}
+	if int64(len(p)) > l.N {
+		p = p[0:l.N]
+	}
+	n, err = l.R.Read(p)
+	l.N -= int64(n)
+	return
+}
+
+func auditLoggerFn(handler http.Handler, logger log.Logger, clientIP string, rw *httphelper.ResponseWriter, req *http.Request) {
+	start := time.Now()
+	logger.Info("request started", "method", req.Method, "path", req.URL.Path, "client_ip", clientIP)
+	bodyBuf := handleRequestWithAuditBodyBuffer(handler, rw, req)
+	logger.Info("request completed", "status", rw.Status(), "duration", time.Since(start), "method", req.Method, "path", req.URL.Path, "client_ip", clientIP, "key_id", req.Header.Get("Flynn-Auth-Key-ID"), "user_agent", req.Header.Get("User-Agent"), "body", bodyBuf.String())
+}

--- a/controller/domain.go
+++ b/controller/domain.go
@@ -45,7 +45,7 @@ func (repo *DomainMigrationRepo) Add(dm *ct.DomainMigration) error {
 
 func (c *controllerAPI) MigrateDomain(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	var dm *ct.DomainMigration
-	if err := json.NewDecoder(req.Body).Decode(&dm); err != nil {
+	if err := httphelper.DecodeJSON(req, &dm); err != nil {
 		respondWithError(w, err)
 		return
 	}

--- a/discoverd/server/handler_test.go
+++ b/discoverd/server/handler_test.go
@@ -734,6 +734,9 @@ func MustNewHTTPRequest(method, urlStr string, body io.Reader) *http.Request {
 	if err != nil {
 		panic(err)
 	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	// Set host
 	req.Host = u.Host


### PR DESCRIPTION
When `AUDIT_LOG=true`, the controller will log details about all HTTP requests including JSON request bodies.

A comma-separated list of auth key IDs can be provided in the `AUTH_KEY_IDS` env var, with one for each configured AUTH_KEY. The corresponding ID corresponding to the key used to authorize the request, will be logged if this variable is set.

Example log message:

```text
t=2017-11-27T22:07:56+0000 lvl=info msg="request completed" component=controller req_id=01a03e5e-7ab4-46e3-b388-bf6eaa17f310 status=200 duration=3.335794ms method=POST path=/releases client_ip=192.0.2.200 key_id=foo user_agent=Go-http-client/1.1 body="{\"app_id\":\"f8fb63d8-0900-4e15-88fc-ee89439625e3\",\"artifacts\":[\"bec2eb8b-7479-48db-8848-72ef945799bd\"],\"env\":{\"AUTH_KEY\":\"[redacted]\",\"PASSWORD_A\":\"[redacted]\"},\"processes\":{\"web\":{\"ports\":[{\"port\":80,\"proto\":\"tcp\",\"service\":{\"name\":\"status-web\",\"create\":true,\"check\":{\"type\":\"tcp\"}}}],\"resources\":{\"cpu\":{\"request\":1000,\"limit\":1000},\"max_fd\":{\"request\":10000,\"limit\":10000},\"memory\":{\"request\":1073741824,\"limit\":1073741824},\"temp_disk\":{\"request\":104857600,\"limit\":104857600}}}},\"created_at\":\"2017-11-27T22:01:13.672608Z\",\"artifact\":\"bec2eb8b-7479-48db-8848-72ef945799bd\"}\n"
```