### PR TITLE
router: Support disabling keep alives

### DIFF
--- a/cli/route.go
+++ b/cli/route.go
@@ -36,8 +36,8 @@ Options:
 	--no-leader                disable leader-only routing mode (update only)
 	-p, --port=<port>          port to accept traffic on
 	--no-drain-backends        don't wait for in-flight requests to complete before stopping backends
-	--disable-keep-alives      disable keep alives between the router and backends for the given route
-	--enable-keep-alives       enable keep alives between the router and backends for the given route
+	--disable-keep-alives      disable keep-alives between the router and backends for the given route
+	--enable-keep-alives       enable keep-alives between the router and backends for the given route
 
 Commands:
 	With no arguments, shows a list of routes.

--- a/cli/route.go
+++ b/cli/route.go
@@ -37,7 +37,7 @@ Options:
 	-p, --port=<port>          port to accept traffic on
 	--no-drain-backends        don't wait for in-flight requests to complete before stopping backends
 	--disable-keep-alives      disable keep-alives between the router and backends for the given route
-	--enable-keep-alives       enable keep-alives between the router and backends for the given route
+	--enable-keep-alives       enable keep-alives between the router and backends for the given route (default for new routes)
 
 Commands:
 	With no arguments, shows a list of routes.

--- a/controller/data/queries.go
+++ b/controller/data/queries.go
@@ -626,31 +626,31 @@ RETURNING created_at, updated_at`
 	volumeDecommissionQuery = `
 UPDATE volumes SET updated_at = now(), decommissioned_at = now() WHERE app_id = $1 AND volume_id = $2 RETURNING updated_at, decommissioned_at`
 	httpRouteListQuery = `
-SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
+SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.disable_keep_alives, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
 LEFT OUTER JOIN route_certificates AS rc on r.id = rc.http_route_id
 LEFT OUTER JOIN certificates AS c ON c.id = rc.certificate_id
 WHERE r.deleted_at IS NULL
 ORDER BY r.domain, r.path`
 	httpRouteListByParentRefQuery = `
-SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
+SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.disable_keep_alives, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
 LEFT OUTER JOIN route_certificates AS rc on r.id = rc.http_route_id
 LEFT OUTER JOIN certificates AS c ON c.id = rc.certificate_id
 WHERE r.parent_ref = $1 AND r.deleted_at IS NULL
 ORDER BY r.domain, r.path`
 	httpRouteInsertQuery = `
-INSERT INTO http_routes (parent_ref, service, port, leader, drain_backends, domain, sticky, path)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO http_routes (parent_ref, service, port, leader, drain_backends, domain, sticky, path, disable_keep_alives)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, path, created_at, updated_at`
 	httpRouteSelectQuery = `
-SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
+SELECT r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.disable_keep_alives, r.created_at, r.updated_at, c.id, c.cert, c.key, c.created_at, c.updated_at FROM http_routes as r
 LEFT OUTER JOIN route_certificates AS rc on r.id = rc.http_route_id
 LEFT OUTER JOIN certificates AS c ON c.id = rc.certificate_id
 WHERE r.id = $1 AND r.deleted_at IS NULL`
 	httpRouteUpdateQuery = `
 UPDATE http_routes as r
-SET parent_ref = $1, service = $2, port = $3, leader = $4, sticky = $5, path = $6
-WHERE id = $7 AND domain = $8 AND deleted_at IS NULL
-RETURNING r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.created_at, r.updated_at`
+SET parent_ref = $1, service = $2, port = $3, leader = $4, sticky = $5, path = $6, disable_keep_alives = $7
+WHERE id = $8 AND domain = $9 AND deleted_at IS NULL
+RETURNING r.id, r.parent_ref, r.service, r.port, r.leader, r.drain_backends, r.domain, r.sticky, r.path, r.disable_keep_alives, r.created_at, r.updated_at`
 	httpRouteDeleteQuery = `
 UPDATE http_routes SET deleted_at = now()
 WHERE id = $1`

--- a/controller/data/route.go
+++ b/controller/data/route.go
@@ -79,6 +79,7 @@ func (r *RouteRepo) addHTTP(tx *postgres.DBTx, route *router.Route) error {
 		route.Domain,
 		route.Sticky,
 		route.Path,
+		route.DisableKeepAlives,
 	).Scan(&route.ID, &route.Path, &route.CreatedAt, &route.UpdatedAt); err != nil {
 		return err
 	}
