### PR TITLE
builder/img: Update to Go 1.10

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/flynn/flynn",
-	"GoVersion": "go1.9",
+	"GoVersion": "go1.10",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."

--- a/builder/img/go.sh
+++ b/builder/img/go.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-version="1.9.2"
-shasum="de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b"
+version="1.10beta1"
+shasum="ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055"
 dir="/usr/local"
 
 apt-get update

--- a/builder/manifest.json
+++ b/builder/manifest.json
@@ -43,7 +43,7 @@
       "layers": [{
         "script": "builder/img/go.sh",
         "inputs": ["builder/go-wrapper.sh"],
-        "limits": { "temp_disk": "1G" }
+        "limits": { "temp_disk": "2G" }
       }]
     },
     {

--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -208,7 +208,7 @@ sed 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
 
 # install go
 curl https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz | tar xz
-./godeb install 1.9.2
+./godeb install 1.10beta1
 rm godeb
 
 # setup tmpdir

--- a/test/scripts/install
+++ b/test/scripts/install
@@ -3,7 +3,7 @@
 set -e
 
 RAMDISK_SIZE="448G"
-GO_VERSION="1.9.2"
+GO_VERSION="1.10beta1"
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 source "${ROOT}/script/lib/ui.sh"


### PR DESCRIPTION
Do not merge yet, this will track CI against the upcoming Go 1.10 release.