### PR TITLE
Bug fix (Ubuntu 18.04) - '/usr/local/bin/flynn: Permission denied'

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,7 @@ are available.
 To install the latest release on OS X or Linux, run this command in a terminal:
 
 ```text
-L=/usr/local/bin/flynn && curl -sSL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >$L && chmod +x $L
+sudo bash -c 'L=/usr/local/bin/flynn && curl -sSL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >$L && chmod +x $L'
 ```
 
 To install the latest release on Windows, run this command in PowerShell:


### PR DESCRIPTION
Bug fix for installation of Flynn CLI(Command Line Interface).