### PR TITLE
slugbuilder: Silence stderr output from detect hooks

### DIFF
--- a/slugbuilder/builder/build.sh
+++ b/slugbuilder/builder/build.sh
@@ -162,7 +162,7 @@ if [[ -n "${BUILDPACK_URL}" ]]; then
   buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_dir}")
 else
   for buildpack in "${buildpacks[@]}"; do
-    buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_dir}") \
+    buildpack_name=$(run_unprivileged ${buildpack}/bin/detect "${build_dir}" 2>/dev/null) \
       && selected_buildpack="${buildpack}" \
       && break
   done


### PR DESCRIPTION
Heroku has added debugging output to the detect hooks that shows up on every push. Silence it by diverting stderr to /dev/null.