### PR TITLE
router: Add option for custom 503 error page

### DIFF
--- a/builder/manifest.json
+++ b/builder/manifest.json
@@ -312,6 +312,9 @@
       "layers": [{
         "gobuild": {
           "router": "/bin/flynn-router"
+        },
+        "copy": {
+          "util/ca-certs/ca-certs.pem": "/etc/ssl/certs/ca-certs.pem"
         }
       }],
       "entrypoint": {

--- a/router/http.go
+++ b/router/http.go
@@ -53,6 +53,8 @@ type HTTPListener struct {
 	keypair       tls.Certificate
 	proxyProtocol bool
 
+	error503Page []byte
+
 	preSync  func()
 	postSync func(<-chan struct{})
 }
@@ -344,6 +346,7 @@ func (h *httpSyncHandler) Set(data *router.Route) error {
 		bf = service.sc.Addrs
 	}
 	r.rp = proxy.NewReverseProxy(bf, h.l.cookieKey, r.Sticky, service, logger)
+	r.rp.Error503Page = h.l.error503Page
 	r.service = service
 	h.l.routes[data.ID] = r
 	domain := net.JoinHostPort(strings.ToLower(r.Domain), strconv.Itoa(r.Port))


### PR DESCRIPTION
If `ERROR_503_PAGE_URL` is set for the router app, it will get the page contents from the URL at startup and serve it as HTML whenever a 503 error is returned.