### PR TITLE
host: Support starting using KVM

### DIFF
--- a/host/cleanup.sh
+++ b/host/cleanup.sh
@@ -5,17 +5,21 @@
 set -e
 
 JOB_ID="$1"
+
 ZPOOL="flynn-${JOB_ID}"
+if zpool status "${ZPOOL}" &>/dev/null; then
+  # try multiple times to destroy the zpool in case it's still busy
+  for i in $(seq 10); do
+    echo "destroying zpool: ${ZPOOL}"
+    if zpool destroy "${ZPOOL}"; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
 HOST_DIR="/var/lib/flynn/${JOB_ID}"
-
-# try multiple times to destroy the zpool in case it's still busy
-for i in $(seq 10); do
-  echo "destroying zpool: ${ZPOOL}"
-  if zpool destroy "${ZPOOL}"; then
-    break
-  fi
-  sleep 1
-done
-
-echo "removing host dir: ${HOST_DIR}"
-rm -rf "${HOST_DIR}"
+if [[ -d "${HOST_DIR}" ]]; then
+  echo "removing host dir: ${HOST_DIR}"
+  rm -rf "${HOST_DIR}"
+fi

--- a/host/img/packages.sh
+++ b/host/img/packages.sh
@@ -1,5 +1,58 @@
 #!/bin/bash
 
+# install packages for starting flynn-host within an existing Flynn cluster
+# either in a container or in a VM
+export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install --yes zfsutils-linux iptables udev net-tools iproute2
+# explicitly install linux 4.13 as the version of ZFS available on xenial is
+# not compatible with linux 4.15 (the 'zfs' command just hangs)
+apt-get install --yes linux-image-4.13.0-1019-gcp initramfs-tools systemd udev zfsutils-linux iptables net-tools iproute2 qemu-kvm
 apt-get clean
+
+# support 9p rootfs when starting in a VM
+printf '%s\n' 9p 9pnet 9pnet_virtio >> /etc/initramfs-tools/modules
+update-initramfs -u
+
+# install jq for reading container config files
+JQ_URL="https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
+JQ_SHA="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
+curl -fsSLo /tmp/jq "${JQ_URL}"
+echo "${JQ_SHA}  /tmp/jq" | sha256sum -c -
+mv /tmp/jq /usr/local/bin/jq
+chmod +x /usr/local/bin/jq
+
+# add a systemd service to start flynn-host in a VM
+cat > /etc/systemd/system/flynn-host.service <<EOF
+[Unit]
+Description=Flynn host daemon
+Documentation=https://flynn.io/docs
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/start-flynn-host.sh --systemd
+Restart=on-failure
+
+# set delegate yes so that systemd does not reset the cgroups of containers
+Delegate=yes
+
+# kill only the flynn-host process, not all processes in the cgroup
+KillMode=process
+
+# every container uses several fds, so make sure there are enough
+LimitNOFILE=10000
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable flynn-host.service
+
+# configure VM networking
+cat > /etc/systemd/network/10-flynn.network <<EOF
+[Match]
+Name=en*
+
+[Network]
+DHCP=ipv4
+EOF
+systemctl enable systemd-networkd.service

--- a/host/start.sh
+++ b/host/start.sh
@@ -5,41 +5,153 @@
 # exit on error
 set -e
 
-# create /etc/mtab to keep ZFS happy
-ln -nfs /proc/mounts /etc/mtab
+DEFAULT_KVM_MEMORY="2048"
+DEFAULT_KVM_CPUS="1"
 
-# start udevd so that ZFS device nodes and symlinks are created in our mount
-# namespace
-/lib/systemd/systemd-udevd --daemon
+main() {
+  # the --systemd flag indicates that the script was executed by systemd
+  # inside a VM, in which case start flynn-host in the VM
+  if [[ $1 = '--systemd' ]]; then
+    start_flynn_host_in_vm
+  elif [[ -e /dev/kvm ]]; then
+    start_kvm
+  else
+    start_flynn_host_in_container
+  fi
+}
 
