### PR TITLE
cli: Fix cluster URLs when domain is provided as a controller URL

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -154,11 +154,11 @@ func runClusterAdd(args *docopt.Args) error {
 		TLSPin:        args.String["--tls-pin"],
 	}
 	domain := args.String["<domain>"]
-	if strings.HasPrefix(domain, "https://") {
-		s.ControllerURL = domain
-	} else {
-		s.ControllerURL = "https://controller." + domain
-	}
+
+	// handle legacy use where <domain> is the controller URL
+	domain = strings.TrimPrefix(domain, "https://controller.")
+
+	s.ControllerURL = "https://controller." + domain
 	if s.GitURL == "" && !args.Bool["--no-git"] {
 		s.GitURL = "https://git." + domain
 	}

--- a/test/test_cli.go
+++ b/test/test_cli.go
@@ -814,6 +814,16 @@ func (s *CLISuite) TestCluster(t *c.C) {
 	t.Assert(flynn("cluster", "add", "--no-git", "-p", "KGCENkp53YF5OvOKkZIry71+czFRkSw2ZdMszZ/0ljs=", "next", "https://controller.next.example.com", "e09dc5301d72be755a3d666f617c4600"), Succeeds)
 	t.Assert(flynn("cluster", "remove", "test"), SuccessfulOutputContains, "Cluster \"test\" removed and \"next\" is now the default cluster.")
 	t.Assert(flynn("cluster", "default"), SuccessfulOutputContains, "next")
+
+	// check GitURL and DockerPushURL are configured correctly
+	cluster := s.clusterConf(t)
+	t.Assert(flynn("cluster", "add", "--tls-pin", cluster.TLSPin, "--docker", "baz", cluster.ControllerURL, cluster.Key), Succeeds)
+	cfg, err = config.ReadFile(file.Name())
+	t.Assert(err, c.IsNil)
+	domain := strings.TrimPrefix(cluster.ControllerURL, "https://controller.")
+	t.Assert(cfg.Clusters[1].Name, c.Equals, "baz")
+	t.Assert(cfg.Clusters[1].GitURL, c.Equals, "https://git."+domain)
+	t.Assert(cfg.Clusters[1].DockerPushURL, c.Equals, "https://docker."+domain)
 }
 
 func (s *CLISuite) TestRelease(t *c.C) {


### PR DESCRIPTION
When adding a cluster with `<domain>` set to a controller URL like `https://controller.example.com`, the `ControllerURL` would be set correctly but `GitURL` would end up being `https://git.https://controller.example.com`.

This fixes `GitURL` and `DockerPushURL` in the case that `<domain>` starts with `https://controller.` by stripping the prefix.

@titanous we should also update the docs to use `$CLUSTER_DOMAIN` rather than `https://controller.$CLUSTER_DOMAIN` [here](https://flynn.io/docs/cli#adding-clusters) (I don't know how to do it myself).

Fixes #4495.