### PR TITLE
router: Ensure root-path routes are processed before sub-path routes

### DIFF
--- a/router/setup_test.go
+++ b/router/setup_test.go
@@ -56,6 +56,10 @@ type testStore struct {
 
 	streamsMtx sync.Mutex
 	streams    map[chan *router.Event]*stream.Basic
+
+	// sortRouteList when set will be called to sort the list of routes
+	// returned from List()
+	sortRouteList func([]*router.Route)
 }
 
 func newTestStore() *testStore {
@@ -71,6 +75,9 @@ func (t *testStore) List() ([]*router.Route, error) {
 	routes := make([]*router.Route, 0, len(t.routes))
 	for _, r := range t.routes {
 		routes = append(routes, r)
+	}
+	if t.sortRouteList != nil {
+		t.sortRouteList(routes)
 	}
 	return routes, nil
 }


### PR DESCRIPTION
The router used to load routes from the database in a specific order to ensure that it processed root-path routes before sub-path routes, but now the routes come from the controller there is no guarantee that they are still returned in that order, so this change enforces the order once the routes are loaded.

This broken behavior was witnessed when restoring a backup that included routes with sub-paths and seeing the following in the router logs:

```
t=2020-03-28T17:58:27+0100 lvl=eror msg="Failed insert of path based route, consistency violation."
```

As well as the router test included in this PR, I've also manually tested restoring a backup with this fix and checking that sub-path routes work correctly.