### PR TITLE
cli: show env vars from job first

### DIFF
--- a/cli/env.go
+++ b/cli/env.go
@@ -136,11 +136,12 @@ func runEnvGet(args *docopt.Args, client controller.Client) error {
 		return fmt.Errorf("process type %q not found in release %s", envProc, release.ID)
 	}
 
-	if v, ok := release.Env[arg]; ok {
+	if v, ok := release.Processes[envProc].Env[arg]; ok {
 		fmt.Println(v)
 		return nil
 	}
-	if v, ok := release.Processes[envProc].Env[arg]; ok {
+
+	if v, ok := release.Env[arg]; ok {
 		fmt.Println(v)
 		return nil
 	}

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -331,6 +331,9 @@ func (s *CLISuite) TestEnv(t *c.C) {
 	t.Assert(app.flynn("env", "set", "ENV_TEST=var", "SECOND_VAL=2"), Succeeds)
 	t.Assert(app.flynn("env"), SuccessfulOutputContains, "ENV_TEST=var\nSECOND_VAL=2")
 	t.Assert(app.flynn("env", "get", "ENV_TEST"), Outputs, "var\n")
+	t.Assert(app.flynn("env", "set", "-t", "ping", "ENV_TEST=foo"), Succeeds)
+	t.Assert(app.flynn("env", "get", "-t", "ping", "ENV_TEST"), Outputs, "foo\n")
+	t.Assert(app.flynn("env", "get", "ENV_TEST"), Outputs, "var\n")
 	// test that containers do contain the ENV var
 	t.Assert(app.sh("echo $ENV_TEST"), Outputs, "var\n")
 	t.Assert(app.flynn("env", "unset", "ENV_TEST"), Succeeds)


### PR DESCRIPTION
Show env var from job if specified, instead from app.

Fixes #4108