### PR TITLE
builder: add flags to speed up building specific images

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -48,12 +48,17 @@ options:
   -x, --version=<version>   version to use [default: dev]
   -t, --tuf-db=<path>       path to TUF database [default: build/tuf.db]
   -v, --verbose             be verbose
+  --filter=<imageIDs>       imageIDs to build (defaults to all)
 
 Build Flynn images using builder/manifest.json.
 `[1:],
 }
 
 type Builder struct {
+	// imageWhitelist is used to limit which images are built
+	imageWhitelist    []string
+	imageWhitelistMap map[string]struct{}
+
 	// baseLayer is used when building an image which has no
 	// dependencies (e.g. the ubuntu-bionic image)
 	baseLayer *host.Mountspec
@@ -246,10 +251,11 @@ func runBuild(args *docopt.Args) error {
 
 	tufRootKeys, _ := json.Marshal(manifest.TUFConfig.RootKeys)
 	builder := &Builder{
-		tufClient: tufClient,
-		tufConfig: manifest.TUFConfig,
-		baseLayer: manifest.BaseLayer,
-		artifacts: make(map[string]*ct.Artifact),
+		imageWhitelist: strings.Split(args.String["--filter"], ","),
+		tufClient:      tufClient,
+		tufConfig:      manifest.TUFConfig,
+		baseLayer:      manifest.BaseLayer,
+		artifacts:      make(map[string]*ct.Artifact),
 		envTemplateData: map[string]string{
 			"TUFRootKeys":   string(tufRootKeys),
 			"TUFRepository": manifest.TUFConfig.Repository,
@@ -373,11 +379,72 @@ func (b *Builder) Build(images []*Image) error {
 		}
 	}
 
+	// make sure all builds specified with --filter have themselfs and their
+	// dependencies whitelisted
+	imageWhitelistMap := make(map[string]struct{}, len(b.imageWhitelist))
+	var addToWhitelist func(*Build)
+	addToWhitelist = func(build *Build) {
+		imageWhitelistMap[build.Image.ID] = struct{}{}
+		for dep := range build.Dependencies {
+			addToWhitelist(dep)
+		}
+	}
+	for _, id := range b.imageWhitelist {
+		if build, ok := builds[id]; ok {
+			addToWhitelist(build)
+		}
+	}
+	b.imageWhitelistMap = imageWhitelistMap
+	imageWhitelist := make([]string, 0, len(imageWhitelistMap))
+	for imageID := range imageWhitelistMap {
+		imageWhitelist = append(imageWhitelist, imageID)
+	}
+	sort.Strings(imageWhitelist)
+	b.imageWhitelist = imageWhitelist
+	if len(imageWhitelist) > 0 {
+		b.log.Info(fmt.Sprintf("build restricted to the following images: %s", strings.Join(imageWhitelist, ", ")))
+	}
+
 	// build images until there are no pending builds left
 	done := make(chan *Build, len(builds))
 	failures := make(map[string]error)
 	for len(builds) > 0 {
 		for _, build := range builds {
+			// see --filter option
+			if len(imageWhitelistMap) > 0 {
+				if _, ok := imageWhitelistMap[build.Image.ID]; !ok {
+					build.Once.Do(func() {
+						b.log.Debug(fmt.Sprintf("%s build skip", build.Image.ID))
+
+						// attempt to load image artifact for use in WriteManifests
+						artifact := &ct.Artifact{}
+						path := filepath.Join("build", "image", build.Image.ID+".json")
+						f, err := os.Open(path)
+						if err != nil {
+							build.Err = fmt.Errorf("error reading image artifact for %q: %s", build.Image.ID, err)
+							b.log.Debug(build.Err.Error())
+							done <- build
+							return
+						}
+						defer f.Close()
+						if err := json.NewDecoder(f).Decode(artifact); err != nil {
+							build.Err = fmt.Errorf("error decoding image artifact for %q: %s", build.Image.ID, err)
+							b.log.Debug(build.Err.Error())
+							done <- build
+							return
+						}
+
+						b.artifactsMtx.Lock()
+						b.artifacts[build.Image.ID] = artifact
+						b.artifactsMtx.Unlock()
+
+						build.StartedAt = time.Now()
+						done <- build
+					})
+					continue
+				}
+			}
+
 			// if the build has no more pending dependencies, build it
 			if len(build.Dependencies) == 0 {
 				build.Once.Do(func() {

--- a/script/build-flynn
+++ b/script/build-flynn
@@ -16,6 +16,7 @@ OPTIONS:
   -v, --verbose           Be verbose
   -x, --version=VERSION   Explicit version to use [default: dev]
   -f, --force-bootstrap   Force bootstrap
+  --filter=ImageIDs       Only build images in given comma-seperated list of IDs
   --host=HOST             Host to run the build on
   --git-version           Generate the version using git status
 USAGE
@@ -26,6 +27,7 @@ main() {
   local version="dev"
   local verbose=false
   local force_bootstrap=false
+  local filter=""
 
   while true; do
     case "$1" in
@@ -47,6 +49,13 @@ main() {
       -f | --force-bootstrap)
         force_bootstrap=true
         shift
+        ;;
+      --filter)
+        if [[ -z "$2" ]]; then
+          fail "--filter flag requires an argument"
+        fi
+        filter="$2"
+        shift 2
         ;;
       -x | --version)
         if [[ -z "$2" ]]; then
@@ -116,6 +125,9 @@ main() {
   local args=("--version" "${version}")
   if $verbose; then
     args+=("--verbose")
+  fi
+  if [ -n "$filter" ]; then
+    args+=("--filter=${filter}")
   fi
   args+=("--tuf-db=/tmp/tuf.db")
 

--- a/script/build-flynn
+++ b/script/build-flynn
@@ -16,6 +16,7 @@ OPTIONS:
   -v, --verbose           Be verbose
   -x, --version=VERSION   Explicit version to use [default: dev]
   -f, --force-bootstrap   Force bootstrap
+  --force                 Force images to be built without using layer cache
   --filter=ImageIDs       Only build images in given comma-seperated list of IDs
   --host=HOST             Host to run the build on
   --git-version           Generate the version using git status
@@ -28,6 +29,7 @@ main() {
   local verbose=false
   local force_bootstrap=false
   local filter=""
+  local force=false
 
   while true; do
     case "$1" in
@@ -56,6 +58,10 @@ main() {
         fi
         filter="$2"
         shift 2
+        ;;
+      --force)
+        force=true
+        shift
         ;;
       -x | --version)
         if [[ -z "$2" ]]; then
@@ -128,6 +134,9 @@ main() {
   fi
   if [ -n "$filter" ]; then
     args+=("--filter=${filter}")
+  fi
+  if $force; then
+    args+=("--force")
   fi
   args+=("--tuf-db=/tmp/tuf.db")
 


### PR DESCRIPTION
This speeds up the build process when you know which image(s) need to be rebuilt.

Example usage:

```sh
$ vagrant up && vagrant ssh
# build "controller" and "status" images if not already cached
# and use layer cache for all other images
vagrant@flynn:~/go/src/github.com/flynn/flynn$ ./script/build-flynn --filter controller,status
# force building of the "controller" image and use layer cache for all other images
vagrant@flynn:~/go/src/github.com/flynn/flynn$ ./script/build-flynn --filter controller --force
```