@@ -203,6 +204,7 @@ func scanHTTPRoute(s postgres.Scanner) (*router.Route, error) {
 		&route.Domain,
 		&route.Sticky,
 		&route.Path,
+		&route.DisableKeepAlives,
 		&route.CreatedAt,
 		&route.UpdatedAt,
 		&certID,
@@ -347,6 +349,7 @@ func (r *RouteRepo) updateHTTP(tx *postgres.DBTx, route *router.Route) error {
 		route.Leader,
 		route.Sticky,
 		route.Path,
+		route.DisableKeepAlives,
 		route.ID,
 		route.Domain,
 	).Scan(
@@ -359,6 +362,7 @@ func (r *RouteRepo) updateHTTP(tx *postgres.DBTx, route *router.Route) error {
 		&route.Domain,
 		&route.Sticky,
 		&route.Path,
+		&route.DisableKeepAlives,
 		&route.CreatedAt,
 		&route.UpdatedAt,
 	); err != nil {

--- a/controller/data/schema.go
+++ b/controller/data/schema.go
@@ -954,6 +954,9 @@ CREATE FUNCTION deployment_status(deployment_id uuid) RETURNS text AS $$
   SELECT data->>'status' FROM events WHERE object_type = 'deployment' AND object_id::uuid = deployment_id ORDER BY created_at DESC LIMIT 1;
 $$ LANGUAGE SQL;
 	`)
+	migrations.Add(49, `
+ALTER TABLE http_routes ADD COLUMN disable_keep_alives boolean NOT NULL DEFAULT false;
+	`)
 }
 
 func MigrateDB(db *postgres.DB) error {

--- a/router/http.go
+++ b/router/http.go
@@ -249,7 +249,14 @@ func (h *httpSyncHandler) Set(data *router.Route) error {
 	} else {
 		bf = backendFunc(r.Service, service.sc.Instances)
 	}
-	r.rp = proxy.NewReverseProxy(bf, h.l.cookieKey, r.Sticky, r.DisableKeepAlives, service, logger.New("service", r.Service))
+	r.rp = proxy.NewReverseProxy(proxy.ReverseProxyConfig{
+		BackendListFunc:   bf,
+		StickyKey:         h.l.cookieKey,
+		Sticky:            r.Sticky,
+		DisableKeepAlives: r.DisableKeepAlives,
+		RequestTracker:    service,
+		Logger:            logger.New("service", r.Service),
+	})
 	r.rp.Error503Page = h.l.error503Page
 	r.service = service
 	h.l.routes[data.ID] = r

--- a/router/http.go
+++ b/router/http.go
@@ -249,7 +249,7 @@ func (h *httpSyncHandler) Set(data *router.Route) error {
 	} else {
 		bf = backendFunc(r.Service, service.sc.Instances)
 	}
-	r.rp = proxy.NewReverseProxy(bf, h.l.cookieKey, r.Sticky, service, logger.New("service", r.Service))
+	r.rp = proxy.NewReverseProxy(bf, h.l.cookieKey, r.Sticky, r.DisableKeepAlives, service, logger.New("service", r.Service))
 	r.rp.Error503Page = h.l.error503Page
 	r.service = service
 	h.l.routes[data.ID] = r

--- a/router/http_test.go
+++ b/router/http_test.go
@@ -1659,13 +1659,13 @@ func (s *S) TestHTTPDisableKeepalive(c *C) {
 		}
 	}
 
-	// check that routes use keep alives by default
+	// check that routes use keep-alives by default
 	assertGet(c, "http://"+l.Addrs[0], "example.com", "1")
 	assertStates(http.StateNew, http.StateActive, http.StateIdle)
 	assertGet(c, "http://"+l.Addrs[0], "example.com", "1")
 	assertStates(http.StateActive, http.StateIdle)
 
-	// check that routes with keep alives disabled lead to new connections
+	// check that routes with keep-alives disabled lead to new connections
 	// per request
 	r.DisableKeepAlives = true
 	s.addRoute(c, l, r)
@@ -1674,7 +1674,7 @@ func (s *S) TestHTTPDisableKeepalive(c *C) {
 	assertGet(c, "http://"+l.Addrs[0], "example.com", "1")
 	assertStates(http.StateNew, http.StateActive, http.StateClosed)
 
-	// check that keep alives can be re-enabled
+	// check that keep-alives can be re-enabled
 	r.DisableKeepAlives = false
 	s.addRoute(c, l, r)
 	assertGet(c, "http://"+l.Addrs[0], "example.com", "1")

--- a/router/proxy/reverseproxy.go
+++ b/router/proxy/reverseproxy.go
@@ -70,9 +70,10 @@ type RequestTracker interface {
 // NewReverseProxy initializes a new ReverseProxy with a callback to get
 // backends, a stickyKey for encrypting sticky session cookies, and a flag
 // sticky to enable sticky sessions.
-func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky bool, rt RequestTracker, l log15.Logger) *ReverseProxy {
+func NewReverseProxy(bf BackendListFunc, stickyKey *[32]byte, sticky, disableKeepAlives bool, rt RequestTracker, l log15.Logger) *ReverseProxy {
 	return &ReverseProxy{
 		transport: &transport{
+			Transport:         newHTTPTransport(disableKeepAlives),
 			getBackends:       bf,
 			stickyCookieKey:   stickyKey,
 			useStickySessions: sticky,

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -189,7 +189,7 @@ func (h *tcpSyncHandler) Set(data *router.Route) error {
 	} else {
 		bf = backendFunc(r.Service, service.sc.Instances)
 	}
-	r.rp = proxy.NewReverseProxy(bf, nil, false, service, logger)
+	r.rp = proxy.NewReverseProxy(bf, nil, false, false, service, logger)
 	if listener, ok := h.l.listeners[r.Port]; ok {
 		r.l = listener
 		delete(h.l.listeners, r.Port)

--- a/router/tcp.go
+++ b/router/tcp.go
@@ -189,7 +189,11 @@ func (h *tcpSyncHandler) Set(data *router.Route) error {
 	} else {
 		bf = backendFunc(r.Service, service.sc.Instances)
 	}
-	r.rp = proxy.NewReverseProxy(bf, nil, false, false, service, logger)
+	r.rp = proxy.NewReverseProxy(proxy.ReverseProxyConfig{
+		BackendListFunc: bf,
+		RequestTracker:  service,
+		Logger:          logger,
+	})
 	if listener, ok := h.l.listeners[r.Port]; ok {
 		r.l = listener
 		delete(h.l.listeners, r.Port)

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -67,7 +67,7 @@ type Route struct {
 	// completed).
 	DrainBackends bool `json:"drain_backends,omitempty"`
 
-	// DisableKeepAlives when set will disable keep alives between the
+	// DisableKeepAlives when set will disable keep-alives between the
 	// router and backends for this route
 	DisableKeepAlives bool `json:"disable_keep_alives,omitempty"`
 }

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -66,6 +66,10 @@ type Route struct {
 	// (used by the scheduler to only stop jobs once all requests have
 	// completed).
 	DrainBackends bool `json:"drain_backends,omitempty"`
+
+	// DisableKeepAlives when set will disable keep alives between the
+	// router and backends for this route
+	DisableKeepAlives bool `json:"disable_keep_alives,omitempty"`
 }
 
 func (r Route) FormattedID() string {
@@ -83,12 +87,13 @@ func (r Route) HTTPRoute() *HTTPRoute {
 		CreatedAt:     r.CreatedAt,
 		UpdatedAt:     r.UpdatedAt,
 
-		Domain:        r.Domain,
-		Certificate:   r.Certificate,
-		LegacyTLSCert: r.LegacyTLSCert,
-		LegacyTLSKey:  r.LegacyTLSKey,
-		Sticky:        r.Sticky,
-		Path:          r.Path,
+		Domain:            r.Domain,
+		Certificate:       r.Certificate,
+		LegacyTLSCert:     r.LegacyTLSCert,
+		LegacyTLSKey:      r.LegacyTLSKey,
+		Sticky:            r.Sticky,
+		Path:              r.Path,
+		DisableKeepAlives: r.DisableKeepAlives,
 	}
 }
 
@@ -116,12 +121,13 @@ type HTTPRoute struct {
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 
-	Domain        string
-	Certificate   *Certificate `json:"certificate,omitempty"`
-	LegacyTLSCert string       `json:"tls_cert,omitempty"`
-	LegacyTLSKey  string       `json:"tls_key,omitempty"`
-	Sticky        bool
-	Path          string
+	Domain            string
+	Certificate       *Certificate `json:"certificate,omitempty"`
+	LegacyTLSCert     string       `json:"tls_cert,omitempty"`
+	LegacyTLSKey      string       `json:"tls_key,omitempty"`
+	Sticky            bool
+	Path              string
+	DisableKeepAlives bool
 }
 
 func (r HTTPRoute) FormattedID() string {
@@ -146,12 +152,13 @@ func (r HTTPRoute) ToRoute() *Route {
 		UpdatedAt:     r.UpdatedAt,
 
 		// http-specific fields
-		Domain:        r.Domain,
-		Certificate:   r.Certificate,
-		LegacyTLSCert: r.LegacyTLSCert,
-		LegacyTLSKey:  r.LegacyTLSKey,
-		Sticky:        r.Sticky,
-		Path:          r.Path,
+		Domain:            r.Domain,
+		Certificate:       r.Certificate,
+		LegacyTLSCert:     r.LegacyTLSCert,
+		LegacyTLSKey:      r.LegacyTLSKey,
+		Sticky:            r.Sticky,
+		Path:              r.Path,
+		DisableKeepAlives: r.DisableKeepAlives,
 	}
 }
 

--- a/schema/router/route.json
+++ b/schema/router/route.json
@@ -58,6 +58,10 @@
       "type": "boolean",
       "description": "Whether to trigger drain events when backends shutdown."
     },
+    "disable_keep_alives": {
+      "type": "boolean",
+      "description": "Whether to disable keep alives between the router and backends for this route."
+    },
     "port": {
       "type": "integer",
       "description": "The TCP port to listen on for TCP Routes."

--- a/schema/router/route.json
+++ b/schema/router/route.json
@@ -60,7 +60,7 @@
     },
     "disable_keep_alives": {
       "type": "boolean",
-      "description": "Whether to disable keep alives between the router and backends for this route."
+      "description": "Whether to disable keep-alives between the router and backends for this route."
     },
     "port": {
       "type": "integer",


### PR DESCRIPTION
This allows keep alives between the router and backends to be disabled with the `--disable-keep-alives` flag, or re-enabled with the `--enable-keep-alives` flag:

```bash
$ flynn route add http -s app-web --disable-keep-alives $domain

$ flynn route update $id --disable-keep-alives

$ flynn route update $id --enable-keep-alives
```