### PR TITLE
More CI Fixes

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -206,7 +206,7 @@ func runClusterAdd(args *docopt.Args) error {
 	}
 
 	if s.DockerPushURL != "" {
-		fmt.Fprintln(os.Stderr, "DEPRECATED: Pushing via a Docker registry has been deprecated in favour of pushing via the Flynn image service, set --image-url instead\n")
+		fmt.Fprintln(os.Stderr, "DEPRECATED: Pushing via a Docker registry has been deprecated in favour of pushing via the Flynn image service, set --image-url instead")
 		host, err := s.DockerPushHost()
 		if err != nil {
 			return err

--- a/host/cli/bootstrap.go
+++ b/host/cli/bootstrap.go
@@ -809,7 +809,7 @@ DELETE FROM volumes WHERE created_at < '%s';`,
 	}
 
 	if migrateDocker {
-		fmt.Fprintln(os.Stderr, `
+		fmt.Fprint(os.Stderr, `
 WARN:
 WARN: There are some legacy Docker images in the backup that can no longer
 WARN: be imported to new clusters. You will need to boot a cluster with version

--- a/script/start-flynn-host
+++ b/script/start-flynn-host
@@ -164,6 +164,7 @@ main() {
     --init-log-level "debug" \
     --tags "host_id=${id}" \
     --max-job-concurrency=100 \
+    --enable-dhcp \
     ${peer_ips} \
     &>"${log}"
 

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -16,7 +16,7 @@ import (
 	units "github.com/docker/go-units"
 	"github.com/flynn/flynn/cli/config"
 	controller "github.com/flynn/flynn/controller/client"
-	"github.com/flynn/flynn/discoverd/client"
+	discoverd "github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/pkg/random"
 	"github.com/flynn/flynn/test/buildlog"
 )
@@ -394,6 +394,7 @@ set -e -x
 
 export GOPATH=~/go
 flynn=$GOPATH/src/github.com/flynn/flynn
+export PATH="${flynn}/build/bin:${PATH}"
 cd $flynn
 
 if [[ -f test/scripts/test-unit.sh ]]; then

--- a/test/rootfs/build.sh
+++ b/test/rootfs/build.sh
@@ -14,6 +14,7 @@ image="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-
 curl -L ${image} | tar -xzC ${dir}
 
 mount -t proc proc "${dir}/proc"
+cp /etc/resolv.conf "${dir}/etc/resolv.conf"
 chroot ${dir} bash < "${src_dir}/setup.sh"
 
 cp ${dir}/boot/vmlinuz-* ${build_dir}/vmlinuz

--- a/test/rootfs/setup.sh
+++ b/test/rootfs/setup.sh
@@ -29,7 +29,6 @@ systemctl enable systemd-networkd.service
 
 # configure hosts and dns resolution
 echo "127.0.0.1 localhost localhost.localdomain" > /etc/hosts
-echo -e "nameserver 8.8.8.8\nnameserver 8.8.4.4" > /etc/resolv.conf
 
 # enable universe
 sed -i "s/^#\s*\(deb.*universe\)\$/\1/g" /etc/apt/sources.list


### PR DESCRIPTION
- Fix `fmt` usage (this was causing `go test` to fail)
- Add `build/bin` to `PATH` when running unit tests (`gofmt` couldn't be found)
- Use the host `resolv.conf` (CI doesn't like Google DNS in VMs, lookups just hang)
- Enable DHCP in dev (so I can run CI in dev)