### PR TITLE
router: Ensure that drain_backends is consistent for service

### DIFF
--- a/host/containerinit/init.go
+++ b/host/containerinit/init.go
@@ -39,8 +39,8 @@ import (
 	hh "github.com/flynn/flynn/pkg/httphelper"
 	"github.com/flynn/flynn/pkg/rpcplus"
 	"github.com/flynn/flynn/pkg/rpcplus/fdrpc"
-	"github.com/kr/pty"
 	"github.com/inconshreveable/log15"
+	"github.com/kr/pty"
 )
 
 var logger log15.Logger
@@ -510,6 +510,7 @@ func babySit(init *ContainerInit, hbs []discoverd.Heartbeater) int {
 				continue
 			}
 			if sig == syscall.SIGTERM || sig == syscall.SIGINT {
+				log.Info("deregistering service due to signal")
 				shutdownOnce.Do(closeHBs)
 			}
 			log.Info("forwarding signal to job", "type", sig)


### PR DESCRIPTION
If there are multiple routes that point at the same service, and some have `drain_backends` disabled, while others have `drain_backends` enabled, all routes will have the flag set to a single non-deterministic value in the router service cache, which can result in routes not being drained properly.

This patch solves the problem by toggling any existing routes with mismatched `drain_backends` to true, and adding a database check so that new routes cannot be created with this inconsistency.