### PR TITLE
Allow specifying an alternative 'docker' binary via DOCKER_BIN

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -44,7 +44,7 @@ Example:
 	Assuming you have a Docker image tagged "my-custom-image:v2":
 
 	$ flynn docker push my-custom-image:v2
-	flynn: getting image config with "docker inspect -f {{ json .Config }} my-custom-image:v2"
+	flynn: getting image config with "docker inspect -f {{ json .ContainerConfig }} my-custom-image:v2"
 	flynn: tagging Docker image with "docker tag my-custom-image:v2 docker.1.localflynn.com/my-app:latest"
 	flynn: pushing Docker image with "docker push docker.1.localflynn.com/my-app:latest"
 	The push refers to a repository [docker.1.localflynn.com/my-app] (len: 1)
@@ -201,7 +201,7 @@ func runDockerPush(args *docopt.Args, client controller.Client) error {
 	}
 
 	// get the image config to determine Cmd, Entrypoint and Env
-	cmd := exec.Command("docker", "inspect", "-f", "{{ json .Config }}", image)
+	cmd := exec.Command("docker", "inspect", "-f", "{{ json .ContainerConfig }}", image)
 	log.Printf("flynn: getting image config with %q", strings.Join(cmd.Args, " "))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
The patch introduces the ability to use different `docker` - or compatible - binaries to the `flynn docker` subcommands by providing their path in the environment variable `DOCKER_BIN`. This is useful if you want to use a different Docker build or an alternative CLI like [`podman`](https://github.com/containers/libpod) temporarily.

fixes #4465