### PR TITLE
host/logmux: Add timeouts to sink writes

### DIFF
--- a/host/logmux/sink.go
+++ b/host/logmux/sink.go
@@ -442,6 +442,7 @@ func (s *LogAggregatorSink) GetCursor(hostID string) (*utils.HostCursor, error) 
 }
 
 func (s *LogAggregatorSink) Write(m message) error {
+	s.conn.SetWriteDeadline(time.Now().Add(time.Second))
 	_, err := s.conn.Write(rfc6587.Bytes(m.Message))
 	return err
 }
@@ -650,6 +651,7 @@ func (s *SyslogSink) Write(m message) error {
 	case ct.SyslogFormatNewline:
 		data = append(msg.Bytes(), '\n')
 	}
+	s.conn.SetWriteDeadline(time.Now().Add(time.Second))
 	_, err := s.conn.Write(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
These basic timeouts prevent a potential scenario where the stdout pipe from a container fills up due to a blocked sink, in turn blocking the containerized process in a write(2) to the pipe.

Both timeouts were tested manually via code modifications due to the complexity and fragility of an integration test for these paths.