### PR TITLE
Various CI Updates

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -31,6 +31,7 @@ type State struct {
 	MinHosts    int
 	Hosts       []*cluster.Host
 	HostTimeout time.Duration
+	JobTimeout  time.Duration
 
 	discoverd     *discoverd.Client
 	controller    controller.Client
@@ -125,6 +126,7 @@ type Config struct {
 	MinHosts   int
 	Timeout    int
 	Singleton  bool
+	JobTimeout int
 }
 
 type Manifest []Step
@@ -145,6 +147,7 @@ func (m Manifest) Run(ch chan<- *StepInfo, cfg Config) (state *State, err error)
 		MinHosts:    cfg.MinHosts,
 		ClusterURL:  cfg.ClusterURL,
 		HostTimeout: time.Duration(cfg.Timeout) * time.Second,
+		JobTimeout:  time.Duration(cfg.JobTimeout) * time.Second,
 	}
 
 	var hostURLs []string

--- a/bootstrap/run_app_action.go
+++ b/bootstrap/run_app_action.go
@@ -134,6 +134,7 @@ func startJob(s *State, hc *cluster.Host, job *host.Job) error {
 	if err != nil {
 		return err
 	}
+	timeout := time.After(s.JobTimeout)
 	go func() {
 		defer stream.Close()
 	loop:
@@ -161,7 +162,7 @@ func startJob(s *State, hc *cluster.Host, job *host.Job) error {
 					return
 				default:
 				}
-			case <-time.After(30 * time.Second):
+			case <-timeout:
 				jobStatus <- errors.New("bootstrap: timed out waiting for job event")
 				return
 			}

--- a/host/cleanup.sh
+++ b/host/cleanup.sh
@@ -2,9 +2,20 @@
 #
 # A script to cleanup after flynn-host has exited inside a container.
 
-set -ex
+set -e
 
 JOB_ID="$1"
+ZPOOL="flynn-${JOB_ID}"
+HOST_DIR="/var/lib/flynn/${JOB_ID}"
 
-zpool destroy "flynn-${JOB_ID}"
-rm -rf "/var/lib/flynn/${JOB_ID}"
+# try multiple times to destroy the zpool in case it's still busy
+for i in $(seq 10); do
+  echo "destroying zpool: ${ZPOOL}"
+  if zpool destroy "${ZPOOL}"; then
+    break
+  fi
+  sleep 1
+done
+
+echo "removing host dir: ${HOST_DIR}"
+rm -rf "${HOST_DIR}"

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -40,6 +40,7 @@ Options:
   --discovery=TOKEN    use discovery token to connect to cluster
   --peer-ips=IPLIST    use IP address list to connect to cluster
   --steps=STEPS        only run the given STEPS (comma separated)
+  --job-timeout=SECS   seconds to wait for jobs to start [default: 30]
 
 Bootstrap layer 1 using the provided manifest`)
 }
@@ -85,7 +86,12 @@ func runBootstrap(args *docopt.Args) error {
 
 	cfg.Timeout, err = strconv.Atoi(args.String["--timeout"])
 	if err != nil {
-		return fmt.Errorf("invalid --timeout value")
+		return fmt.Errorf("invalid --timeout value %q: %s", args.String["--timeout"], err)
+	}
+
+	cfg.JobTimeout, err = strconv.Atoi(args.String["--job-timeout"])
+	if err != nil {
+		return fmt.Errorf("invalid --job-timeout value %q: %s", args.String["--job-timeout"], err)
 	}
 
 	if ipList := args.String["--peer-ips"]; ipList != "" {

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -466,7 +466,7 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	var cmdErr error
 	go func() {
 		command := fmt.Sprintf(
-			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s DISCOVERD=%s:1111 flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s --job-timeout=120 /etc/flynn-bootstrap.json",
+			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s DISCOVERD=%s:1111 FLANNEL_NETWORK=100.65.0.0/16 flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s --job-timeout=120 /etc/flynn-bootstrap.json",
 			c.ClusterDomain, c.ControllerKey, inst.IP, len(instances), strings.Join(ips, ","),
 		)
 		cmdErr = inst.Run(command, &Streams{Stdout: wr, Stderr: c.out})

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -466,7 +466,7 @@ func (c *Cluster) bootstrapLayer1(instances []*Instance) error {
 	var cmdErr error
 	go func() {
 		command := fmt.Sprintf(
-			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s DISCOVERD=%s:1111 flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s /etc/flynn-bootstrap.json",
+			"CLUSTER_DOMAIN=%s CONTROLLER_KEY=%s DISCOVERD=%s:1111 flynn-host bootstrap --json --min-hosts=%d --peer-ips=%s --job-timeout=120 /etc/flynn-bootstrap.json",
 			c.ClusterDomain, c.ControllerKey, inst.IP, len(instances), strings.Join(ips, ","),
 		)
 		cmdErr = inst.Run(command, &Streams{Stdout: wr, Stderr: c.out})

--- a/test/cluster2/cluster.go
+++ b/test/cluster2/cluster.go
@@ -222,6 +222,7 @@ func Boot(c *BootConfig) (*Cluster, error) {
 	bootstrapArgs := []string{
 		"--min-hosts", strconv.Itoa(c.Size),
 		"--peer-ips", strings.Join(peerIPs, ","),
+		"--job-timeout", "120",
 	}
 	if c.Backup != "" {
 		bootstrapArgs = append(bootstrapArgs, "--from-backup", c.Backup)

--- a/test/test_host.go
+++ b/test/test_host.go
@@ -629,14 +629,12 @@ func (s *HostSuite) TestVolumeDeleteOnStop(t *c.C) {
 
 func (s *HostSuite) TestUpdate(t *c.C) {
 	dir := t.MkDir()
-	flynnHost := filepath.Join(dir, "flynn-host")
-	run(t, osexec.Command("cp", args.FlynnHost, flynnHost))
 
 	// start flynn-host
 	id := random.String(8)
 	var out bytes.Buffer
 	cmd := osexec.Command(
-		flynnHost,
+		"flynn-host",
 		"daemon",
 		"--http-port", "11113",
 		"--state", filepath.Join(dir, "host-state.bolt"),
@@ -678,7 +676,7 @@ func (s *HostSuite) TestUpdate(t *c.C) {
 
 	// exec flynn-host and check we get the status from the new daemon
 	pid, err := client.Update(
-		flynnHost,
+		"flynn-host",
 		"daemon",
 		"--http-port", "11113",
 		"--state", filepath.Join(dir, "host-state.bolt"),


### PR DESCRIPTION
Summary:

* fix the failing `HostSuite.TestUpdate`
* increase the timeout for starting jobs in test clusters
* use a different Flannel network for test clusters to avoid clashing with the host network
* destroy test clusters that fail to boot to avoid them leaking and slowing down other tests
* retry destroying zpools when stopping a test flynn-host