-# use a unique directory in /var/lib/flynn (which is bind mounted from the
-# host)
-DIR="/var/lib/flynn/${FLYNN_JOB_ID}"
-mkdir -p "${DIR}"
+start_flynn_host_in_vm() {
+  # load the environment variables
+  source <(jq -r '.Env | to_entries[] | "export \(.key)=\(.value)"' /.containerconfig)
 
-# create a tmpdir in /var/lib/flynn to avoid ENOSPC when downloading image
-# layers
-export TMPDIR="${DIR}/tmp"
-mkdir -p "${TMPDIR}"
+  # mount /dev/sda as an ext4 filesystem at /var/lib/flynn and use it as the
+  # temp disk to avoid EINVAL issues with 9p filesystems
+  mkfs.ext4 -L FLYNN /dev/sda
+  mkdir -p /var/lib/flynn
+  mount /dev/sda /var/lib/flynn
+  mkdir -p /var/lib/flynn/tmp
+  export TMPDIR=/var/lib/flynn/tmp
 
-# use a unique zpool to avoid conflicts with other daemons
-ZPOOL="flynn-${FLYNN_JOB_ID}"
+  # mount the layer cache so that built images can be mounted
+  mkdir -p /var/lib/flynn/layer-cache
+  mount -t 9p -o trans=virtio layer-cache /var/lib/flynn/layer-cache
 
-ARGS=(
-  --state      "${DIR}/host-state.bolt"
-  --sink-state "${DIR}/sink-state.bolt"
-  --volpath    "${DIR}/volumes"
-  --log-dir    "${DIR}/logs"
-  --log-file   "/dev/stdout"
-  --zpool-name "${ZPOOL}"
-  --no-resurrect
-)
+  # setup the daemon args
+  local args=(--no-resurrect)
+  if [[ -n "${DISCOVERY_SERVICE}" ]]; then
+    args+=(--discovery-service "${DISCOVERY_SERVICE}")
+  fi
 
-if [[ -n "${DISCOVERY_SERVICE}" ]]; then
-  ARGS+=(
-    --discovery-service "${DISCOVERY_SERVICE}"
+  # start flynn-host
+  exec /usr/local/bin/flynn-host daemon ${args[@]}
+}
+
+start_kvm() {
+  local memory="${MEMORY:-${DEFAULT_KVM_MEMORY}}"
+  local cpus="${CPUS:-${DEFAULT_KVM_CPUS}}"
+
+  # read MAC address from /.containerconfig
+  local mac="$(jq --raw-output '.MAC' /.containerconfig)"
+  if [[ -z "${mac}" ]]; then
+    fail "MAC not found in /.containerconfig"
+  fi
+
+  # remove the IP and MAC from eth0 and bridge it with a TAP
+  # interface so the VM can use the IP and MAC instead
+  ip link set eth0 down
+  ip addr flush dev eth0
+  ip link set eth0 address "$(random_mac)"
+  ip link set eth0 up
+  ip link add br0 type bridge
+  ip link set br0 up
+  ip link set dev eth0 master br0
+  ip tuntap add dev tap0 mode tap
+  ip link set dev tap0 master br0
+  ip link set dev tap0 up
+
+  # use the container's filesystem as the root VM filesystem
+  local cmdline="root=rootfs rw rootfstype=9p rootflags=trans=virtio"
+
+  # set /etc/hostname
+  local hostname="$(jq --raw-output '.Hostname' /.containerconfig)"
+  if [[ -z "${hostname}" ]]; then
+    fail "Hostname not found in /.containerconfig"
+  fi
+  echo "${hostname}" > /etc/hostname
+
+  # attach to the console if stdout is a tty
+  if [[ -t 1 ]]; then
+    cmdline="${cmdline} console=ttyS0 console=tty0 noembed nomodeset norestore"
+  fi
+
+  # create a dedicated disk for /var/lib/flynn
+  truncate -s 10G /tmp/flynn.disk
+
+  # run the VM
+  exec /usr/bin/qemu-system-x86_64 \
+    -enable-kvm \
+    -m      "${memory}" \
+    -smp    "${cpus}" \
+    -kernel /boot/vmlinuz-* \
+    -initrd /boot/initrd.img-* \
+    -append "${cmdline}" \
+    -virtfs "fsdriver=local,path=/,security_model=passthrough,mount_tag=rootfs" \
+    -drive  "file=/tmp/flynn.disk,format=raw,index=0,media=disk" \
+    -virtfs "fsdriver=local,path=/var/lib/flynn/layer-cache,security_model=passthrough,mount_tag=layer-cache" \
+    -device "virtio-net,netdev=net0,mac=${mac}" \
+    -netdev "tap,id=net0,ifname=tap0,script=no,downscript=no" \
+    -nographic
+}
+
+start_flynn_host_in_container() {
+  # create /etc/mtab to keep ZFS happy
+  ln -nfs /proc/mounts /etc/mtab
+
+  # start udevd so that ZFS device nodes and symlinks are created in our mount
+  # namespace
+  /lib/systemd/systemd-udevd --daemon
+
+  # use a unique directory in /var/lib/flynn (which is bind mounted from the
+  # host)
+  DIR="/var/lib/flynn/${FLYNN_JOB_ID}"
+  mkdir -p "${DIR}"
+
+  # create a tmpdir in /var/lib/flynn to avoid ENOSPC when downloading image
+  # layers
+  export TMPDIR="${DIR}/tmp"
+  mkdir -p "${TMPDIR}"
+
+  # use a unique zpool to avoid conflicts with other daemons
+  ZPOOL="flynn-${FLYNN_JOB_ID}"
+
+  ARGS=(
+    --state      "${DIR}/host-state.bolt"
+    --sink-state "${DIR}/sink-state.bolt"
+    --volpath    "${DIR}/volumes"
+    --log-dir    "${DIR}/logs"
+    --log-file   "/dev/stdout"
+    --zpool-name "${ZPOOL}"
+    --no-resurrect
   )
-fi
 
-# start flynn-host
-exec /usr/local/bin/flynn-host daemon ${ARGS[@]}
+  if [[ -n "${DISCOVERY_SERVICE}" ]]; then
+    ARGS+=(
+      --discovery-service "${DISCOVERY_SERVICE}"
+    )
+  fi
+
+  # start flynn-host
+  exec /usr/local/bin/flynn-host daemon ${ARGS[@]}
+}
+
+random_mac () {
+  printf 'fe:%02x:%02x:%02x:%02x:%02x' $[RANDOM%256] $[RANDOM%256] $[RANDOM%256] $[RANDOM%256] $[RANDOM%256]
+}
+
+fail() {
+  local msg=$1
+  echo "ERROR: ${msg}" >&2
+  exit 1
+}
+
+main $@

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -121,6 +121,7 @@ main() {
     /usr/bin/env \
     ROOT="/go/src/github.com/flynn/flynn" \
     CLUSTER_ADD_ARGS="${cluster_add:18}" \
+    USE_KVM="$([[ -e /dev/kvm ]] && echo true)" \
     /bin/run-flynn-test.sh \
     ${args[@]}
 }

--- a/test/cluster2/cluster.go
+++ b/test/cluster2/cluster.go
@@ -130,15 +130,13 @@ func Boot(c *BootConfig) (*Cluster, error) {
 		return nil, err
 	}
 
-	var hostEnv map[string]string
-	if c.Size >= 3 {
-		hostEnv = map[string]string{"DISCOVERY_SERVICE": app.Name}
-	}
 	release := &ct.Release{
 		ArtifactIDs: []string{hostImage.ID},
 		Processes: map[string]ct.ProcessType{
 			"host": {
-				Env:      hostEnv,
+				Env: map[string]string{
+					"DISCOVERY_SERVICE": app.Name,
+				},
 				Profiles: []host.JobProfile{host.JobProfileZFS},
 				Mounts: []host.Mount{
 					{
@@ -150,11 +148,6 @@ func Boot(c *BootConfig) (*Cluster, error) {
 				Ports: []ct.Port{{
 					Port:  1113,
 					Proto: "tcp",
-					Service: &host.Service{
-						Name:   app.Name,
-						Create: true,
-						Check:  &host.HealthCheck{Type: "tcp"},
-					},
 				}},
 				LinuxCapabilities: append(host.DefaultCapabilities, []string{
 					"CAP_SYS_ADMIN",

--- a/test/helper.go
+++ b/test/helper.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/flynn/flynn/cli/config"
-	"github.com/flynn/flynn/controller/client"
+	controller "github.com/flynn/flynn/controller/client"
 	ct "github.com/flynn/flynn/controller/types"
-	"github.com/flynn/flynn/discoverd/client"
+	discoverd "github.com/flynn/flynn/discoverd/client"
 	"github.com/flynn/flynn/host/resource"
-	"github.com/flynn/flynn/host/types"
+	host "github.com/flynn/flynn/host/types"
 	"github.com/flynn/flynn/pkg/cluster"
 	flynnexec "github.com/flynn/flynn/pkg/exec"
 	"github.com/flynn/flynn/pkg/random"
@@ -188,6 +188,8 @@ func (h *Helper) bootClusterWithConfig(t *c.C, conf *cluster2.BootConfig) *Clust
 
 	conf.Logger = log15.New()
 	conf.Logger.SetHandler(log15.StreamHandler(debugLogWriter(t), log15.LogfmtFormat()))
+
+	conf.UseKVM = os.Getenv("USE_KVM") == "true"
 
 	s, err := cluster2.Boot(conf)
 	t.Assert(err, c.IsNil)


### PR DESCRIPTION
This allows us to run nested clusters on Ubuntu hosts that are running newer kernels that would otherwise fail due to a ZFS kernel bug.

KVM will be used when running `script/run-integration-tests` if `/dev/kvm` exists.