### PR TITLE
CI Updates

### DIFF
--- a/test/cluster/instance.go
+++ b/test/cluster/instance.go
@@ -267,6 +267,9 @@ func (i *Instance) dialSSH(stderr io.Writer) error {
 			Auth:            []ssh.AuthMethod{ssh.Password("ubuntu")},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		})
+		if err != nil {
+			fmt.Fprintf(stderr, "Error connecting to %s:22: %s\n", i.IP, err)
+		}
 		return
 	})
 	if sc != nil {

--- a/test/test_release.go
+++ b/test/test_release.go
@@ -175,7 +175,7 @@ func (s *ReleaseSuite) TestReleaseImages(t *c.C) {
 	t.Assert(client.CreateApp(slugApp), c.IsNil)
 	gitreceive, err := client.GetAppRelease("gitreceive")
 	t.Assert(err, c.IsNil)
-	imageArtifact, err := client.GetArtifact(gitreceive.Env["SLUGRUNNER_IMAGE_ID"])
+	imageArtifact, err := client.GetArtifact(gitreceive.Env["SLUGRUNNER_18_IMAGE_ID"])
 	t.Assert(err, c.IsNil)
 	slugArtifact, err := client.GetArtifact(slugImageID)
 	t.Assert(err, c.IsNil)

--- a/test/vm.sh
+++ b/test/vm.sh
@@ -38,19 +38,13 @@ main() {
   ip link set dev tap0 master br0
   ip link set dev tap0 up
 
-  # attach to the console if stdout is a tty
-  local append="root=/dev/sda"
-  if [[ -t 1 ]]; then
-    append="${append} console=ttyS0 console=tty0 noembed nomodeset norestore"
-  fi
-
   # run the VM
   exec /usr/bin/qemu-system-x86_64 \
     -enable-kvm \
     -m      "${memory}" \
     -smp    "${cpus}" \
     -kernel "${kernel}" \
-    -append "${append}" \
+    -append "root=/dev/sda console=ttyS0 noembed nomodeset norestore quiet systemd.journald.forward_to_console=1" \
     -drive  "file=${disk},index=0,media=disk" \
     -device "e1000,netdev=net0,mac=${mac}" \
     -netdev "tap,id=net0,ifname=tap0,script=no,downscript=no" \


### PR DESCRIPTION
This fixes an image reference in `TestReleaseImages` and also updates test VMs to log the systemd journal to help investigate why some VMs don't start in CI.

Opening as a draft as I suspect this will lead to a fix for the failing VMs once run in CI.