### PR TITLE
logmux: Add support for prefixed newline format

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -85,7 +85,7 @@ Commands:
         options:
             --use-ids          Use app IDs instead of app names in the syslog APP-NAME field.
             --insecure         Don't verify servers certificate chain or hostname. Should only be used for testing.
-            --format=<format>  One of rfc6587 or newline, defaults to rfc6587.
+            --format=<format>  One of rfc6587, newline, or prefixed_newline. Defaults to rfc6587.
 
         examples:
             $ flynn cluster log-sink add syslog syslog+tls://rsyslog.host:514/
@@ -498,6 +498,8 @@ func runLogSinkAddSyslog(args *docopt.Args, client controller.Client) error {
 	switch args.String["--format"] {
 	case "newline":
 		format = ct.SyslogFormatNewline
+	case "prefixed_newline":
+		format = ct.SyslogFormatPrefixedNewline
 	case "rfc6587", "":
 		format = ct.SyslogFormatRFC6587
 	default:

--- a/controller/types/types.go
+++ b/controller/types/types.go
@@ -705,8 +705,9 @@ type Sink struct {
 type SyslogFormat string
 
 const (
-	SyslogFormatRFC6587 SyslogFormat = "rfc6587"
-	SyslogFormatNewline SyslogFormat = "newline"
+	SyslogFormatRFC6587         SyslogFormat = "rfc6587"
+	SyslogFormatNewline         SyslogFormat = "newline"
+	SyslogFormatPrefixedNewline SyslogFormat = "prefixed_newline"
 )
 
 type SyslogSinkConfig struct {

--- a/host/logmux/logmux.go
+++ b/host/logmux/logmux.go
@@ -288,6 +288,8 @@ func (m *Mux) Follow(r io.ReadCloser, buffer string, msgID logagg.MsgID, config 
 		Hostname: []byte(config.HostID),
 		AppName:  []byte(config.AppID),
 		MsgID:    []byte(msgID),
+		Severity: 6,  // Info
+		Facility: 23, // local7
 	}
 	if config.JobType != "" {
 		hdr.ProcID = []byte(config.JobType + "." + config.JobID)

--- a/host/logmux/sink.go
+++ b/host/logmux/sink.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/boltdb/bolt"
 	ct "github.com/flynn/flynn/controller/types"
-	"github.com/flynn/flynn/discoverd/client"
-	"github.com/flynn/flynn/host/types"
+	discoverd "github.com/flynn/flynn/discoverd/client"
+	host "github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/logaggregator/client"
 	"github.com/flynn/flynn/logaggregator/utils"
 	"github.com/flynn/flynn/pkg/dialer"
@@ -634,7 +634,7 @@ func (s *SyslogSink) Write(m message) error {
 	}
 
 	// If the generated/cached prefix isn't 0 length then modify the message body
-	if len(prefix) != 0 {
+	if len(prefix) != 0 && s.format != ct.SyslogFormatPrefixedNewline {
 		msg.Msg = bytes.Join([][]byte{prefix, m.Message.Msg}, msgSep)
 	}
 
@@ -650,6 +650,8 @@ func (s *SyslogSink) Write(m message) error {
 		data = rfc6587.Bytes(msg)
 	case ct.SyslogFormatNewline:
 		data = append(msg.Bytes(), '\n')
+	case ct.SyslogFormatPrefixedNewline:
+		data = bytes.Join([][]byte{prefix, []byte{' '}, msg.Bytes(), []byte{'\n'}}, nil)
 	}
 	s.conn.SetWriteDeadline(time.Now().Add(time.Second))
 	_, err := s.conn.Write(data)


### PR DESCRIPTION
This enables support for some log sinks that require an API key to be prefixed. Also fixed the severity/facility to not be the default 0.