### PR TITLE
builder: Downgrade host image to ubuntu-xenial

### DIFF
--- a/builder/img/ubuntu-xenial.sh
+++ b/builder/img/ubuntu-xenial.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+TMP="$(mktemp --directory)"
+
+URL="https://partner-images.canonical.com/core/xenial/20191108/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz"
+SHA="bd9f1a6f5da8379ab0918ea4b36ccf93d35b0052f2e47bad659794d0cd91aa5f"
+curl -fSLo "${TMP}/ubuntu.tar.gz" "${URL}"
+echo "${SHA}  ${TMP}/ubuntu.tar.gz" | sha256sum -c -
+
+mkdir -p "${TMP}/root"
+tar xf "${TMP}/ubuntu.tar.gz" -C "${TMP}/root"
+
+cp "/etc/resolv.conf" "${TMP}/root/etc/resolv.conf"
+mount --bind "/dev/pts" "${TMP}/root/dev/pts"
+cleanup() {
+  umount "${TMP}/root/dev/pts"
+  >"${TMP}/root/etc/resolv.conf"
+}
+trap cleanup EXIT
+
+chroot "${TMP}/root" bash -e < "builder/ubuntu-setup.sh"
+
+mksquashfs "${TMP}/root" "/mnt/out/layer.squashfs" -noappend

--- a/builder/manifest.json
+++ b/builder/manifest.json
@@ -23,6 +23,15 @@
       }]
     },
     {
+      "id": "ubuntu-xenial",
+      "layers": [{
+        "script": "builder/img/ubuntu-xenial.sh",
+        "inputs": ["builder/ubuntu-setup.sh"],
+        "limits": { "temp_disk": "2GB" },
+        "linux_capabilities": ["CAP_SYS_ADMIN"]
+      }]
+    },
+    {
       "id": "ubuntu-bionic",
       "layers": [{
         "script": "builder/img/ubuntu-bionic.sh",
@@ -98,7 +107,7 @@
     },
     {
       "id": "host",
-      "base": "ubuntu-bionic",
+      "base": "ubuntu-xenial",
       "layers": [
         {
           "name": "host-packages",


### PR DESCRIPTION
The bionic ZFS packages are not compatible with the older xenial packages used in CI (due to a bug in recent versions of ZFS using backing files), and so the host image needs to be based off xenial so
that its ZFS package can be used to create zpools when starting test clusters.

This has no effect on the released flynn-host as the binary will continue to be built with the Go image (that is based on bionic) and the host image is only used for testing.

(This is a blind fix, I'll know if it's effective once this PR is opened and CI runs...)