### PR TITLE
cli: Ensure curl in export uses HTTP/1.1

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -129,7 +129,7 @@ func runExport(args *docopt.Args, client controller.Client) error {
 			Artifacts:          release.ArtifactIDs[:1],
 			DeprecatedArtifact: release.ArtifactIDs[0],
 			DisableLog:         true,
-			Args:               []string{"curl", "--include", "--location", "--raw", url},
+			Args:               []string{"curl", "--include", "--http1.1", "--location", "--raw", url},
 			Stdout:             reqW,
 			Stderr:             ioutil.Discard,
 		}


### PR DESCRIPTION
If curl gets redirected to a server that supports HTTP/2 (for example with the GCS blobstore backend), it will return output that is not parsed correctly and the export will hang.

Closes #4548